### PR TITLE
docs: add example for wait http

### DIFF
--- a/wait/http_test.go
+++ b/wait/http_test.go
@@ -1,0 +1,31 @@
+package wait_test
+
+import (
+	"context"
+
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/wait"
+)
+
+//
+// https://github.com/testcontainers/testcontainers-go/issues/183
+func ExampleHTTPStrategy() {
+	ctx := context.Background()
+	req := testcontainers.ContainerRequest{
+		Image:        "gogs/gogs:0.11.91",
+		ExposedPorts: []string{"3000/tcp"},
+		WaitingFor:   wait.ForHTTP("/").WithPort("3000/tcp"),
+	}
+
+	gogs, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
+		ContainerRequest: req,
+		Started:          true,
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	defer gogs.Terminate(ctx)
+
+	// Here you have a running container
+}


### PR DESCRIPTION
Based on the issue #183 I decided to add this example to explain that by
default wait.HTTP looks for port `80/tcp` but you can override it.

Signed-off-by: Gianluca Arbezzano <gianarb92@gmail.com>