### PR TITLE
expose CopyToContainer so file can be created only in memory

### DIFF
--- a/container.go
+++ b/container.go
@@ -51,6 +51,7 @@ type Container interface {
 	NetworkAliases(context.Context) (map[string][]string, error) // get container network aliases for a network
 	Exec(ctx context.Context, cmd []string) (int, error)
 	ContainerIP(context.Context) (string, error) // get container ip
+	CopyToContainer(ctx context.Context, fileContent []byte, containerFilePath string, fileMode int64) error
 	CopyFileToContainer(ctx context.Context, hostFilePath string, containerFilePath string, fileMode int64) error
 	CopyFileFromContainer(ctx context.Context, filePath string) (io.ReadCloser, error)
 }

--- a/docker.go
+++ b/docker.go
@@ -395,7 +395,11 @@ func (c *DockerContainer) CopyFileToContainer(ctx context.Context, hostFilePath 
 	if err != nil {
 		return err
 	}
+	return c.CopyToContainer(ctx, fileContent, containerFilePath, fileMode)
+}
 
+// CopyToContainer copies fileContent data to a file in container
+func (c *DockerContainer) CopyToContainer(ctx context.Context, fileContent []byte, containerFilePath string, fileMode int64) error {
 	buffer := &bytes.Buffer{}
 
 	tw := tar.NewWriter(buffer)


### PR DESCRIPTION
this is especially useful in tests, since we do not
need to create a file for testing,
we can just generate it in memory and then
copy it to a container directly