### PR TITLE
Fix panic in wait host port

### DIFF
--- a/wait/host_port.go
+++ b/wait/host_port.go
@@ -3,12 +3,13 @@ package wait
 import (
 	"context"
 	"fmt"
-	"github.com/pkg/errors"
 	"net"
 	"os"
 	"strconv"
 	"syscall"
 	"time"
+
+	"github.com/pkg/errors"
 
 	"github.com/docker/go-connections/nat"
 )
@@ -70,6 +71,9 @@ func (hp *HostPortStrategy) WaitUntilReady(ctx context.Context, target StrategyT
 	address := net.JoinHostPort(ipAddress, portString)
 	for {
 		conn, err := dialer.DialContext(ctx, proto, address)
+		if err != nil {
+			return err
+		}
 		defer conn.Close()
 		if err != nil {
 			if v, ok := err.(*net.OpError); ok {


### PR DESCRIPTION
When DialWithContext fails we were not checking for error.

Fixed #139

Signed-off-by: Gianluca Arbezzano <gianarb92@gmail.com>