### PR TITLE
fix: pass docker context key when reusing a container

### DIFF
--- a/docker.go
+++ b/docker.go
@@ -1111,7 +1111,7 @@ func (p *DockerProvider) ReuseOrCreateContainer(ctx context.Context, req Contain
 	sessionID := uuid.New()
 	var termSignal chan bool
 	if !req.SkipReaper {
-		r, err := NewReaper(ctx, sessionID.String(), p, req.ReaperImage)
+		r, err := NewReaper(context.WithValue(ctx, dockerHostContextKey, p.host), sessionID.String(), p, req.ReaperImage)
 		if err != nil {
 			return nil, fmt.Errorf("%w: creating reaper failed", err)
 		}


### PR DESCRIPTION
## What does this PR do?
It passes the docker_host key to the reaper creation when using the ReuseOrCreate container function, so that the reaper is able to extract the Docker host.

Reuse is available as a field in the GenericContainerRequest struct.

## Why is it important?
Consistency. Any other call to NewReaper is passing the host from the provider. Before these changes it was not passed, so the reaper directly returns `/var/run/docker.sock` when the `TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE` environment variable is not set.

