### PR TITLE
docs: add contributing guides

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -10,16 +10,3 @@
     * when updating documentation, please see [our guidance for documentation contributions](contributing_docs.md).
     * apply format running `go fmt`, or the shell script `./scripts/checks.sh`
     * verify all tests are passing. Build and test the project with `make test-all` to do this.
-
-## Combining Dependabot PRs
-
-Since we generally get quite a few Dependabot PRs, we regularly combine them into single commits. 
-For this, we are using the [gh-combine-prs](https://github.com/rnorth/gh-combine-prs) extension for [GitHub CLI](https://cli.github.com/).
-
-The whole process is as follow:
-
-1. Check that all open Dependabot PRs did succeed their build. If they did not succeed, trigger a rerun if the cause were external factors or else document the reason if obvious.
-2. Run the extension from an up-to-date local `main` branch: `gh combine-prs --query "author:app/dependabot"`
-3. Merge conflicts might appear. Just ignore them, we will get those PRs in a future run.
-4. Once the build of the combined PR did succeed, temporarily enable merge commits and merge the PR using a merge commit through the GitHub UI.
-5. After the merge, disable merge commits again.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,4 +1,25 @@
 # Contributing
 
-We follow the same guidelines used by testcontainers-java -- please [check them
-out](https://www.testcontainers.org/contributing/).
+* Star the project on [Github](https://github.com/testcontainers/testcontainers-go) and help spread the word :)
+* Join our [Slack group](http://slack.testcontainers.org)
+* [Post an issue](https://github.com/testcontainers/testcontainers-go/issues) if you find any bugs
+* Contribute improvements or fixes using a [Pull Request](https://github.com/testcontainers/testcontainers-go/pulls). If you're going to contribute, thank you! Please just be sure to:
+    * discuss with the authors on an issue ticket prior to doing anything big.
+    * follow the style, naming and structure conventions of the rest of the project.
+    * make commits atomic and easy to merge.
+    * when updating documentation, please see [our guidance for documentation contributions](contributing_docs.md).
+    * apply format running `go fmt`, or the shell script `./scripts/checks.sh`
+    * verify all tests are passing. Build and test the project with `make test-all` to do this.
+
+## Combining Dependabot PRs
+
+Since we generally get quite a few Dependabot PRs, we regularly combine them into single commits. 
+For this, we are using the [gh-combine-prs](https://github.com/rnorth/gh-combine-prs) extension for [GitHub CLI](https://cli.github.com/).
+
+The whole process is as follow:
+
+1. Check that all open Dependabot PRs did succeed their build. If they did not succeed, trigger a rerun if the cause were external factors or else document the reason if obvious.
+2. Run the extension from an up-to-date local `main` branch: `gh combine-prs --query "author:app/dependabot"`
+3. Merge conflicts might appear. Just ignore them, we will get those PRs in a future run.
+4. Once the build of the combined PR did succeed, temporarily enable merge commits and merge the PR using a merge commit through the GitHub UI.
+5. After the merge, disable merge commits again.

--- a/e2e/go.sum
+++ b/e2e/go.sum
@@ -328,8 +328,9 @@ github.com/docker/go-events v0.0.0-20170721190031-9461782956ad/go.mod h1:Uw6Uezg
 github.com/docker/go-events v0.0.0-20190806004212-e31b211e4f1c/go.mod h1:Uw6UezgYA44ePAFQYUehOuCzmy5zmg/+nl2ZfMWGkpA=
 github.com/docker/go-metrics v0.0.0-20180209012529-399ea8c73916/go.mod h1:/u0gXw0Gay3ceNrsHubL3BtdOL2fHf93USgMTe0W5dI=
 github.com/docker/go-metrics v0.0.1/go.mod h1:cG1hvH2utMXtqgqqYE9plW6lDxS3/5ayHzueweSI3Vw=
-github.com/docker/go-units v0.4.0 h1:3uh0PgVws3nIA0Q+MwDC8yjEPf9zjRfZZWXZYDct3Tw=
 github.com/docker/go-units v0.4.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
+github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4=
+github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/docker/libtrust v0.0.0-20150114040149-fa567046d9b1/go.mod h1:cyGadeNEkKy96OOhEzfZl+yxihPEzKnqJwvfuSUqbZE=
 github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96/go.mod h1:Qh8CwZgvJUkLughtfhJv5dyTYa91l1fOUCrgjqmcifM=
 github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=


### PR DESCRIPTION
## What does this PR do?
It adapts the contributing guides from tc-java to tc-go, removing what it's not needed.


## Why is it important?
The community should have a clear understanding of what are the expectations of the maintainers when receiving a contribution.

This document is a live one, which means that we will be adding and/or removing sections if/when needed.

## Related issues
- Closes #234
