### PR TITLE
Add ability to configure tmpfs for a container

### DIFF
--- a/container.go
+++ b/container.go
@@ -68,6 +68,7 @@ type ContainerRequest struct {
 	Labels         map[string]string
 	BindMounts     map[string]string
 	VolumeMounts   map[string]string
+	Tmpfs          map[string]string
 	RegistryCred   string
 	WaitingFor     wait.Strategy
 	Name           string              // for specifying container name

--- a/docker.go
+++ b/docker.go
@@ -443,6 +443,7 @@ func (p *DockerProvider) CreateContainer(ctx context.Context, req ContainerReque
 	hostConfig := &container.HostConfig{
 		PortBindings: exposedPortMap,
 		Mounts:       mounts,
+		Tmpfs:		  req.Tmpfs,
 		AutoRemove:   req.AutoRemove,
 		Privileged:   req.Privileged,
 	}

--- a/docker.go
+++ b/docker.go
@@ -443,7 +443,7 @@ func (p *DockerProvider) CreateContainer(ctx context.Context, req ContainerReque
 	hostConfig := &container.HostConfig{
 		PortBindings: exposedPortMap,
 		Mounts:       mounts,
-		Tmpfs:		  req.Tmpfs,
+		Tmpfs:        req.Tmpfs,
 		AutoRemove:   req.AutoRemove,
 		Privileged:   req.Privileged,
 	}


### PR DESCRIPTION
When testing against database containers, most of the time, those containers are thrown away after the tests are finished and we do not care about the data. Docker [provides](https://docs.docker.com/storage/tmpfs/) `tmpfs` mounts that work well for such use cases - the data is only written in memory and not to disk, which in turn allows for tests to run faster.

testcontainers-java [has](https://github.com/testcontainers/testcontainers-java/blob/3cb33792328e49b5ab8d78f747a256d65593dd64/core/src/main/java/org/testcontainers/containers/GenericContainer.java#L1449) an option to configure tmpfs and pass it to docker client too.

This change adds such option for the go library.

I do not know how to best demonstrate in a test that it makes an impact when used.
My local results on a linux computer for the added mysql test (just start a mysql container and wait for msql to be ready for use):
- `PASS: TestContainerWithTmpFs (9.69s)` - with tmpfs
- `PASS: TestContainerWithTmpFs (15.40s)` - when tmpfs is commented out