### PR TITLE
Added CopyFileFromContainer to DockerContainer

### DIFF
--- a/container.go
+++ b/container.go
@@ -52,6 +52,7 @@ type Container interface {
 	Exec(ctx context.Context, cmd []string) (int, error)
 	ContainerIP(context.Context) (string, error) // get container ip
 	CopyFileToContainer(ctx context.Context, hostFilePath string, containerFilePath string, fileMode int64) error
+	CopyFileFromContainer(ctx context.Context, filePath string) ([]byte, error)
 }
 
 // ImageBuildInfo defines what is needed to build an image

--- a/container.go
+++ b/container.go
@@ -52,7 +52,7 @@ type Container interface {
 	Exec(ctx context.Context, cmd []string) (int, error)
 	ContainerIP(context.Context) (string, error) // get container ip
 	CopyFileToContainer(ctx context.Context, hostFilePath string, containerFilePath string, fileMode int64) error
-	CopyFileFromContainer(ctx context.Context, filePath string) ([]byte, error)
+	CopyFileFromContainer(ctx context.Context, filePath string) (io.ReadCloser, error)
 }
 
 // ImageBuildInfo defines what is needed to build an image

--- a/docker.go
+++ b/docker.go
@@ -336,7 +336,7 @@ func (c *DockerContainer) Exec(ctx context.Context, cmd []string) (int, error) {
 
 type FileFromContainer struct {
 	underlying *io.ReadCloser
-	tarreader *tar.Reader
+	tarreader  *tar.Reader
 }
 
 func (fc *FileFromContainer) Read(b []byte) (int, error) {

--- a/docker_test.go
+++ b/docker_test.go
@@ -1482,11 +1482,51 @@ func TestDockerContainerCopyFileFromContainer(t *testing.T) {
 		t.Fatalf("File %s should exist, expected return code 0, got %v", copiedFileName, c)
 	}
 
-	fileContentFromContainer, err := nginxC.CopyFileFromContainer(ctx, "/"+copiedFileName)
+	reader, err := nginxC.CopyFileFromContainer(ctx, "/"+copiedFileName)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	fileContentFromContainer, err := ioutil.ReadAll(reader)
 	if err != nil {
 		t.Fatal(err)
 	}
 	assert.Equal(t, fileContent, fileContentFromContainer)
+}
+
+func TestDockerContainerCopyEmptyFileFromContainer(t *testing.T) {
+	ctx := context.Background()
+
+	nginxC, err := GenericContainer(ctx, GenericContainerRequest{
+		ContainerRequest: ContainerRequest{
+			Image:        "nginx:1.17.6",
+			ExposedPorts: []string{"80/tcp"},
+			WaitingFor:   wait.ForListeningPort("80/tcp"),
+		},
+		Started: true,
+	})
+	defer nginxC.Terminate(ctx)
+
+	copiedFileName := "hello_copy.sh"
+	nginxC.CopyFileToContainer(ctx, "./testresources/empty.sh", "/"+copiedFileName, 700)
+	c, err := nginxC.Exec(ctx, []string{"bash", copiedFileName})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if c != 0 {
+		t.Fatalf("File %s should exist, expected return code 0, got %v", copiedFileName, c)
+	}
+
+	reader, err := nginxC.CopyFileFromContainer(ctx, "/"+copiedFileName)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	fileContentFromContainer, err := ioutil.ReadAll(reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Empty(t, fileContentFromContainer)
 }
 
 func TestContainerWithReaperNetwork(t *testing.T) {


### PR DESCRIPTION
# Why ?
While working on a k3s-container I needed to extract the kubeconfig from the running container and discovered that there is no CopyFileFromContainer available.

# What ?
Added CopyFileFromContainer to DockerContainer.
Added Unit-test for the new Function.