### PR TITLE
chore: run travis in multiple versions of Go

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: go
 go:
+  - stable
+  - 1.x
+  - 1.13.x
   - 1.14.x
 
 install: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ language: go
 go:
   - stable
   - 1.x
-  - 1.13.x
   - 1.14.x
+  - 1.15.x
 
 install: true
 


### PR DESCRIPTION
## What does this PR do?
It enables Travis to run multiple versions of Go

## Why is it important?
It will allow us to detect potential errors earlier