### PR TITLE
Remove intermediate containers when building from Dockerfile

### DIFF
--- a/docker.go
+++ b/docker.go
@@ -653,10 +653,10 @@ func (p *DockerProvider) BuildImage(ctx context.Context, img ImageBuildInfo) (st
 	}
 
 	buildOptions := types.ImageBuildOptions{
-		BuildArgs:  img.GetBuildArgs(),
-		Dockerfile: img.GetDockerfile(),
-		Context:    buildContext,
-		Tags:       []string{repoTag},
+		BuildArgs:   img.GetBuildArgs(),
+		Dockerfile:  img.GetDockerfile(),
+		Context:     buildContext,
+		Tags:        []string{repoTag},
 		Remove:      true,
 		ForceRemove: true,
 	}

--- a/docker.go
+++ b/docker.go
@@ -657,6 +657,8 @@ func (p *DockerProvider) BuildImage(ctx context.Context, img ImageBuildInfo) (st
 		Dockerfile: img.GetDockerfile(),
 		Context:    buildContext,
 		Tags:       []string{repoTag},
+		Remove:      true,
+		ForceRemove: true,
 	}
 
 	resp, err := p.client.ImageBuild(ctx, buildContext, buildOptions)


### PR DESCRIPTION
This is to prevent these intermediate containers from piling up when images are getting built from a Dockerfile on a local machine.

Related documentation: https://docs.docker.com/engine/reference/commandline/image_build/#options

![image](https://user-images.githubusercontent.com/6256480/153751094-1e0aa955-cf9a-4f76-9673-561807a6c615.png)
