### PR TITLE
Add more info about failing test on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,10 +10,13 @@ services:
 env:
   - GO111MODULE=on
 
+before_script:
+  - go get gotest.tools/gotestsum
+
 script:
   - go mod verify
   - go mod tidy
   - go fmt ./...
   - go vet ./...
-  - go test ./...
+  - gotestsum --format short-verbose ./...
 


### PR DESCRIPTION
## What does this PR do?
It adds test info to Travis logs when running Go tests.

## Why is it important?
Travis logs are not good to debug/trace what happens when a test fails. Here we find a manner to check what is the status of each test method, with a summary at the end of the log (see screenshot)

<img width="783" alt="Screenshot 2019-11-20 at 14 28 06" src="https://user-images.githubusercontent.com/951580/69242890-21544600-0ba2-11ea-91af-5654d287165a.png">
