### PR TITLE
Bump travis-ci Go to 1.14.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-  - 1.11.4
+  - 1.14.x
 
 install: true
 


### PR DESCRIPTION
This PR bumps the Go version in travis ci to 1.14.x

Signed-off-by: Gianluca Arbezzano <gianarb92@gmail.com>