### PR TITLE
Docker compose: Add the output of the command to the returning struct

### DIFF
--- a/compose.go
+++ b/compose.go
@@ -243,10 +243,12 @@ func (dc *LocalDockerCompose) validate() error {
 // ExecError is super struct that holds any information about an execution error, so the client code
 // can handle the result
 type ExecError struct {
-	Command []string
-	Error   error
-	Stdout  error
-	Stderr  error
+	Command      []string
+	StdoutOutput []byte
+	StderrOutput []byte
+	Error        error
+	Stdout       error
+	Stderr       error
 }
 
 // execute executes a program with arguments and environment variables inside a specific directory
@@ -276,10 +278,12 @@ func execute(
 
 		return ExecError{
 			// add information about the CMD and arguments used
-			Command: execCmd,
-			Error:   err,
-			Stderr:  errStderr,
-			Stdout:  errStdout,
+			Command:      execCmd,
+			StdoutOutput: stdout.Bytes(),
+			StderrOutput: stderr.Bytes(),
+			Error:        err,
+			Stderr:       errStderr,
+			Stdout:       errStdout,
 		}
 	}
 
@@ -300,10 +304,12 @@ func execute(
 	execCmd = append(execCmd, args...)
 
 	return ExecError{
-		Command: execCmd,
-		Error:   err,
-		Stderr:  errStderr,
-		Stdout:  errStdout,
+		Command:      execCmd,
+		StdoutOutput: stdout.Bytes(),
+		StderrOutput: stderr.Bytes(),
+		Error:        err,
+		Stderr:       errStderr,
+		Stdout:       errStdout,
 	}
 }
 
@@ -377,7 +383,11 @@ func (w *capturingPassThroughWriter) Write(d []byte) (int, error) {
 
 // Bytes returns bytes written to the writer
 func (w *capturingPassThroughWriter) Bytes() []byte {
-	return w.buf.Bytes()
+	b := w.buf.Bytes()
+	if b == nil {
+		b = []byte{}
+	}
+	return b
 }
 
 // Which checks if a binary is present in PATH

--- a/compose_test.go
+++ b/compose_test.go
@@ -453,6 +453,9 @@ func checkIfError(t *testing.T, err ExecError) {
 	if err.Stderr != nil {
 		t.Fatalf("An error in Stderr happened when running %v: %v", err.Command, err.Stderr)
 	}
+
+	assert.NotNil(t, err.StdoutOutput)
+	assert.NotNil(t, err.StderrOutput)
 }
 
 func executeAndGetOutput(command string, args []string) (string, ExecError) {

--- a/compose_test.go
+++ b/compose_test.go
@@ -461,9 +461,10 @@ func checkIfError(t *testing.T, err ExecError) {
 func executeAndGetOutput(command string, args []string) (string, ExecError) {
 	cmd := exec.Command(command, args...)
 	out, err := cmd.CombinedOutput()
-	if err != nil {
-		return string(out), ExecError{Error: err}
-	}
 
-	return string(out), ExecError{Error: nil}
+	return string(out), ExecError{
+		Error:        err,
+		StderrOutput: out,
+		StdoutOutput: out,
+	}
 }


### PR DESCRIPTION
There was no interface for getting the output of the compose command after calling `Invoke`.
Because you are allowing running any command (using `WithCommand`), it is essential that the user will be able to get the output of the command.

I saw that you're already implemented `capturingPassThroughWriter` that copies the output to a buffer as well as stdout\stderr, so I used it and just added the output to the returning struct.
