### PR TITLE
#145 Update default reaper images to 0.2.3

### DIFF
--- a/reaper.go
+++ b/reaper.go
@@ -16,7 +16,7 @@ const (
 	TestcontainerLabelSessionID = TestcontainerLabel + ".sessionId"
 	TestcontainerLabelIsReaper  = TestcontainerLabel + ".reaper"
 
-	ReaperDefaultImage = "quay.io/testcontainers/ryuk:0.2.2"
+	ReaperDefaultImage = "quay.io/testcontainers/ryuk:0.2.3"
 )
 
 // ReaperProvider represents a provider for the reaper to run itself with


### PR DESCRIPTION
Hello everybody!

In this version reaper fixed 
https://quay.io/repository/testcontainers/ryuk/manifest/sha256:bb5a635cac4bd96c93cc476969ce11dc56436238ec7cd028d0524462f4739dd9?tab=vulnerabilities