### PR TITLE
fix container NetworkMode usage

### DIFF
--- a/docker.go
+++ b/docker.go
@@ -993,7 +993,7 @@ func (p *DockerProvider) CreateContainer(ctx context.Context, req ContainerReque
 	}
 
 	exposedPorts := req.ExposedPorts
-	if len(exposedPorts) == 0 {
+	if len(exposedPorts) == 0 && !req.NetworkMode.IsContainer() {
 		image, _, err := p.client.ImageInspectWithRaw(ctx, tag)
 		if err != nil {
 			return nil, err

--- a/docker_test.go
+++ b/docker_test.go
@@ -2323,6 +2323,33 @@ func TestProviderHasConfig(t *testing.T) {
 	assert.NotNil(t, provider.Config(), "expecting DockerProvider to provide the configuration")
 }
 
+func TestNetworkModeWithContainerReference(t *testing.T) {
+	ctx := context.Background()
+	nginxA, err := GenericContainer(ctx, GenericContainerRequest{
+		ProviderType: providerType,
+		ContainerRequest: ContainerRequest{
+			Image: nginxAlpineImage,
+		},
+		Started: true,
+	})
+
+	require.NoError(t, err)
+	terminateContainerOnEnd(t, ctx, nginxA)
+
+	networkMode := fmt.Sprintf("container:%v", nginxA.GetContainerID())
+	nginxB, err := GenericContainer(ctx, GenericContainerRequest{
+		ProviderType: providerType,
+		ContainerRequest: ContainerRequest{
+			Image:       nginxAlpineImage,
+			NetworkMode: container.NetworkMode(networkMode),
+		},
+		Started: true,
+	})
+
+	require.NoError(t, err)
+	terminateContainerOnEnd(t, ctx, nginxB)
+}
+
 // creates a temporary dir in which the files will be extracted. Then it will compare the bytes of each file in the source with the bytes from the copied-from-container file
 func assertExtractedFiles(t *testing.T, ctx context.Context, container Container, hostFilePath string, containerFilePath string) {
 	// create all copied files into a temporary dir


### PR DESCRIPTION
docker cannot do container network mode with exposed ports.
in order to make it work, only calculate the default exposed
ports if the NetworkMode is NOT container.