### PR TITLE
docs: document testcontainers properties file

### DIFF
--- a/docs/features/custom_configuration.md
+++ b/docs/features/custom_configuration.md
@@ -1,0 +1,30 @@
+# Custom configuration
+
+You can override some default properties if your environment requires that.
+
+## Configuration locations
+The configuration will be loaded from multiple locations. Properties are considered in the following order:
+
+1. Environment variables
+2. `.testcontainers.properties` in user's home folder. Example locations:  
+**Linux:** `/home/myuser/.testcontainers.properties`  
+**Windows:** `C:/Users/myuser/.testcontainers.properties`  
+**macOS:** `/Users/myuser/.testcontainers.properties`
+
+## Customizing Docker host detection
+
+Testcontainers will attempt to detect the Docker environment and configure everything to work automatically.
+
+However, sometimes customization is required. Testcontainers will respect the following **environment variables**:
+
+> **DOCKER_HOST** = unix:///var/run/docker.sock  
+> See [Docker environment variables](https://docs.docker.com/engine/reference/commandline/cli/#environment-variables)
+
+For advanced users, the Docker host connection can be configured **via configuration** in `~/.testcontainers.properties`.
+The example below illustrates usage:
+
+```properties
+docker.host=tcp\://my.docker.host\:1234     # Equivalent to the DOCKER_HOST environment variable. Colons should be escaped.
+docker.tls.verify=1                         # Equivalent to the DOCKER_TLS_VERIFY environment variable
+docker.cert.path=/some/path                 # Equivalent to the DOCKER_CERT_PATH environment variable
+```

--- a/docs/system_requirements/index.md
+++ b/docs/system_requirements/index.md
@@ -1,0 +1,15 @@
+# General System requirements
+
+## Docker environment discovery
+
+Testcontainers will try to connect to a Docker daemon using the following strategies in order:
+
+* Environment variables:
+	* `DOCKER_HOST`
+	* `DOCKER_TLS_VERIFY`
+	* `DOCKER_CERT_PATH`
+* Defaults:
+	* `DOCKER_HOST=https://localhost:2376`
+	* `DOCKER_TLS_VERIFY=1`
+	* `DOCKER_CERT_PATH=~/.docker`
+* If Docker Machine is installed, the docker machine environment for the *first* machine found. Docker Machine needs to be on the PATH for this to succeed.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -32,6 +32,8 @@ nav:
           - features/follow_logs.md
           - features/override_container_command.md
           - features/custom_configuration.md
+    - System Requirements:
+          - system_requirements/index.md
     - Examples:
           - examples/cockroachdb.md
           - examples/nginx.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -31,6 +31,7 @@ nav:
           - features/docker_compose.md
           - features/follow_logs.md
           - features/override_container_command.md
+          - features/custom_configuration.md
     - Examples:
           - examples/cockroachdb.md
           - examples/nginx.md


### PR DESCRIPTION
## What does this PR do?
It adds the recently supported `.testcontainers.properties` file to the Docs.

I basically copied Java's version for this file (https://www.testcontainers.org/features/configuration/), removing anything not related to this project

## Why is it important?
Keep docs up-to-date!

## How to test this PR?

```shell
pip install -r requirements.txt 
mkdocs serve
open http://127.0.0.1:8000/features/custom_configuration/
```

<img width="1789" alt="Screenshot 2021-11-08 at 10 08 19" src="https://user-images.githubusercontent.com/951580/140714388-c08be933-acd0-4dc2-9f7e-049fc0d89dd8.png">
