### PR TITLE
#138 Add NetworkMode host 

### DIFF
--- a/container.go
+++ b/container.go
@@ -2,6 +2,7 @@ package testcontainers
 
 import (
 	"context"
+	"github.com/docker/docker/api/types/container"
 	"io"
 
 	"github.com/docker/docker/pkg/archive"
@@ -77,6 +78,7 @@ type ContainerRequest struct {
 	SkipReaper     bool                // indicates whether we skip setting up a reaper for this
 	ReaperImage    string              // alternative reaper image
 	AutoRemove     bool                // if set to true, the container will be removed from the host when stopped
+	NetworkMode    container.NetworkMode
 }
 
 // ProviderType is an enum for the possible providers

--- a/docker.go
+++ b/docker.go
@@ -445,6 +445,7 @@ func (p *DockerProvider) CreateContainer(ctx context.Context, req ContainerReque
 		Mounts:       mounts,
 		AutoRemove:   req.AutoRemove,
 		Privileged:   req.Privileged,
+		NetworkMode:  req.NetworkMode,
 	}
 
 	endpointConfigs := map[string]*network.EndpointSettings{}

--- a/docker_test.go
+++ b/docker_test.go
@@ -128,22 +128,10 @@ func TestContainerWithNetworkModeAndNetworkTogether(t *testing.T) {
 		Started: true,
 	}
 
-	nginxC, err := GenericContainer(ctx, gcr)
+	_, err := GenericContainer(ctx, gcr)
 	if err != nil {
 		// Error when NetworkMode = host and Network = []string{"bridge"}
-		t.Errorf("Can't use Network and NetworkMode together, %s", err)
-	}
-
-	defer nginxC.Terminate(ctx)
-
-	host, err := nginxC.Host(ctx)
-	if err != nil {
-		t.Errorf("Expected host %s. Got '%d'.", host, err)
-	}
-
-	_, err = http.Get("http://" + host + ":80")
-	if err != nil {
-		t.Errorf("Expected OK response. Got '%d'.", err)
+		t.Logf("Can't use Network and NetworkMode together, %s", err)
 	}
 }
 

--- a/docker_test.go
+++ b/docker_test.go
@@ -89,6 +89,32 @@ func TestContainerAttachedToNewNetwork(t *testing.T) {
 	}
 }
 
+func TestContainerWithHostNetworkOptions(t *testing.T) {
+	ctx := context.Background()
+	gcr := GenericContainerRequest{ContainerRequest: ContainerRequest{
+		Image:       "nginx",
+		SkipReaper:  true,
+		NetworkMode: "host",
+	},
+		Started: true,
+	}
+
+	nginxC, err := GenericContainer(ctx, gcr)
+	if err != nil {
+		fmt.Errorf("Error %s", err)
+	}
+
+	host, err := nginxC.Host(ctx)
+	if err != nil {
+		t.Errorf("Expected host %s. Got '%d'.", host, err)
+	}
+
+	_, err = http.Get("http://" + host + ":80")
+	if err != nil {
+		t.Errorf("Expected OK response. Got '%d'.", err)
+	}
+}
+
 func TestContainerReturnItsContainerID(t *testing.T) {
 	ctx := context.Background()
 	nginxA, err := GenericContainer(ctx, GenericContainerRequest{

--- a/docker_test.go
+++ b/docker_test.go
@@ -101,7 +101,7 @@ func TestContainerWithHostNetworkOptions(t *testing.T) {
 
 	nginxC, err := GenericContainer(ctx, gcr)
 	if err != nil {
-		fmt.Errorf("Error %s", err)
+		t.Fatal(err)
 	}
 
 	defer nginxC.Terminate(ctx)

--- a/docker_test.go
+++ b/docker_test.go
@@ -117,6 +117,36 @@ func TestContainerWithHostNetworkOptions(t *testing.T) {
 	}
 }
 
+func TestContainerWithNetworkModeAndNetworkTogether(t *testing.T) {
+	ctx := context.Background()
+	gcr := GenericContainerRequest{ContainerRequest: ContainerRequest{
+		Image:       "nginx",
+		SkipReaper:  true,
+		NetworkMode: "host",
+		Networks:    []string{"new-network"},
+	},
+		Started: true,
+	}
+
+	nginxC, err := GenericContainer(ctx, gcr)
+	if err != nil {
+		// Error when NetworkMode = host and Network = []string{"bridge"}
+		t.Errorf("Can't use Network and NetworkMode together, %s", err)
+	}
+
+	defer nginxC.Terminate(ctx)
+
+	host, err := nginxC.Host(ctx)
+	if err != nil {
+		t.Errorf("Expected host %s. Got '%d'.", host, err)
+	}
+
+	_, err = http.Get("http://" + host + ":80")
+	if err != nil {
+		t.Errorf("Expected OK response. Got '%d'.", err)
+	}
+}
+
 func TestContainerReturnItsContainerID(t *testing.T) {
 	ctx := context.Background()
 	nginxA, err := GenericContainer(ctx, GenericContainerRequest{

--- a/docker_test.go
+++ b/docker_test.go
@@ -104,6 +104,8 @@ func TestContainerWithHostNetworkOptions(t *testing.T) {
 		fmt.Errorf("Error %s", err)
 	}
 
+	defer nginxC.Terminate(ctx)
+
 	host, err := nginxC.Host(ctx)
 	if err != nil {
 		t.Errorf("Expected host %s. Got '%d'.", host, err)


### PR DESCRIPTION
Hello everyone!

I debugged this issue and founded out that:
When I start container with network: []string{"host"} docker inspect <id> returns in HostConfig.Network = 'default'

Add property in ContainerRequest struct
 