### PR TITLE
feat: Use exposed ports specified in image if it is not specified in ContainerRequest

### DIFF
--- a/docker.go
+++ b/docker.go
@@ -759,11 +759,6 @@ func (p *DockerProvider) CreateContainer(ctx context.Context, req ContainerReque
 		}
 	}
 
-	exposedPortSet, exposedPortMap, err := nat.ParsePortSpecs(req.ExposedPorts)
-	if err != nil {
-		return nil, err
-	}
-
 	env := []string{}
 	for envKey, envVar := range req.Env {
 		env = append(env, envKey+"="+envVar)
@@ -846,6 +841,22 @@ func (p *DockerProvider) CreateContainer(ctx context.Context, req ContainerReque
 				return nil, err
 			}
 		}
+	}
+
+	exposedPorts := req.ExposedPorts
+	if len(exposedPorts) == 0 {
+		image, _, err := p.client.ImageInspectWithRaw(ctx, tag)
+		if err != nil {
+			return nil, err
+		}
+		for p, _ := range image.ContainerConfig.ExposedPorts {
+			exposedPorts = append(exposedPorts, string(p))
+		}
+	}
+
+	exposedPortSet, exposedPortMap, err := nat.ParsePortSpecs(exposedPorts)
+	if err != nil {
+		return nil, err
 	}
 
 	dockerInput := &container.Config{

--- a/docker_test.go
+++ b/docker_test.go
@@ -146,6 +146,36 @@ func TestContainerWithHostNetworkOptions(t *testing.T) {
 	}
 }
 
+func TestContainerWithHostNetworkOptions_UseExposePortsFromImageConfigs(t *testing.T) {
+	ctx := context.Background()
+	gcr := GenericContainerRequest{
+		ContainerRequest: ContainerRequest{
+			Image:      "nginx",
+			Privileged: true,
+			SkipReaper: true,
+			WaitingFor: wait.ForListeningPort(""),
+		},
+		Started: true,
+	}
+
+	nginxC, err := GenericContainer(ctx, gcr)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer nginxC.Terminate(ctx)
+
+	endpoint, err := nginxC.Endpoint(ctx, "http")
+	if err != nil {
+		t.Errorf("Expected server endpoint. Got '%v'.", err)
+	}
+
+	_, err = http.Get(endpoint)
+	if err != nil {
+		t.Errorf("Expected OK response. Got '%d'.", err)
+	}
+}
+
 func TestContainerWithNetworkModeAndNetworkTogether(t *testing.T) {
 	ctx := context.Background()
 	gcr := GenericContainerRequest{

--- a/docker_test.go
+++ b/docker_test.go
@@ -153,7 +153,7 @@ func TestContainerWithHostNetworkOptions_UseExposePortsFromImageConfigs(t *testi
 			Image:      "nginx",
 			Privileged: true,
 			SkipReaper: true,
-			WaitingFor: wait.ForListeningPort(""),
+			WaitingFor: wait.ForExposedPort(),
 		},
 		Started: true,
 	}

--- a/wait/exec_test.go
+++ b/wait/exec_test.go
@@ -44,6 +44,10 @@ func (st mockExecTarget) Host(_ context.Context) (string, error) {
 	return "", errors.New("not implemented")
 }
 
+func (st mockExecTarget) Ports(ctx context.Context) (nat.PortMap, error) {
+	return nil, errors.New("not implemented")
+}
+
 func (st mockExecTarget) MappedPort(_ context.Context, n nat.Port) (nat.Port, error) {
 	return n, errors.New("not implemented")
 }

--- a/wait/exit_test.go
+++ b/wait/exit_test.go
@@ -19,6 +19,10 @@ func (st exitStrategyTarget) Host(ctx context.Context) (string, error) {
 	return "", nil
 }
 
+func (st exitStrategyTarget) Ports(ctx context.Context) (nat.PortMap, error) {
+	return nil, nil
+}
+
 func (st exitStrategyTarget) MappedPort(ctx context.Context, n nat.Port) (nat.Port, error) {
 	return n, nil
 }

--- a/wait/host_port.go
+++ b/wait/host_port.go
@@ -16,6 +16,8 @@ import (
 var _ Strategy = (*HostPortStrategy)(nil)
 
 type HostPortStrategy struct {
+	// Port is a string containing port number and protocol in the format "80/tcp"
+	// which
 	Port nat.Port
 	// all WaitStrategies should have a startupTimeout to avoid waiting infinitely
 	startupTimeout time.Duration
@@ -37,6 +39,12 @@ func NewHostPortStrategy(port nat.Port) *HostPortStrategy {
 // https://github.com/testcontainers/testcontainers-java/blob/1d85a3834bd937f80aad3a4cec249c027f31aeb4/core/src/main/java/org/testcontainers/containers/wait/strategy/Wait.java
 func ForListeningPort(port nat.Port) *HostPortStrategy {
 	return NewHostPortStrategy(port)
+}
+
+// ForExposedPort constructs an exposed port strategy. Alias for `NewHostPortStrategy("")`.
+// This strategy waits port exposed in Docker container.
+func ForExposedPort() *HostPortStrategy {
+	return NewHostPortStrategy("")
 }
 
 func (hp *HostPortStrategy) WithStartupTimeout(startupTimeout time.Duration) *HostPortStrategy {

--- a/wait/host_port.go
+++ b/wait/host_port.go
@@ -72,6 +72,11 @@ func (hp *HostPortStrategy) WaitUntilReady(ctx context.Context, target StrategyT
 		}
 	}
 
+	if internalPort == "" {
+		err = fmt.Errorf("no port to waiting")
+		return
+	}
+
 	var port nat.Port
 	port, err = target.MappedPort(ctx, internalPort)
 	var i = 0

--- a/wait/host_port.go
+++ b/wait/host_port.go
@@ -73,7 +73,7 @@ func (hp *HostPortStrategy) WaitUntilReady(ctx context.Context, target StrategyT
 	}
 
 	if internalPort == "" {
-		err = fmt.Errorf("no port to waiting")
+		err = fmt.Errorf("no port to wait for")
 		return
 	}
 

--- a/wait/host_port.go
+++ b/wait/host_port.go
@@ -42,7 +42,7 @@ func ForListeningPort(port nat.Port) *HostPortStrategy {
 }
 
 // ForExposedPort constructs an exposed port strategy. Alias for `NewHostPortStrategy("")`.
-// This strategy waits port exposed in Docker container.
+// This strategy waits for the first port exposed in the Docker container.
 func ForExposedPort() *HostPortStrategy {
 	return NewHostPortStrategy("")
 }

--- a/wait/log_test.go
+++ b/wait/log_test.go
@@ -23,6 +23,7 @@ func (st noopStrategyTarget) Host(ctx context.Context) (string, error) {
 func (st noopStrategyTarget) Ports(ctx context.Context) (nat.PortMap, error) {
 	return nil, nil
 }
+
 func (st noopStrategyTarget) MappedPort(ctx context.Context, n nat.Port) (nat.Port, error) {
 	return n, nil
 }

--- a/wait/log_test.go
+++ b/wait/log_test.go
@@ -20,6 +20,9 @@ func (st noopStrategyTarget) Host(ctx context.Context) (string, error) {
 	return "", nil
 }
 
+func (st noopStrategyTarget) Ports(ctx context.Context) (nat.PortMap, error) {
+	return nil, nil
+}
 func (st noopStrategyTarget) MappedPort(ctx context.Context, n nat.Port) (nat.Port, error) {
 	return n, nil
 }

--- a/wait/wait.go
+++ b/wait/wait.go
@@ -15,6 +15,7 @@ type Strategy interface {
 
 type StrategyTarget interface {
 	Host(context.Context) (string, error)
+	Ports(ctx context.Context) (nat.PortMap, error)
 	MappedPort(context.Context, nat.Port) (nat.Port, error)
 	Logs(context.Context) (io.ReadCloser, error)
 	Exec(ctx context.Context, cmd []string) (int, io.Reader, error)


### PR DESCRIPTION
Relates to https://github.com/testcontainers/testcontainers-go/issues/343

Example:
```dockerfile
# Dockerfile
EXPOSE 11211
CMD ["memcached"]
```

Old:

```go
port := "11211/tcp"
rq := testcontainers.ContainerRequest{
	Image:        "memcached:1.6.10",
	ExposedPorts: []string{port},
	WaitingFor:   wait.ForListeningPort(nat.Port(port)),
}
```
New:

```go
rq := testcontainers.ContainerRequest{
	Image:        "memcached:1.6.10",
	WaitingFor:   wait.ForListeningPort(""),
}
```
