### PR TITLE
feat: adding the ability to get container for any service via docker-compose

### DIFF
--- a/compose.go
+++ b/compose.go
@@ -81,6 +81,7 @@ type DockerCompose interface {
 	WithCommand([]string) DockerCompose
 	WithEnv(map[string]string) DockerCompose
 	WithExposedService(string, int, wait.Strategy) DockerCompose
+	ServiceContainer(service string) (Container, error)
 }
 
 type waitService struct {
@@ -172,6 +173,7 @@ func NewLocalDockerCompose(filePaths []string, identifier string, opts ...LocalD
 	dc.Identifier = strings.ToLower(identifier)
 	dc.waitStrategySupplied = false
 	dc.WaitStrategyMap = make(map[waitService]wait.Strategy)
-
+	dc.ServiceContainers = make(map[string]Container)
+	
 	return dc
 }

--- a/compose_test.go
+++ b/compose_test.go
@@ -523,3 +523,35 @@ func checkIfError(t *testing.T, err ExecError) {
 	assert.NotNil(t, err.StdoutOutput)
 	assert.NotNil(t, err.StderrOutput)
 }
+
+func TestLocalDockerCompose_GetServiceContainer(t *testing.T) {
+	path := "./testresources/docker-compose-simple.yml"
+
+	identifier := strings.ToLower(uuid.New().String())
+
+	compose := NewLocalDockerCompose([]string{path}, identifier, WithLogger(TestLogger(t)))
+	destroyFn := func() {
+		err := compose.Down()
+		checkIfError(t, err)
+	}
+	defer destroyFn()
+
+	compose_err := compose.
+		WithCommand([]string{"up", "-d"}).
+		WithEnv(map[string]string{
+			"bar": "BAR",
+		}).
+		Invoke()
+	checkIfError(t, compose_err)
+
+	serviceContainer, err := compose.ServiceContainer("nginx")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	containerName, err := serviceContainer.Name(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Contains(t, containerName, "nginx")
+}


### PR DESCRIPTION
### What does this PR do?
This adds `GetServiceContainer` method  to `LocalDockerCompose`

### Why is it important?
My team and I are working to build a automated integration testing using testcontainers-go for our project. All of our services were written up to use docker-compose, and we would have needed to write code to create containers for each service we had to interact with containers.  This PR is important, because it saves developers time to write individual container code if they have many services to test. 

### Examples
See `GetServiceContainer` test understand how to use it 

Signed-off-by: Marc-Philippe Fuller <marc-philippe.fuller@intel.com>