### PR TITLE
Fixed API Version Negotiation

### DIFF
--- a/docker.go
+++ b/docker.go
@@ -187,6 +187,7 @@ func NewDockerProvider() (*DockerProvider, error) {
 	if err != nil {
 		return nil, err
 	}
+	client.NegotiateAPIVersion(context.Background())
 	p := &DockerProvider{
 		client: client,
 	}

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ require (
 	github.com/Microsoft/go-winio v0.4.11 // indirect
 	github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5 // indirect
 	github.com/docker/distribution v2.7.0+incompatible // indirect
-	github.com/docker/docker v0.7.3-0.20180815000130-e05b657120a6
+	github.com/docker/docker v0.7.3-0.20190506211059-b20a14b54661
 	github.com/docker/go-connections v0.4.0
 	github.com/docker/go-units v0.3.3 // indirect
 	github.com/go-sql-driver/mysql v1.4.1

--- a/go.sum
+++ b/go.sum
@@ -12,6 +12,9 @@ github.com/docker/distribution v2.7.0+incompatible h1:neUDAlf3wX6Ml4HdqTrbcOHXtf
 github.com/docker/distribution v2.7.0+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docker/docker v0.7.3-0.20180815000130-e05b657120a6 h1:BlqEAizRwUVWCgX+/kOLaX7XcpjNWDLHbxNjUZWqDN4=
 github.com/docker/docker v0.7.3-0.20180815000130-e05b657120a6/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
+github.com/docker/docker v0.7.3-0.20190506211059-b20a14b54661 h1:ZuxGvIvF01nfc/G9RJ5Q7Va1zQE2WJyG18Zv3DqCEf4=
+github.com/docker/docker v0.7.3-0.20190506211059-b20a14b54661/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
+github.com/docker/docker v1.13.1 h1:IkZjBSIc8hBjLpqeAbeE5mca5mNgeatLHBy3GO78BWo=
 github.com/docker/go-connections v0.4.0 h1:El9xVISelRB7BuFusrZozjnkIM5YnzCViNKohAFqRJQ=
 github.com/docker/go-connections v0.4.0/go.mod h1:Gbd7IOopHjR8Iph03tsViu4nIes5XhDvyHbTtUxmeec=
 github.com/docker/go-units v0.3.3 h1:Xk8S3Xj5sLGlG5g67hJmYMmUgXv5N4PhkjJHHqrwnTk=


### PR DESCRIPTION
The docker client can negotiate the right version of the API based on
the docker daemon but there is a specific function to call. We was not
calling it.

Now it should be smart enough to figure out which version of the API to
use.

Fixed #61

Signed-off-by: Gianluca Arbezzano <gianarb92@gmail.com>