### PR TITLE
Allow uid:gid to be specified during container creation

### DIFF
--- a/container.go
+++ b/container.go
@@ -93,6 +93,7 @@ type ContainerRequest struct {
 	Privileged      bool                // for starting privileged container
 	Networks        []string            // for specifying network names
 	NetworkAliases  map[string][]string // for specifying network aliases
+	User            string              // for specifying uid:gid
 	SkipReaper      bool                // indicates whether we skip setting up a reaper for this
 	ReaperImage     string              // alternative reaper image
 	AutoRemove      bool                // if set to true, the container will be removed from the host when stopped

--- a/docker.go
+++ b/docker.go
@@ -675,6 +675,7 @@ func (p *DockerProvider) CreateContainer(ctx context.Context, req ContainerReque
 		Labels:       req.Labels,
 		Cmd:          req.Cmd,
 		Hostname:     req.Hostname,
+		User:         req.User,
 	}
 
 	// prepare mounts


### PR DESCRIPTION
Fixes #361 

Adds a `User` field to ContainerRequest and includes that value in the container config so that `uid[:gid]` can be specified for the container.