### PR TITLE
#391: remember service map from all docker compose files

### DIFF
--- a/compose.go
+++ b/compose.go
@@ -198,7 +198,13 @@ func (dc *LocalDockerCompose) validate() error {
 			return err
 		}
 
-		dc.Services = c.Services
+		if dc.Services == nil {
+			dc.Services = c.Services
+		} else {
+			for k, v := range c.Services {
+				dc.Services[k] = v
+			}
+		}
 	}
 
 	return nil

--- a/compose_test.go
+++ b/compose_test.go
@@ -333,6 +333,7 @@ func TestLocalDockerComposeWithEnvironment(t *testing.T) {
 func TestLocalDockerComposeWithMultipleComposeFiles(t *testing.T) {
 	composeFiles := []string{
 		"testresources/docker-compose-simple.yml",
+		"testresources/docker-compose-postgres.yml",
 		"testresources/docker-compose-override.yml",
 	}
 
@@ -354,9 +355,10 @@ func TestLocalDockerComposeWithMultipleComposeFiles(t *testing.T) {
 		Invoke()
 	checkIfError(t, err)
 
-	assert.Equal(t, 2, len(compose.Services))
+	assert.Equal(t, 3, len(compose.Services))
 	assert.Contains(t, compose.Services, "nginx")
 	assert.Contains(t, compose.Services, "mysql")
+	assert.Contains(t, compose.Services, "postgres")
 
 	containerNameNginx := compose.Identifier + "_nginx_1"
 

--- a/testresources/docker-compose-postgres.yml
+++ b/testresources/docker-compose-postgres.yml
@@ -1,0 +1,6 @@
+version: '3'
+services:
+  postgres:
+    image: postgres:14
+    ports:
+     - "15432:5432"


### PR DESCRIPTION
Fixes #391 

I added a new docker-compose file with postgres image. Hope thats okay.
Without this fix, services field keeps map for only the last docker-compose file passed. But there could be service that are not overridden in the last file, and it should keep those values in the map.

