### PR TITLE
Add options to redirect compose command stdout and stderr to custom writers

### DIFF
--- a/compose_test.go
+++ b/compose_test.go
@@ -454,8 +454,6 @@ func checkIfError(t *testing.T, err ExecError) {
 		t.Fatalf("An error in Stderr happened when running %v: %v", err.Command, err.Stderr)
 	}
 
-	assert.NotNil(t, err.StdoutOutput)
-	assert.NotNil(t, err.StderrOutput)
 }
 
 func executeAndGetOutput(command string, args []string) (string, ExecError) {
@@ -463,8 +461,6 @@ func executeAndGetOutput(command string, args []string) (string, ExecError) {
 	out, err := cmd.CombinedOutput()
 
 	return string(out), ExecError{
-		Error:        err,
-		StderrOutput: out,
-		StdoutOutput: out,
+		Error: err,
 	}
 }


### PR DESCRIPTION
Close https://github.com/testcontainers/testcontainers-go/issues/398

Instead of copying all the command output in a separate buffer and return it when the command stops, this PR allows to stream command output to a specific `io.Writer`