### PR TITLE
Expose configuration of logger

### DIFF
--- a/container.go
+++ b/container.go
@@ -3,6 +3,8 @@ package testcontainers
 import (
 	"context"
 	"io"
+	"log"
+	"os"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
@@ -13,6 +15,9 @@ import (
 
 	"github.com/testcontainers/testcontainers-go/wait"
 )
+
+// Logger is the default log instance
+var Logger = log.New(os.Stderr, "", log.LstdFlags)
 
 // DeprecatedContainer shows methods that were supported before, but are now deprecated
 // Deprecated: Use Container

--- a/docker.go
+++ b/docker.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"log"
 	"net/url"
 	"os"
 	"os/exec"
@@ -157,7 +156,7 @@ func (c *DockerContainer) SessionID() string {
 // Start will start an already created container
 func (c *DockerContainer) Start(ctx context.Context) error {
 	shortID := c.ID[:12]
-	log.Printf("Starting container id: %s image: %s", shortID, c.Image)
+	Logger.Printf("Starting container id: %s image: %s", shortID, c.Image)
 
 	if err := c.provider.client.ContainerStart(ctx, c.ID, types.ContainerStartOptions{}); err != nil {
 		return err
@@ -165,12 +164,12 @@ func (c *DockerContainer) Start(ctx context.Context) error {
 
 	// if a Wait Strategy has been specified, wait before returning
 	if c.WaitingFor != nil {
-		log.Printf("Waiting for container id %s image: %s", shortID, c.Image)
+		Logger.Printf("Waiting for container id %s image: %s", shortID, c.Image)
 		if err := c.WaitingFor.WaitUntilReady(ctx, c); err != nil {
 			return err
 		}
 	}
-	log.Printf("Container is ready id: %s image: %s", shortID, c.Image)
+	Logger.Printf("Container is ready id: %s image: %s", shortID, c.Image)
 
 	return nil
 }
@@ -777,7 +776,7 @@ func (p *DockerProvider) attemptToPullImage(ctx context.Context, tag string, pul
 			if _, ok := err.(errdefs.ErrNotFound); ok {
 				return backoff.Permanent(err)
 			}
-			log.Printf("Failed to pull image: %s, will retry", err)
+			Logger.Printf("Failed to pull image: %s, will retry", err)
 			return err
 		}
 		return nil


### PR DESCRIPTION
Allow the log instance to be configured independently from other uses of the `log` package.

```go
testcontainers.Logger.SetPrefix(io.Discard)
testcontainers.Logger.SetOutput(io.Discard)
```

This is still global & it would be better to be able to pass in an instance of `*log.Logger` but that can be a follow-up PR. I wanted to land something small & hopefully non-contencious.