### PR TITLE
docs: fix format for create-container feature

### DIFF
--- a/docs/features/creating_container.md
+++ b/docs/features/creating_container.md
@@ -91,24 +91,33 @@ the function will create a new generic container. If `Reuse` is true and `Name` 
 
 The following test creates an NGINX container, adds a file into it and then reuses the container again for checking the file:
 ```go
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/testcontainers/testcontainers-go"
+)
 
 const (
-    reusableContainerName = "my_test_reusable_container"
+	reusableContainerName = "my_test_reusable_container"
 )
 
 ctx := context.Background()
 
 n1, err := GenericContainer(ctx, GenericContainerRequest{
-    ContainerRequest: ContainerRequest{
-        Image:        "nginx:1.17.6",
-        ExposedPorts: []string{"80/tcp"},
-        WaitingFor:   wait.ForListeningPort("80/tcp"),
-        Name:         reusableContainerName,
-    },
-    Started: true,
+	ContainerRequest: ContainerRequest{
+		Image:        "nginx:1.17.6",
+		ExposedPorts: []string{"80/tcp"},
+		WaitingFor:   wait.ForListeningPort("80/tcp"),
+		Name:         reusableContainerName,
+	},
+	Started: true,
 })
 if err != nil {
-    log.Fatal(err)
+	log.Fatal(err)
 }
 defer n1.Terminate(ctx)
 
@@ -116,26 +125,26 @@ copiedFileName := "hello_copy.sh"
 err = n1.CopyFileToContainer(ctx, "./testresources/hello.sh", "/"+copiedFileName, 700)
 
 if err != nil {
-    log.Fatal(err)
+	log.Fatal(err)
 }
 
 n2, err := GenericContainer(ctx, GenericContainerRequest{
-    ContainerRequest: ContainerRequest{
-        Image:        "nginx:1.17.6",
-        ExposedPorts: []string{"80/tcp"},
-        WaitingFor:   wait.ForListeningPort("80/tcp"),
-        Name:         reusableContainerName,
+	ContainerRequest: ContainerRequest{
+		Image:        "nginx:1.17.6",
+		ExposedPorts: []string{"80/tcp"},
+		WaitingFor:   wait.ForListeningPort("80/tcp"),
+		Name:         reusableContainerName,
     },
-    Started: true,
+	Started: true,
 	Reuse: true,
 })
 if err != nil {
-    log.Fatal(err)
+	log.Fatal(err)
 }
 
 c, _, err := n2.Exec(ctx, []string{"bash", copiedFileName})
 if err != nil {
-    log.Fatal(err)
+	log.Fatal(err)
 }
 fmt.Println(c)
 ```

--- a/docs/features/creating_container.md
+++ b/docs/features/creating_container.md
@@ -138,9 +138,9 @@ if err != nil {
     log.Fatal(err)
 }
 fmt.Println(c)
-````
+```
 
-# Parallel running
+## Parallel running
 
 `testcontainers.ParallelContainers` - defines the containers that should be run in parallel mode.
 


### PR DESCRIPTION
## What does this PR do?
It uses tabs instead of spaces in the examples for the create_container.md file, also fixing the code block before the parallel container section.

## Why is it important?
Consistency across existing docs, also fixing the ParallelContainer section, which was embedded into the previous code block

**Before this PR:** https://golang.testcontainers.org/features/creating_container/#parallel-running
<img width="1350" alt="Screenshot 2022-07-06 at 07 59 35" src="https://user-images.githubusercontent.com/951580/177479578-4c17954a-4fe1-4535-86e9-ebdf3dc3a8eb.png">

**After this PR:** https://deploy-preview-481--testcontainers-go.netlify.app/features/creating_container/#parallel-running
<img width="1405" alt="Screenshot 2022-07-06 at 08 01 06" src="https://user-images.githubusercontent.com/951580/177479722-808e1277-d430-43a2-87be-5e862fd1350b.png">
