### PR TITLE
refactor: read RYUK_CONTAINER_PRIVILEGED once

### DIFF
--- a/docker.go
+++ b/docker.go
@@ -663,7 +663,8 @@ func WithDefaultBridgeNetwork(bridgeNetworkName string) DockerProviderOption {
 }
 
 func NewDockerClient() (cli *client.Client, host string, tcConfig TestContainersConfig, err error) {
-	tcConfig = readTCPropsFile()
+	tcConfig = configureTC()
+
 	host = tcConfig.Host
 
 	opts := []client.Opt{client.FromEnv}
@@ -732,8 +733,9 @@ func NewDockerProvider(provOpts ...DockerProviderOption) (*DockerProvider, error
 	return p, nil
 }
 
-// readTCPropsFile reads from testcontainers properties file, if it exists
-func readTCPropsFile() TestContainersConfig {
+// configureTC reads from testcontainers properties file, if it exists
+// it is possible that certain values get overridden when set as environment variables
+func configureTC() TestContainersConfig {
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return TestContainersConfig{}
@@ -750,6 +752,11 @@ func readTCPropsFile() TestContainersConfig {
 	if err := properties.Decode(&cfg); err != nil {
 		fmt.Printf("invalid testcontainers properties file, returning an empty Testcontainers configuration: %v\n", err)
 		return TestContainersConfig{}
+	}
+
+	ryukPrivilegedEnv := os.Getenv("TESTCONTAINERS_RYUK_CONTAINER_PRIVILEGED")
+	if ryukPrivilegedEnv != "" {
+		cfg.RyukPrivileged = ryukPrivilegedEnv == "true"
 	}
 
 	return cfg

--- a/reaper.go
+++ b/reaper.go
@@ -73,9 +73,7 @@ func NewReaper(ctx context.Context, sessionID string, provider ReaperProvider, r
 	}
 
 	tcConfig := provider.Config()
-	if tcConfig.RyukPrivileged || os.Getenv("TESTCONTAINERS_RYUK_CONTAINER_PRIVILEGED") == "true" {
-		req.Privileged = true
-	}
+	req.Privileged = tcConfig.RyukPrivileged
 
 	// Attach reaper container to a requested network if it is specified
 	if p, ok := provider.(*DockerProvider); ok {


### PR DESCRIPTION
Now the environment variable `TESTCONTAINERS_RYUK_CONTAINER_PRIVILEGED` is read only once in the `configureTC` function that reads the `.testcontainers.properties` file and accesses the environment variable.
