### PR TITLE
Remove unused import in redis example

### DIFF
--- a/docs/examples/redis.md
+++ b/docs/examples/redis.md
@@ -11,7 +11,6 @@ import (
 
 	"github.com/go-redis/redis/v8"
 	"github.com/google/uuid"
-	_ "github.com/jackc/pgx/v4/stdlib"
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/wait"
 )


### PR DESCRIPTION
`_ "github.com/jackc/pgx/v4/stdlib"` seems like CockroachDB related import.
