### PR TITLE
Bugfix: log-consumer go-routine should recover from closed-connection

### DIFF
--- a/docker.go
+++ b/docker.go
@@ -435,7 +435,7 @@ func (c *DockerContainer) StartLogProducer(ctx context.Context) error {
 				_, err := r.Read(h)
 				if err != nil {
 					// proper type matching requires https://go-review.googlesource.com/c/go/+/250357/ (go 1.16)
-					if strings.Contains(err.Error(), "use of closed connection") {
+					if strings.Contains(err.Error(), "use of closed network connection") {
 						now := time.Now()
 						since = fmt.Sprintf("%d.%09d", now.Unix(), int64(now.Nanosecond()))
 						goto BEGIN


### PR DESCRIPTION
As best I can tell, a direct commit to the master branch [bc6fdab](https://github.com/testcontainers/testcontainers-go/commit/bc6fdab92dd3c623ad6654bf301b1a659efeb50e) made an attempt at recovering the log-position of a container in the scenario of a closed connection. The logic is all sound, but I think the string used to detect a closed-connection is not (has never been) correct.

The source of the error is `internal/poll`'s `errNetClosing`. It's error string has been set as: `"use of closed network connection"` since the beginning (5 years ago). Of course it would be much cleaner to detect a connection-closed error without string-matching but as stated in the mentioned commit, the error type for this was only exported by the `net` package in go 1.16