### PR TITLE
(#93) Reset internal state after container.Terminate(), and expose InspectContainer

### DIFF
--- a/docker.go
+++ b/docker.go
@@ -153,6 +153,12 @@ func (c *DockerContainer) Terminate(ctx context.Context) error {
 		RemoveVolumes: true,
 		Force:         true,
 	})
+
+	if err == nil {
+		c.sessionID = uuid.UUID{}
+		c.raw = nil
+	}
+
 	return err
 }
 


### PR DESCRIPTION
## What does this PR do?
The original purpose of this PR was to expose the inspectContainer method on the DockerContainer model. In that process, I found that there is a local cache (raw) that allowed to invoke the public methods that internally use `inspectContainer` (Host, Ports...) even after terminating the container, because that local cache was not removed.

For that reason this PR adds that ability to remove the local cache (raw and sessionID) when terminating a container.

## Why is this PR important?
Nowadays the API allows to invoke another container method (Host, Ports...) after the container is terminated, and the internal cached state would satisfy the request even when the container is not existing anymore at Docker client level. We are removing the cached values so that we receive the response directly from the container provider.