### PR TITLE
chore: proper messaging on disabling ryuk

### DIFF
--- a/docker.go
+++ b/docker.go
@@ -934,6 +934,12 @@ func (p *DockerProvider) CreateContainer(ctx context.Context, req ContainerReque
 				req.Labels[k] = v
 			}
 		}
+	} else {
+		ryukDisabledMessage := `
+*************************************************************************************************
+Ryuk has been disabled for the container. This can cause unexpected behavior in your environment.
+*************************************************************************************************`
+		p.Logger.Printf(ryukDisabledMessage)
 	}
 
 	if err = req.Validate(); err != nil {
@@ -1145,6 +1151,12 @@ func (p *DockerProvider) ReuseOrCreateContainer(ctx context.Context, req Contain
 		if err != nil {
 			return nil, fmt.Errorf("%w: connecting to reaper failed", err)
 		}
+	} else {
+		ryukDisabledMessage := `
+*************************************************************************************************
+Ryuk has been disabled for the container. This can cause unexpected behavior in your environment.
+*************************************************************************************************`
+		p.Logger.Printf(ryukDisabledMessage)
 	}
 	dc := &DockerContainer{
 		ID:                c.ID,
@@ -1304,6 +1316,12 @@ func (p *DockerProvider) CreateNetwork(ctx context.Context, req NetworkRequest) 
 				req.Labels[k] = v
 			}
 		}
+	} else {
+		ryukDisabledMessage := `
+**********************************************************************************************
+Ryuk has been disabled for the network. This can cause unexpected behavior in your environment.
+**********************************************************************************************`
+		p.Logger.Printf(ryukDisabledMessage)
 	}
 
 	response, err := p.client.NetworkCreate(ctx, req.Name, nc)

--- a/docker.go
+++ b/docker.go
@@ -938,6 +938,7 @@ func (p *DockerProvider) CreateContainer(ctx context.Context, req ContainerReque
 		ryukDisabledMessage := `
 *************************************************************************************************
 Ryuk has been disabled for the container. This can cause unexpected behavior in your environment.
+More on this: https://golang.testcontainers.org/features/garbage_collector/
 *************************************************************************************************`
 		p.Logger.Printf(ryukDisabledMessage)
 	}
@@ -1155,6 +1156,7 @@ func (p *DockerProvider) ReuseOrCreateContainer(ctx context.Context, req Contain
 		ryukDisabledMessage := `
 *************************************************************************************************
 Ryuk has been disabled for the container. This can cause unexpected behavior in your environment.
+More on this: https://golang.testcontainers.org/features/garbage_collector/
 *************************************************************************************************`
 		p.Logger.Printf(ryukDisabledMessage)
 	}
@@ -1320,6 +1322,7 @@ func (p *DockerProvider) CreateNetwork(ctx context.Context, req NetworkRequest) 
 		ryukDisabledMessage := `
 **********************************************************************************************
 Ryuk has been disabled for the network. This can cause unexpected behavior in your environment.
+More on this: https://golang.testcontainers.org/features/garbage_collector/
 **********************************************************************************************`
 		p.Logger.Printf(ryukDisabledMessage)
 	}

--- a/docker.go
+++ b/docker.go
@@ -935,12 +935,7 @@ func (p *DockerProvider) CreateContainer(ctx context.Context, req ContainerReque
 			}
 		}
 	} else {
-		ryukDisabledMessage := `
-*************************************************************************************************
-Ryuk has been disabled for the container. This can cause unexpected behavior in your environment.
-More on this: https://golang.testcontainers.org/features/garbage_collector/
-*************************************************************************************************`
-		p.Logger.Printf(ryukDisabledMessage)
+		p.printReaperBanner("container")
 	}
 
 	if err = req.Validate(); err != nil {
@@ -1153,12 +1148,7 @@ func (p *DockerProvider) ReuseOrCreateContainer(ctx context.Context, req Contain
 			return nil, fmt.Errorf("%w: connecting to reaper failed", err)
 		}
 	} else {
-		ryukDisabledMessage := `
-*************************************************************************************************
-Ryuk has been disabled for the container. This can cause unexpected behavior in your environment.
-More on this: https://golang.testcontainers.org/features/garbage_collector/
-*************************************************************************************************`
-		p.Logger.Printf(ryukDisabledMessage)
+		p.printReaperBanner("container")
 	}
 	dc := &DockerContainer{
 		ID:                c.ID,
@@ -1319,12 +1309,7 @@ func (p *DockerProvider) CreateNetwork(ctx context.Context, req NetworkRequest) 
 			}
 		}
 	} else {
-		ryukDisabledMessage := `
-**********************************************************************************************
-Ryuk has been disabled for the network. This can cause unexpected behavior in your environment.
-More on this: https://golang.testcontainers.org/features/garbage_collector/
-**********************************************************************************************`
-		p.Logger.Printf(ryukDisabledMessage)
+		p.printReaperBanner("network")
 	}
 
 	response, err := p.client.NetworkCreate(ctx, req.Name, nc)
@@ -1381,6 +1366,15 @@ func (p *DockerProvider) GetGatewayIP(ctx context.Context) (string, error) {
 	}
 
 	return ip, nil
+}
+
+func (p *DockerProvider) printReaperBanner(resource string) {
+	ryukDisabledMessage := `
+	**********************************************************************************************
+	Ryuk has been disabled for the ` + resource + `. This can cause unexpected behavior in your environment.
+	More on this: https://golang.testcontainers.org/features/garbage_collector/
+	**********************************************************************************************`
+	p.Logger.Printf(ryukDisabledMessage)
 }
 
 func inAContainer() bool {

--- a/docs/features/garbage_collector.md
+++ b/docs/features/garbage_collector.md
@@ -37,9 +37,9 @@ container labels to determine which resources were created by the package
 to determine the entities that are safe to remove. If a container is running
 for more than 10 seconds, it will be killed.
 
-!!!tip
+!!!warning
 
-    This feature can be disabled when creating a container.
+    This feature can be disabled when creating a container or a network, but it can cause **unexpected behavior** in your environment.
 
 Even if you do not call Terminate, Ryuk ensures that the environment will be
 kept clean and even cleans itself when there is nothing left to do.

--- a/docs/features/garbage_collector.md
+++ b/docs/features/garbage_collector.md
@@ -39,7 +39,11 @@ for more than 10 seconds, it will be killed.
 
 !!!warning
 
-    This feature can be disabled when creating a container or a network, but it can cause **unexpected behavior** in your environment.
+    This feature can be disabled when creating a container or a network,
+    but it can cause **unexpected behavior** in your environment.
+
+    We recommend using it only for Continuous Integration services that have their
+    own mechanism to clean up resources.
 
 Even if you do not call Terminate, Ryuk ensures that the environment will be
 kept clean and even cleans itself when there is nothing left to do.


### PR DESCRIPTION
## What does this PR do?
It does :

- prints a simple banner if Ryuk is skipped for a container or a network, displaying a link to the docs.
- changes the block section for the reaper in the docs from a tip to a warning, including reasons why it's not recommended to disable Ryuk.

## Why is it important?
In the light of #561, good conversations have appeared around disabling Ryuk. For that reason, we are improving the docs and the outcomes of disabling Ryuk at the container request.

