### PR TITLE
chore: include test flakiness in the release drafter

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -15,6 +15,7 @@ categories:
   - title: 🧹 Housekeeping
     labels:
       - type/housekeeping
+      - type/test-flakiness
       - type/test-improvement
   - title: 📦 Dependency updates
     label: dependencies


### PR DESCRIPTION
## What does this PR do?
It includes the `type/test-flakiness` GH label into the `Housekeeping` section of the release drafter

## Why is it important?
To add PRs/issues with that label into the changelog/release notes

## Related issues
- Discovered while testing #528