### PR TITLE
feat: add sessionID HTTP Header to the Docker client setup

### DIFF
--- a/docker.go
+++ b/docker.go
@@ -745,6 +745,12 @@ func NewDockerClient() (cli *client.Client, host string, tcConfig TestContainers
 		host = "unix:///var/run/docker.sock"
 	}
 
+	opts = append(opts, client.WithHTTPHeaders(
+		map[string]string{
+			"x-tc-sid": "",
+		}),
+	)
+
 	cli, err = client.NewClientWithOpts(opts...)
 
 	if err != nil {
@@ -1310,10 +1316,9 @@ func (p *DockerProvider) CreateNetwork(ctx context.Context, req NetworkRequest) 
 		IPAM:           req.IPAM,
 	}
 
-	sessionID := uuid.New()
-
 	var termSignal chan bool
 	if !req.SkipReaper {
+		sessionID := uuid.New()
 		r, err := NewReaper(context.WithValue(ctx, dockerHostContextKey, p.host), sessionID.String(), p, req.ReaperImage)
 		if err != nil {
 			return nil, fmt.Errorf("%w: creating network reaper failed", err)

--- a/docker.go
+++ b/docker.go
@@ -747,7 +747,7 @@ func NewDockerClient() (cli *client.Client, host string, tcConfig TestContainers
 
 	opts = append(opts, client.WithHTTPHeaders(
 		map[string]string{
-			"x-tc-sid": SessionID().String(),
+			"x-tc-sid": sessionID().String(),
 		}),
 	)
 
@@ -940,7 +940,7 @@ func (p *DockerProvider) CreateContainer(ctx context.Context, req ContainerReque
 		req.Labels = make(map[string]string)
 	}
 
-	sessionID := SessionID()
+	sessionID := sessionID()
 
 	var termSignal chan bool
 	if !req.SkipReaper {
@@ -1161,7 +1161,7 @@ func (p *DockerProvider) ReuseOrCreateContainer(ctx context.Context, req Contain
 		return p.CreateContainer(ctx, req)
 	}
 
-	sessionID := SessionID()
+	sessionID := sessionID()
 	var termSignal chan bool
 	if !req.SkipReaper {
 		r, err := NewReaper(ctx, sessionID.String(), p, req.ReaperImage)
@@ -1318,7 +1318,7 @@ func (p *DockerProvider) CreateNetwork(ctx context.Context, req NetworkRequest) 
 
 	var termSignal chan bool
 	if !req.SkipReaper {
-		sessionID := SessionID()
+		sessionID := sessionID()
 		r, err := NewReaper(context.WithValue(ctx, dockerHostContextKey, p.host), sessionID.String(), p, req.ReaperImage)
 		if err != nil {
 			return nil, fmt.Errorf("%w: creating network reaper failed", err)

--- a/docker.go
+++ b/docker.go
@@ -747,7 +747,7 @@ func NewDockerClient() (cli *client.Client, host string, tcConfig TestContainers
 
 	opts = append(opts, client.WithHTTPHeaders(
 		map[string]string{
-			"x-tc-sid": "",
+			"x-tc-sid": SessionID().String(),
 		}),
 	)
 
@@ -940,7 +940,7 @@ func (p *DockerProvider) CreateContainer(ctx context.Context, req ContainerReque
 		req.Labels = make(map[string]string)
 	}
 
-	sessionID := uuid.New()
+	sessionID := SessionID()
 
 	var termSignal chan bool
 	if !req.SkipReaper {
@@ -1161,7 +1161,7 @@ func (p *DockerProvider) ReuseOrCreateContainer(ctx context.Context, req Contain
 		return p.CreateContainer(ctx, req)
 	}
 
-	sessionID := uuid.New()
+	sessionID := SessionID()
 	var termSignal chan bool
 	if !req.SkipReaper {
 		r, err := NewReaper(ctx, sessionID.String(), p, req.ReaperImage)
@@ -1318,7 +1318,7 @@ func (p *DockerProvider) CreateNetwork(ctx context.Context, req NetworkRequest) 
 
 	var termSignal chan bool
 	if !req.SkipReaper {
-		sessionID := uuid.New()
+		sessionID := SessionID()
 		r, err := NewReaper(context.WithValue(ctx, dockerHostContextKey, p.host), sessionID.String(), p, req.ReaperImage)
 		if err != nil {
 			return nil, fmt.Errorf("%w: creating network reaper failed", err)

--- a/reaper.go
+++ b/reaper.go
@@ -63,13 +63,17 @@ func NewReaper(ctx context.Context, sessionID string, provider ReaperProvider, r
 		ExposedPorts: []string{string(listeningPort)},
 		NetworkMode:  Bridge,
 		Labels: map[string]string{
-			TestcontainerLabel:         "true",
 			TestcontainerLabelIsReaper: "true",
 		},
 		SkipReaper: true,
 		Mounts:     Mounts(BindMount(dockerHost, "/var/run/docker.sock")),
 		AutoRemove: true,
 		WaitingFor: wait.ForListeningPort(listeningPort),
+	}
+
+	// include reaper-specific labels to the reaper container
+	for k, v := range reaper.Labels() {
+		req.Labels[k] = v
 	}
 
 	tcConfig := provider.Config()

--- a/reaper_test.go
+++ b/reaper_test.go
@@ -35,8 +35,9 @@ func createContainerRequest(customize func(ContainerRequest) ContainerRequest) C
 		Image:        "reaperImage",
 		ExposedPorts: []string{"8080/tcp"},
 		Labels: map[string]string{
-			TestcontainerLabel:         "true",
-			TestcontainerLabelIsReaper: "true",
+			TestcontainerLabel:          "true",
+			TestcontainerLabelIsReaper:  "true",
+			TestcontainerLabelSessionID: "sessionId",
 		},
 		SkipReaper:  true,
 		Mounts:      Mounts(BindMount("/var/run/docker.sock", "/var/run/docker.sock")),

--- a/session.go
+++ b/session.go
@@ -1,0 +1,18 @@
+package testcontainers
+
+import (
+	"sync"
+
+	"github.com/google/uuid"
+)
+
+var sessionID uuid.UUID
+var sessionIDOnce sync.Once
+
+func SessionID() uuid.UUID {
+	sessionIDOnce.Do(func() {
+		sessionID = uuid.New()
+	})
+
+	return sessionID
+}

--- a/session.go
+++ b/session.go
@@ -6,13 +6,13 @@ import (
 	"github.com/google/uuid"
 )
 
-var sessionID uuid.UUID
-var sessionIDOnce sync.Once
+var tcSessionID uuid.UUID
+var tcSessionIDOnce sync.Once
 
-func SessionID() uuid.UUID {
-	sessionIDOnce.Do(func() {
-		sessionID = uuid.New()
+func sessionID() uuid.UUID {
+	tcSessionIDOnce.Do(func() {
+		tcSessionID = uuid.New()
 	})
 
-	return sessionID
+	return tcSessionID
 }


### PR DESCRIPTION
## What does this PR do?
It initialises the sessionID of the containers just once, as in the past it was created per-container, and this is not the expected behavior.

For that, we have created a global sessionID variable that is protected by sync.Once, therefore it's called just once.

This variable is used in the library with a singleton method, which is called from everywhere that a new UUID was required by a container. Therefore, all containers will share the same sessionID during a test execution/session.

Besides that, we detected a minor change in how the reaper was declaring its sessionID, using a variable with a wider scope: we have moved that sessionID variable to its own scope.

Finally, we are adding an HTTP header to the setup of the Docker client, which will allow improving tracing and other operations.

## Why is it important
Better observability at the Docker API level, as we are instrumenting the HTTP requests.

With these changes we are also decoupling bit-by-bit the existing codebase: before them, the calculation of the sessionID happened everytime a container/network was created. Now, it happens just once per test execution. 

## Related issues
- Relates https://github.com/testcontainers/testcontainers-java/pull/5145
- Relates https://github.com/testcontainers/testcontainers-dotnet/commit/0eaea8b0e26e6457e168d160f237c7c33d8f61a7
- Relates https://github.com/testcontainers/testcontainers-go/issues/549

