### PR TITLE
docs: add snippet to prevent dangling volumes

### DIFF
--- a/docs/features/docker_compose.md
+++ b/docs/features/docker_compose.md
@@ -51,3 +51,10 @@ if err != nil {
 return nil
 ```
 
+If your compose stack creates volumes you may need to remove them with the `--volumes` option to prevent dangling volumes accumulating on test runners.
+
+```go
+execError := compose.
+	WithCommand([]string{"down", "--volumes"}).
+	Invoke()
+```


### PR DESCRIPTION
Ran into an issue where a container in a compose stack was creating an anonymous volume. The `Down()` method doesn't remove it and I had to pass the `--volumes` option to prevent dangling volumes accumulating on the test runner.

Great library, by the way. Thank you! 🏅 