### PR TITLE
Adding a wait for sql strategy

### DIFF
--- a/wait/sql.go
+++ b/wait/sql.go
@@ -1,0 +1,63 @@
+package wait
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"github.com/docker/go-connections/nat"
+	"time"
+)
+
+func ForSQL(port nat.Port, driver string, url func(nat.Port) string) *waitForSql {
+	return &waitForSql{
+		Port: port,
+		URL: url,
+		Driver: driver,
+	}
+}
+
+type waitForSql struct {
+	URL            func(port nat.Port) string
+	Driver         string
+	Port           nat.Port
+	startupTimeout time.Duration
+}
+
+func (w *waitForSql) Timeout(duration time.Duration) *waitForSql {
+	w.startupTimeout = duration
+	return w
+}
+
+func (w *waitForSql) WaitUntilReady(ctx context.Context, target StrategyTarget) (err error) {
+	if w.startupTimeout == 0 {
+		w.startupTimeout = time.Second*10
+	}
+	ctx, cancel := context.WithTimeout(ctx, w.startupTimeout)
+	defer cancel()
+
+	ticker := time.NewTicker(time.Millisecond * 100)
+	defer ticker.Stop()
+
+	port, err := target.MappedPort(ctx, w.Port)
+	if err != nil {
+		return fmt.Errorf("target.MappedPort: %w", err)
+	}
+
+	db, err := sql.Open(w.Driver, w.URL(port))
+	if err != nil {
+		return fmt.Errorf("sql.Open: %w", err)
+	}
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+
+			if _, err := db.ExecContext(ctx, "SELECT 1"); err != nil {
+				continue
+			}
+			return nil
+		}
+	}
+}
+

--- a/wait/sql.go
+++ b/wait/sql.go
@@ -8,10 +8,11 @@ import (
 	"time"
 )
 
+//ForSQL constructs a new waitForSql strategy for the given driver
 func ForSQL(port nat.Port, driver string, url func(nat.Port) string) *waitForSql {
 	return &waitForSql{
-		Port: port,
-		URL: url,
+		Port:   port,
+		URL:    url,
 		Driver: driver,
 	}
 }
@@ -23,14 +24,17 @@ type waitForSql struct {
 	startupTimeout time.Duration
 }
 
+//Timeout sets the maximum waiting time for the strategy after which it'll give up and return an error
 func (w *waitForSql) Timeout(duration time.Duration) *waitForSql {
 	w.startupTimeout = duration
 	return w
 }
 
+//WaitUntilReady repeatedly tries to run "SELECT 1" query on the given port using sql and driver.
+// If the it doesn't succeed until the timeout value which defaults to 10 seconds, it will return an error
 func (w *waitForSql) WaitUntilReady(ctx context.Context, target StrategyTarget) (err error) {
 	if w.startupTimeout == 0 {
-		w.startupTimeout = time.Second*10
+		w.startupTimeout = time.Second * 10
 	}
 	ctx, cancel := context.WithTimeout(ctx, w.startupTimeout)
 	defer cancel()
@@ -60,4 +64,3 @@ func (w *waitForSql) WaitUntilReady(ctx context.Context, target StrategyTarget) 
 		}
 	}
 }
-

--- a/wait/sql.go
+++ b/wait/sql.go
@@ -44,12 +44,12 @@ func (w *waitForSql) WaitUntilReady(ctx context.Context, target StrategyTarget) 
 
 	port, err := target.MappedPort(ctx, w.Port)
 	if err != nil {
-		return fmt.Errorf("target.MappedPort: %w", err)
+		return fmt.Errorf("target.MappedPort: %v", err)
 	}
 
 	db, err := sql.Open(w.Driver, w.URL(port))
 	if err != nil {
-		return fmt.Errorf("sql.Open: %w", err)
+		return fmt.Errorf("sql.Open: %v", err)
 	}
 	for {
 		select {


### PR DESCRIPTION
#121

A simplified sql db waiting strategy without adding any new dependency to the library. An example usage for a postgres container:

```go

	var env = map[string]string{
		"POSTGRES_PASSWORD": "password",
		"POSTGRES_USER":     "postgres",
		"POSTGRES_DB":       "service",
	}

	var port = "5432/tcp"

	dbURL := func(port nat.Port) string {
		return fmt.Sprintf("postgres://postgres:password@localhost:%s/service?sslmode=disable", port.Port())
	}

	req := testcontainers.GenericContainerRequest{
		ContainerRequest: testcontainers.ContainerRequest{
			Image:        "postgres:latest",
			ExposedPorts: []string{port},
			Cmd:          []string{"postgres", "-c", "fsync=off"},
			Env:          env,
			WaitingFor:   wait.ForSQL(nat.Port(port), "postgres", dbURL).Timeout(time.Second*5),
		},
		Started: true,
	}
	container, err := testcontainers.GenericContainer(context.Background(), req)

	if err != nil {
		log.Fatal("start ", err)
	}
	mappedPort, err := container.MappedPort(context.Background(), nat.Port(port))
	if err != nil {
		log.Fatal(err)
	}
	defer container.Terminate(context.Background())

	log.Println("postgres container ready and running at port: ",mappedPort)
	time.Sleep(time.Minute)
	time.Sleep(time.Minute)
```