### PR TITLE
Added occurrence for the WaitLogStrategy

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -32,3 +32,5 @@ require (
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
 	gotest.tools v0.0.0-20181223230014-1083505acf35 // indirect
 )
+
+go 1.13

--- a/go.sum
+++ b/go.sum
@@ -71,6 +71,7 @@ golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73r
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd h1:nTDtHvHSdCn1m6ITfMRqtOd/9+7a3s8RBNOZ3eYZzJA=
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
+golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f h1:wMNYb4v58l5UBM7MYRLPG6ZhfOqbKu7X5eyFl8ZhKvA=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/wait/log_test.go
+++ b/wait/log_test.go
@@ -1,0 +1,65 @@
+package wait
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"io/ioutil"
+	"testing"
+	"time"
+
+	"github.com/docker/go-connections/nat"
+)
+
+type noopStrategyTarget struct {
+	ioReaderCloser io.ReadCloser
+}
+
+func (st noopStrategyTarget) Host(ctx context.Context) (string, error) {
+	return "", nil
+}
+
+func (st noopStrategyTarget) MappedPort(ctx context.Context, n nat.Port) (nat.Port, error) {
+	return n, nil
+}
+
+func (st noopStrategyTarget) Logs(ctx context.Context) (io.ReadCloser, error) {
+	return st.ioReaderCloser, nil
+}
+
+func TestWaitForLog(t *testing.T) {
+	target := noopStrategyTarget{
+		ioReaderCloser: ioutil.NopCloser(bytes.NewReader([]byte("dude"))),
+	}
+	wg := NewLogStrategy("dude").WithStartupTimeout(100 * time.Microsecond)
+	err := wg.WaitUntilReady(context.Background(), target)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestWaitWithMaxOccurrence(t *testing.T) {
+	target := noopStrategyTarget{
+		ioReaderCloser: ioutil.NopCloser(bytes.NewReader([]byte("hello\r\ndude\n\rdude"))),
+	}
+	wg := NewLogStrategy("dude").
+		WithStartupTimeout(100 * time.Microsecond).
+		WithOccurrence(2)
+	err := wg.WaitUntilReady(context.Background(), target)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestWaitWithMaxOccurrenceButItWillNeverHappen(t *testing.T) {
+	target := noopStrategyTarget{
+		ioReaderCloser: ioutil.NopCloser(bytes.NewReader([]byte("hello\r\ndude"))),
+	}
+	wg := NewLogStrategy("blaaa").
+		WithStartupTimeout(100 * time.Microsecond).
+		WithOccurrence(2)
+	err := wg.WaitUntilReady(context.Background(), target)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}


### PR DESCRIPTION
This is related to the work @giorgioazzinnaro is doing here
https://github.com/testcontainers/testcontainers-go/pull/98 .

Now you can declare how many times a log line should appear before
having the container declared as ready.

Signed-off-by: Gianluca Arbezzano <gianarb92@gmail.com>