### PR TITLE
feature/container-ip

### DIFF
--- a/container.go
+++ b/container.go
@@ -38,6 +38,7 @@ type Container interface {
 	Logs(context.Context) (io.ReadCloser, error)                    // Get logs of the container
 	Name(context.Context) (string, error)                           // get container name
 	Networks(context.Context) ([]string, error)                     // get container networks
+	ContainerIP(context.Context) (string, error)                    // get container ip
 	NetworkAliases(context.Context) (map[string][]string, error)    // get container network aliases for a network
 }
 

--- a/docker.go
+++ b/docker.go
@@ -212,6 +212,16 @@ func (c *DockerContainer) Networks(ctx context.Context) ([]string, error) {
 	return n, nil
 }
 
+// ContainerIP gets the IP address of the primary network within the container.
+func (c *DockerContainer) ContainerIP(ctx context.Context) (string, error) {
+	inspect, err := c.inspectContainer(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	return inspect.NetworkSettings.IPAddress, nil
+}
+
 // NetworkAliases gets the aliases of the container for the networks it is attached to.
 func (c *DockerContainer) NetworkAliases(ctx context.Context) (map[string][]string, error) {
 	inspect, err := c.inspectContainer(ctx)

--- a/docker_test.go
+++ b/docker_test.go
@@ -398,6 +398,13 @@ func TestContainerCreation(t *testing.T) {
 	if resp.StatusCode != http.StatusOK {
 		t.Errorf("Expected status code %d. Got %d.", http.StatusOK, resp.StatusCode)
 	}
+	networkIP, err := nginxC.ContainerIP(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(networkIP) == 0 {
+		t.Errorf("Expected an IP address, got %v", networkIP)
+	}
 	networkAliases, err := nginxC.NetworkAliases(ctx)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Expose the IP address of the container to allow clients to query the network directly 