### PR TITLE
Wait strategies must poll ports

### DIFF
--- a/docker.go
+++ b/docker.go
@@ -44,7 +44,7 @@ type DockerContainer struct {
 	ID         string
 	WaitingFor wait.Strategy
 	Image      string
-	
+
 	provider          *DockerProvider
 	sessionID         uuid.UUID
 	terminationSignal chan bool

--- a/docker.go
+++ b/docker.go
@@ -44,9 +44,7 @@ type DockerContainer struct {
 	ID         string
 	WaitingFor wait.Strategy
 	Image      string
-
-	// Cache to retrieve container information without re-fetching them from dockerd
-	raw               *types.ContainerJSON
+	
 	provider          *DockerProvider
 	sessionID         uuid.UUID
 	terminationSignal chan bool
@@ -130,6 +128,9 @@ func (c *DockerContainer) MappedPort(ctx context.Context, port nat.Port) (nat.Po
 		if port.Proto() != "" && k.Proto() != port.Proto() {
 			continue
 		}
+		if len(p) == 0 {
+			continue
+		}
 		return nat.NewPort(k.Proto(), p[0].HostPort)
 	}
 
@@ -180,23 +181,18 @@ func (c *DockerContainer) Terminate(ctx context.Context) error {
 
 	if err == nil {
 		c.sessionID = uuid.UUID{}
-		c.raw = nil
 	}
 
 	return err
 }
 
 func (c *DockerContainer) inspectContainer(ctx context.Context) (*types.ContainerJSON, error) {
-	if c.raw != nil {
-		return c.raw, nil
-	}
 	inspect, err := c.provider.client.ContainerInspect(ctx, c.ID)
 	if err != nil {
 		return nil, err
 	}
-	c.raw = &inspect
 
-	return c.raw, nil
+	return &inspect, nil
 }
 
 // Logs will fetch both STDOUT and STDERR from the current container. Returns a

--- a/wait/host_port.go
+++ b/wait/host_port.go
@@ -62,7 +62,7 @@ func (hp *HostPortStrategy) WaitUntilReady(ctx context.Context, target StrategyT
 	port, err = target.MappedPort(ctx, hp.Port)
 	var i = 0
 
-	for port == ""{
+	for port == "" {
 		i++
 
 		select {

--- a/wait/host_port.go
+++ b/wait/host_port.go
@@ -56,9 +56,24 @@ func (hp *HostPortStrategy) WaitUntilReady(ctx context.Context, target StrategyT
 		return
 	}
 
-	port, err := target.MappedPort(ctx, hp.Port)
-	if err != nil {
-		return
+	var waitInterval = 100 * time.Millisecond
+
+	var port nat.Port
+	port, err = target.MappedPort(ctx, hp.Port)
+	var i = 0
+
+	for port == ""{
+		i++
+
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("%s:%w", ctx.Err(), err)
+		case <-time.After(waitInterval):
+			port, err = target.MappedPort(ctx, hp.Port)
+			if err != nil {
+				fmt.Printf("(%d) [%s] %s\n", i, port, err)
+			}
+		}
 	}
 
 	proto := port.Proto()
@@ -74,7 +89,7 @@ func (hp *HostPortStrategy) WaitUntilReady(ctx context.Context, target StrategyT
 			if v, ok := err.(*net.OpError); ok {
 				if v2, ok := (v.Err).(*os.SyscallError); ok {
 					if isConnRefusedErr(v2.Err) {
-						time.Sleep(100 * time.Millisecond)
+						time.Sleep(waitInterval)
 						continue
 					}
 				}

--- a/wait/http.go
+++ b/wait/http.go
@@ -127,7 +127,7 @@ func (ws *HTTPStrategy) WaitUntilReady(ctx context.Context, target StrategyTarge
 	var port nat.Port
 	port, err = target.MappedPort(ctx, ws.Port)
 
-	for port == ""{
+	for port == "" {
 		select {
 		case <-ctx.Done():
 			return fmt.Errorf("%s:%w", ctx.Err(), err)

--- a/wait/http.go
+++ b/wait/http.go
@@ -124,9 +124,16 @@ func (ws *HTTPStrategy) WaitUntilReady(ctx context.Context, target StrategyTarge
 		return
 	}
 
-	port, err := target.MappedPort(ctx, ws.Port)
-	if err != nil {
-		return
+	var port nat.Port
+	port, err = target.MappedPort(ctx, ws.Port)
+
+	for port == ""{
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("%s:%w", ctx.Err(), err)
+		case <-time.After(ws.PollInterval):
+			port, err = target.MappedPort(ctx, ws.Port)
+		}
 	}
 
 	if port.Proto() != "tcp" {

--- a/wait/sql.go
+++ b/wait/sql.go
@@ -49,9 +49,16 @@ func (w *waitForSql) WaitUntilReady(ctx context.Context, target StrategyTarget) 
 	ticker := time.NewTicker(w.PollInterval)
 	defer ticker.Stop()
 
-	port, err := target.MappedPort(ctx, w.Port)
-	if err != nil {
-		return fmt.Errorf("target.MappedPort: %v", err)
+	var port nat.Port
+	port, err = target.MappedPort(ctx, w.Port)
+
+	for port == ""{
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("%s:%w", ctx.Err(), err)
+		case <-ticker.C:
+			port, err = target.MappedPort(ctx, w.Port)
+		}
 	}
 
 	db, err := sql.Open(w.Driver, w.URL(port))

--- a/wait/sql.go
+++ b/wait/sql.go
@@ -52,7 +52,7 @@ func (w *waitForSql) WaitUntilReady(ctx context.Context, target StrategyTarget) 
 	var port nat.Port
 	port, err = target.MappedPort(ctx, w.Port)
 
-	for port == ""{
+	for port == "" {
 		select {
 		case <-ctx.Done():
 			return fmt.Errorf("%s:%w", ctx.Err(), err)


### PR DESCRIPTION
Docker engine 20.10.3 has changed the way ports are returned from InspectContainer. The array is not always populated which triggers a panic.

Related to #294 