### PR TITLE
close reaper go routines on `DockerContainer.Terminate` & `DockerNetwork.Remove`

### DIFF
--- a/docker.go
+++ b/docker.go
@@ -426,6 +426,11 @@ type DockerNetwork struct {
 
 // Remove is used to remove the network. It is usually triggered by as defer function.
 func (n *DockerNetwork) Remove(ctx context.Context) error {
+	select {
+	// close reaper if it was created
+	case n.terminationSignal <- true:
+	default:
+	}
 	return n.provider.client.NetworkRemove(ctx, n.ID)
 }
 

--- a/docker.go
+++ b/docker.go
@@ -174,6 +174,11 @@ func (c *DockerContainer) Start(ctx context.Context) error {
 
 // Terminate is used to kill the container. It is usually triggered by as defer function.
 func (c *DockerContainer) Terminate(ctx context.Context) error {
+	select {
+	// close reaper if it was created
+	case c.terminationSignal <- true:
+	default:
+	}
 	err := c.provider.client.ContainerRemove(ctx, c.GetContainerID(), types.ContainerRemoveOptions{
 		RemoveVolumes: true,
 		Force:         true,


### PR DESCRIPTION
This fixes the issue #319.

When `Reaper` is used, the `DockerContainer.Terminate` and `DockerNetwork.Remove` functions should close the spawned go routine by `Reaper.Connect`.

