### PR TITLE
add import statements to quick start

### DIFF
--- a/docs/quickstart/gotest.md
+++ b/docs/quickstart/gotest.md
@@ -16,6 +16,11 @@ go get github.com/testcontainers/testcontainers-go
 ## 2. Spin up Redis
 
 ```go
+import (
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/wait"
+)
+
 func TestWithRedis(t *testing.T) {
 	ctx := context.Background()
 	req := testcontainers.ContainerRequest{


### PR DESCRIPTION
This allows users to easily copy and paste the test case example.