### PR TITLE
#173: Reaper reuse

### DIFF
--- a/docker.go
+++ b/docker.go
@@ -383,11 +383,9 @@ type DockerNetwork struct {
 }
 
 // Remove is used to remove the network. It is usually triggered by as defer function.
-func (n *DockerNetwork) Remove(_ context.Context) error {
-	if n.terminationSignal != nil {
-		n.terminationSignal <- true
-	}
-	return nil
+func (n *DockerNetwork) Remove(ctx context.Context) error {
+
+	return n.provider.client.NetworkRemove(ctx, n.ID)
 }
 
 // DockerProvider implements the ContainerProvider interface
@@ -704,6 +702,7 @@ func (p *DockerProvider) CreateNetwork(ctx context.Context, req NetworkRequest) 
 		Driver:            req.Driver,
 		Name:              req.Name,
 		terminationSignal: termSignal,
+		provider:          p,
 	}
 
 	return n, nil

--- a/generic.go
+++ b/generic.go
@@ -13,6 +13,26 @@ type GenericContainerRequest struct {
 	ProviderType     ProviderType // which provider to use, Docker if empty
 }
 
+// GenericNetworkRequest represents parameters to a generic network
+type GenericNetworkRequest struct {
+	NetworkRequest              // embedded request for provider
+	ProviderType   ProviderType // which provider to use, Docker if empty
+}
+
+// GenericNetwork creates a generic network with parameters
+func GenericNetwork(ctx context.Context, req GenericNetworkRequest) (Network, error) {
+	provider, err := req.ProviderType.GetProvider()
+	if err != nil {
+		return nil, err
+	}
+	network, err := provider.CreateNetwork(ctx, req.NetworkRequest)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create network")
+	}
+
+	return network, nil
+}
+
 // GenericContainer creates a generic container with parameters
 func GenericContainer(ctx context.Context, req GenericContainerRequest) (Container, error) {
 	provider, err := req.ProviderType.GetProvider()

--- a/network_test.go
+++ b/network_test.go
@@ -1,6 +1,12 @@
 package testcontainers
 
-import "context"
+import (
+	"context"
+	"fmt"
+	"github.com/testcontainers/testcontainers-go/wait"
+	"testing"
+	"time"
+)
 
 // Create a network using a provider. By default it is Docker.
 func ExampleNetworkProvider_CreateNetwork() {
@@ -27,4 +33,78 @@ func ExampleNetworkProvider_CreateNetwork() {
 	nginxC, _ := GenericContainer(ctx, gcr)
 	defer nginxC.Terminate(ctx)
 	nginxC.GetContainerID()
+}
+
+func Test_MultipleContainersInTheNewNetwork(t *testing.T) {
+	ctx := context.Background()
+
+	networkName := "test-network"
+
+	networkRequest := NetworkRequest{
+		Driver:     "bridge",
+		Name:       networkName,
+		Attachable: true,
+	}
+
+	env := make(map[string]string)
+	env["POSTGRES_PASSWORD"] = "Password1"
+	dbContainerRequest := ContainerRequest{
+		Image:        "postgres:12.2",
+		ExposedPorts: []string{"5432/tcp"},
+		AutoRemove:   true,
+		Env:          env,
+		WaitingFor:   wait.ForListeningPort("5432/tcp"),
+		Networks:     []string{networkName},
+	}
+
+	gcr := GenericContainerRequest{
+		ContainerRequest: dbContainerRequest,
+		Started:          true,
+	}
+
+	provider, err := gcr.ProviderType.GetProvider()
+	if err != nil {
+		t.Fatal("cannot get provider")
+	}
+
+	net, err := provider.CreateNetwork(ctx, networkRequest)
+	if err != nil {
+		t.Fatal("cannot create network")
+	}
+
+	defer net.Remove(ctx)
+
+	postgres, err := GenericContainer(ctx, gcr)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer postgres.Terminate(ctx)
+
+	env = make(map[string]string)
+	env["RABBITMQ_ERLANG_COOKIE"] = "f2a2d3d27c75"
+	env["RABBITMQ_DEFAULT_USER"] = "admin"
+	env["RABBITMQ_DEFAULT_PASS"] = "Password1"
+	hp := wait.ForListeningPort("5672/tcp")
+	hp.WithStartupTimeout(3 * time.Minute)
+	amqpRequest := ContainerRequest{
+		Image:        "rabbitmq:management-alpine",
+		ExposedPorts: []string{"15672/tcp", "5672/tcp"},
+		Env:          env,
+		AutoRemove:   true,
+		WaitingFor:   hp,
+		Networks:     []string{networkName},
+	}
+	rabbitmq, err := GenericContainer(ctx, GenericContainerRequest{
+		ContainerRequest: amqpRequest,
+		Started:          true,
+	})
+	if err != nil {
+		t.Fatal(err)
+		return
+	}
+
+	defer rabbitmq.Terminate(ctx)
+	fmt.Println(postgres.GetContainerID())
+	fmt.Println(rabbitmq.GetContainerID())
 }


### PR DESCRIPTION
Reusing existing reaper for subsequent container/network create calls. This ensures that any networks, created as part of the test case will be removed.
Fixes #173