### PR TITLE
chore: support removing orphan containers when destroying the compose

### DIFF
--- a/compose.go
+++ b/compose.go
@@ -72,7 +72,7 @@ func NewLocalDockerCompose(filePaths []string, identifier string) *LocalDockerCo
 
 // Down executes docker-compose down
 func (dc *LocalDockerCompose) Down() ExecError {
-	return executeCompose(dc, []string{"down"})
+	return executeCompose(dc, []string{"down", "--remove-orphans"})
 }
 
 func (dc *LocalDockerCompose) getDockerComposeEnvironment() map[string]string {


### PR DESCRIPTION
To make sure we do not leak containers when destroying a compose 