### PR TITLE
Copy file out from a container

### DIFF
--- a/container.go
+++ b/container.go
@@ -50,6 +50,7 @@ type Container interface {
 	Exec(ctx context.Context, cmd []string) (int, error)
 	ContainerIP(context.Context) (string, error) // get container ip
 	CopyFileToContainer(ctx context.Context, hostFilePath string, containerFilePath string, fileMode int64) error
+	CopyFileFromContainer(ctx context.Context, containerFilePath string) (io.Reader, error)
 }
 
 // ImageBuildInfo defines what is needed to build an image

--- a/docker.go
+++ b/docker.go
@@ -342,6 +342,7 @@ func (c *DockerContainer) CopyFileFromContainer(ctx context.Context, containerFi
 	if err != nil {
 		return nil, err
 	}
+	defer r.Close()
 
 	buf := &bytes.Buffer{}
 	tr := tar.NewReader(r)

--- a/go.sum
+++ b/go.sum
@@ -42,6 +42,7 @@ github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5a
 github.com/google/uuid v1.1.2 h1:EVhdT+1Kseyi1/pUmXKaFxYsDNy9RQYkMWRH68J/W7Y=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.4/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/google/uuid v1.2.0 h1:qJYtXnJRWmpe7m/3XlyhrsLrEURqHRM2kxzoxXqyUDs=
 github.com/google/uuid v1.2.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gorilla/context v1.1.1 h1:AWwleXJkX/nhcU9bZSnZoi3h/qGYqQAGhq6zZe/aQW8=
 github.com/gorilla/context v1.1.1/go.mod h1:kBGZzfjB9CEq2AlWe17Uuf7NDRt0dE0s8S51q0aT7Yg=


### PR DESCRIPTION
Adds support for copying files out of containers via an `io.Reader`. I really need this functionality for a project that I'm working on, so I thought the quickest option was to fix it upstream. If this PR looks OK, I would love a new release 🙏🏻