### PR TITLE
Retry on EOF response from http

### DIFF
--- a/wait/http.go
+++ b/wait/http.go
@@ -5,8 +5,10 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
+	netUrl "net/url"
 	"os"
 	"strconv"
 	"syscall"
@@ -141,6 +143,14 @@ func (ws *HTTPStrategy) WaitUntilReady(ctx context.Context, target StrategyTarge
 					}
 				}
 			}
+
+			if v, ok := err.(*netUrl.Error); ok {
+				if v.Err == io.EOF {
+					time.Sleep(100 * time.Millisecond)
+					continue
+				}
+			}
+
 			return err
 		}
 


### PR DESCRIPTION
Many http containers return an EOF response after the port is live, but the server is not yet ready. This fixes to perform the http retry when receiving an EOF error.