### PR TITLE
Support for cap-add/cap-drop

### DIFF
--- a/container.go
+++ b/container.go
@@ -116,7 +116,9 @@ type ContainerRequest struct {
 	AlwaysPullImage bool            // Always pull image
 	ImagePlatform   string          // ImagePlatform describes the platform which the image runs on.
 	Binds           []string
-	ShmSize         int64 // Amount of memory shared with the host (in bytes)
+	ShmSize         int64    // Amount of memory shared with the host (in bytes)
+	CapAdd          []string // Add Linux capabilities
+	CapDrop         []string // Drop Linux capabilities
 }
 
 type (

--- a/docker.go
+++ b/docker.go
@@ -1033,6 +1033,8 @@ func (p *DockerProvider) CreateContainer(ctx context.Context, req ContainerReque
 		NetworkMode:  req.NetworkMode,
 		Resources:    req.Resources,
 		ShmSize:      req.ShmSize,
+		CapAdd:       req.CapAdd,
+		CapDrop:      req.CapDrop,
 	}
 
 	endpointConfigs := map[string]*network.EndpointSettings{}

--- a/docker_test.go
+++ b/docker_test.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/strslice"
 	"github.com/docker/go-units"
 	"github.com/go-redis/redis/v8"
 	"github.com/stretchr/testify/assert"
@@ -2223,6 +2224,39 @@ func TestContainerWithReaperNetwork(t *testing.T) {
 	assert.Equal(t, 2, len(cnt.NetworkSettings.Networks))
 	assert.NotNil(t, cnt.NetworkSettings.Networks[networks[0]])
 	assert.NotNil(t, cnt.NetworkSettings.Networks[networks[1]])
+}
+
+func TestContainerCapAdd(t *testing.T) {
+	if providerType == ProviderPodman {
+		t.Skip("Rootless Podman does not support setting cap-add/cap-drop")
+	}
+
+	ctx := context.Background()
+
+	expected := "IPC_LOCK"
+
+	nginx, err := GenericContainer(ctx, GenericContainerRequest{
+		ProviderType: providerType,
+		ContainerRequest: ContainerRequest{
+			Image:        nginxAlpineImage,
+			ExposedPorts: []string{nginxDefaultPort},
+			WaitingFor:   wait.ForListeningPort(nginxDefaultPort),
+			CapAdd:       []string{expected},
+		},
+		Started: true,
+	})
+	require.NoError(t, err)
+	terminateContainerOnEnd(t, ctx, nginx)
+
+	dockerClient, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
+	require.NoError(t, err)
+	defer dockerClient.Close()
+
+	containerID := nginx.GetContainerID()
+	resp, err := dockerClient.ContainerInspect(ctx, containerID)
+	require.NoError(t, err)
+
+	assert.Equal(t, strslice.StrSlice{expected}, resp.HostConfig.CapAdd)
 }
 
 func TestContainerRunningCheckingStatusCode(t *testing.T) {


### PR DESCRIPTION
[context from slack](https://testcontainers.slack.com/archives/C1SUBPZK6/p1665000052571229)

adds cap-add/cap-drop to container request and passes to docker host config