### PR TITLE
Add host for sql waiter URL function.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+.idea
 debug.test
 vendor


### PR DESCRIPTION
Issue:
In case container is started in docker which is not in localhost (ci environment with tests already running in container), mapped port is not enough to establish connection to a database.

Solution:
Add `host` parameter for `url` function, which is part of `wait.ForSQL` strategy, so it will be possible to construct connection url with docker host and mapped port.