### PR TITLE
chore: add emoji to breaking changes in release drafter

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -6,7 +6,7 @@ template: |
 categories:
   - title: 🚀 Features
     label: type/feature
-  - title: BC Break
+  - title: ⚠️ Breaking Changes
     label: type/bc-break
   - title: 🐛 Bug Fixes
     label: type/bug


### PR DESCRIPTION
## What does this PR do?
It adds the warning emoji to the `Breaking changes` section in the Release Drafter's configuration file

## Why is it important?
Consistency with the rest of the sections (emoji + title) and with the Java changelog, which uses the same emoji

