### PR TITLE
chore(ci): run tests for more recent Go versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.14.x, 1.15.x, 1.x]
+        go-version: [1.14.x, 1.15.x, 1.16.x, 1.17.x, 1.x]
         platform: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.platform }}
     steps:


### PR DESCRIPTION
## What does this PR do?
It adds Go 1.16 and 1.17 to the CI matrix to run the tests

## Why is it important?
Go versions coverage

## Other concerns
Should we retire 1.14 (or any other) from the matrix? Which versions should we be compatible with?