### PR TITLE
fix: Add Go formatting to README code block

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Testcontainers-go gives you the ability to build and image and run a container f
 
 You can do so by specifiying a `Context` and optionally a `Dockerfile` (defaults to "Dockerfile") like so:
 
-```
+```go
 req := ContainerRequest{
 		FromDockerfile: testcontainers.FromDockerfile{
 			Context: "/path/to/build/context",


### PR DESCRIPTION
Added formatting to Go code block in README. 😎 