### PR TITLE
Read only bind and volume mounts

### DIFF
--- a/container.go
+++ b/container.go
@@ -88,8 +88,8 @@ type ContainerRequest struct {
 	ExposedPorts    []string // allow specifying protocol info
 	Cmd             []string
 	Labels          map[string]string
-	BindMounts      map[string]string
-	VolumeMounts    map[string]string
+	BindMounts      []Mount
+	VolumeMounts    []Mount
 	Tmpfs           map[string]string
 	RegistryCred    string
 	WaitingFor      wait.Strategy
@@ -104,6 +104,15 @@ type ContainerRequest struct {
 	AutoRemove      bool                // if set to true, the container will be removed from the host when stopped
 	NetworkMode     container.NetworkMode
 	AlwaysPullImage bool // Always pull image
+}
+
+// Mount represents a bind or volume mount.
+type Mount struct {
+	// Source should be a volume name if desired mount is volume and host path if it is bind.
+	Source string
+	// Target specifies a path where the Source will be mounted at inside the container
+	Target   string
+	ReadOnly bool
 }
 
 // ProviderType is an enum for the possible providers

--- a/container.go
+++ b/container.go
@@ -82,14 +82,20 @@ type FromDockerfile struct {
 // ContainerRequest represents the parameters used to get a running container
 type ContainerRequest struct {
 	FromDockerfile
-	Image           string
-	Entrypoint      []string
-	Env             map[string]string
-	ExposedPorts    []string // allow specifying protocol info
-	Cmd             []string
-	Labels          map[string]string
-	BindMounts      []Mount
-	VolumeMounts    []Mount
+	Image        string
+	Entrypoint   []string
+	Env          map[string]string
+	ExposedPorts []string // allow specifying protocol info
+	Cmd          []string
+	Labels       map[string]string
+	// BindMounts specifies a mount where key is dir in container and value is host dir.
+	// If key ends with :ro directory will be mounted as ReadOnly.
+	// If key ends with :rw directory will be mounted as ReadWrite. It's also the default mode.
+	BindMounts map[string]string
+	// VolumeMounts specifies a mount where key is dir in container and value is the name of the volume.
+	// If key ends with :ro directory will be mounted as ReadOnly.
+	// If key ends with :rw directory will be mounted as ReadWrite. It's also the default mode.
+	VolumeMounts    map[string]string
 	Tmpfs           map[string]string
 	RegistryCred    string
 	WaitingFor      wait.Strategy
@@ -104,15 +110,6 @@ type ContainerRequest struct {
 	AutoRemove      bool                // if set to true, the container will be removed from the host when stopped
 	NetworkMode     container.NetworkMode
 	AlwaysPullImage bool // Always pull image
-}
-
-// Mount represents a bind or volume mount.
-type Mount struct {
-	// Source should be a volume name if desired mount is volume and host path if it is bind.
-	Source string
-	// Target specifies a path where the Source will be mounted at inside the container
-	Target   string
-	ReadOnly bool
 }
 
 // ProviderType is an enum for the possible providers

--- a/docker.go
+++ b/docker.go
@@ -742,7 +742,7 @@ func (p *DockerProvider) CreateContainer(ctx context.Context, req ContainerReque
 	}
 
 	// prepare mounts
-	mounts := []mount.Mount{}
+	mounts := make([]mount.Mount, 0, len(req.BindMounts)+len(req.VolumeMounts))
 	for innerPath, hostPath := range req.BindMounts {
 		mounts = append(mounts, mount.Mount{
 			Type:   mount.TypeBind,
@@ -752,9 +752,10 @@ func (p *DockerProvider) CreateContainer(ctx context.Context, req ContainerReque
 	}
 	for innerPath, volumeName := range req.VolumeMounts {
 		mounts = append(mounts, mount.Mount{
-			Type:   mount.TypeVolume,
-			Source: volumeName,
-			Target: innerPath,
+			Type:     mount.TypeVolume,
+			Source:   volume.Source,
+			Target:   volume.Target,
+			ReadOnly: volume.ReadOnly,
 		})
 	}
 

--- a/docker_test.go
+++ b/docker_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/stretchr/testify/require"
 	"io/ioutil"
 	"math/rand"
 	"net/http"
@@ -1421,6 +1422,58 @@ func TestContainerCreationWithBindAndVolume(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
+	}()
+}
+
+func TestContainerCreationWithReadonlyBindAndVolume(t *testing.T) {
+	absPath, err := filepath.Abs("./testresources/")
+	require.NoError(t, err)
+	ctx, cnl := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cnl()
+	// Create a Docker client.
+	dockerCli, err := client.NewClientWithOpts(client.FromEnv)
+	require.NoError(t, err)
+	dockerCli.NegotiateAPIVersion(ctx)
+	// Create the volume.
+	vol, err := dockerCli.VolumeCreate(ctx, volume.VolumeCreateBody{
+		Driver: "local",
+	})
+	require.NoError(t, err)
+	volumeName := vol.Name
+	defer func() {
+		ctx, cnl := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cnl()
+		err := dockerCli.VolumeRemove(ctx, volumeName, true)
+		require.NoError(t, err)
+	}()
+	// Create the container that writes into the mounted volume.
+	bashC, err := GenericContainer(ctx, GenericContainerRequest{
+		ContainerRequest: ContainerRequest{
+			Image: "bash",
+			BindMounts: []Mount{{
+				Source:   absPath,
+				Target:   "/bind",
+				ReadOnly: true,
+			}},
+			VolumeMounts: []Mount{{
+				Source:   volumeName,
+				Target:   "/volume",
+				ReadOnly: true,
+			}},
+			Cmd: []string{"touch", "/bind/aFile", "&&", "touch", "/volume/anotherFile"},
+			WaitingFor: wait.ForAll(
+				wait.ForLog("/bind/aFile: Read-only file system"),
+				wait.ForLog("/volume/anotherFile: Read-only file system"),
+			),
+		},
+		Started: true,
+	})
+	require.NoError(t, err)
+	defer func() {
+		ctx, cnl := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cnl()
+		err := bashC.Terminate(ctx)
+		require.NoError(t, err)
 	}()
 }
 

--- a/reaper.go
+++ b/reaper.go
@@ -63,10 +63,9 @@ func NewReaper(ctx context.Context, sessionID string, provider ReaperProvider, r
 			TestcontainerLabelIsReaper: "true",
 		},
 		SkipReaper: true,
-		BindMounts: []Mount{{
-			Source: "/var/run/docker.sock",
-			Target: "/var/run/docker.sock",
-		}},
+		BindMounts: map[string]string{
+			"/var/run/docker.sock": "/var/run/docker.sock",
+		},
 		AutoRemove: true,
 		WaitingFor: wait.ForListeningPort(listeningPort),
 	}

--- a/reaper.go
+++ b/reaper.go
@@ -63,9 +63,10 @@ func NewReaper(ctx context.Context, sessionID string, provider ReaperProvider, r
 			TestcontainerLabelIsReaper: "true",
 		},
 		SkipReaper: true,
-		BindMounts: map[string]string{
-			"/var/run/docker.sock": "/var/run/docker.sock",
-		},
+		BindMounts: []Mount{{
+			Source: "/var/run/docker.sock",
+			Target: "/var/run/docker.sock",
+		}},
 		AutoRemove: true,
 		WaitingFor: wait.ForListeningPort(listeningPort),
 	}


### PR DESCRIPTION
Added the ability to specify read-only bind and volume mounts.
That ability is present in docker client itself as well as in java version of testcontainers - see https://www.testcontainers.org/features/files/