### PR TITLE
* fix filesys_windows.go:111:24: cannot use uintptr(unsafe.Pointer(&sd[0]))

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,5 @@
 module github.com/testcontainers/testcontainers-go
 
-replace golang.org/x/sys => golang.org/x/sys v0.0.0-20190813064441-fde4db37ae7a
-
 go 1.13
 
 require (
@@ -40,3 +38,4 @@ require (
 )
 
 replace github.com/docker/docker => github.com/docker/engine v0.0.0-20190717161051-705d9623b7c1
+replace golang.org/x/sys => golang.org/x/sys v0.0.0-20190813064441-fde4db37ae7a

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/testcontainers/testcontainers-go
 
+replace golang.org/x/sys => golang.org/x/sys v0.0.0-20190813064441-fde4db37ae7a
+
 go 1.13
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -129,6 +129,8 @@ golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20190813064441-fde4db37ae7a h1:aYOabOQFp6Vj6W1F80affTUvO9UxmJRx8K0gsfABByQ=
+golang.org/x/sys v0.0.0-20190813064441-fde4db37ae7a/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200116001909-b77594299b42 h1:vEOn+mP2zCOVzKckCZy6YsCtDblrpj/w7B9nxGNELpg=
 golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=


### PR DESCRIPTION
Yesterday, I started to make a POC by using testcontainsers. I initialized my go modules as expected and ran `go get github.com/testcontainers/testcontainers-go` and got the error below.

```
go: downloading github.com/testcontainers/testcontainers-go v0.8.0
go: github.com/testcontainers/testcontainers-go upgrade => v0.8.0
go: downloading github.com/docker/docker v1.13.1
go: finding module for package github.com/docker/docker/errdefs
go: finding module for package github.com/Sirupsen/logrus
go: downloading github.com/Sirupsen/logrus v1.6.0
go: found github.com/Sirupsen/logrus in github.com/Sirupsen/logrus v1.6.0
go: github.com/testcontainers/testcontainers-go imports
        github.com/docker/docker/pkg/archive imports
        github.com/Sirupsen/logrus: github.com/Sirupsen/logrus@v1.6.0: parsing go.mod:
        module declares its path as: github.com/sirupsen/logrus
                but was required as: github.com/Sirupsen/logrus
```

As a second step, I replaced Sirupsen.

`replace github.com/Sirupsen/logrus => github.com/sirupsen/logrus v1.6.0`

But got the error below.

`..\..\..\..\go\pkg\mod\github.com\testcontainers\testcontainers-go@v0.8.0\docker.go:20:2: module github.com/docker/docker@latest found (v1.13.1), but does not contain package github.com/docker/docker/errdefs`

Therefore, I cloned the project and run `go get`, I got the error below.

**filesys_windows.go:111:24: cannot use uintptr(unsafe.Pointer(&sd[0])) (type uintptr) as type *"golang.org/x/sys/windows".SECURITY_DESCRIPTOR in assignment**

In order to fix it, I made a replacement.