### PR TITLE
feat: implement skip utility function for testing

### DIFF
--- a/container.go
+++ b/container.go
@@ -25,6 +25,7 @@ type DeprecatedContainer interface {
 type ContainerProvider interface {
 	CreateContainer(context.Context, ContainerRequest) (Container, error) // create a container without starting it
 	RunContainer(context.Context, ContainerRequest) (Container, error)    // create a container and start it
+	Health(context.Context) error
 }
 
 // Container allows getting info about and controlling a single container instance

--- a/docker.go
+++ b/docker.go
@@ -624,6 +624,13 @@ func (p *DockerProvider) attemptToPullImage(ctx context.Context, tag string, pul
 	return err
 }
 
+// Helth measure the healthiness of the provider. Right now we leverage the
+// docker-client ping endpoint to see if the daemon is reachable.
+func (p *DockerProvider) Health(ctx context.Context) (err error) {
+	_, err = p.client.Ping(ctx)
+	return
+}
+
 // RunContainer takes a RequestContainer as input and it runs a container via the docker sdk
 func (p *DockerProvider) RunContainer(ctx context.Context, req ContainerRequest) (Container, error) {
 	c, err := p.CreateContainer(ctx, req)

--- a/docker_test.go
+++ b/docker_test.go
@@ -27,7 +27,6 @@ import (
 
 func TestContainerAttachedToNewNetwork(t *testing.T) {
 	networkName := "new-network"
-
 	ctx := context.Background()
 	gcr := GenericContainerRequest{
 		ContainerRequest: ContainerRequest{

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/Microsoft/hcsshim v0.8.6 // indirect
 	github.com/cenkalti/backoff v2.2.1+incompatible
 	github.com/containerd/continuity v0.0.0-20190426062206-aaeac12a7ffc // indirect
-	github.com/docker/distribution v2.7.1-0.20190205005809-0d3efadf0154+incompatible // indirect
+	github.com/docker/distribution v2.7.1-0.20190205005809-0d3efadf0154+incompatible
 	github.com/docker/docker v0.7.3-0.20190506211059-b20a14b54661
 	github.com/docker/go-connections v0.4.0
 	github.com/docker/go-units v0.3.3 // indirect

--- a/testing.go
+++ b/testing.go
@@ -1,0 +1,22 @@
+package testcontainers
+
+import (
+	"context"
+	"testing"
+)
+
+// SkipIfProviderIsNotHealthy is an utility function capable of skipping tests
+// if the provider is not healthy, or runnig at all.
+// This is a function designed to be used in your test, when Docker is not mandatory for CI/CD.
+// In this way tests that depends on testcontainers won't run if the provider is provisioned correctly.
+func SkipIfProviderIsNotHealthy(t *testing.T) {
+	ctx := context.Background()
+	provider, err := ProviderDocker.GetProvider()
+	if err != nil {
+		t.Skipf("Docker is not running. TestContainers can't perform is work without it: %s", err)
+	}
+	err = provider.Health(ctx)
+	if err != nil {
+		t.Skipf("Docker is not running. TestContainers can't perform is work without it: %s", err)
+	}
+}

--- a/testing_test.go
+++ b/testing_test.go
@@ -1,0 +1,7 @@
+package testcontainers
+
+import "testing"
+
+func ExampleSkipIfProviderIsNotHealthy() {
+	SkipIfProviderIsNotHealthy(&testing.T{})
+}


### PR DESCRIPTION
I implement a new function to use as testing utility.
It skips the test if the provider is not reachable or well provisioned.

You have to declare it in your test, so if you depend on Docker and you
know you need it just keep doing as you are doing today.

In my use case we use testcontainers only for some particular tests, and
I do not like the idea to mark the testsuite as `FAILED` if a colleague
does not have Docker enabled in their local environment. Worst case if
something has to fail CI/CD will tell the truth.

Signed-off-by: Gianluca Arbezzano <gianarb92@gmail.com>