### PR TITLE
fix: return bad error after parallel running

### DIFF
--- a/parallel.go
+++ b/parallel.go
@@ -114,7 +114,7 @@ func ParallelContainers(ctx context.Context, reqs ParallelContainerRequest, opt 
 
 	<-waitRes
 
-	if len(errors) == 0 {
+	if len(errors) != 0 {
 		return containers, ParallelContainersError{Errors: errors}
 	}
 

--- a/parallel_test.go
+++ b/parallel_test.go
@@ -3,6 +3,8 @@ package testcontainers
 import (
 	"context"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestParallelContainers(t *testing.T) {
@@ -100,6 +102,7 @@ func TestParallelContainers(t *testing.T) {
 			res, err := ParallelContainers(context.Background(), tc.reqs, ParallelContainersOptions{})
 
 			if err != nil {
+				require.NotZero(t, tc.expErrors)
 				e, _ := err.(ParallelContainersError)
 
 				if len(e.Errors) != tc.expErrors {


### PR DESCRIPTION
Hello) I found a small bug in `ParallelContainers` method. Fixed!