### PR TITLE
chore: retire non-supported Go versions

### DIFF
--- a/.github/workflows/ci-podman.yml
+++ b/.github/workflows/ci-podman.yml
@@ -6,7 +6,7 @@ jobs:
   build:
     strategy:
       matrix:
-        go-version: [1.14.x, 1.15.x, 1.16.x, 1.17.x, 1.x]
+        go-version: [1.16.x, 1.17.x, 1.x]
     runs-on: ubuntu-22.04
     steps:
       - name: Set up Go 1.x

--- a/.github/workflows/ci-podman.yml
+++ b/.github/workflows/ci-podman.yml
@@ -9,7 +9,7 @@ jobs:
         go-version: [1.16.x, 1.17.x, 1.x]
     runs-on: ubuntu-22.04
     steps:
-      - name: Set up Go 1.x
+      - name: Set up Go
         uses: actions/setup-go@v3
         with:
           go-version: ${{ matrix.go-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.14.x, 1.15.x, 1.16.x, 1.17.x, 1.x]
+        go-version: [1.16.x, 1.17.x, 1.x]
         platform: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ${{ matrix.platform }}
     steps:
 
-      - name: Set up Go 1.x
+      - name: Set up Go
         uses: actions/setup-go@v3
         with:
           go-version: ${{ matrix.go-version }}


### PR DESCRIPTION
- chore: retire not supported Go versions from CI
- chore: better CI step name

## What does this PR do?
It retires Go 1.14 and 1.15 from the CI, in both testing pipelines (Docker and Podman)

## Why is it important?
New PRs using code from 1.16 and above will fail because of the CI complains that the code does not compile in older Go versions

This specially important for security fixes provided by dependabot

## Related issues
- Closes #492 