### PR TITLE
Fix default network is not initialize when get gateway ip

### DIFF
--- a/docker.go
+++ b/docker.go
@@ -892,6 +892,13 @@ func (p *DockerProvider) GetNetwork(ctx context.Context, req NetworkRequest) (ty
 
 func (p *DockerProvider) GetGatewayIP(ctx context.Context) (string, error) {
 	// Use a default network as defined in the DockerProvider
+	var err error
+	if p.defaultNetwork == "" {
+		p.defaultNetwork, err = getDefaultNetwork(ctx, p.client)
+		if err != nil {
+			return "", err
+		}
+	}
 	nw, err := p.GetNetwork(ctx, NetworkRequest{Name: p.defaultNetwork})
 	if err != nil {
 		return "", err

--- a/docker.go
+++ b/docker.go
@@ -892,8 +892,8 @@ func (p *DockerProvider) GetNetwork(ctx context.Context, req NetworkRequest) (ty
 
 func (p *DockerProvider) GetGatewayIP(ctx context.Context) (string, error) {
 	// Use a default network as defined in the DockerProvider
-	var err error
 	if p.defaultNetwork == "" {
+		var err error
 		p.defaultNetwork, err = getDefaultNetwork(ctx, p.client)
 		if err != nil {
 			return "", err

--- a/docker_test.go
+++ b/docker_test.go
@@ -1513,8 +1513,12 @@ func TestGetGatewayIP(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := provider.GetGatewayIP(context.Background()); err != nil {
+	ip, err := provider.GetGatewayIP(context.Background())
+	if err != nil {
 		t.Fatal(err)
+	}
+	if ip == "" {
+		t.Fatal("could not get gateway ip")
 	}
 }
 

--- a/docker_test.go
+++ b/docker_test.go
@@ -1506,6 +1506,18 @@ func TestContainerWithReaperNetwork(t *testing.T) {
 	assert.NotNil(t, cnt.NetworkSettings.Networks[networks[1]])
 }
 
+func TestGetGatewayIP(t *testing.T) {
+	// When using docker-compose with DinD mode, and using host port or http wait strategy
+	// It's need to invoke GetGatewayIP for get the host
+	provider, err := NewDockerProvider()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := provider.GetGatewayIP(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func randomString() string {
 	rand.Seed(time.Now().UnixNano())
 	chars := []rune("ABCDEFGHIJKLMNOPQRSTUVWXYZ" +


### PR DESCRIPTION
When I try to use docker in docker through the share UNIX socket on GitHub Action, the IP address in the Host Port wait strategy is incorrect.

I found when we trying to get the target host, the default network may not initialize: https://github.com/testcontainers/testcontainers-go/blob/59631817dd3515c7c97e3c84e0201eaa746d6773/docker.go#L895