### PR TITLE
Add extra hosts to the container request

### DIFF
--- a/container.go
+++ b/container.go
@@ -92,6 +92,7 @@ type ContainerRequest struct {
 	WaitingFor      wait.Strategy
 	Name            string // for specifying container name
 	Hostname        string
+	ExtraHosts      []string
 	Privileged      bool                // for starting privileged container
 	Networks        []string            // for specifying network names
 	NetworkAliases  map[string][]string // for specifying network aliases

--- a/docker.go
+++ b/docker.go
@@ -856,6 +856,7 @@ func (p *DockerProvider) CreateContainer(ctx context.Context, req ContainerReque
 	mounts := mapToDockerMounts(req.Mounts)
 
 	hostConfig := &container.HostConfig{
+		ExtraHosts:   req.ExtraHosts,
 		PortBindings: exposedPortMap,
 		Mounts:       mounts,
 		Tmpfs:        req.Tmpfs,


### PR DESCRIPTION
The code-way of specifying `--add-hosts` on the Docker command-line.

E.g.
```go
var extraHosts = []string{
    "subdomain.localhost:127.0.0.1",
}
```

Useful in test scenario's where dynamic domain names are used.