### PR TITLE
Logger per container instance

### DIFF
--- a/compose_test.go
+++ b/compose_test.go
@@ -95,7 +95,7 @@ func TestLocalDockerCompose(t *testing.T) {
 
 	identifier := strings.ToLower(uuid.New().String())
 
-	compose := NewLocalDockerCompose([]string{path}, identifier)
+	compose := NewLocalDockerCompose([]string{path}, identifier, WithLogger(TestLogger(t)))
 	destroyFn := func() {
 		err := compose.Down()
 		checkIfError(t, err)
@@ -112,7 +112,7 @@ func TestDockerComposeStrategyForInvalidService(t *testing.T) {
 
 	identifier := strings.ToLower(uuid.New().String())
 
-	compose := NewLocalDockerCompose([]string{path}, identifier)
+	compose := NewLocalDockerCompose([]string{path}, identifier, WithLogger(TestLogger(t)))
 	destroyFn := func() {
 		err := compose.Down()
 		checkIfError(t, err)
@@ -135,7 +135,7 @@ func TestDockerComposeWithWaitLogStrategy(t *testing.T) {
 
 	identifier := strings.ToLower(uuid.New().String())
 
-	compose := NewLocalDockerCompose([]string{path}, identifier)
+	compose := NewLocalDockerCompose([]string{path}, identifier, WithLogger(TestLogger(t)))
 	destroyFn := func() {
 		err := compose.Down()
 		checkIfError(t, err)
@@ -159,7 +159,7 @@ func TestDockerComposeWithWaitForService(t *testing.T) {
 
 	identifier := strings.ToLower(uuid.New().String())
 
-	compose := NewLocalDockerCompose([]string{path}, identifier)
+	compose := NewLocalDockerCompose([]string{path}, identifier, WithLogger(TestLogger(t)))
 	destroyFn := func() {
 		err := compose.Down()
 		checkIfError(t, err)
@@ -184,7 +184,7 @@ func TestDockerComposeWithWaitHTTPStrategy(t *testing.T) {
 
 	identifier := strings.ToLower(uuid.New().String())
 
-	compose := NewLocalDockerCompose([]string{path}, identifier)
+	compose := NewLocalDockerCompose([]string{path}, identifier, WithLogger(TestLogger(t)))
 	destroyFn := func() {
 		err := compose.Down()
 		checkIfError(t, err)
@@ -209,7 +209,7 @@ func TestDockerComposeWithWaitStrategy_NoExposedPorts(t *testing.T) {
 
 	identifier := strings.ToLower(uuid.New().String())
 
-	compose := NewLocalDockerCompose([]string{path}, identifier)
+	compose := NewLocalDockerCompose([]string{path}, identifier, WithLogger(TestLogger(t)))
 	destroyFn := func() {
 		err := compose.Down()
 		checkIfError(t, err)
@@ -231,7 +231,7 @@ func TestDockerComposeWithMultipleWaitStrategies(t *testing.T) {
 
 	identifier := strings.ToLower(uuid.New().String())
 
-	compose := NewLocalDockerCompose([]string{path}, identifier)
+	compose := NewLocalDockerCompose([]string{path}, identifier, WithLogger(TestLogger(t)))
 	destroyFn := func() {
 		err := compose.Down()
 		checkIfError(t, err)
@@ -255,7 +255,7 @@ func TestDockerComposeWithFailedStrategy(t *testing.T) {
 
 	identifier := strings.ToLower(uuid.New().String())
 
-	compose := NewLocalDockerCompose([]string{path}, identifier)
+	compose := NewLocalDockerCompose([]string{path}, identifier, WithLogger(TestLogger(t)))
 	destroyFn := func() {
 		err := compose.Down()
 		checkIfError(t, err)
@@ -282,7 +282,7 @@ func TestLocalDockerComposeComplex(t *testing.T) {
 
 	identifier := strings.ToLower(uuid.New().String())
 
-	compose := NewLocalDockerCompose([]string{path}, identifier)
+	compose := NewLocalDockerCompose([]string{path}, identifier, WithLogger(TestLogger(t)))
 	destroyFn := func() {
 		err := compose.Down()
 		checkIfError(t, err)
@@ -304,7 +304,7 @@ func TestLocalDockerComposeWithEnvironment(t *testing.T) {
 
 	identifier := strings.ToLower(uuid.New().String())
 
-	compose := NewLocalDockerCompose([]string{path}, identifier)
+	compose := NewLocalDockerCompose([]string{path}, identifier, WithLogger(TestLogger(t)))
 	destroyFn := func() {
 		err := compose.Down()
 		checkIfError(t, err)
@@ -340,7 +340,7 @@ func TestLocalDockerComposeWithMultipleComposeFiles(t *testing.T) {
 
 	identifier := strings.ToLower(uuid.New().String())
 
-	compose := NewLocalDockerCompose(composeFiles, identifier)
+	compose := NewLocalDockerCompose(composeFiles, identifier, WithLogger(TestLogger(t)))
 	destroyFn := func() {
 		err := compose.Down()
 		checkIfError(t, err)
@@ -376,7 +376,7 @@ func TestLocalDockerComposeWithVolume(t *testing.T) {
 
 	identifier := strings.ToLower(uuid.New().String())
 
-	compose := NewLocalDockerCompose([]string{path}, identifier)
+	compose := NewLocalDockerCompose([]string{path}, identifier, WithLogger(TestLogger(t)))
 	destroyFn := func() {
 		err := compose.Down()
 		checkIfError(t, err)

--- a/docker_test.go
+++ b/docker_test.go
@@ -279,7 +279,7 @@ func TestContainerReturnItsContainerID(t *testing.T) {
 func TestContainerStartsWithoutTheReaper(t *testing.T) {
 	t.Skip("need to use the sessionID")
 	ctx := context.Background()
-	client, err := client.NewEnvClient()
+	client, err := client.NewClientWithOpts(client.FromEnv)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -315,7 +315,7 @@ func TestContainerStartsWithoutTheReaper(t *testing.T) {
 
 func TestContainerStartsWithTheReaper(t *testing.T) {
 	ctx := context.Background()
-	client, err := client.NewEnvClient()
+	client, err := client.NewClientWithOpts(client.FromEnv)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -350,7 +350,7 @@ func TestContainerStartsWithTheReaper(t *testing.T) {
 
 func TestContainerTerminationResetsState(t *testing.T) {
 	ctx := context.Background()
-	client, err := client.NewEnvClient()
+	client, err := client.NewClientWithOpts(client.FromEnv)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -384,7 +384,7 @@ func TestContainerTerminationResetsState(t *testing.T) {
 
 func TestContainerTerminationWithReaper(t *testing.T) {
 	ctx := context.Background()
-	client, err := client.NewEnvClient()
+	client, err := client.NewClientWithOpts(client.FromEnv)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -421,7 +421,7 @@ func TestContainerTerminationWithReaper(t *testing.T) {
 
 func TestContainerTerminationWithoutReaper(t *testing.T) {
 	ctx := context.Background()
-	client, err := client.NewEnvClient()
+	client, err := client.NewClientWithOpts(client.FromEnv)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1754,7 +1754,7 @@ func TestContainerWithNoUserID(t *testing.T) {
 func TestGetGatewayIP(t *testing.T) {
 	// When using docker-compose with DinD mode, and using host port or http wait strategy
 	// It's need to invoke GetGatewayIP for get the host
-	provider, err := NewDockerProvider()
+	provider, err := NewDockerProvider(WithLogger(TestLogger(t)))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/generic.go
+++ b/generic.go
@@ -10,6 +10,7 @@ type GenericContainerRequest struct {
 	ContainerRequest              // embedded request for provider
 	Started          bool         // whether to auto-start the container
 	ProviderType     ProviderType // which provider to use, Docker if empty
+	Logger           Logging      // provide a container specific Logging - use default global logger if empty
 }
 
 // GenericNetworkRequest represents parameters to a generic network
@@ -34,7 +35,11 @@ func GenericNetwork(ctx context.Context, req GenericNetworkRequest) (Network, er
 
 // GenericContainer creates a generic container with parameters
 func GenericContainer(ctx context.Context, req GenericContainerRequest) (Container, error) {
-	provider, err := req.ProviderType.GetProvider()
+	logging := req.Logger
+	if logging == nil {
+		logging = Logger
+	}
+	provider, err := req.ProviderType.GetProvider(WithLogger(logging))
 	if err != nil {
 		return nil, err
 	}

--- a/logconsumer_test.go
+++ b/logconsumer_test.go
@@ -205,7 +205,7 @@ func TestContainerLogWithErrClosed(t *testing.T) {
 	}
 	defer dind.Terminate(ctx)
 
-	remoteDocker, err := dind.Endpoint(ctx, "tcp")
+	remoteDocker, err := dind.Endpoint(ctx, "2375/tcp")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -217,7 +217,8 @@ func TestContainerLogWithErrClosed(t *testing.T) {
 	defer client.Close()
 
 	client.NegotiateAPIVersion(ctx)
-	provider := &DockerProvider{client: client}
+
+	provider := &DockerProvider{client: client, DockerProviderOptions: &DockerProviderOptions{GenericProviderOptions: &GenericProviderOptions{Logger: TestLogger(t)}}}
 
 	nginx, err := provider.CreateContainer(ctx, ContainerRequest{Image: "nginx", ExposedPorts: []string{"80/tcp"}})
 	if err != nil {

--- a/logger.go
+++ b/logger.go
@@ -14,8 +14,36 @@ type Logging interface {
 	Printf(format string, v ...interface{})
 }
 
+// TestLogger returns a Logging implementation for testing.TB
+// This way logs from testcontainers are part of the test output of a test suite or test case
 func TestLogger(tb testing.TB) Logging {
+	tb.Helper()
 	return testLogger{TB: tb}
+}
+
+// WithLogger is a generic option that implements GenericProviderOption, DockerProviderOption and LocalDockerComposeOption
+// It replaces the global Logging implementation with a user defined one e.g. to aggregate logs from testcontainers
+// with the logs of specific test case
+func WithLogger(logger Logging) LoggerOption {
+	return LoggerOption{
+		logger: logger,
+	}
+}
+
+type LoggerOption struct {
+	logger Logging
+}
+
+func (o LoggerOption) ApplyGenericTo(opts *GenericProviderOptions) {
+	opts.Logger = o.logger
+}
+
+func (o LoggerOption) ApplyDockerTo(opts *DockerProviderOptions) {
+	opts.Logger = o.logger
+}
+
+func (o LoggerOption) ApplyToLocalCompose(opts *LocalDockerComposeOptions) {
+	opts.Logger = o.logger
 }
 
 type testLogger struct {
@@ -23,5 +51,6 @@ type testLogger struct {
 }
 
 func (t testLogger) Printf(format string, v ...interface{}) {
+	t.Helper()
 	t.Logf(format, v...)
 }

--- a/logger.go
+++ b/logger.go
@@ -3,6 +3,7 @@ package testcontainers
 import (
 	"log"
 	"os"
+	"testing"
 )
 
 // Logger is the default log instance
@@ -11,4 +12,16 @@ var Logger Logging = log.New(os.Stderr, "", log.LstdFlags)
 // Logging defines the Logger interface
 type Logging interface {
 	Printf(format string, v ...interface{})
+}
+
+func TestLogger(tb testing.TB) Logging {
+	return testLogger{TB: tb}
+}
+
+type testLogger struct {
+	testing.TB
+}
+
+func (t testLogger) Printf(format string, v ...interface{}) {
+	t.Logf(format, v...)
 }


### PR DESCRIPTION
# What does this PR do?

Follow up PR for #385 to configure logging instance per container.
To achieve this, it adds variadic options to multiple constructors to propagate the logger finally to the `Container` instance.

## Affected functions

- `NewLocalDockerCompose(...)`
- `GetProvider(...)`
- `NewDockerProvider(...)`

## Options pattern

The idea is that there's a `GenericProviderOption` interface to act exactly as the name intends: all providers should support these options. Options only supported by Docker can be added as `DockerProviderOption`.
There's a converter function `Generic2DockerOptions` to wrap `GenericProviderOption` as `DockerProviderOption` for `NewDockerProvider`.

Everywhere a logger option can be applied the default is the global logger which can be overridden.

The `WithLogger` function takes a `Logger` and returns a option instance that can be used for all option types:

- `GenericProviderOption`
- `DockerProviderOption`
- `LocalDockerComposeOption`

## Test logger

The `TestLogger` function takes a `testing.TB` and wraps it to a `Logger` instance allowing to capture all logs from a container instance as output of a specific test case.

# Why is it important?

This way logs from the container instance can be aggregated with the rest of the test output they were created for.