### PR TITLE
#173: Reaper reuse

### DIFF
--- a/container.go
+++ b/container.go
@@ -65,24 +65,25 @@ type FromDockerfile struct {
 // ContainerRequest represents the parameters used to get a running container
 type ContainerRequest struct {
 	FromDockerfile
-	Image          string
-	Env            map[string]string
-	ExposedPorts   []string // allow specifying protocol info
-	Cmd            []string
-	Labels         map[string]string
-	BindMounts     map[string]string
-	VolumeMounts   map[string]string
-	Tmpfs          map[string]string
-	RegistryCred   string
-	WaitingFor     wait.Strategy
-	Name           string              // for specifying container name
-	Privileged     bool                // for starting privileged container
-	Networks       []string            // for specifying network names
-	NetworkAliases map[string][]string // for specifying network aliases
-	SkipReaper     bool                // indicates whether we skip setting up a reaper for this
-	ReaperImage    string              // alternative reaper image
-	AutoRemove     bool                // if set to true, the container will be removed from the host when stopped
-	NetworkMode    container.NetworkMode
+	Image           string
+	Env             map[string]string
+	ExposedPorts    []string // allow specifying protocol info
+	Cmd             []string
+	Labels          map[string]string
+	BindMounts      map[string]string
+	VolumeMounts    map[string]string
+	Tmpfs           map[string]string
+	RegistryCred    string
+	WaitingFor      wait.Strategy
+	Name            string              // for specifying container name
+	Privileged      bool                // for starting privileged container
+	Networks        []string            // for specifying network names
+	NetworkAliases  map[string][]string // for specifying network aliases
+	SkipReaper      bool                // indicates whether we skip setting up a reaper for this
+	ReaperImage     string              // alternative reaper image
+	AutoRemove      bool                // if set to true, the container will be removed from the host when stopped
+	NetworkMode     container.NetworkMode
+	AlwaysPullImage bool // Always pull image
 }
 
 // ProviderType is an enum for the possible providers

--- a/network_test.go
+++ b/network_test.go
@@ -1,6 +1,12 @@
 package testcontainers
 
-import "context"
+import (
+	"context"
+	"fmt"
+	"github.com/testcontainers/testcontainers-go/wait"
+	"testing"
+	"time"
+)
 
 // Create a network using a provider. By default it is Docker.
 func ExampleNetworkProvider_CreateNetwork() {
@@ -27,4 +33,78 @@ func ExampleNetworkProvider_CreateNetwork() {
 	nginxC, _ := GenericContainer(ctx, gcr)
 	defer nginxC.Terminate(ctx)
 	nginxC.GetContainerID()
+}
+
+func Test_MultipleContainersInTheNewNetwork(t *testing.T) {
+	ctx := context.Background()
+
+	networkName := "test-network"
+
+	networkRequest := NetworkRequest{
+		Driver:     "bridge",
+		Name:       networkName,
+		Attachable: true,
+	}
+
+	env := make(map[string]string)
+	env["POSTGRES_PASSWORD"] = "Password1"
+	dbContainerRequest := ContainerRequest{
+		Image:        "postgres:12.2",
+		ExposedPorts: []string{"5432/tcp"},
+		AutoRemove:   true,
+		Env:          env,
+		WaitingFor:   wait.ForListeningPort("5432/tcp"),
+		Networks:     []string{networkName},
+	}
+
+	gcr := GenericContainerRequest{
+		ContainerRequest: dbContainerRequest,
+		Started:          true,
+	}
+
+	provider, err := gcr.ProviderType.GetProvider()
+	if err != nil {
+		t.Fatal("cannot get provider")
+	}
+
+	net, err := provider.CreateNetwork(ctx, networkRequest)
+	if err != nil {
+		t.Fatal("cannot create network")
+	}
+
+	defer net.Remove(ctx)
+
+	postgres, err := GenericContainer(ctx, gcr)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer postgres.Terminate(ctx)
+
+	env = make(map[string]string)
+	env["RABBITMQ_ERLANG_COOKIE"] = "f2a2d3d27c75"
+	env["RABBITMQ_DEFAULT_USER"] = "admin"
+	env["RABBITMQ_DEFAULT_PASS"] = "Password1"
+	hp := wait.ForListeningPort("5672/tcp")
+	hp.WithStartupTimeout(3 * time.Minute)
+	amqpRequest := ContainerRequest{
+		Image:        "rabbitmq:management-alpine",
+		ExposedPorts: []string{"15672/tcp", "5672/tcp"},
+		Env:          env,
+		AutoRemove:   true,
+		WaitingFor:   hp,
+		Networks:     []string{networkName},
+	}
+	rabbitmq, err := GenericContainer(ctx, GenericContainerRequest{
+		ContainerRequest: amqpRequest,
+		Started:          true,
+	})
+	if err != nil {
+		t.Fatal(err)
+		return
+	}
+
+	defer rabbitmq.Terminate(ctx)
+	fmt.Println(postgres.GetContainerID())
+	fmt.Println(rabbitmq.GetContainerID())
 }


### PR DESCRIPTION
Reusing existing reaper for subsequent container/network create calls. This ensures that any networks, created as part of the test case will be removed. 
Fixes #173