### PR TITLE
Fixes to Travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: go
 go:
   - 1.11.4
 
+install: true
+
 services:
   - docker
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![](https://travis-ci.org/testcontainers/testcontainer-go.svg?branch=master)
+[![Build Status](https://travis-ci.org/testcontainers/testcontainers-go.svg?branch=master)](https://travis-ci.org/testcontainers/testcontainers-go)
 
 When I was working on a Zipkin PR I discovered a nice Java library called
 [testcontainers](https://www.testcontainers.org/).


### PR DESCRIPTION
- Fixes broken link to Travis CI job via badge
- Avoids running the default install script (`go get -t -v ./...`) which is unnecessary when using Go modules