### PR TITLE
chore(ci): update podman pipeline

### DIFF
--- a/.github/workflows/ci-podman.yml
+++ b/.github/workflows/ci-podman.yml
@@ -61,7 +61,6 @@ jobs:
         run: make -C tools-tidy
 
       - name: Run e2e tests
-        if: ${{ matrix.platform == 'ubuntu-latest' }}
         run: make test-e2e
 
       - name: Run checker

--- a/.github/workflows/ci-podman.yml
+++ b/.github/workflows/ci-podman.yml
@@ -50,3 +50,7 @@ jobs:
         # we can't put Windows Server in "Linux Mode" in Github actions
         # another, host mode is only available on Linux, and we have tests around that, do we skip them?
         run: sudo go run gotest.tools/gotestsum --format short-verbose --rerun-fails=5 --packages="./..." -- -coverprofile=cover.txt
+
+      - name: Run checker
+        run: |
+          ./scripts/check_environment.sh

--- a/.github/workflows/ci-podman.yml
+++ b/.github/workflows/ci-podman.yml
@@ -58,10 +58,10 @@ jobs:
         run: make test-unit
 
       - name: modTidy e2e tests
-        run: make -C tools-tidy
+        run: sudo make -C tools-tidy
 
       - name: Run e2e tests
-        run: make test-e2e
+        run: sudo make test-e2e
 
       - name: Run checker
         run: |

--- a/.github/workflows/ci-podman.yml
+++ b/.github/workflows/ci-podman.yml
@@ -44,6 +44,12 @@ jobs:
       - name: Set DOCKER_HOST
         run: echo "DOCKER_HOST=unix:///run/podman/podman.sock" >> $GITHUB_ENV
 
+      - name: modVerify
+        run: go mod verify
+
+      - name: modTidy
+        run: go mod tidy
+
       - name: gotestsum
         # only run tests on linux, there are a number of things that won't allow the tests to run on anything else
         # many (maybe, all?) images used can only be build on Linux, they don't have Windows in their manifest, and

--- a/.github/workflows/ci-podman.yml
+++ b/.github/workflows/ci-podman.yml
@@ -49,7 +49,11 @@ jobs:
         # many (maybe, all?) images used can only be build on Linux, they don't have Windows in their manifest, and
         # we can't put Windows Server in "Linux Mode" in Github actions
         # another, host mode is only available on Linux, and we have tests around that, do we skip them?
-        run: sudo go run gotest.tools/gotestsum --format short-verbose --rerun-fails=5 --packages="./..." -- -coverprofile=cover.txt
+        run: make test-unit
+
+      - name: Run e2e tests
+        if: ${{ matrix.platform == 'ubuntu-latest' }}
+        run: make test-e2e
 
       - name: Run checker
         run: |

--- a/.github/workflows/ci-podman.yml
+++ b/.github/workflows/ci-podman.yml
@@ -55,10 +55,10 @@ jobs:
         # many (maybe, all?) images used can only be build on Linux, they don't have Windows in their manifest, and
         # we can't put Windows Server in "Linux Mode" in Github actions
         # another, host mode is only available on Linux, and we have tests around that, do we skip them?
-        run: make test-unit
+        run: sudo make test-unit
 
       - name: modTidy e2e tests
-        run: sudo make -C tools-tidy
+        run: make -C tools-tidy
 
       - name: Run e2e tests
         run: sudo make test-e2e

--- a/.github/workflows/ci-podman.yml
+++ b/.github/workflows/ci-podman.yml
@@ -58,7 +58,7 @@ jobs:
         run: sudo make test-unit
 
       - name: modTidy e2e tests
-        run: make -C tools-tidy
+        run: make -C e2e tools-tidy
 
       - name: Run e2e tests
         run: sudo make test-e2e

--- a/.github/workflows/ci-podman.yml
+++ b/.github/workflows/ci-podman.yml
@@ -57,6 +57,9 @@ jobs:
         # another, host mode is only available on Linux, and we have tests around that, do we skip them?
         run: make test-unit
 
+      - name: modTidy e2e tests
+        run: make -C tools-tidy
+
       - name: Run e2e tests
         if: ${{ matrix.platform == 'ubuntu-latest' }}
         run: make test-e2e

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,10 @@ jobs:
           files: ./cover.txt
           name: testcontainers-go-${{ matrix.go-version }}
 
+      - name: modTidy e2e tests
+        if: ${{ matrix.platform == 'ubuntu-latest' }}
+        run: make -C tools-tidy
+
       - name: Run e2e tests
         if: ${{ matrix.platform == 'ubuntu-latest' }}
         run: make test-e2e

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
 
       - name: modTidy e2e tests
         if: ${{ matrix.platform == 'ubuntu-latest' }}
-        run: make -C tools-tidy
+        run: make -C e2e tools-tidy
 
       - name: Run e2e tests
         if: ${{ matrix.platform == 'ubuntu-latest' }}

--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -6,7 +6,10 @@ test: tools
 		--rerun-fails=5 \
 		--packages="./..." \
 
-
 .PHONY: tools
 tools:
 	go mod download
+
+.PHONY: tools-tidy
+tools-tidy:
+	go mod tidy


### PR DESCRIPTION
## What does this PR do?

It updates the pipeline for Podman with the recent changes about using a Makefile for running the tests, and a shell script checking there is no containers at the end of the test execution.

Besides, it's adding `go mod` commands to standardize the mod file for each Go version that is supported

## Why is it important?
Using Make creates a consistent manner of running the tests

The `go mod` commands should fix the Podman pipeline

