### PR TITLE
Fix compose v2 wait strategy

### DIFF
--- a/compose.go
+++ b/compose.go
@@ -135,6 +135,10 @@ func (dc *LocalDockerCompose) getDockerComposeEnvironment() map[string]string {
 	return environment
 }
 
+func (dc *LocalDockerCompose) containerNameFromServiceName(service, separator string) string {
+	return dc.Identifier + separator + service
+}
+
 func (dc *LocalDockerCompose) applyStrategyToRunningContainer() error {
 	cli, err := client.NewClientWithOpts(client.FromEnv)
 	if err != nil {
@@ -142,8 +146,8 @@ func (dc *LocalDockerCompose) applyStrategyToRunningContainer() error {
 	}
 
 	for k := range dc.WaitStrategyMap {
-		containerName := dc.Identifier + "_" + k.service
-		composeV2ContainerName := dc.Identifier + "-" + k.service
+		containerName := dc.containerNameFromServiceName(k.service, "_")
+		composeV2ContainerName := dc.containerNameFromServiceName(k.service, "-")
 		f := filters.NewArgs(
 			filters.Arg("name", containerName),
 			filters.Arg("name", composeV2ContainerName),

--- a/compose.go
+++ b/compose.go
@@ -143,7 +143,7 @@ func (dc *LocalDockerCompose) applyStrategyToRunningContainer() error {
 
 	for k := range dc.WaitStrategyMap {
 		containerName := dc.Identifier + "_" + k.service
-		composeV2ContainerName := strings.ReplaceAll(containerName, "_", "-")
+		composeV2ContainerName := dc.Identifier + "-" + k.service
 		f := filters.NewArgs(
 			filters.Arg("name", containerName),
 			filters.Arg("name", composeV2ContainerName),


### PR DESCRIPTION
In compose V2, the container name is `<compose name>-<service name>` instead of `<compose name>_<service name>`

The code do referrer it by having `composeV2ContainerName` along `containerName`, but the  `composeV2ContainerName` is constructed by replacing any `_` from `containerName` with `-`. This is a problem because the service may have `_` in its name and it will cause an incorrect container name that won't be found.