### PR TITLE
Negotiate client version for docker compose

### DIFF
--- a/compose.go
+++ b/compose.go
@@ -145,6 +145,8 @@ func (dc *LocalDockerCompose) applyStrategyToRunningContainer() error {
 		return err
 	}
 
+	cli.NegotiateAPIVersion(context.Background())
+
 	for k := range dc.WaitStrategyMap {
 		containerName := dc.containerNameFromServiceName(k.service, "_")
 		composeV2ContainerName := dc.containerNameFromServiceName(k.service, "-")


### PR DESCRIPTION
Even though client version negotiation has been implemented for vanilla docker [here](https://github.com/testcontainers/testcontainers-go/issues/61), it hasn't been implemented for Docker Compose. I ran into the issue while setting up some integration tests and negotiating the client version fixed the issue and allowed me to make progress.