### PR TITLE
(#73) Support attaching containers to different networks than bridge

### DIFF
--- a/container.go
+++ b/container.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"io"
 
-	"github.com/docker/docker/api/types"
 	"github.com/docker/go-connections/nat"
 	"github.com/pkg/errors"
 	"github.com/testcontainers/testcontainers-go/wait"
@@ -21,11 +20,8 @@ type DeprecatedContainer interface {
 
 // ContainerProvider allows the creation of containers on an arbitrary system
 type ContainerProvider interface {
-	CreateContainer(context.Context, ContainerRequest) (Container, error)      // create a container without starting it
-	CreateNetwork(context.Context, NetworkRequest) (Network, error)            // create a network
-	GetNetwork(context.Context, NetworkRequest) (types.NetworkResource, error) // get a network
-	RemoveNetwork(context.Context, NetworkRequest) error                       // remove a network
-	RunContainer(context.Context, ContainerRequest) (Container, error)         // create a container and start it
+	CreateContainer(context.Context, ContainerRequest) (Container, error) // create a container without starting it
+	RunContainer(context.Context, ContainerRequest) (Container, error)    // create a container and start it
 }
 
 // Container allows getting info about and controlling a single container instance
@@ -70,7 +66,7 @@ const (
 )
 
 // GetProvider provides the provider implementation for a certain type
-func (t ProviderType) GetProvider() (ContainerProvider, error) {
+func (t ProviderType) GetProvider() (GenericProvider, error) {
 	switch t {
 	case ProviderDocker:
 		provider, err := NewDockerProvider()

--- a/container.go
+++ b/container.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io"
 
+	"github.com/docker/docker/api/types"
 	"github.com/docker/go-connections/nat"
 	"github.com/pkg/errors"
 	"github.com/testcontainers/testcontainers-go/wait"
@@ -20,8 +21,11 @@ type DeprecatedContainer interface {
 
 // ContainerProvider allows the creation of containers on an arbitrary system
 type ContainerProvider interface {
-	CreateContainer(context.Context, ContainerRequest) (Container, error) // create a container without starting it
-	RunContainer(context.Context, ContainerRequest) (Container, error)    // create a container and start it
+	CreateContainer(context.Context, ContainerRequest) (Container, error)      // create a container without starting it
+	CreateNetwork(context.Context, NetworkRequest) (Network, error)            // create a network
+	GetNetwork(context.Context, NetworkRequest) (types.NetworkResource, error) // get a network
+	RemoveNetwork(context.Context, NetworkRequest) error                       // remove a network
+	RunContainer(context.Context, ContainerRequest) (Container, error)         // create a container and start it
 }
 
 // Container allows getting info about and controlling a single container instance
@@ -37,6 +41,7 @@ type Container interface {
 	Terminate(context.Context) error                                // terminate the container
 	Logs(context.Context) (io.ReadCloser, error)                    // Get logs of the container
 	Name(context.Context) (string, error)                           // get container name
+	Networks(context.Context) ([]string, error)                     // get container networks
 }
 
 // ContainerRequest represents the parameters used to get a running container
@@ -49,8 +54,9 @@ type ContainerRequest struct {
 	BindMounts   map[string]string
 	RegistryCred string
 	WaitingFor   wait.Strategy
-	Name         string // for specifying container name
-	Privileged   bool   // for starting privileged container
+	Name         string   // for specifying container name
+	Privileged   bool     // for starting privileged container
+	Networks     []string // for specifying network names
 
 	SkipReaper bool // indicates whether we skip setting up a reaper for this
 }

--- a/container.go
+++ b/container.go
@@ -38,21 +38,23 @@ type Container interface {
 	Logs(context.Context) (io.ReadCloser, error)                    // Get logs of the container
 	Name(context.Context) (string, error)                           // get container name
 	Networks(context.Context) ([]string, error)                     // get container networks
+	NetworkAliases(context.Context) (map[string][]string, error)    // get container network aliases for a network
 }
 
 // ContainerRequest represents the parameters used to get a running container
 type ContainerRequest struct {
-	Image        string
-	Env          map[string]string
-	ExposedPorts []string // allow specifying protocol info
-	Cmd          string
-	Labels       map[string]string
-	BindMounts   map[string]string
-	RegistryCred string
-	WaitingFor   wait.Strategy
-	Name         string   // for specifying container name
-	Privileged   bool     // for starting privileged container
-	Networks     []string // for specifying network names
+	Image          string
+	Env            map[string]string
+	ExposedPorts   []string // allow specifying protocol info
+	Cmd            string
+	Labels         map[string]string
+	BindMounts     map[string]string
+	RegistryCred   string
+	WaitingFor     wait.Strategy
+	Name           string              // for specifying container name
+	Privileged     bool                // for starting privileged container
+	Networks       []string            // for specifying network names
+	NetworkAliases map[string][]string // for specifying network aliases
 
 	SkipReaper bool // indicates whether we skip setting up a reaper for this
 }

--- a/docker.go
+++ b/docker.go
@@ -457,7 +457,7 @@ func (p *DockerProvider) CreateNetwork(ctx context.Context, req NetworkRequest) 
 	sessionID := uuid.NewV4()
 
 	var termSignal chan bool
-	if req.SkipReaper {
+	if !req.SkipReaper {
 		r, err := NewReaper(ctx, sessionID.String(), p)
 		if err != nil {
 			return nil, errors.Wrap(err, "creating network reaper failed")

--- a/docker.go
+++ b/docker.go
@@ -204,6 +204,24 @@ func (c *DockerContainer) Networks(ctx context.Context) ([]string, error) {
 	return n, nil
 }
 
+// NetworkAliases gets the aliases of the container for the networks it is attached to.
+func (c *DockerContainer) NetworkAliases(ctx context.Context) (map[string][]string, error) {
+	inspect, err := c.inspectContainer(ctx)
+	if err != nil {
+		return map[string][]string{}, err
+	}
+
+	networks := inspect.NetworkSettings.Networks
+
+	a := map[string][]string{}
+
+	for k := range networks {
+		a[k] = networks[k].Aliases
+	}
+
+	return a, nil
+}
+
 // DockerNetwork represents a network started using Docker
 type DockerNetwork struct {
 	ID       string // Network ID from Docker
@@ -338,6 +356,7 @@ func (p *DockerProvider) CreateContainer(ctx context.Context, req ContainerReque
 		})
 		if err == nil {
 			endpointSetting := network.EndpointSettings{
+				Aliases:   req.NetworkAliases[n],
 				NetworkID: nw.ID,
 			}
 			endpointConfigs[n] = &endpointSetting

--- a/docker.go
+++ b/docker.go
@@ -14,6 +14,7 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/mount"
+	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/client"
 	"github.com/docker/go-connections/nat"
 
@@ -185,6 +186,39 @@ func (c *DockerContainer) Name(ctx context.Context) (string, error) {
 	return inspect.Name, nil
 }
 
+// Networks gets the names of the networks the container is attached to.
+func (c *DockerContainer) Networks(ctx context.Context) ([]string, error) {
+	inspect, err := c.inspectContainer(ctx)
+	if err != nil {
+		return []string{}, err
+	}
+
+	networks := inspect.NetworkSettings.Networks
+
+	n := []string{}
+
+	for k := range networks {
+		n = append(n, k)
+	}
+
+	return n, nil
+}
+
+// DockerNetwork represents a network started using Docker
+type DockerNetwork struct {
+	ID       string // Network ID from Docker
+	Driver   string
+	Name     string
+	provider *DockerProvider
+}
+
+// Remove is used to remove the network. It is usually triggered by as defer function.
+func (n *DockerNetwork) Remove(ctx context.Context) error {
+	return n.provider.RemoveNetwork(ctx, NetworkRequest{
+		Name: n.Name,
+	})
+}
+
 // DockerProvider implements the ContainerProvider interface
 type DockerProvider struct {
 	client    *client.Client
@@ -297,7 +331,23 @@ func (p *DockerProvider) CreateContainer(ctx context.Context, req ContainerReque
 		Privileged:   req.Privileged,
 	}
 
-	resp, err := p.client.ContainerCreate(ctx, dockerInput, hostConfig, nil, req.Name)
+	endpointConfigs := map[string]*network.EndpointSettings{}
+	for _, n := range req.Networks {
+		nw, err := p.GetNetwork(ctx, NetworkRequest{
+			Name: n,
+		})
+		if err == nil {
+			endpointSetting := network.EndpointSettings{
+				NetworkID: nw.ID,
+			}
+			endpointConfigs[n] = &endpointSetting
+		}
+	}
+	networkingConfig := network.NetworkingConfig{
+		EndpointsConfig: endpointConfigs,
+	}
+
+	resp, err := p.client.ContainerCreate(ctx, dockerInput, hostConfig, &networkingConfig, req.Name)
 	if err != nil {
 		return nil, err
 	}
@@ -366,6 +416,51 @@ func (p *DockerProvider) daemonHost() (string, error) {
 	}
 
 	return p.hostCache, nil
+}
+
+// CreateNetwork returns the object representing a new network identified by its name
+func (p *DockerProvider) CreateNetwork(ctx context.Context, req NetworkRequest) (Network, error) {
+	nc := types.NetworkCreate{
+		Driver:         req.Driver,
+		CheckDuplicate: req.CheckDuplicate,
+		Internal:       req.Internal,
+		EnableIPv6:     req.EnableIPv6,
+		Attachable:     req.Attachable,
+	}
+
+	response, err := p.client.NetworkCreate(ctx, req.Name, nc)
+	if err != nil {
+		return &DockerNetwork{}, err
+	}
+
+	n := &DockerNetwork{
+		ID:     response.ID,
+		Driver: req.Driver,
+		Name:   req.Name,
+	}
+
+	return n, nil
+}
+
+// GetNetwork returns the object representing the network identified by its name
+func (p *DockerProvider) GetNetwork(ctx context.Context, req NetworkRequest) (types.NetworkResource, error) {
+	networkResource, err := p.client.NetworkInspect(ctx, req.Name, types.NetworkInspectOptions{
+		Verbose: true,
+	})
+	if err != nil {
+		return types.NetworkResource{}, err
+	}
+
+	return networkResource, err
+}
+
+// RemoveNetwork removes a network
+func (p *DockerProvider) RemoveNetwork(ctx context.Context, req NetworkRequest) error {
+	if err := p.client.NetworkRemove(ctx, req.Name); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func inAContainer() bool {

--- a/docker_test.go
+++ b/docker_test.go
@@ -31,6 +31,11 @@ func TestContainerAttachedToNewNetwork(t *testing.T) {
 			Networks: []string{
 				networkName,
 			},
+			NetworkAliases: map[string][]string{
+				networkName: []string{
+					"alias1", "alias2", "alias3",
+				},
+			},
 		},
 	}
 
@@ -57,6 +62,23 @@ func TestContainerAttachedToNewNetwork(t *testing.T) {
 	network := networks[0]
 	if network != networkName {
 		t.Errorf("Expected network name '%s'. Got '%s'.", networkName, network)
+	}
+
+	networkAliases, err := nginx.NetworkAliases(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(networkAliases) != 1 {
+		t.Errorf("Expected network aliases for 1 network. Got '%d'.", len(networkAliases))
+	}
+	networkAlias := networkAliases[networkName]
+	if len(networkAlias) != 3 {
+		t.Errorf("Expected network aliases %d. Got '%d'.", 3, len(networkAlias))
+	}
+	if networkAlias[0] != "alias1" || networkAlias[1] != "alias2" || networkAlias[2] != "alias3" {
+		t.Errorf(
+			"Expected network aliases '%s', '%s' and '%s'. Got '%s', '%s' and '%s'.",
+			"alias1", "alias2", "alias3", networkAlias[0], networkAlias[1], networkAlias[2])
 	}
 }
 
@@ -336,6 +358,17 @@ func TestContainerCreation(t *testing.T) {
 	}
 	if resp.StatusCode != http.StatusOK {
 		t.Errorf("Expected status code %d. Got %d.", http.StatusOK, resp.StatusCode)
+	}
+	networkAliases, err := nginxC.NetworkAliases(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(networkAliases) != 1 {
+		fmt.Printf("%v", networkAliases)
+		t.Errorf("Expected number of connected networks %d. Got %d.", 0, len(networkAliases))
+	}
+	if len(networkAliases["bridge"]) != 0 {
+		t.Errorf("Expected number of aliases for 'bridge' network %d. Got %d.", 0, len(networkAliases["bridge"]))
 	}
 }
 

--- a/docker_test.go
+++ b/docker_test.go
@@ -45,6 +45,9 @@ func TestContainerAttachedToNewNetwork(t *testing.T) {
 		Name:           networkName,
 		CheckDuplicate: true,
 	})
+	defer provider.RemoveNetwork(ctx, NetworkRequest{
+		Name: networkName,
+	})
 
 	nginx, err := GenericContainer(ctx, gcr)
 	if err != nil {

--- a/docker_test.go
+++ b/docker_test.go
@@ -41,13 +41,14 @@ func TestContainerAttachedToNewNetwork(t *testing.T) {
 
 	provider, err := gcr.ProviderType.GetProvider()
 
-	provider.CreateNetwork(ctx, NetworkRequest{
+	newNetwork, err := provider.CreateNetwork(ctx, NetworkRequest{
 		Name:           networkName,
 		CheckDuplicate: true,
 	})
-	defer provider.RemoveNetwork(ctx, NetworkRequest{
-		Name: networkName,
-	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer newNetwork.Remove(ctx)
 
 	nginx, err := GenericContainer(ctx, gcr)
 	if err != nil {

--- a/docker_test.go
+++ b/docker_test.go
@@ -18,6 +18,48 @@ import (
 	"github.com/testcontainers/testcontainers-go/wait"
 )
 
+func TestContainerAttachedToNewNetwork(t *testing.T) {
+	networkName := "new-network"
+
+	ctx := context.Background()
+	gcr := GenericContainerRequest{
+		ContainerRequest: ContainerRequest{
+			Image: "nginx",
+			ExposedPorts: []string{
+				"80/tcp",
+			},
+			Networks: []string{
+				networkName,
+			},
+		},
+	}
+
+	provider, err := gcr.ProviderType.GetProvider()
+
+	provider.CreateNetwork(ctx, NetworkRequest{
+		Name:           networkName,
+		CheckDuplicate: true,
+	})
+
+	nginx, err := GenericContainer(ctx, gcr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer nginx.Terminate(ctx)
+
+	networks, err := nginx.Networks(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(networks) != 1 {
+		t.Errorf("Expected networks 1. Got '%d'.", len(networks))
+	}
+	network := networks[0]
+	if network != networkName {
+		t.Errorf("Expected network name '%s'. Got '%s'.", networkName, network)
+	}
+}
+
 func TestContainerReturnItsContainerID(t *testing.T) {
 	ctx := context.Background()
 	nginxA, err := GenericContainer(ctx, GenericContainerRequest{
@@ -309,7 +351,8 @@ func TestContainerCreationWithName(t *testing.T) {
 			ExposedPorts: []string{
 				nginxPort,
 			},
-			Name: creationName,
+			Name:     creationName,
+			Networks: []string{"bridge"},
 		},
 		Started: true,
 	})
@@ -328,6 +371,17 @@ func TestContainerCreationWithName(t *testing.T) {
 	}
 	if name != expectedName {
 		t.Errorf("Expected container name '%s'. Got '%s'.", expectedName, name)
+	}
+	networks, err := nginxC.Networks(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(networks) != 1 {
+		t.Errorf("Expected networks 1. Got '%d'.", len(networks))
+	}
+	network := networks[0]
+	if network != "bridge" {
+		t.Errorf("Expected network name '%s'. Got '%s'.", "bridge", network)
 	}
 	ip, err := nginxC.Host(ctx)
 	if err != nil {

--- a/generic.go
+++ b/generic.go
@@ -33,3 +33,9 @@ func GenericContainer(ctx context.Context, req GenericContainerRequest) (Contain
 
 	return c, nil
 }
+
+// GenericProvider represents an abstraction for container and network providers
+type GenericProvider interface {
+	ContainerProvider
+	NetworkProvider
+}

--- a/network.go
+++ b/network.go
@@ -1,0 +1,18 @@
+package testcontainers
+
+import "context"
+
+// Network allows getting info about a single network instance
+type Network interface {
+	Remove(context.Context) error // removes the network
+}
+
+// NetworkRequest represents the parameters used to get a network
+type NetworkRequest struct {
+	Driver         string
+	CheckDuplicate bool
+	Internal       bool
+	EnableIPv6     bool
+	Name           string
+	Attachable     bool
+}

--- a/network.go
+++ b/network.go
@@ -10,7 +10,6 @@ import (
 type NetworkProvider interface {
 	CreateNetwork(context.Context, NetworkRequest) (Network, error)            // create a network
 	GetNetwork(context.Context, NetworkRequest) (types.NetworkResource, error) // get a network
-	RemoveNetwork(context.Context, NetworkRequest) error                       // remove a network
 }
 
 // Network allows getting info about a single network instance
@@ -25,5 +24,8 @@ type NetworkRequest struct {
 	Internal       bool
 	EnableIPv6     bool
 	Name           string
+	Labels         map[string]string
 	Attachable     bool
+
+	SkipReaper bool // indicates whether we skip setting up a reaper for this
 }

--- a/network.go
+++ b/network.go
@@ -1,6 +1,17 @@
 package testcontainers
 
-import "context"
+import (
+	"context"
+
+	"github.com/docker/docker/api/types"
+)
+
+// NetworkProvider allows the creation of networks on an arbitrary system
+type NetworkProvider interface {
+	CreateNetwork(context.Context, NetworkRequest) (Network, error)            // create a network
+	GetNetwork(context.Context, NetworkRequest) (types.NetworkResource, error) // get a network
+	RemoveNetwork(context.Context, NetworkRequest) error                       // remove a network
+}
 
 // Network allows getting info about a single network instance
 type Network interface {


### PR DESCRIPTION
## What does this PR do?
This PR adds support for client code to be able to configure networks a container is connected to, which nowadays is impossible as the default network configuration when invoking the Docker client to create and run a container is passed as `nil`.

For that reason, a Network request object is needed, alongside the methods to create/remove/get a network from the Docker client. Those methods have been defined at a new NetworkProvider interface.

As a container could have multiple aliases when connecting to a network, we are also adding that support: when adding a network it's possible to set the aliases for the container in that network.

## Why is this PR important?
Client code would eventually like to connect a container run by this library to a specific set of networks, and this library currently disallows it always using the default Docker bridge network.

## Testing
A unit test that verifies that a container created with one network is connected to it.

## Other considerations
Any feedback about naming and Go-conventions is super well received! 😃 

Thanks!