### PR TITLE
Return container IP when attached to a single named network

### DIFF
--- a/docker.go
+++ b/docker.go
@@ -379,7 +379,18 @@ func (c *DockerContainer) ContainerIP(ctx context.Context) (string, error) {
 		return "", err
 	}
 
-	return inspect.NetworkSettings.IPAddress, nil
+	ip := inspect.NetworkSettings.IPAddress
+	if ip == "" {
+		// use IP from "Networks" if only single network defined
+		networks := inspect.NetworkSettings.Networks
+		if len(networks) == 1 {
+			for _, v := range networks {
+				ip = v.IPAddress
+			}
+		}
+	}
+
+	return ip, nil
 }
 
 // NetworkAliases gets the aliases of the container for the networks it is attached to.

--- a/docker_test.go
+++ b/docker_test.go
@@ -70,6 +70,7 @@ func TestContainerAttachedToNewNetwork(t *testing.T) {
 				networkName: aliases,
 			},
 		},
+		Started: true,
 	}
 
 	newNetwork, err := GenericNetwork(ctx, GenericNetworkRequest{
@@ -117,6 +118,14 @@ func TestContainerAttachedToNewNetwork(t *testing.T) {
 
 	for _, alias := range aliases {
 		require.Contains(t, networkAlias, alias)
+	}
+
+	networkIP, err := nginx.ContainerIP(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(networkIP) == 0 {
+		t.Errorf("Expected an IP address, got %v", networkIP)
 	}
 }
 


### PR DESCRIPTION
In many cases the container is attached to a single, named network of the "bridge" mode. In such scenarios, `DockerContainer.ContainerIP()` should resolve this IP and return it.

For example, imaging the following container definition.
```go
testcontainers.ContainerRequest{
    // ...
    Networks:     []string{"some-network"},
}
```

Before this change, the function `container.ContainerIP(ctx)` returns an empty string. After this change, it returns the correct container IP.