### PR TITLE
fix: use nginx other that localstack/localstack

### DIFF
--- a/container_test.go
+++ b/container_test.go
@@ -319,12 +319,9 @@ func TestShouldStartContainersInParallel(t *testing.T) {
 
 func createTestContainer(t *testing.T, ctx context.Context) int {
 	req := ContainerRequest{
-		Image:        "localstack/localstack:latest",
-		ExposedPorts: []string{"4584/tcp", "8080/tcp"},
-		Env: map[string]string{
-			"SERVICES": "secretsmanager",
-		},
-		WaitingFor: wait.ForListeningPort("4584/tcp"),
+		Image:        "nginx",
+		ExposedPorts: []string{"80/tcp"},
+		WaitingFor:   wait.ForHTTP("/"),
 	}
 	container, err := GenericContainer(ctx, GenericContainerRequest{
 		ContainerRequest: req,
@@ -333,7 +330,7 @@ func createTestContainer(t *testing.T, ctx context.Context) int {
 	if err != nil {
 		t.Fatalf("could not start container: %v", err)
 	}
-	port, err := container.MappedPort(ctx, "4584")
+	port, err := container.MappedPort(ctx, "80")
 	if err != nil {
 		t.Fatalf("could not get mapped port: %v", err)
 	}


### PR DESCRIPTION
master is red and the cause looks like a flaky test introduced by #198.
I can't point the flakyness to code itself. And there are not race
detected running `go test --race`.

I spot that we are using a different image
`localstack/localstack:latest` for that test. it is also very big 500mb.

I changed it with nginx to keep consistency.