### PR TITLE
chore: retire old versions of Go

### DIFF
--- a/.github/workflows/ci-podman.yml
+++ b/.github/workflows/ci-podman.yml
@@ -6,7 +6,7 @@ jobs:
   build:
     strategy:
       matrix:
-        go-version: [1.16.x, 1.17.x, 1.x]
+        go-version: [1.18.x, 1.x]
     runs-on: ubuntu-22.04
     steps:
       - name: Set up Go

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.16.x, 1.17.x, 1.x]
+        go-version: [1.18.x, 1.x]
         platform: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/e2e/go.mod
+++ b/e2e/go.mod
@@ -1,6 +1,6 @@
 module e2e
 
-go 1.19
+go 1.18
 
 require (
 	github.com/docker/go-connections v0.4.0

--- a/e2e/go.mod
+++ b/e2e/go.mod
@@ -1,6 +1,6 @@
 module e2e
 
-go 1.13
+go 1.19
 
 require (
 	github.com/docker/go-connections v0.4.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/testcontainers/testcontainers-go
 
-go 1.13
+go 1.19
 
 require (
 	github.com/cenkalti/backoff/v4 v4.1.3

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/testcontainers/testcontainers-go
 
-go 1.19
+go 1.18
 
 require (
 	github.com/cenkalti/backoff/v4 v4.1.3


### PR DESCRIPTION
## What does this PR do?
It removes go1.16 and go1.17 from the CI, as they are not supported any more

## Why is it important?
Let's keep only the supported versions (last two minors)

## Related issues
- Closes #529
- Discoverd while testing #528

## Follow-ups
We could automate the bump of the Go versions that are supported at CI time, see #529 comment
