### PR TITLE
Change isReaper with SkipReaper

### DIFF
--- a/container.go
+++ b/container.go
@@ -51,7 +51,7 @@ type ContainerRequest struct {
 	WaitingFor   wait.Strategy
 	Name         string // for specifying container name
 
-	isReaper bool // indicates whether we skip setting up a reaper for this
+	SkipReaper bool // indicates whether we skip setting up a reaper for this
 }
 
 // ProviderType is an enum for the possible providers

--- a/docker.go
+++ b/docker.go
@@ -222,7 +222,7 @@ func (p *DockerProvider) CreateContainer(ctx context.Context, req ContainerReque
 	sessionID := uuid.NewV4()
 
 	var termSignal chan bool
-	if !req.isReaper {
+	if req.SkipReaper {
 		r, err := NewReaper(ctx, sessionID.String(), p)
 		if err != nil {
 			return nil, errors.Wrap(err, "creating reaper failed")

--- a/reaper.go
+++ b/reaper.go
@@ -50,7 +50,7 @@ func NewReaper(ctx context.Context, sessionID string, provider ReaperProvider) (
 		BindMounts: map[string]string{
 			"/var/run/docker.sock": "/var/run/docker.sock",
 		},
-		isReaper: true,
+		SkipReaper: false,
 	}
 
 	c, err := provider.RunContainer(ctx, req)


### PR DESCRIPTION
Change the name and the visibility of the skip Reaper flag included
in the ContainerRequest structure. Now is possible disable the Reaper
creation from during the container creation request.