### PR TITLE
chore: add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,88 @@
+name: Bug Report
+description: File a bug report
+title: "[Bug]: "
+labels: ["type/bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report!
+  - type: input
+    id: tc-version
+    attributes:
+      label: Testcontainers version
+      description: Which Testcontainers version are you using?
+      placeholder: ex. 0.13.0
+    validations:
+      required: true
+  - type: dropdown
+    id: latest-version
+    attributes:
+      label: Using the latest Testcontainers version?
+      description: If you are not using the latest version, can you update your project and try to reproduce the issue? Is it still happening?
+      options:
+        - 'Yes'
+        - 'No'
+    validations:
+      required: true
+  - type: input
+    id: host-os
+    attributes:
+      label: Host OS
+      description: Which Operating System are you using?
+      placeholder: e.g. Linux, Windows
+    validations:
+      required: true
+  - type: input
+    id: host-arch
+    attributes:
+      label: Host Arch
+      description: Which architecture are you using?
+      placeholder: e.g. x86, ARM
+    validations:
+      required: true
+  - type: input
+    id: go-version
+    attributes:
+      label: Go Version
+      description: Which Go version are you using?
+      placeholder: e.g. 1.18
+    validations:
+      required: true
+  - type: textarea
+    id: docker-version
+    attributes:
+      label: Docker version
+      description: Please run `docker version` and copy and paste the output into this field.
+      render: shell
+    validations:
+      required: true
+  - type: textarea
+    id: docker-info
+    attributes:
+      label: Docker info
+      description: Please run `docker info` and copy and paste the output into this field.
+      render: shell
+    validations:
+      required: true
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: Provide the context and the expected result.
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant log output
+      description: Please copy and paste any relevant log output. The content will be automatically formatted as code, so no need for backticks.
+      render: shell
+  - type: textarea
+    id: additional-information
+    attributes:
+      label: Additional Information
+      description: |
+        Any links or references to have more context about the issue.
+
+        Tip: You can attach a minimal sample project to reproduce the issue or provide further log files by clicking into this area to focus it and then dragging files in.

--- a/.github/ISSUE_TEMPLATE/discussions.yml
+++ b/.github/ISSUE_TEMPLATE/discussions.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Have a question or want to drive a Community conversation?
+    url: https://github.com/testcontainers/testcontainers-go/discussions/
+    about: Visit our Discussions page.

--- a/.github/ISSUE_TEMPLATE/enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement.yml
@@ -1,0 +1,16 @@
+name: Enhancement
+description: Suggest an enhancement
+title: "[Enhancement]: "
+labels: ["type/enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please provide the following information
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposal
+      description: What should be improved? What are the limitations of the current implications that would be solved by the proposal?
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,46 @@
+name: Feature
+description: Suggest a new feature
+title: "[Feature]: "
+labels: ["type/feature"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please provide the following information
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: Is this feature related to a problem? Please describe it.
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Solution
+      description: What's the proposed solution for this feature?
+    validations:
+      required: true
+  - type: textarea
+    id: benefit
+    attributes:
+      label: Benefit
+      description: What's the benefit of adding this feature to the project?
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives
+      description: Are there other alternatives? Please describe them.
+    validations:
+      required: true
+  - type: dropdown
+    id: contribute
+    attributes:
+      label: Would you like to help contributing this feature?
+      options:
+        - 'Yes'
+        - 'No'
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/slack.yml
+++ b/.github/ISSUE_TEMPLATE/slack.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Need help?
+    url: https://slack.testcontainers.org/
+    about: Visit our slack channel.


### PR DESCRIPTION
## What does this PR do?
It copies the issue templates that exist in the java project, adapted to Go, such as adding Go version and Go info in the bug report, and inspired by Moby's ones.

Besides that, it adds an issue template linking to the recently added Discussions page

## Why is it important?
Create a consistent experience reporting issues, enhancements or new features, providing a simple entrypoint for Slack or Discussions

## Related issues
- Closes #502 

