### PR TITLE
Swap incorrect key and value of BindMounts and VolumeMounts

### DIFF
--- a/docker.go
+++ b/docker.go
@@ -679,14 +679,14 @@ func (p *DockerProvider) CreateContainer(ctx context.Context, req ContainerReque
 
 	// prepare mounts
 	mounts := []mount.Mount{}
-	for hostPath, innerPath := range req.BindMounts {
+	for innerPath, hostPath := range req.BindMounts {
 		mounts = append(mounts, mount.Mount{
 			Type:   mount.TypeBind,
 			Source: hostPath,
 			Target: innerPath,
 		})
 	}
-	for volumeName, innerPath := range req.VolumeMounts {
+	for innerPath, volumeName := range req.VolumeMounts {
 		mounts = append(mounts, mount.Mount{
 			Type:   mount.TypeVolume,
 			Source: volumeName,

--- a/docker_test.go
+++ b/docker_test.go
@@ -1279,8 +1279,8 @@ func TestContainerCreationWithBindAndVolume(t *testing.T) {
 	bashC, err := GenericContainer(ctx, GenericContainerRequest{
 		ContainerRequest: ContainerRequest{
 			Image:        "bash",
-			BindMounts:   map[string]string{absPath: "/hello.sh"},
-			VolumeMounts: map[string]string{volumeName: "/data"},
+			BindMounts:   map[string]string{"/hello.sh": absPath},
+			VolumeMounts: map[string]string{"/data": volumeName},
 			Cmd:          []string{"bash", "/hello.sh"},
 			WaitingFor:   wait.ForLog("done"),
 		},


### PR DESCRIPTION
It is currently not possible to mount a local path to multiple paths in
the container.

BindMounts are currently stored in a `map[string]string` with the
hostPath being the key and containerPath as the value.
This prevents me from mounting a hostPath to multiple paths in the
container. Using a map actually makes sense because it is not possible
to mount multiple host paths to the same path in the container. Key and
value are just swapped. Same with VolumeMounts.

Yes, i know, this a huge breaking change and probably not the best fix.
We could also add an additional map like `BindMountsFixed` and deprecate
the old one. But as this library is still in version 0, a breaking
change might not be a problem?