### PR TITLE
feat: allow viewing of logs from stopped container

### DIFF
--- a/container.go
+++ b/container.go
@@ -76,6 +76,7 @@ type ContainerRequest struct {
 	NetworkAliases map[string][]string // for specifying network aliases
 	SkipReaper     bool                // indicates whether we skip setting up a reaper for this
 	ReaperImage    string              // alternative reaper image
+	AutoRemove     bool                // if set to true, the container will be removed from the host when stopped
 }
 
 // ProviderType is an enum for the possible providers

--- a/docker.go
+++ b/docker.go
@@ -443,7 +443,7 @@ func (p *DockerProvider) CreateContainer(ctx context.Context, req ContainerReque
 	hostConfig := &container.HostConfig{
 		PortBindings: exposedPortMap,
 		Mounts:       mounts,
-		AutoRemove:   true,
+		AutoRemove:   req.AutoRemove,
 		Privileged:   req.Privileged,
 	}
 

--- a/reaper.go
+++ b/reaper.go
@@ -52,6 +52,7 @@ func NewReaper(ctx context.Context, sessionID string, provider ReaperProvider, r
 		BindMounts: map[string]string{
 			"/var/run/docker.sock": "/var/run/docker.sock",
 		},
+		AutoRemove: true,
 	}
 
 	c, err := provider.RunContainer(ctx, req)


### PR DESCRIPTION
setting any container besides a reaper to not auto-remove when creating

fixes #118 

Now when creating containers, allowing a user to set the `AutoRemove` parameter in the container request, if this is done, then the container will be removed upon stopping.  This is by default set to `false` for user-created containers, but when running a reaper container, this will set it to `true` (reaper cleans up containers, but nothing cleans up reaper so we have to make sure it auto-removes)