### PR TITLE
Improve Podman compatibility

### DIFF
--- a/container.go
+++ b/container.go
@@ -108,7 +108,8 @@ type (
 
 	// GenericProviderOptions defines options applicable to all providers
 	GenericProviderOptions struct {
-		Logger Logging
+		Logger         Logging
+		DefaultNetwork string
 	}
 
 	// GenericProviderOption defines a common interface to modify GenericProviderOptions

--- a/docker.go
+++ b/docker.go
@@ -323,8 +323,10 @@ func (c *DockerContainer) NetworkAliases(ctx context.Context) (map[string][]stri
 func (c *DockerContainer) Exec(ctx context.Context, cmd []string) (int, error) {
 	cli := c.provider.client
 	response, err := cli.ContainerExecCreate(ctx, c.ID, types.ExecConfig{
-		Cmd:    cmd,
-		Detach: false,
+		Cmd:          cmd,
+		Detach:       false,
+		AttachStderr: true,
+		AttachStdout: true,
 	})
 	if err != nil {
 		return 0, err
@@ -527,9 +529,9 @@ func (n *DockerNetwork) Remove(ctx context.Context) error {
 // DockerProvider implements the ContainerProvider interface
 type DockerProvider struct {
 	*DockerProviderOptions
-	client         *client.Client
-	hostCache      string
-	defaultNetwork string // default container network
+	client    *client.Client
+	host      string
+	hostCache string
 }
 
 var _ ContainerProvider = (*DockerProvider)(nil)
@@ -604,6 +606,10 @@ func NewDockerProvider(provOpts ...DockerProviderOption) (*DockerProvider, error
 
 			opts = append(opts, client.WithTLSClientConfig(cacertPath, certPath, keyPath))
 		}
+	} else if dockerHostEnv := os.Getenv("DOCKER_HOST"); dockerHostEnv != "" {
+		host = dockerHostEnv
+	} else {
+		host = "unix:///var/run/docker.sock"
 	}
 
 	c, err := client.NewClientWithOpts(opts...)
@@ -623,6 +629,7 @@ func NewDockerProvider(provOpts ...DockerProviderOption) (*DockerProvider, error
 	c.NegotiateAPIVersion(context.Background())
 	p := &DockerProvider{
 		DockerProviderOptions: o,
+		host:                  host,
 		client:                c,
 	}
 
@@ -705,24 +712,26 @@ func (p *DockerProvider) CreateContainer(ctx context.Context, req ContainerReque
 
 	// Make sure that bridge network exists
 	// In case it is disabled we will create reaper_default network
-	p.defaultNetwork, err = getDefaultNetwork(ctx, p.client)
-	if err != nil {
-		return nil, err
+	if p.DefaultNetwork == "" {
+		p.DefaultNetwork, err = getDefaultNetwork(ctx, p.client)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	// If default network is not bridge make sure it is attached to the request
 	// as container won't be attached to it automatically
-	if p.defaultNetwork != Bridge {
+	if p.DefaultNetwork != Bridge {
 		isAttached := false
 		for _, net := range req.Networks {
-			if net == p.defaultNetwork {
+			if net == p.DefaultNetwork {
 				isAttached = true
 				break
 			}
 		}
 
 		if !isAttached {
-			req.Networks = append(req.Networks, p.defaultNetwork)
+			req.Networks = append(req.Networks, p.DefaultNetwork)
 		}
 	}
 
@@ -744,7 +753,7 @@ func (p *DockerProvider) CreateContainer(ctx context.Context, req ContainerReque
 
 	var termSignal chan bool
 	if !req.SkipReaper {
-		r, err := NewReaper(ctx, sessionID.String(), p, req.ReaperImage)
+		r, err := NewReaper(context.WithValue(ctx, dockerHostContextKey, p.host), sessionID.String(), p, req.ReaperImage)
 		if err != nil {
 			return nil, fmt.Errorf("%w: creating reaper failed", err)
 		}
@@ -828,6 +837,9 @@ func (p *DockerProvider) CreateContainer(ctx context.Context, req ContainerReque
 
 	// prepare mounts
 	mounts := mapToDockerMounts(req.Mounts)
+	if req.NetworkMode == "" {
+		req.NetworkMode = Bridge
+	}
 
 	hostConfig := &container.HostConfig{
 		PortBindings: exposedPortMap,
@@ -1001,7 +1013,11 @@ func (p *DockerProvider) CreateNetwork(ctx context.Context, req NetworkRequest) 
 
 	// Make sure that bridge network exists
 	// In case it is disabled we will create reaper_default network
-	p.defaultNetwork, err = getDefaultNetwork(ctx, p.client)
+	if p.DefaultNetwork == "" {
+		if p.DefaultNetwork, err = getDefaultNetwork(ctx, p.client); err != nil {
+			return nil, err
+		}
+	}
 
 	if req.Labels == nil {
 		req.Labels = make(map[string]string)
@@ -1020,7 +1036,7 @@ func (p *DockerProvider) CreateNetwork(ctx context.Context, req NetworkRequest) 
 
 	var termSignal chan bool
 	if !req.SkipReaper {
-		r, err := NewReaper(ctx, sessionID.String(), p, req.ReaperImage)
+		r, err := NewReaper(context.WithValue(ctx, dockerHostContextKey, p.host), sessionID.String(), p, req.ReaperImage)
 		if err != nil {
 			return nil, fmt.Errorf("%w: creating network reaper failed", err)
 		}
@@ -1065,14 +1081,14 @@ func (p *DockerProvider) GetNetwork(ctx context.Context, req NetworkRequest) (ty
 
 func (p *DockerProvider) GetGatewayIP(ctx context.Context) (string, error) {
 	// Use a default network as defined in the DockerProvider
-	if p.defaultNetwork == "" {
+	if p.DefaultNetwork == "" {
 		var err error
-		p.defaultNetwork, err = getDefaultNetwork(ctx, p.client)
+		p.DefaultNetwork, err = getDefaultNetwork(ctx, p.client)
 		if err != nil {
 			return "", err
 		}
 	}
-	nw, err := p.GetNetwork(ctx, NetworkRequest{Name: p.defaultNetwork})
+	nw, err := p.GetNetwork(ctx, NetworkRequest{Name: p.DefaultNetwork})
 	if err != nil {
 		return "", err
 	}
@@ -1112,7 +1128,7 @@ func getDefaultGatewayIP() (string, error) {
 	if len(ip) == 0 {
 		return "", errors.New("Failed to parse default gateway IP")
 	}
-	return string(ip), nil
+	return ip, nil
 }
 
 func getDefaultNetwork(ctx context.Context, cli *client.Client) (string, error) {

--- a/docker_test.go
+++ b/docker_test.go
@@ -41,6 +41,7 @@ import (
 )
 
 func TestContainerAttachedToNewNetwork(t *testing.T) {
+	t.Parallel()
 	networkName := "new-network"
 	ctx := context.Background()
 	gcr := GenericContainerRequest{
@@ -108,6 +109,7 @@ func TestContainerAttachedToNewNetwork(t *testing.T) {
 }
 
 func TestContainerWithHostNetworkOptions(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	gcr := GenericContainerRequest{
 		ContainerRequest: ContainerRequest{
@@ -147,6 +149,7 @@ func TestContainerWithHostNetworkOptions(t *testing.T) {
 }
 
 func TestContainerWithNetworkModeAndNetworkTogether(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	gcr := GenericContainerRequest{
 		ContainerRequest: ContainerRequest{
@@ -166,6 +169,7 @@ func TestContainerWithNetworkModeAndNetworkTogether(t *testing.T) {
 }
 
 func TestContainerWithHostNetworkOptionsAndWaitStrategy(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	gcr := GenericContainerRequest{
 		ContainerRequest: ContainerRequest{
@@ -196,6 +200,7 @@ func TestContainerWithHostNetworkOptionsAndWaitStrategy(t *testing.T) {
 }
 
 func TestContainerWithHostNetworkAndEndpoint(t *testing.T) {
+	t.Parallel()
 	nginxPort := "80/tcp"
 	ctx := context.Background()
 	gcr := GenericContainerRequest{
@@ -228,6 +233,7 @@ func TestContainerWithHostNetworkAndEndpoint(t *testing.T) {
 }
 
 func TestContainerWithHostNetworkAndPortEndpoint(t *testing.T) {
+	t.Parallel()
 	nginxPort := "80/tcp"
 	ctx := context.Background()
 	gcr := GenericContainerRequest{
@@ -260,6 +266,7 @@ func TestContainerWithHostNetworkAndPortEndpoint(t *testing.T) {
 }
 
 func TestContainerReturnItsContainerID(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	nginxA, err := GenericContainer(ctx, GenericContainerRequest{
 		ContainerRequest: ContainerRequest{
@@ -279,19 +286,19 @@ func TestContainerReturnItsContainerID(t *testing.T) {
 }
 
 func TestContainerStartsWithoutTheReaper(t *testing.T) {
-	t.Skip("need to use the sessionID")
+	t.Parallel()
 	ctx := context.Background()
 	client, err := client.NewClientWithOpts(client.FromEnv)
 	if err != nil {
 		t.Fatal(err)
 	}
 	client.NegotiateAPIVersion(ctx)
-	_, err = GenericContainer(ctx, GenericContainerRequest{
+	var container Container
+	container, err = GenericContainer(ctx, GenericContainerRequest{
 		ContainerRequest: ContainerRequest{
 			Image: "nginx",
 			ExposedPorts: []string{
 				"80/tcp",
-				"gotest.tools/assert",
 			},
 			SkipReaper: true,
 		},
@@ -300,13 +307,9 @@ func TestContainerStartsWithoutTheReaper(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	filtersJSON := fmt.Sprintf(`{"label":{"%s":true}}`, TestcontainerLabelIsReaper)
-	f, err := filters.FromJSON(filtersJSON)
-	if err != nil {
-		t.Fatal(err)
-	}
+
 	resp, err := client.ContainerList(ctx, types.ContainerListOptions{
-		Filters: f,
+		Filters: filters.NewArgs(filters.Arg("label", fmt.Sprintf("%s=%s", TestcontainerLabelSessionID, container.SessionID()))),
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -317,6 +320,7 @@ func TestContainerStartsWithoutTheReaper(t *testing.T) {
 }
 
 func TestContainerStartsWithTheReaper(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	client, err := client.NewClientWithOpts(client.FromEnv)
 	if err != nil {
@@ -352,6 +356,7 @@ func TestContainerStartsWithTheReaper(t *testing.T) {
 }
 
 func TestContainerTerminationResetsState(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	client, err := client.NewClientWithOpts(client.FromEnv)
 	if err != nil {
@@ -386,6 +391,7 @@ func TestContainerTerminationResetsState(t *testing.T) {
 }
 
 func TestContainerTerminationWithReaper(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	client, err := client.NewClientWithOpts(client.FromEnv)
 	if err != nil {
@@ -423,6 +429,7 @@ func TestContainerTerminationWithReaper(t *testing.T) {
 }
 
 func TestContainerTerminationWithoutReaper(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	client, err := client.NewClientWithOpts(client.FromEnv)
 	if err != nil {
@@ -461,7 +468,9 @@ func TestContainerTerminationWithoutReaper(t *testing.T) {
 }
 
 func TestContainerTerminationRemovesDockerImage(t *testing.T) {
+	t.Parallel()
 	t.Run("if not built from Dockerfile", func(t *testing.T) {
+		t.Parallel()
 		ctx := context.Background()
 		client, err := client.NewClientWithOpts(client.FromEnv)
 		if err != nil {
@@ -492,6 +501,7 @@ func TestContainerTerminationRemovesDockerImage(t *testing.T) {
 	})
 
 	t.Run("if built from Dockerfile", func(t *testing.T) {
+		t.Parallel()
 		ctx := context.Background()
 		client, err := client.NewClientWithOpts(client.FromEnv)
 		if err != nil {
@@ -531,6 +541,7 @@ func TestContainerTerminationRemovesDockerImage(t *testing.T) {
 }
 
 func TestTwoContainersExposingTheSamePort(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	nginxA, err := GenericContainer(ctx, GenericContainerRequest{
 		ContainerRequest: ContainerRequest{
@@ -606,6 +617,7 @@ func TestTwoContainersExposingTheSamePort(t *testing.T) {
 }
 
 func TestContainerCreation(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 
 	nginxPort := "80/tcp"
@@ -664,6 +676,7 @@ func TestContainerCreation(t *testing.T) {
 }
 
 func TestContainerCreationWithName(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 
 	creationName := fmt.Sprintf("%s_%d", "test_container", time.Now().Unix())
@@ -726,6 +739,7 @@ func TestContainerCreationWithName(t *testing.T) {
 }
 
 func TestContainerCreationAndWaitForListeningPortLongEnough(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 
 	nginxPort := "80/tcp"
@@ -763,7 +777,7 @@ func TestContainerCreationAndWaitForListeningPortLongEnough(t *testing.T) {
 }
 
 func TestContainerCreationTimesOut(t *testing.T) {
-	t.Skip("Wait needs to be fixed")
+	t.Parallel()
 	ctx := context.Background()
 	// delayed-nginx will wait 2s before opening port
 	nginxC, err := GenericContainer(ctx, GenericContainerRequest{
@@ -786,7 +800,7 @@ func TestContainerCreationTimesOut(t *testing.T) {
 }
 
 func TestContainerRespondsWithHttp200ForIndex(t *testing.T) {
-	t.Skip("Wait needs to be fixed")
+	t.Parallel()
 	ctx := context.Background()
 
 	nginxPort := "80/tcp"
@@ -825,7 +839,7 @@ func TestContainerRespondsWithHttp200ForIndex(t *testing.T) {
 }
 
 func TestContainerCreationTimesOutWithHttp(t *testing.T) {
-	t.Skip("Wait needs to be fixed")
+	t.Parallel()
 	ctx := context.Background()
 	// delayed-nginx will wait 2s before opening port
 	nginxC, err := GenericContainer(ctx, GenericContainerRequest{
@@ -851,6 +865,7 @@ func TestContainerCreationTimesOutWithHttp(t *testing.T) {
 }
 
 func TestContainerCreationWaitsForLogContextTimeout(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	req := ContainerRequest{
 		Image:        "mysql:latest",
@@ -872,6 +887,7 @@ func TestContainerCreationWaitsForLogContextTimeout(t *testing.T) {
 }
 
 func TestContainerCreationWaitsForLog(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	req := ContainerRequest{
 		Image:        "mysql:latest",
@@ -917,6 +933,7 @@ func TestContainerCreationWaitsForLog(t *testing.T) {
 }
 
 func Test_BuildContainerFromDockerfile(t *testing.T) {
+	t.Parallel()
 	t.Log("getting context")
 	context := context.Background()
 	t.Log("got context, creating container request")
@@ -973,6 +990,7 @@ func Test_BuildContainerFromDockerfile(t *testing.T) {
 }
 
 func Test_BuildContainerFromDockerfileWithBuildArgs(t *testing.T) {
+	t.Parallel()
 	t.Log("getting ctx")
 	ctx := context.Background()
 
@@ -1030,6 +1048,7 @@ func Test_BuildContainerFromDockerfileWithBuildArgs(t *testing.T) {
 }
 
 func Test_BuildContainerFromDockerfileWithBuildLog(t *testing.T) {
+	t.Parallel()
 	rescueStdout := os.Stderr
 	r, w, _ := os.Pipe()
 	os.Stderr = w
@@ -1076,6 +1095,7 @@ func Test_BuildContainerFromDockerfileWithBuildLog(t *testing.T) {
 }
 
 func TestContainerCreationWaitsForLogAndPortContextTimeout(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	req := ContainerRequest{
 		Image:        "mysql:latest",
@@ -1100,6 +1120,7 @@ func TestContainerCreationWaitsForLogAndPortContextTimeout(t *testing.T) {
 }
 
 func TestContainerCreationWaitingForHostPort(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	req := ContainerRequest{
 		Image:        "nginx:1.17.6",
@@ -1123,6 +1144,7 @@ func TestContainerCreationWaitingForHostPort(t *testing.T) {
 }
 
 func TestContainerCreationWaitingForHostPortWithoutBashThrowsAnError(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	req := ContainerRequest{
 		Image:        "nginx:1.17.6-alpine",
@@ -1146,6 +1168,7 @@ func TestContainerCreationWaitingForHostPortWithoutBashThrowsAnError(t *testing.
 }
 
 func TestContainerCreationWaitsForLogAndPort(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	req := ContainerRequest{
 		Image:        "mysql:latest",
@@ -1201,6 +1224,7 @@ func TestCMD(t *testing.T) {
 		and it will be run when we run the container
 	*/
 
+	t.Parallel()
 	ctx := context.Background()
 
 	req := ContainerRequest{
@@ -1230,6 +1254,7 @@ func TestEntrypoint(t *testing.T) {
 		and it will be run when we run the container
 	*/
 
+	t.Parallel()
 	ctx := context.Background()
 
 	req := ContainerRequest{
@@ -1423,6 +1448,7 @@ func ExampleContainer_MappedPort() {
 }
 
 func TestContainerCreationWithBindAndVolume(t *testing.T) {
+	t.Parallel()
 	absPath, err := filepath.Abs("./testresources/hello.sh")
 	if err != nil {
 		t.Fatal(err)
@@ -1475,6 +1501,7 @@ func TestContainerCreationWithBindAndVolume(t *testing.T) {
 }
 
 func TestContainerWithTmpFs(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	req := ContainerRequest{
 		Image: "busybox",
@@ -1525,7 +1552,9 @@ func TestContainerWithTmpFs(t *testing.T) {
 }
 
 func TestContainerNonExistentImage(t *testing.T) {
+	t.Parallel()
 	t.Run("if the image not found don't propagate the error", func(t *testing.T) {
+		t.Parallel()
 		_, err := GenericContainer(context.Background(), GenericContainerRequest{
 			ContainerRequest: ContainerRequest{
 				Image:      "postgres:nonexistent-version",
@@ -1541,6 +1570,7 @@ func TestContainerNonExistentImage(t *testing.T) {
 	})
 
 	t.Run("the context cancellation is propagated to container creation", func(t *testing.T) {
+		t.Parallel()
 		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 		defer cancel()
 		_, err := GenericContainer(ctx, GenericContainerRequest{
@@ -1558,7 +1588,9 @@ func TestContainerNonExistentImage(t *testing.T) {
 }
 
 func TestContainerCustomPlatformImage(t *testing.T) {
+	t.Parallel()
 	t.Run("error with a non-existent platform", func(t *testing.T) {
+		t.Parallel()
 		nonExistentPlatform := "windows/arm12"
 		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 		defer cancel()
@@ -1581,6 +1613,7 @@ func TestContainerCustomPlatformImage(t *testing.T) {
 	})
 
 	t.Run("specific platform should be propagated", func(t *testing.T) {
+		t.Parallel()
 		ctx := context.Background()
 
 		c, err := GenericContainer(ctx, GenericContainerRequest{
@@ -1615,6 +1648,7 @@ func TestContainerCustomPlatformImage(t *testing.T) {
 }
 
 func TestContainerWithCustomHostname(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	name := fmt.Sprintf("some-nginx-%s-%d", t.Name(), rand.Int())
 	hostname := fmt.Sprintf("my-nginx-%s-%d", t.Name(), rand.Int())
@@ -1664,6 +1698,7 @@ func readHostname(t *testing.T, containerId string) string {
 }
 
 func TestDockerContainerCopyFileToContainer(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 
 	nginxC, err := GenericContainer(ctx, GenericContainerRequest{
@@ -1688,6 +1723,7 @@ func TestDockerContainerCopyFileToContainer(t *testing.T) {
 }
 
 func TestDockerContainerCopyFileFromContainer(t *testing.T) {
+	t.Parallel()
 	fileContent, err := ioutil.ReadFile("./testresources/hello.sh")
 	if err != nil {
 		t.Fatal(err)
@@ -1727,6 +1763,7 @@ func TestDockerContainerCopyFileFromContainer(t *testing.T) {
 }
 
 func TestDockerContainerCopyEmptyFileFromContainer(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 
 	nginxC, err := GenericContainer(ctx, GenericContainerRequest{
@@ -1762,6 +1799,7 @@ func TestDockerContainerCopyEmptyFileFromContainer(t *testing.T) {
 }
 
 func TestDockerContainerResources(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 
 	expected := []*units.Ulimit{
@@ -1805,6 +1843,7 @@ func TestDockerContainerResources(t *testing.T) {
 }
 
 func TestContainerWithReaperNetwork(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	networks := []string{
 		"test_network_" + randomString(),
@@ -1856,6 +1895,7 @@ func TestContainerWithReaperNetwork(t *testing.T) {
 }
 
 func TestContainerWithUserID(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	req := ContainerRequest{
 		Image:      "alpine:latest",
@@ -1886,6 +1926,7 @@ func TestContainerWithUserID(t *testing.T) {
 }
 
 func TestContainerWithNoUserID(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	req := ContainerRequest{
 		Image:      "alpine:latest",
@@ -1917,6 +1958,7 @@ func TestContainerWithNoUserID(t *testing.T) {
 func TestGetGatewayIP(t *testing.T) {
 	// When using docker-compose with DinD mode, and using host port or http wait strategy
 	// It's need to invoke GetGatewayIP for get the host
+	t.Parallel()
 	provider, err := NewDockerProvider(WithLogger(TestLogger(t)))
 	if err != nil {
 		t.Fatal(err)

--- a/network.go
+++ b/network.go
@@ -17,6 +17,16 @@ type Network interface {
 	Remove(context.Context) error // removes the network
 }
 
+type DefaultNetwork string
+
+func (n DefaultNetwork) ApplyGenericTo(opts *GenericProviderOptions) {
+	opts.DefaultNetwork = string(n)
+}
+
+func (n DefaultNetwork) ApplyDockerTo(opts *DockerProviderOptions) {
+	opts.DefaultNetwork = string(n)
+}
+
 // NetworkRequest represents the parameters used to get a network
 type NetworkRequest struct {
 	Driver         string


### PR DESCRIPTION
# What does this PR do?

Although Podman claims to be API compatible with Docker and for instance in #336 the consent seems to be _let's wait until all problems are gone_ :sweat_smile: I thought I'd see what can be done as kind of a compromise.

The problems I could identify (and solve) are:

- The current implementation assumes the default network name is `bridge` which isn't the case for Podman. Even worse, `bridge` is not even a valid network name with Podman because it's also a network mode and Podman does not allow the creation of networks conflicting with network modes.
- The current implementation of the reaper has a hard coded path where it expects the Docker socket. Neither `DOCKER_HOST` env variable nor any other customization the [testcontainers docs](https://www.testcontainers.org/features/configuration/#customizing-ryuk-resource-reaper) are describing are honored.  This is also an issue with rootless Docker.
- Podman requires at least one stream to be attached when a command is executed. It doesn't hurt to attach `stdout` and/or `stderr` but otherwise it breaks the exec wait strategy.

## `DefaultNetwork` option

The `DefaultNetwork` option allows Podman users to configure the name of the default network. If it's not set the previous auto-detection is applied so no breaking change.

## Honoring `DOCKER_HOST` and `TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE`

The `DOCKER_HOST` env variable was already considered when creating the Docker API client. Now its value is propagated (via the `context.Context`) to the reaper as a fallback if `TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE` isnt' set. If both env variables are empty the default socket path `/var/run/docker.sock` will be assumed.

## Default `NetworkMode` if not set

In cases when the `NetworkMode` isn't set it will be set to `bridge` to avoid issues with Podman. Docker apparently assumes `bridge` if nothing's set therefore this shouldn't break anything either.

## Parallel tests

To speed up the test suite I marked all Docker tests to be executed in parallel.