### PR TITLE
Replace ContainerRequest.BindMounts and ContainerRequest.VolumeMounts with ContainerRequest.Mounts as dedicated type

### DIFF
--- a/container.go
+++ b/container.go
@@ -205,7 +205,7 @@ func (c *ContainerRequest) validateMounts() error {
 
 	for idx := range c.Mounts {
 		m := c.Mounts[idx]
-		targetPath := m.Target.String()
+		targetPath := m.Target.Target()
 		if targets[targetPath] {
 			return fmt.Errorf("%w: %s", ErrDuplicateMountTarget, targetPath)
 		} else {

--- a/container_test.go
+++ b/container_test.go
@@ -247,7 +247,7 @@ func Test_BuildImageWithContexts(t *testing.T) {
 			ContextArchive: func() (io.Reader, error) {
 				return nil, nil
 			},
-			ExpectedError: errors.New("failed to create container: you must specify either a build context or an image"),
+			ExpectedError: errors.New("you must specify either a build context or an image: failed to create container"),
 		},
 	}
 
@@ -299,7 +299,7 @@ func Test_GetLogsFromFailedContainer(t *testing.T) {
 		Started:          true,
 	})
 
-	if err != nil && err.Error() != "failed to start container: context deadline exceeded" {
+	if err != nil && !errors.Is(err, context.DeadlineExceeded) {
 		t.Fatal(err)
 	} else if err == nil {
 		c.Terminate(ctx)

--- a/container_test.go
+++ b/container_test.go
@@ -372,12 +372,12 @@ func TestBindMount(t *testing.T) {
 		{
 			name: "/var/run/docker.sock:/var/run/docker.sock",
 			args: args{hostPath: "/var/run/docker.sock", mountTarget: "/var/run/docker.sock"},
-			want: ContainerMount{Source: BindMountSource{HostPath: "/var/run/docker.sock"}, Target: "/var/run/docker.sock"},
+			want: ContainerMount{Source: GenericBindMountSource{HostPath: "/var/run/docker.sock"}, Target: "/var/run/docker.sock"},
 		},
 		{
 			name: "/var/lib/app/data:/data",
 			args: args{hostPath: "/var/lib/app/data", mountTarget: "/data"},
-			want: ContainerMount{Source: BindMountSource{HostPath: "/var/lib/app/data"}, Target: "/data"},
+			want: ContainerMount{Source: GenericBindMountSource{HostPath: "/var/lib/app/data"}, Target: "/data"},
 		},
 	}
 	for _, tt := range tests {
@@ -400,12 +400,12 @@ func TestVolumeMount(t *testing.T) {
 		{
 			name: "sample-data:/data",
 			args: args{volumeName: "sample-data", mountTarget: "/data"},
-			want: ContainerMount{Source: VolumeMountSource{Name: "sample-data"}, Target: "/data"},
+			want: ContainerMount{Source: GenericVolumeMountSource{Name: "sample-data"}, Target: "/data"},
 		},
 		{
 			name: "web:/var/nginx/html",
 			args: args{volumeName: "web", mountTarget: "/var/nginx/html"},
-			want: ContainerMount{Source: VolumeMountSource{Name: "web"}, Target: "/var/nginx/html"},
+			want: ContainerMount{Source: GenericVolumeMountSource{Name: "web"}, Target: "/var/nginx/html"},
 		},
 	}
 	for _, tt := range tests {

--- a/docker.go
+++ b/docker.go
@@ -744,7 +744,7 @@ func (p *DockerProvider) CreateContainer(ctx context.Context, req ContainerReque
 	}
 
 	// prepare mounts
-	mounts := req.Mounts.PrepareMounts()
+	mounts := mapToDockerMounts(req.Mounts)
 
 	hostConfig := &container.HostConfig{
 		PortBindings: exposedPortMap,

--- a/docker.go
+++ b/docker.go
@@ -19,7 +19,6 @@ import (
 	"github.com/cenkalti/backoff/v4"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
-	"github.com/docker/docker/api/types/mount"
 	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/client"
 	"github.com/docker/docker/errdefs"
@@ -32,8 +31,12 @@ import (
 	"github.com/testcontainers/testcontainers-go/wait"
 )
 
-// Implement interfaces
-var _ Container = (*DockerContainer)(nil)
+var (
+	// Implement interfaces
+	_ Container = (*DockerContainer)(nil)
+
+	ErrDuplicateMountTarget = errors.New("duplicate mount target detected")
+)
 
 const (
 	Bridge        = "bridge"         // Bridge network name (as well as driver)
@@ -741,21 +744,7 @@ func (p *DockerProvider) CreateContainer(ctx context.Context, req ContainerReque
 	}
 
 	// prepare mounts
-	mounts := []mount.Mount{}
-	for innerPath, hostPath := range req.BindMounts {
-		mounts = append(mounts, mount.Mount{
-			Type:   mount.TypeBind,
-			Source: hostPath,
-			Target: innerPath,
-		})
-	}
-	for innerPath, volumeName := range req.VolumeMounts {
-		mounts = append(mounts, mount.Mount{
-			Type:   mount.TypeVolume,
-			Source: volumeName,
-			Target: innerPath,
-		})
-	}
+	mounts := req.Mounts.PrepareMounts()
 
 	hostConfig := &container.HostConfig{
 		PortBindings: exposedPortMap,

--- a/docker_mounts.go
+++ b/docker_mounts.go
@@ -1,0 +1,116 @@
+package testcontainers
+
+import "github.com/docker/docker/api/types/mount"
+
+var (
+	mountTypeMapping = map[MountType]mount.Type{
+		MountTypeBind:   mount.TypeBind,
+		MountTypeVolume: mount.TypeVolume,
+		MountTypeTmpfs:  mount.TypeTmpfs,
+		MountTypePipe:   mount.TypeNamedPipe,
+	}
+)
+
+// BindMounter can optionally be implemented by mount sources
+// to support advanced scenarios based on mount.BindOptions
+type BindMounter interface {
+	GetBindOptions() *mount.BindOptions
+}
+
+// VolumeMounter can optionally be implemented by mount sources
+// to support advanced scenarios based on mount.VolumeOptions
+type VolumeMounter interface {
+	GetVolumeOptions() *mount.VolumeOptions
+}
+
+// TmpfsMounter can optionally be implemented by mount sources
+// to support advanced scenarios based on mount.TmpfsOptions
+type TmpfsMounter interface {
+	GetTmpfsOptions() *mount.TmpfsOptions
+}
+
+type DockerBindMountSource struct {
+	*mount.BindOptions
+
+	// HostPath is the path mounted into the container
+	// the same host path might be mounted to multiple locations withing a single container
+	HostPath string
+}
+
+func (s DockerBindMountSource) Source() string {
+	return s.HostPath
+}
+
+func (DockerBindMountSource) Type() MountType {
+	return MountTypeBind
+}
+
+func (s DockerBindMountSource) GetBindOptions() *mount.BindOptions {
+	return s.BindOptions
+}
+
+type DockerVolumeMountSource struct {
+	*mount.VolumeOptions
+
+	// Name refers to the name of the volume to be mounted
+	// the same volume might be mounted to multiple locations within a single container
+	Name string
+}
+
+func (s DockerVolumeMountSource) Source() string {
+	return s.Name
+}
+
+func (DockerVolumeMountSource) Type() MountType {
+	return MountTypeVolume
+}
+
+func (s DockerVolumeMountSource) GetVolumeOptions() *mount.VolumeOptions {
+	return s.VolumeOptions
+}
+
+type DockerTmpfsMountSource struct {
+	GenericTmpfsMountSource
+	*mount.TmpfsOptions
+}
+
+func (s DockerTmpfsMountSource) GetTmpfsOptions() *mount.TmpfsOptions {
+	return s.TmpfsOptions
+}
+
+// mapToDockerMounts maps the given []ContainerMount to the corresponding
+// []mount.Mount for further processing
+func mapToDockerMounts(containerMounts ContainerMounts) []mount.Mount {
+	mounts := make([]mount.Mount, 0, len(containerMounts))
+
+	for idx := range containerMounts {
+		m := containerMounts[idx]
+
+		var mountType mount.Type
+		if mt, ok := mountTypeMapping[m.Source.Type()]; ok {
+			mountType = mt
+		} else {
+			continue
+		}
+
+		containerMount := mount.Mount{
+			Type:     mountType,
+			Source:   m.Source.Source(),
+			ReadOnly: m.ReadOnly,
+			Target:   m.Target.Target(),
+		}
+
+		switch typedMounter := m.Source.(type) {
+		case BindMounter:
+			containerMount.BindOptions = typedMounter.GetBindOptions()
+		case VolumeMounter:
+			containerMount.VolumeOptions = typedMounter.GetVolumeOptions()
+		case TmpfsMounter:
+			containerMount.TmpfsOptions = typedMounter.GetTmpfsOptions()
+		}
+
+		mounts = append(mounts, containerMount)
+	}
+
+	return mounts
+}

--- a/docker_test.go
+++ b/docker_test.go
@@ -1391,11 +1391,10 @@ func TestContainerCreationWithBindAndVolume(t *testing.T) {
 	// Create the container that writes into the mounted volume.
 	bashC, err := GenericContainer(ctx, GenericContainerRequest{
 		ContainerRequest: ContainerRequest{
-			Image:        "bash",
-			BindMounts:   map[string]string{"/hello.sh": absPath},
-			VolumeMounts: map[string]string{"/data": volumeName},
-			Cmd:          []string{"bash", "/hello.sh"},
-			WaitingFor:   wait.ForLog("done"),
+			Image:      "bash",
+			Mounts:     Mounts(BindMount(absPath, "/hello.sh"), VolumeMount(volumeName, "/data")),
+			Cmd:        []string{"bash", "/hello.sh"},
+			WaitingFor: wait.ForLog("done"),
 		},
 		Started: true,
 	})

--- a/mounts.go
+++ b/mounts.go
@@ -1,0 +1,136 @@
+package testcontainers
+
+import (
+	"fmt"
+
+	"github.com/docker/docker/api/types/mount"
+)
+
+type BindMounter interface {
+	GetBindOptions() *mount.BindOptions
+}
+
+type VolumeMounter interface {
+	GetVolumeOptions() *mount.VolumeOptions
+}
+
+type TmpfsMounter interface {
+	GetTmpfsOptions() *mount.TmpfsOptions
+}
+
+type ContainerMountSource interface {
+	fmt.Stringer
+	Type() mount.Type
+}
+
+type BindMountSource struct {
+	*mount.BindOptions
+	HostPath string
+}
+
+func (s BindMountSource) String() string {
+	return s.HostPath
+}
+
+func (BindMountSource) Type() mount.Type {
+	return mount.TypeBind
+}
+func (s BindMountSource) GetBindOptions() *mount.BindOptions {
+	return s.BindOptions
+}
+
+type VolumeMountSource struct {
+	*mount.VolumeOptions
+	Name string
+}
+
+func (s VolumeMountSource) String() string {
+	return s.Name
+}
+
+func (VolumeMountSource) Type() mount.Type {
+	return mount.TypeVolume
+}
+
+func (s VolumeMountSource) GetVolumeOptions() *mount.VolumeOptions {
+	return s.VolumeOptions
+}
+
+type TmpfsMountSource struct {
+	*mount.TmpfsOptions
+}
+
+func (s TmpfsMountSource) String() string {
+	return ""
+}
+
+func (TmpfsMountSource) Type() mount.Type {
+	return mount.TypeTmpfs
+}
+
+func (s TmpfsMountSource) GetTmpfsOptions() *mount.TmpfsOptions {
+	return s.TmpfsOptions
+}
+
+type ContainerMountTarget string
+
+func (t ContainerMountTarget) String() string {
+	return string(t)
+}
+
+func BindMount(hostPath string, mountTarget ContainerMountTarget) ContainerMount {
+	return ContainerMount{
+		Source: BindMountSource{HostPath: hostPath},
+		Target: mountTarget,
+	}
+}
+
+func VolumeMount(volumeName string, mountTarget ContainerMountTarget) ContainerMount {
+	return ContainerMount{
+		Source: VolumeMountSource{Name: volumeName},
+		Target: mountTarget,
+	}
+}
+
+func Mounts(mounts ...ContainerMount) ContainerMounts {
+	return mounts
+}
+
+// ContainerMount models a mount into a container
+type ContainerMount struct {
+	// Source is typically either a BindMountSource or a VolumeMountSource
+	Source ContainerMountSource
+	// Target is the path where the mount should be mounted within the container
+	Target ContainerMountTarget
+	// ReadOnly determines if the mount should be read-only
+	ReadOnly bool
+}
+
+type ContainerMounts []ContainerMount
+
+func (m ContainerMounts) PrepareMounts() []mount.Mount {
+	mounts := make([]mount.Mount, 0, len(m))
+
+	for idx := range m {
+		m := m[idx]
+		containerMount := mount.Mount{
+			Type:     m.Source.Type(),
+			Source:   m.Source.String(),
+			ReadOnly: m.ReadOnly,
+			Target:   m.Target.String(),
+		}
+
+		switch typedMounter := m.Source.(type) {
+		case BindMounter:
+			containerMount.BindOptions = typedMounter.GetBindOptions()
+		case VolumeMounter:
+			containerMount.VolumeOptions = typedMounter.GetVolumeOptions()
+		case TmpfsMounter:
+			containerMount.TmpfsOptions = typedMounter.GetTmpfsOptions()
+		}
+
+		mounts = append(mounts, containerMount)
+	}
+
+	return mounts
+}

--- a/mounts.go
+++ b/mounts.go
@@ -1,50 +1,71 @@
 package testcontainers
 
 import (
-	"fmt"
-
 	"github.com/docker/docker/api/types/mount"
 )
 
+// BindMounter can optionally be implemented by mount sources
+// to support advanced scenarios based on mount.BindOptions
 type BindMounter interface {
 	GetBindOptions() *mount.BindOptions
 }
 
+// VolumeMounter can optionally be implemented by mount sources
+// to support advanced scenarios based on mount.VolumeOptions
 type VolumeMounter interface {
 	GetVolumeOptions() *mount.VolumeOptions
 }
 
+// TmpfsMounter can optionally be implemented by mount sources
+// to support advanced scenarios based on mount.TmpfsOptions
 type TmpfsMounter interface {
 	GetTmpfsOptions() *mount.TmpfsOptions
 }
 
+// ContainerMountSource is the base for all mount sources
 type ContainerMountSource interface {
-	fmt.Stringer
+	// Source will be used as Source field in the final mount
+	// this might either be a volume name, a host path or might be empty e.g. for Tmpfs
+	Source() string
+
+	// Type determines the final mount type
+	// possible options are limited by the Docker API
 	Type() mount.Type
 }
 
+// BindMountSource implements ContainerMountSource and represents a bind mount
+// Optionally mount.BindOptions might be added for advanced scenarios
 type BindMountSource struct {
 	*mount.BindOptions
+
+	// HostPath is the path mounted into the container
+	// the same host path might be mounted to multiple locations withing a single container
 	HostPath string
 }
 
-func (s BindMountSource) String() string {
+func (s BindMountSource) Source() string {
 	return s.HostPath
 }
 
 func (BindMountSource) Type() mount.Type {
 	return mount.TypeBind
 }
+
 func (s BindMountSource) GetBindOptions() *mount.BindOptions {
 	return s.BindOptions
 }
 
+// VolumeMountSource implements ContainerMountSource and represents a volume mount
+// Optionally mount.VolumeOptions might be added for advanced scenarios
 type VolumeMountSource struct {
 	*mount.VolumeOptions
+
+	// Name refers to the name of the volume to be mounted
+	// the same volume might be mounted to multiple locations within a single container
 	Name string
 }
 
-func (s VolumeMountSource) String() string {
+func (s VolumeMountSource) Source() string {
 	return s.Name
 }
 
@@ -56,11 +77,13 @@ func (s VolumeMountSource) GetVolumeOptions() *mount.VolumeOptions {
 	return s.VolumeOptions
 }
 
+// TmpfsMountSource implements ContainerMountSource and represents a TmpFS mount
+// Optionally mount.TmpfsOptions might be added for advanced scenarios
 type TmpfsMountSource struct {
 	*mount.TmpfsOptions
 }
 
-func (s TmpfsMountSource) String() string {
+func (s TmpfsMountSource) Source() string {
 	return ""
 }
 
@@ -72,12 +95,16 @@ func (s TmpfsMountSource) GetTmpfsOptions() *mount.TmpfsOptions {
 	return s.TmpfsOptions
 }
 
+// ContainerMountTarget represents the target path within a container where the mount will be available
+// Note that mount targets must be unique. It's not supported to mount different sources to the same target.
 type ContainerMountTarget string
 
-func (t ContainerMountTarget) String() string {
+func (t ContainerMountTarget) Target() string {
 	return string(t)
 }
 
+// BindMount returns a new ContainerMount with a BindMountSource as source
+// This is a convenience method to cover typical use cases.
 func BindMount(hostPath string, mountTarget ContainerMountTarget) ContainerMount {
 	return ContainerMount{
 		Source: BindMountSource{HostPath: hostPath},
@@ -85,6 +112,8 @@ func BindMount(hostPath string, mountTarget ContainerMountTarget) ContainerMount
 	}
 }
 
+// VolumeMount returns a new ContainerMount with a VolumeMountSource as source
+// This is a convenience method to cover typical use cases.
 func VolumeMount(volumeName string, mountTarget ContainerMountTarget) ContainerMount {
 	return ContainerMount{
 		Source: VolumeMountSource{Name: volumeName},
@@ -92,6 +121,7 @@ func VolumeMount(volumeName string, mountTarget ContainerMountTarget) ContainerM
 	}
 }
 
+// Mounts returns a ContainerMounts to support a more fluent API
 func Mounts(mounts ...ContainerMount) ContainerMounts {
 	return mounts
 }
@@ -106,8 +136,11 @@ type ContainerMount struct {
 	ReadOnly bool
 }
 
+// ContainerMounts represents a collection of mounts for a container
 type ContainerMounts []ContainerMount
 
+// PrepareMounts maps the given []ContainerMount to the corresponding
+// []mount.Mount for further processing
 func (m ContainerMounts) PrepareMounts() []mount.Mount {
 	mounts := make([]mount.Mount, 0, len(m))
 
@@ -115,9 +148,9 @@ func (m ContainerMounts) PrepareMounts() []mount.Mount {
 		m := m[idx]
 		containerMount := mount.Mount{
 			Type:     m.Source.Type(),
-			Source:   m.Source.String(),
+			Source:   m.Source.Source(),
 			ReadOnly: m.ReadOnly,
-			Target:   m.Target.String(),
+			Target:   m.Target.Target(),
 		}
 
 		switch typedMounter := m.Source.(type) {

--- a/mounts_test.go
+++ b/mounts_test.go
@@ -21,7 +21,7 @@ func TestContainerMounts_PrepareMounts(t *testing.T) {
 		},
 		{
 			name:   "Single bind mount",
-			mounts: ContainerMounts{{Source: BindMountSource{HostPath: "/var/lib/app/data"}, Target: "/data"}},
+			mounts: ContainerMounts{{Source: GenericBindMountSource{HostPath: "/var/lib/app/data"}, Target: "/data"}},
 			want: []mount.Mount{
 				{
 					Type:   mount.TypeBind,
@@ -32,7 +32,7 @@ func TestContainerMounts_PrepareMounts(t *testing.T) {
 		},
 		{
 			name:   "Single bind mount - read-only",
-			mounts: ContainerMounts{{Source: BindMountSource{HostPath: "/var/lib/app/data"}, Target: "/data", ReadOnly: true}},
+			mounts: ContainerMounts{{Source: GenericBindMountSource{HostPath: "/var/lib/app/data"}, Target: "/data", ReadOnly: true}},
 			want: []mount.Mount{
 				{
 					Type:     mount.TypeBind,
@@ -46,7 +46,7 @@ func TestContainerMounts_PrepareMounts(t *testing.T) {
 			name: "Single bind mount - with options",
 			mounts: ContainerMounts{
 				{
-					Source: BindMountSource{
+					Source: DockerBindMountSource{
 						HostPath: "/var/lib/app/data",
 						BindOptions: &mount.BindOptions{
 							Propagation: mount.PropagationPrivate,
@@ -68,7 +68,7 @@ func TestContainerMounts_PrepareMounts(t *testing.T) {
 		},
 		{
 			name:   "Single volume mount",
-			mounts: ContainerMounts{{Source: VolumeMountSource{Name: "app-data"}, Target: "/data"}},
+			mounts: ContainerMounts{{Source: GenericVolumeMountSource{Name: "app-data"}, Target: "/data"}},
 			want: []mount.Mount{
 				{
 					Type:   mount.TypeVolume,
@@ -79,7 +79,7 @@ func TestContainerMounts_PrepareMounts(t *testing.T) {
 		},
 		{
 			name:   "Single volume mount - read-only",
-			mounts: ContainerMounts{{Source: VolumeMountSource{Name: "app-data"}, Target: "/data", ReadOnly: true}},
+			mounts: ContainerMounts{{Source: GenericVolumeMountSource{Name: "app-data"}, Target: "/data", ReadOnly: true}},
 			want: []mount.Mount{
 				{
 					Type:     mount.TypeVolume,
@@ -93,7 +93,7 @@ func TestContainerMounts_PrepareMounts(t *testing.T) {
 			name: "Single volume mount - with options",
 			mounts: ContainerMounts{
 				{
-					Source: VolumeMountSource{
+					Source: DockerVolumeMountSource{
 						Name: "app-data",
 						VolumeOptions: &mount.VolumeOptions{
 							NoCopy: true,
@@ -122,7 +122,7 @@ func TestContainerMounts_PrepareMounts(t *testing.T) {
 
 		{
 			name:   "Single tmpfs mount",
-			mounts: ContainerMounts{{Source: TmpfsMountSource{}, Target: "/data"}},
+			mounts: ContainerMounts{{Source: GenericTmpfsMountSource{}, Target: "/data"}},
 			want: []mount.Mount{
 				{
 					Type:   mount.TypeTmpfs,
@@ -132,7 +132,7 @@ func TestContainerMounts_PrepareMounts(t *testing.T) {
 		},
 		{
 			name:   "Single volume mount - read-only",
-			mounts: ContainerMounts{{Source: TmpfsMountSource{}, Target: "/data", ReadOnly: true}},
+			mounts: ContainerMounts{{Source: GenericTmpfsMountSource{}, Target: "/data", ReadOnly: true}},
 			want: []mount.Mount{
 				{
 					Type:     mount.TypeTmpfs,
@@ -145,7 +145,7 @@ func TestContainerMounts_PrepareMounts(t *testing.T) {
 			name: "Single volume mount - with options",
 			mounts: ContainerMounts{
 				{
-					Source: TmpfsMountSource{
+					Source: DockerTmpfsMountSource{
 						TmpfsOptions: &mount.TmpfsOptions{
 							SizeBytes: 50 * 1024 * 1024,
 							Mode:      0o644,
@@ -170,7 +170,7 @@ func TestContainerMounts_PrepareMounts(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			assert.Equalf(t, tt.want, tt.mounts.PrepareMounts(), "PrepareMounts()")
+			assert.Equalf(t, tt.want, mapToDockerMounts(tt.mounts), "PrepareMounts()")
 		})
 	}
 }

--- a/mounts_test.go
+++ b/mounts_test.go
@@ -1,0 +1,176 @@
+package testcontainers
+
+import (
+	"testing"
+
+	"github.com/docker/docker/api/types/mount"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestContainerMounts_PrepareMounts(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		mounts ContainerMounts
+		want   []mount.Mount
+	}{
+		{
+			name:   "Empty",
+			mounts: nil,
+			want:   make([]mount.Mount, 0),
+		},
+		{
+			name:   "Single bind mount",
+			mounts: ContainerMounts{{Source: BindMountSource{HostPath: "/var/lib/app/data"}, Target: "/data"}},
+			want: []mount.Mount{
+				{
+					Type:   mount.TypeBind,
+					Source: "/var/lib/app/data",
+					Target: "/data",
+				},
+			},
+		},
+		{
+			name:   "Single bind mount - read-only",
+			mounts: ContainerMounts{{Source: BindMountSource{HostPath: "/var/lib/app/data"}, Target: "/data", ReadOnly: true}},
+			want: []mount.Mount{
+				{
+					Type:     mount.TypeBind,
+					Source:   "/var/lib/app/data",
+					Target:   "/data",
+					ReadOnly: true,
+				},
+			},
+		},
+		{
+			name: "Single bind mount - with options",
+			mounts: ContainerMounts{
+				{
+					Source: BindMountSource{
+						HostPath: "/var/lib/app/data",
+						BindOptions: &mount.BindOptions{
+							Propagation: mount.PropagationPrivate,
+						},
+					},
+					Target: "/data",
+				},
+			},
+			want: []mount.Mount{
+				{
+					Type:   mount.TypeBind,
+					Source: "/var/lib/app/data",
+					Target: "/data",
+					BindOptions: &mount.BindOptions{
+						Propagation: mount.PropagationPrivate,
+					},
+				},
+			},
+		},
+		{
+			name:   "Single volume mount",
+			mounts: ContainerMounts{{Source: VolumeMountSource{Name: "app-data"}, Target: "/data"}},
+			want: []mount.Mount{
+				{
+					Type:   mount.TypeVolume,
+					Source: "app-data",
+					Target: "/data",
+				},
+			},
+		},
+		{
+			name:   "Single volume mount - read-only",
+			mounts: ContainerMounts{{Source: VolumeMountSource{Name: "app-data"}, Target: "/data", ReadOnly: true}},
+			want: []mount.Mount{
+				{
+					Type:     mount.TypeVolume,
+					Source:   "app-data",
+					Target:   "/data",
+					ReadOnly: true,
+				},
+			},
+		},
+		{
+			name: "Single volume mount - with options",
+			mounts: ContainerMounts{
+				{
+					Source: VolumeMountSource{
+						Name: "app-data",
+						VolumeOptions: &mount.VolumeOptions{
+							NoCopy: true,
+							Labels: map[string]string{
+								"hello": "world",
+							},
+						},
+					},
+					Target: "/data",
+				},
+			},
+			want: []mount.Mount{
+				{
+					Type:   mount.TypeVolume,
+					Source: "app-data",
+					Target: "/data",
+					VolumeOptions: &mount.VolumeOptions{
+						NoCopy: true,
+						Labels: map[string]string{
+							"hello": "world",
+						},
+					},
+				},
+			},
+		},
+
+		{
+			name:   "Single tmpfs mount",
+			mounts: ContainerMounts{{Source: TmpfsMountSource{}, Target: "/data"}},
+			want: []mount.Mount{
+				{
+					Type:   mount.TypeTmpfs,
+					Target: "/data",
+				},
+			},
+		},
+		{
+			name:   "Single volume mount - read-only",
+			mounts: ContainerMounts{{Source: TmpfsMountSource{}, Target: "/data", ReadOnly: true}},
+			want: []mount.Mount{
+				{
+					Type:     mount.TypeTmpfs,
+					Target:   "/data",
+					ReadOnly: true,
+				},
+			},
+		},
+		{
+			name: "Single volume mount - with options",
+			mounts: ContainerMounts{
+				{
+					Source: TmpfsMountSource{
+						TmpfsOptions: &mount.TmpfsOptions{
+							SizeBytes: 50 * 1024 * 1024,
+							Mode:      0o644,
+						},
+					},
+					Target: "/data",
+				},
+			},
+			want: []mount.Mount{
+				{
+					Type:   mount.TypeTmpfs,
+					Target: "/data",
+					TmpfsOptions: &mount.TmpfsOptions{
+						SizeBytes: 50 * 1024 * 1024,
+						Mode:      0o644,
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equalf(t, tt.want, tt.mounts.PrepareMounts(), "PrepareMounts()")
+		})
+	}
+}

--- a/reaper.go
+++ b/reaper.go
@@ -63,9 +63,7 @@ func NewReaper(ctx context.Context, sessionID string, provider ReaperProvider, r
 			TestcontainerLabelIsReaper: "true",
 		},
 		SkipReaper: true,
-		BindMounts: map[string]string{
-			"/var/run/docker.sock": "/var/run/docker.sock",
-		},
+		Mounts:     Mounts(BindMount("/var/run/docker.sock", "/var/run/docker.sock")),
 		AutoRemove: true,
 		WaitingFor: wait.ForListeningPort(listeningPort),
 	}


### PR DESCRIPTION
# What does this PR do?

- introduce dedicated type for mounts
- introduce generic and Docker specific types for different mount sources (bind, volume, tmpfs)
- introduce convenience methods to support common mount scenarios
- add validation to avoid duplicate mount targets

# Why is it important?

The current map based data structure is somehow confusing. This change avoids confusion by introducing dedicated types for all components to get help by IDEs and the compiler.

# How to migrate

## Simple bind mount

```go
req := ContainerRequest {
    		//...
    		BindMounts: map[string]string{
		    "/var/run/docker.sock": "/var/run/docker.sock",
    		}
    		//...
}
```

becomes:

```go
req := ContainerRequest {
    		//...
    		Mounts: Mounts(BindMount("/var/run/docker.sock", "/var/run/docker.sock")),
    		//...
}
```

## Multiple mounts including a volume mount

```go
req := ContainerRequest {
    		//...
    		BindMounts: map[string]string {
		    // container path : host path
		    "/hello.sh", absPath
    		},
    		VolumeMounts: map[string]string {
		    // container path : volume name
		    "/data": volumeName
    		//...
}
```

becomes

```go
req := ContainerRequest {
    		//...
    		Mounts: Mounts(BindMount(absPath, "/hello.sh"), VolumeMount(volumeName, "/data")),
    		//...
}
```