### PR TITLE
chore: tell dependabot about the new module

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,7 @@ updates:
   open-pull-requests-limit: 3
   rebase-strategy: disabled
 - package-ecosystem: gomod
-  directory: "/e2e/"
+  directory: "/e2e"
   schedule:
     interval: daily
   open-pull-requests-limit: 3

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,9 @@ updates:
     interval: daily
   open-pull-requests-limit: 3
   rebase-strategy: disabled
+- package-ecosystem: gomod
+  directory: "/e2e/"
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 3
+  rebase-strategy: disabled


### PR DESCRIPTION
## What does this PR do?
It adds the new e2e module to dependabot's configuration file

## Why is it important?
Because otherwise, the PRs from dependabot could fail in Go 1.18

