### PR TITLE
Issue #243: Introducing the default network in case "bridge" is disabled

### DIFF
--- a/docker_test.go
+++ b/docker_test.go
@@ -1342,3 +1342,32 @@ func TestDockerContainerCopyFileToContainer(t *testing.T) {
 		t.Fatalf("File %s should exist, expected return code 0, got %v", copiedFileName, c)
 	}
 }
+
+func TestContainerWithReaperNetwork(t *testing.T) {
+	ctx := context.Background()
+	req := ContainerRequest{
+		Image:        "nginx",
+		ExposedPorts: []string{"80/tcp"},
+		WaitingFor: wait.ForAll(
+			wait.ForListeningPort("80/tcp"),
+			wait.ForLog("Configuration complete; ready for start up"),
+		),
+	}
+
+	nginxC, err := GenericContainer(ctx, GenericContainerRequest{
+		ContainerRequest: req,
+		Started:          true,
+	})
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer func() {
+		t.Log("terminating container")
+		err := nginxC.Terminate(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}()
+}

--- a/reaper.go
+++ b/reaper.go
@@ -70,6 +70,11 @@ func NewReaper(ctx context.Context, sessionID string, provider ReaperProvider, r
 		WaitingFor: wait.ForListeningPort(listeningPort),
 	}
 
+	// Attach reaper container to a requested network if it is specified
+	if p, ok := provider.(*DockerProvider); ok {
+		req.Networks = append(req.Networks, p.defaultNetwork)
+	}
+
 	c, err := provider.RunContainer(ctx, req)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This commit resolves the issue of inability to run the tests in the Docker environment with disabled "bridge" network.
The CreateContainer or CreateNetwork function will check if bridge network exists and if does not it creates a reaper_default network and ensure that container is attached to the reaper_default network.