### PR TITLE
chore: add GH action badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+![Main pipeline](https://github.com/testcontainers/testcontainers-go/workflows/Main%20pipeline/badge.svg?branch=master)
 [![Build Status](https://travis-ci.org/testcontainers/testcontainers-go.svg?branch=master)](https://travis-ci.org/testcontainers/testcontainers-go)
 [![Go Report Card](https://goreportcard.com/badge/github.com/testcontainers/testcontainers-go)](https://goreportcard.com/report/github.com/testcontainers/testcontainers-go)
 [![GoDoc Reference](https://camo.githubusercontent.com/8609cfcb531fa0f5598a3d4353596fae9336cce3/68747470733a2f2f676f646f632e6f72672f6769746875622e636f6d2f79616e6777656e6d61692f686f772d746f2d6164642d62616467652d696e2d6769746875622d726561646d653f7374617475732e737667)](https://godoc.org/github.com/testcontainers/testcontainers-go)


### PR DESCRIPTION
## What does this PR do?
It adds the GH badge

## Why is it important?
To communicate project status on CI

## Follows up
Remove travis integration?