### PR TITLE
docker:getGatewayIp: rewrite with netlink?

### DIFF
--- a/docker.go
+++ b/docker.go
@@ -731,6 +731,7 @@ func inAContainer() bool {
 
 func getGatewayIp() (string, error) {
 	// see https://github.com/testcontainers/testcontainers-java/blob/3ad8d80e2484864e554744a4800a81f6b7982168/core/src/main/java/org/testcontainers/dockerclient/DockerClientConfigUtils.java#L27
+	// Replace this with netlink (linux only)? Or something like https://github.com/jackpal/gateway?
 	cmd := exec.Command("sh", "-c", "ip route|awk '/default/ { print $3 }'")
 	stdout, err := cmd.Output()
 	if err != nil {


### PR DESCRIPTION
Hi,

Thanks for the great library, I am using this in many projects, working great :-) 

I am running this lib from within a Container and I keep bumping into the same issue over and over again: I start with a fresh container, without iproutes2, get the `Failed to parse default gateway IP` error, dig into the code, and then I remember that it depends on it :-)

Have you considered replacing this by a netlink call (linux only)? Or parsing /proc/net/route?
I think it would be much cleaner not to rely on external tools such as iproute & awk.

WDYT? I would be happy to make the patch.

Signed-off-by: Gregory Vander Schueren <gregory.vanderschueren@tessares.net>