### PR TITLE
Multiple wait strategy

### DIFF
--- a/wait/multi.go
+++ b/wait/multi.go
@@ -1,0 +1,47 @@
+package wait
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+// Implement interface
+var _ Strategy = (*MultiStrategy)(nil)
+
+type MultiStrategy struct {
+	// all Strategies should have a startupTimeout to avoid waiting infinitely
+	startupTimeout time.Duration
+
+	// additional properties
+	Strategies []Strategy
+}
+
+func (ms *MultiStrategy) WithStartupTimeout(startupTimeout time.Duration) *MultiStrategy {
+	ms.startupTimeout = startupTimeout
+	return ms
+}
+
+func ForAll(strategies ...Strategy) *MultiStrategy {
+	return &MultiStrategy{
+		startupTimeout: defaultStartupTimeout(),
+		Strategies:     strategies,
+	}
+}
+
+func (ms *MultiStrategy) WaitUntilReady(ctx context.Context, target StrategyTarget) (err error) {
+	ctx, cancelContext := context.WithTimeout(ctx, ms.startupTimeout)
+	defer cancelContext()
+
+	if len(ms.Strategies) == 0 {
+		return fmt.Errorf("no wait strategy supplied")
+	}
+
+	for _, strategy := range ms.Strategies {
+		err := strategy.WaitUntilReady(ctx, target)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
reference #37 

This add a new wait strategy called MultiStrategy that allows waiting for multiple conditions as proposed in #37 

The feature can be used like this

```go
ctx := context.Background()
req := ContainerRequest{
	Image:        "mysql:latest",
	ExposedPorts: []string{"3306/tcp", "33060/tcp"},
	Env: map[string]string{
		"MYSQL_ROOT_PASSWORD": "password",
		"MYSQL_DATABASE":      "database",
	},
	WaitingFor: wait.ForAll(
		wait.ForLog("port: 3306  MySQL Community Server - GPL"),
		wait.ForListeningPort("3306/tcp"),
	),
}
```