### PR TITLE
chore: simplify complex docker-compose file

### DIFF
--- a/compose_test.go
+++ b/compose_test.go
@@ -125,7 +125,7 @@ func TestLocalDockerComposeComplex(t *testing.T) {
 	checkIfError(t, err)
 
 	assert.Equal(t, 2, len(compose.Services))
-	assert.Contains(t, compose.Services, "portal")
+	assert.Contains(t, compose.Services, "nginx")
 	assert.Contains(t, compose.Services, "mysql")
 }
 

--- a/testresources/docker-compose-complex.yml
+++ b/testresources/docker-compose-complex.yml
@@ -1,23 +1,13 @@
 version: '3'
 services:
-  portal:
-    image: liferay/portal:7.2.1-ga2
-    depends_on:
-     - mysql
-    environment:
-      - LIFERAY_JDBC_PERIOD_DEFAULT_PERIOD_DRIVER_UPPERCASEC_LASS_UPPERCASEN_AME=com.mysql.cj.jdbc.Driver
-      - LIFERAY_JDBC_PERIOD_DEFAULT_PERIOD_PASSWORD=my-secret-pw
-      - LIFERAY_JDBC_PERIOD_DEFAULT_PERIOD_URL=jdbc:mysql://mysql:13306/lportal?characterEncoding=UTF-8&dontTrackOpenResources=true&holdResultsOpenOverStatementClose=true&serverTimezone=GMT&useFastDateParsing=false&useUnicode=true
-      - LIFERAY_JDBC_PERIOD_DEFAULT_PERIOD_USERNAME=root
-      - LIFERAY_RETRY_PERIOD_JDBC_PERIOD_ON_PERIOD_STARTUP_PERIOD_MAX_PERIOD_RETRIES=5
-      - LIFERAY_RETRY_PERIOD_JDBC_PERIOD_ON_PERIOD_STARTUP_PERIOD_DELAY=5
+  nginx:
+    image: nginx:stable-alpine
     ports:
-     - "8080:8080"
-     - "11311:11311"
+     - "9080:80"
   mysql:
-    image: mdelapenya/mysql-utf8:5.7
+    image: mysql:5.7
     environment:
-      - MYSQL_DATABASE=lportal
+      - MYSQL_DATABASE=db
       - MYSQL_ROOT_PASSWORD=my-secret-pw
     ports:
      - "13306:3306"


### PR DESCRIPTION
## What does this PR do?
It uses Nginx instead of portal, reducing the size from < 2Gb to tens of Mb

## Why is it important?
Both CI builds and local execution of tests will be faster

## Related issues
- Relates #213