### PR TITLE
fix: edit link in documentation

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -58,5 +58,6 @@ nav:
           - contributing.md
           - contributing_docs.md
     - Getting help: getting_help.md
+edit_uri: edit/main/docs/
 extra:
     latest_version: 0.14.0


### PR DESCRIPTION
previously the edit links always showed a 404
as the master branch is not used anymore
now the link is updated to use the current main branch
