### PR TITLE
chore: do not skip test

### DIFF
--- a/logconsumer_test.go
+++ b/logconsumer_test.go
@@ -35,7 +35,6 @@ func (g *TestLogConsumer) Accept(l Log) {
 }
 
 func Test_LogConsumerGetsCalled(t *testing.T) {
-	t.Skip("This test is randomly failing for different versions of Go")
 	/*
 		send one request at a time to a server that will
 		print whatever was sent in the "echo" parameter, the log


### PR DESCRIPTION
## What does this PR do?
It removes the skip condition in the `Test_LogConsumerGetsCalled` test function.

## Why is it important?
As described in #331, we skipped it because there was flakiness with Go 1.14 and Go 1.15

Since we are supporting only the latest two minor versions of Go in the CI (see #492 and #493), we expect the flakiness disappears.

## Related issues
- Closes #331
