### PR TITLE
Support volume mounts

### DIFF
--- a/container.go
+++ b/container.go
@@ -67,7 +67,7 @@ type ContainerRequest struct {
 	Cmd            []string
 	Labels         map[string]string
 	BindMounts     map[string]string
-	VolumeMounts     map[string]string
+	VolumeMounts   map[string]string
 	RegistryCred   string
 	WaitingFor     wait.Strategy
 	Name           string              // for specifying container name

--- a/container.go
+++ b/container.go
@@ -67,6 +67,7 @@ type ContainerRequest struct {
 	Cmd            []string
 	Labels         map[string]string
 	BindMounts     map[string]string
+	VolumeMounts     map[string]string
 	RegistryCred   string
 	WaitingFor     wait.Strategy
 	Name           string              // for specifying container name

--- a/docker.go
+++ b/docker.go
@@ -424,18 +424,25 @@ func (p *DockerProvider) CreateContainer(ctx context.Context, req ContainerReque
 	}
 
 	// prepare mounts
-	bindMounts := []mount.Mount{}
+	mounts := []mount.Mount{}
 	for hostPath, innerPath := range req.BindMounts {
-		bindMounts = append(bindMounts, mount.Mount{
+		mounts = append(mounts, mount.Mount{
 			Type:   mount.TypeBind,
 			Source: hostPath,
+			Target: innerPath,
+		})
+	}
+	for volumeName, innerPath := range req.VolumeMounts {
+		mounts = append(mounts, mount.Mount{
+			Type:   mount.TypeVolume,
+			Source: volumeName,
 			Target: innerPath,
 		})
 	}
 
 	hostConfig := &container.HostConfig{
 		PortBindings: exposedPortMap,
-		Mounts:       bindMounts,
+		Mounts:       mounts,
 		AutoRemove:   true,
 		Privileged:   req.Privileged,
 	}

--- a/docker_test.go
+++ b/docker_test.go
@@ -3,7 +3,9 @@ package testcontainers
 import (
 	"context"
 	"fmt"
+	"github.com/docker/docker/api/types/volume"
 	"net/http"
+	"path/filepath"
 	"testing"
 	"time"
 

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ replace github.com/docker/docker => github.com/docker/engine v0.0.0-201907171610
 require (
 	github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78 // indirect
 	github.com/Microsoft/go-winio v0.4.11 // indirect
+	github.com/Microsoft/hcsshim v0.8.6 // indirect
 	github.com/cenkalti/backoff v2.2.1+incompatible
 	github.com/containerd/continuity v0.0.0-20190426062206-aaeac12a7ffc // indirect
 	github.com/docker/distribution v2.7.1-0.20190205005809-0d3efadf0154+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,9 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78/go.mod h1:LmzpDX56iTiv29bbRTIsUNlaFfuhWRQBWjQdVyAevI8=
+github.com/Microsoft/go-winio v0.4.11 h1:zoIOcVf0xPN1tnMVbTtEdI+P8OofVk3NObnwOQ6nK2Q=
 github.com/Microsoft/go-winio v0.4.11/go.mod h1:VhR8bwka0BXejwEJY73c50VrPtXAaKcyvVC4A4RozmA=
+github.com/Microsoft/hcsshim v0.8.6 h1:ZfF0+zZeYdzMIVMZHKtDKJvLHj76XCuVae/jNkjj0IA=
+github.com/Microsoft/hcsshim v0.8.6/go.mod h1:Op3hHsoHPAvb6lceZHDtd9OkTew38wNoXnJs8iY7rUg=
 github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=
 github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
@@ -39,6 +42,7 @@ github.com/gorilla/mux v1.6.2/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2z
 github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
+github.com/konsorten/go-windows-terminal-sequences v1.0.1 h1:mweAR1A6xJ3oS2pRaGiHgQ4OO8tzTaLawm8vnODuwDk=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=

--- a/testresources/hello.sh
+++ b/testresources/hello.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+echo "hello world" > /data/hello.txt
+echo "done"


### PR DESCRIPTION
### Context
I wanted to run an [ETCD](https://etcd.io/) cluster using testcontainers-go.
In order to simulate ETCD node crash and recovery, I needed my data to be kept after a terminate of the container so that the new container can use it.
To do this, I used a bind mount so that the data stays on my host.
However, at start-up, ETCD does some Fsync on the data files which, I don't know why, is not working on my environment (Docker for Windows 10).

### Solution
The alternative I found is to use a Docker volume and mount it into the ETCD container.
