### PR TITLE
feat: support binds in addition to mounts

### DIFF
--- a/container.go
+++ b/container.go
@@ -104,6 +104,7 @@ type ContainerRequest struct {
 	AutoRemove      bool   // if set to true, the container will be removed from the host when stopped
 	AlwaysPullImage bool   // Always pull image
 	ImagePlatform   string // ImagePlatform describes the platform which the image runs on.
+	Binds           []string
 }
 
 type (

--- a/docker.go
+++ b/docker.go
@@ -865,6 +865,7 @@ func (p *DockerProvider) CreateContainer(ctx context.Context, req ContainerReque
 	hostConfig := &container.HostConfig{
 		ExtraHosts:   req.ExtraHosts,
 		PortBindings: exposedPortMap,
+		Binds:        req.Binds,
 		Mounts:       mounts,
 		Tmpfs:        req.Tmpfs,
 		AutoRemove:   req.AutoRemove,


### PR DESCRIPTION
This is needed for providing additional options, such as SELinux label.