### PR TITLE
#110 feature: Context as io.Reader

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,8 @@ nginxC.Terminate(ctx, t)`. `t` is `*testing.T` and it is used to notify is the
 
 Testcontainers-go gives you the ability to build and image and run a container from a Dockerfile.
 
-You can do so by specifiying a `Context` and optionally a `Dockerfile` (defaults to "Dockerfile") like so:
+You can do so by specifiying a `Context` (the filepath to the build context on your local filesystem) 
+and optionally a `Dockerfile` (defaults to "Dockerfile") like so:
 
 ```
 req := ContainerRequest{
@@ -77,6 +78,30 @@ req := ContainerRequest{
 		},
 	}
 ```
+
+### Dynamic Build Context
+
+If you would like to send a build context that you created in code (maybe you have a dynamic Dockerfile), you can
+send the build context as an `io.Reader` since the Docker Daemon accepts is as a tar file, you can use the [tar](https://golang.org/pkg/archive/tar/) package to create your context.
+
+
+To do this you would use the `ContextArchive` attribute in the `FromDockerfile` struct.
+
+```go
+var buf bytes.Buffer
+tarWriter := tar.NewWriter(&buf)
+// ... add some files
+if err := tarWriter.Close(); err != nil {
+	// do something with err
+}
+reader := bytes.NewReader(buf.Bytes())
+fromDockerfile := testcontainers.FromDockerfile{
+	ContextArchive: reader,
+}
+```
+
+**Please Note** if you specify a `ContextArchive` this will cause testcontainers to ignore the path passed
+in to `Context`
 
 ## Sending a CMD to a Container
 

--- a/container_test.go
+++ b/container_test.go
@@ -1,9 +1,15 @@
 package testcontainers
 
 import (
+	"archive/tar"
+	"bytes"
+	"context"
+	"io"
 	"testing"
+	"time"
 
 	"github.com/pkg/errors"
+	"github.com/testcontainers/testcontainers-go/wait"
 )
 
 func Test_ContainerValidation(t *testing.T) {
@@ -98,5 +104,164 @@ func Test_GetDockerfile(t *testing.T) {
 				t.Fatalf("expected Dockerfile name: %s, received: %s", testCase.ExpectedDockerfileName, n)
 			}
 		})
+	}
+}
+
+func Test_BuildImageWithContexts(t *testing.T) {
+	type TestCase struct {
+		Name               string
+		ContextPath        string
+		ContextArchive     func() (io.Reader, error)
+		ExpectedEchoOutput string
+		Dockerfile         string
+		ExpectedError      error
+	}
+
+	testCases := []TestCase{
+		TestCase{
+			Name: "test build from context archive",
+			ContextArchive: func() (io.Reader, error) {
+				var buf bytes.Buffer
+				tarWriter := tar.NewWriter(&buf)
+				files := []struct {
+					Name     string
+					Contents string
+				}{
+					{
+						Name:     "Dockerfile",
+						Contents: `FROM alpine
+						CMD ["echo", "this is from the archive"]`,
+					},
+				}
+
+				for _, f := range files {
+					header := tar.Header{
+						Name:     f.Name,
+						Mode:     0777,
+						Size:     int64(len(f.Contents)),
+						Typeflag: tar.TypeReg,
+						Format:   tar.FormatGNU,
+					}
+
+					if err := tarWriter.WriteHeader(&header); err != nil {
+						return nil, err
+					}
+
+					if _, err := tarWriter.Write([]byte(f.Contents)); err != nil {
+						return nil, err
+					}
+
+					if err := tarWriter.Close(); err != nil {
+						return nil, err
+					}
+				}
+
+				reader := bytes.NewReader(buf.Bytes())
+
+				return reader, nil
+			},
+			ExpectedEchoOutput: "this is from the archive",
+		},
+		TestCase{
+			Name: "test build from context archive and be able to use files in it",
+			ContextArchive: func() (io.Reader, error) {
+				var buf bytes.Buffer
+				tarWriter := tar.NewWriter(&buf)
+				files := []struct {
+					Name     string
+					Contents string
+				}{
+					{
+						Name: "say_hi.sh",
+						Contents: `echo hi this is from the say_hi.sh file!`,
+					},
+					{
+						Name:     "Dockerfile",
+						Contents: `FROM alpine
+						WORKDIR /app
+						COPY . .
+						CMD ["sh", "./say_hi.sh"]`,
+					},
+				}
+
+				for _, f := range files {
+					header := tar.Header{
+						Name:     f.Name,
+						Mode:     0777,
+						Size:     int64(len(f.Contents)),
+						Typeflag: tar.TypeReg,
+						Format:   tar.FormatGNU,
+					}
+
+					if err := tarWriter.WriteHeader(&header); err != nil {
+						return nil, err
+					}
+
+					if _, err := tarWriter.Write([]byte(f.Contents)); err != nil {
+						return nil, err
+					}
+				}
+
+				if err := tarWriter.Close(); err != nil {
+					return nil, err
+				}
+
+				reader := bytes.NewReader(buf.Bytes())
+
+				return reader, nil
+			},
+			ExpectedEchoOutput: "hi this is from the say_hi.sh file!",
+		},
+		TestCase{
+			Name:               "test buildling from a context on the filesystem",
+			ContextPath:        "./testresources",
+			Dockerfile:         "echo.Dockerfile",
+			ExpectedEchoOutput: "this is from the echo test Dockerfile",
+			ContextArchive: func() (io.Reader, error) {
+				return nil, nil
+			},
+		},
+		TestCase{
+			Name:        "it should error if neither a context nor a context archive are specified",
+			ContextPath: "",
+			ContextArchive: func() (io.Reader, error) {
+				return nil, nil
+			},
+			ExpectedError: errors.New("failed to create container: you must specify either a build context or an image"),
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.Name, func(t *testing.T) {
+			ctx := context.Background()
+			a, err := testCase.ContextArchive()
+			if err != nil {
+				t.Fatal(err)
+			}
+			req := ContainerRequest{
+				FromDockerfile: FromDockerfile{
+					ContextArchive: a,
+					Context:        testCase.ContextPath,
+					Dockerfile:     testCase.Dockerfile,
+				},
+				WaitingFor: wait.ForLog(testCase.ExpectedEchoOutput).WithStartupTimeout(1 * time.Minute),
+			}
+
+			c, err := GenericContainer(ctx, GenericContainerRequest{
+				ContainerRequest: req,
+				Started:          true,
+			})
+			if testCase.ExpectedError != nil && err != nil {
+				if testCase.ExpectedError.Error() != err.Error() {
+					t.Fatalf("unexpected error: %s, was expecting %s", err.Error(), testCase.ExpectedError.Error())
+				}
+			} else if err != nil {
+				t.Fatal(err)
+			} else {
+				c.Terminate(ctx)
+			}
+
+		})
+
 	}
 }

--- a/docker.go
+++ b/docker.go
@@ -17,7 +17,6 @@ import (
 	"github.com/docker/docker/api/types/mount"
 	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/client"
-	"github.com/docker/docker/pkg/archive"
 	"github.com/docker/go-connections/nat"
 
 	"github.com/pkg/errors"
@@ -275,7 +274,7 @@ func (p *DockerProvider) BuildImage(ctx context.Context, img ImageBuildInfo) (st
 
 	repoTag := fmt.Sprintf("%s:%s", repo, tag)
 
-	buildContext, err := archive.TarWithOptions(img.GetContext(), &archive.TarOptions{})
+	buildContext, err := img.GetContext()
 	if err != nil {
 		return "", err
 	}
@@ -344,7 +343,7 @@ func (p *DockerProvider) CreateContainer(ctx context.Context, req ContainerReque
 	}
 
 	var tag string
-	if req.FromDockerfile.Context != "" {
+	if req.ShouldBuildImage() {
 		tag, err = p.BuildImage(ctx, &req)
 		if err != nil {
 			return nil, err

--- a/testresources/echo.Dockerfile
+++ b/testresources/echo.Dockerfile
@@ -1,0 +1,3 @@
+FROM alpine
+
+CMD ["echo", "this is from the echo test Dockerfile"]


### PR DESCRIPTION
resolves #110

Added a ContextArchive attribute to the FromDockerfile struct, this
allows a user to pass in an io.Reader as the Docker build context.
A user will now be allowed to create a dynamic build in code and send it
to the build.

Added test cases for both scenarios (using a local filepath and an
archive).  Added example to README.