### PR TITLE
chore: add WaitForService method to compose

### DIFF
--- a/compose.go
+++ b/compose.go
@@ -29,6 +29,7 @@ const (
 type DockerCompose interface {
 	Down() ExecError
 	Invoke() ExecError
+	WaitForService(string, wait.Strategy) DockerCompose
 	WithCommand([]string) DockerCompose
 	WithEnv(map[string]string) DockerCompose
 	WithExposedService(string, int, wait.Strategy) DockerCompose
@@ -149,6 +150,13 @@ func (dc *LocalDockerCompose) applyStrategyToRunningContainer() error {
 // Invoke invokes the docker compose
 func (dc *LocalDockerCompose) Invoke() ExecError {
 	return executeCompose(dc, dc.Cmd)
+}
+
+// WaitForService sets the strategy for the service that is to be waited on
+func (dc *LocalDockerCompose) WaitForService(service string, strategy wait.Strategy) DockerCompose {
+	dc.waitStrategySupplied = true
+	dc.WaitStrategyMap[waitService{service: service}] = strategy
+	return dc
 }
 
 // WithCommand assigns the command


### PR DESCRIPTION
## What does this PR do?
We are providing a simple API to wait for services by service name, only

## Why is it important?
It will allow consumer to wait on a service without having to pass a port.