### PR TITLE
Exposed containerID with the function GetContainerID

### DIFF
--- a/container.go
+++ b/container.go
@@ -25,6 +25,7 @@ type ContainerProvider interface {
 
 // Container allows getting info about and controlling a single container instance
 type Container interface {
+	GetContainerID() string                                         // get the container id from the provider
 	Endpoint(context.Context, string) (string, error)               // get proto://ip:port string for the first exposed port
 	PortEndpoint(context.Context, nat.Port, string) (string, error) // get proto://ip:port string for the given exposed port
 	Host(context.Context) (string, error)                           // get host where the container port is exposed

--- a/docker.go
+++ b/docker.go
@@ -37,6 +37,10 @@ type DockerContainer struct {
 	terminationSignal chan bool
 }
 
+func (c *DockerContainer) GetContainerID() string {
+	return c.ID
+}
+
 // Endpoint gets proto://host:port string for the first exposed port
 // Will returns just host:port if proto is ""
 func (c *DockerContainer) Endpoint(ctx context.Context, proto string) (string, error) {

--- a/docker_test.go
+++ b/docker_test.go
@@ -11,6 +11,25 @@ import (
 	"github.com/testcontainers/testcontainers-go/wait"
 )
 
+func TestContainerReturnItsContainerID(t *testing.T) {
+	ctx := context.Background()
+	nginxA, err := GenericContainer(ctx, GenericContainerRequest{
+		ContainerRequest: ContainerRequest{
+			Image: "nginx",
+			ExposedPorts: []string{
+				"80/tcp",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer nginxA.Terminate(ctx)
+	if nginxA.GetContainerID() == "" {
+		t.Errorf("expected a containerID but we got an empty string.")
+	}
+}
+
 func TestTwoContainersExposingTheSamePort(t *testing.T) {
 	ctx := context.Background()
 	nginxA, err := GenericContainer(ctx, GenericContainerRequest{


### PR DESCRIPTION
Close #52

Now the Container exposes a method called `GetContainerID`. It exposes
the container id provided by the provider (docker atm).

@m4x-h4xx how does it sounds? Thanks

Signed-off-by: Gianluca Arbezzano <gianarb92@gmail.com>