### PR TITLE
feat: ability to configure running privileged Ryuk

### DIFF
--- a/docker.go
+++ b/docker.go
@@ -569,9 +569,10 @@ var _ ContainerProvider = (*DockerProvider)(nil)
 
 // or through Decode
 type TestContainersConfig struct {
-	Host      string `properties:"docker.host,default="`
-	TLSVerify int    `properties:"docker.tls.verify,default=0"`
-	CertPath  string `properties:"docker.cert.path,default="`
+	Host           string `properties:"docker.host,default="`
+	TLSVerify      int    `properties:"docker.tls.verify,default=0"`
+	CertPath       string `properties:"docker.cert.path,default="`
+	RyukPrivileged bool   `properties:"ryuk.container.privileged,default=false"`
 }
 
 type (

--- a/reaper.go
+++ b/reaper.go
@@ -74,6 +74,11 @@ func NewReaper(ctx context.Context, sessionID string, provider ReaperProvider, r
 		WaitingFor: wait.ForListeningPort(listeningPort),
 	}
 
+	tcConfig := readTCPropsFile()
+	if tcConfig.RyukPrivileged || os.Getenv("TESTCONTAINERS_RYUK_CONTAINER_PRIVILEGED") == "true" {
+		req.Privileged = true
+	}
+
 	// Attach reaper container to a requested network if it is specified
 	if p, ok := provider.(*DockerProvider); ok {
 		req.Networks = append(req.Networks, p.defaultNetwork)


### PR DESCRIPTION
Adds support for running the Ryuk (reaper) container in privileged mode
either by setting `ryuk.container.privileged=true` in
`$HOME/.testcontainers.properties` or by setting
`TESTCONTAINERS_RYUK_CONTAINER_PRIVILEGED=true` environment variable.