### PR TITLE
feat: additionally remove volumes by default on compose down

### DIFF
--- a/compose.go
+++ b/compose.go
@@ -88,7 +88,7 @@ func NewLocalDockerCompose(filePaths []string, identifier string) *LocalDockerCo
 
 // Down executes docker-compose down
 func (dc *LocalDockerCompose) Down() ExecError {
-	return executeCompose(dc, []string{"down", "--remove-orphans"})
+	return executeCompose(dc, []string{"down", "--remove-orphans", "--volumes"})
 }
 
 func (dc *LocalDockerCompose) getDockerComposeEnvironment() map[string]string {

--- a/testresources/docker-compose-volume.yml
+++ b/testresources/docker-compose-volume.yml
@@ -1,0 +1,17 @@
+version: '3'
+services:
+  nginx:
+    image: nginx:stable-alpine
+    volumes:
+      - type: volume
+        source: mydata
+        target: /data
+        volume:
+          nocopy: true
+    environment:
+      bar: ${bar}
+    ports:
+     - "9080:80"
+
+volumes:
+  mydata:


### PR DESCRIPTION
Following the discussion [here](https://github.com/testcontainers/testcontainers-go/pull/380#discussion_r749166320) this PR adds removal of volumes by default to the compose `Down()` method.
