### PR TITLE
fixes #192 - guard access to reaper with a mutex

### DIFF
--- a/reaper.go
+++ b/reaper.go
@@ -8,6 +8,7 @@ import (
 	"github.com/testcontainers/testcontainers-go/wait"
 	"net"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/pkg/errors"
@@ -22,6 +23,7 @@ const (
 )
 
 var reaper *Reaper // We would like to create reaper only once
+var mutex sync.Mutex
 
 // ReaperProvider represents a provider for the reaper to run itself with
 // The ContainerProvider interface should usually satisfy this as well, so it is pluggable
@@ -38,6 +40,8 @@ type Reaper struct {
 
 // NewReaper creates a Reaper with a sessionID to identify containers and a provider to use
 func NewReaper(ctx context.Context, sessionID string, provider ReaperProvider, reaperImageName string) (*Reaper, error) {
+	mutex.Lock()
+	defer mutex.Unlock()
 	// If reaper already exists re-use it
 	if reaper != nil {
 		return reaper, nil


### PR DESCRIPTION
Fixes #192 by guarding access to shared reaper with a mutex making it thread safe.