### PR TITLE
Expose HostConfig Resources via ContainerRequest

### DIFF
--- a/container.go
+++ b/container.go
@@ -46,7 +46,7 @@ type Container interface {
 	StartLogProducer(context.Context) error
 	StopLogProducer() error
 	Name(context.Context) (string, error)                        // get container name
-	State(context.Context) (*types.ContainerState, error)        //returns container's running state
+	State(context.Context) (*types.ContainerState, error)        // returns container's running state
 	Networks(context.Context) ([]string, error)                  // get container networks
 	NetworkAliases(context.Context) (map[string][]string, error) // get container network aliases for a network
 	Exec(ctx context.Context, cmd []string) (int, error)
@@ -92,11 +92,12 @@ type ContainerRequest struct {
 	Privileged      bool                // for starting privileged container
 	Networks        []string            // for specifying network names
 	NetworkAliases  map[string][]string // for specifying network aliases
-	User            string              // for specifying uid:gid
-	SkipReaper      bool                // indicates whether we skip setting up a reaper for this
-	ReaperImage     string              // alternative reaper image
-	AutoRemove      bool                // if set to true, the container will be removed from the host when stopped
 	NetworkMode     container.NetworkMode
+	Resources       container.Resources
+	User            string // for specifying uid:gid
+	SkipReaper      bool   // indicates whether we skip setting up a reaper for this
+	ReaperImage     string // alternative reaper image
+	AutoRemove      bool   // if set to true, the container will be removed from the host when stopped
 	AlwaysPullImage bool   // Always pull image
 	ImagePlatform   string // ImagePlatform describes the platform which the image runs on.
 }

--- a/docker.go
+++ b/docker.go
@@ -28,8 +28,8 @@ import (
 	"github.com/google/uuid"
 	"github.com/magiconair/properties"
 	"github.com/moby/term"
-
 	specs "github.com/opencontainers/image-spec/specs-go/v1"
+
 	"github.com/testcontainers/testcontainers-go/wait"
 )
 
@@ -363,8 +363,8 @@ func (c *DockerContainer) CopyFileFromContainer(ctx context.Context, filePath st
 	}
 	tarReader := tar.NewReader(r)
 
-	//if we got here we have exactly one file in the TAR-stream
-	//so we advance the index by one so the next call to Read will start reading it
+	// if we got here we have exactly one file in the TAR-stream
+	// so we advance the index by one so the next call to Read will start reading it
 	_, err = tarReader.Next()
 	if err != nil {
 		return nil, err
@@ -822,6 +822,7 @@ func (p *DockerProvider) CreateContainer(ctx context.Context, req ContainerReque
 		AutoRemove:   req.AutoRemove,
 		Privileged:   req.Privileged,
 		NetworkMode:  req.NetworkMode,
+		Resources:    req.Resources,
 	}
 
 	endpointConfigs := map[string]*network.EndpointSettings{}


### PR DESCRIPTION
## Description

I have a use case where I need to set the `ulimits` for a container

```yaml
version: "3"
services:
  elasticsearch:
    container_name: elasticsearch
    image: docker.elastic.co/elasticsearch/elasticsearch:7.15.1
    ports:
      - '9200:9200'
    ulimits:
      memlock:
        soft: -1
        hard: -1
      nofile:
        soft: 65536
        hard: 65536
    environment:
      - xpack.security.enabled=false
      - discovery.type=single-node
      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
    healthcheck:
      test: [ "CMD-SHELL", "curl --silent --fail localhost:9200/_cluster/health || exit 1" ]
      interval: 30s
      timeout: 30s
      retries: 3
```

I see we don't expose that configuration so it's impossible to achieve the same thing with testcontainers

## Solution

Expose HostConfig Resources via ContainerRequest