### PR TITLE
chore: check error message in parts when testing the CreateContainerWithDirs method

### DIFF
--- a/docker_test.go
+++ b/docker_test.go
@@ -1996,7 +1996,7 @@ func TestDockerCreateContainerWithDirs(t *testing.T) {
 	tests := []struct {
 		name   string
 		dir    ContainerFile
-		errMsg string
+		errMsg []string
 	}{
 		{
 			name: "success copy directory",
@@ -2013,10 +2013,11 @@ func TestDockerCreateContainerWithDirs(t *testing.T) {
 				ContainerFilePath: "/tmp/" + hostDirName, // the parent dir must exist
 				FileMode:          700,
 			},
-			errMsg: "can't copy " +
-				"./testresources123 to container: open " +
-				"./testresources123: no such file or directory: " +
+			errMsg: []string{
+				"can't copy ./testresources123 to container",
+				"open ./testresources123: no such file or directory",
 				"failed to create container",
+			},
 		},
 		{
 			name: "container dir not found",
@@ -2025,7 +2026,10 @@ func TestDockerCreateContainerWithDirs(t *testing.T) {
 				ContainerFilePath: "/parent-does-not-exist/testresources123", // does not exist
 				FileMode:          700,
 			},
-			errMsg: "can't copy ./testresources to container: Error: No such container:path",
+			errMsg: []string{
+				"can't copy ./testresources to container",
+				"No such container:path",
+			},
 		},
 	}
 
@@ -2043,7 +2047,9 @@ func TestDockerCreateContainerWithDirs(t *testing.T) {
 
 			if err != nil {
 				require.NotEmpty(t, tc.errMsg)
-				require.Contains(t, err.Error(), tc.errMsg)
+				for _, msg := range tc.errMsg {
+					require.Contains(t, err.Error(), msg)
+				}
 			} else {
 				dir := tc.dir
 


### PR DESCRIPTION
## What does this PR do?
In the `TestDockerCreateContainerWithDirs` test method, there is a test table including an error message to be checked against the possible failure modes of that feature. This error message was created as a string to be compared with the expected error message from the Docker daemon while trying to copy the dirs to the container.

In this PR, we are changing the type of that error message, from a string to an array of strings, so that we are able to check that all parts are contained in the error message from the daemon.

I acknowledge that testing an error message could lead to flakiness in the future, so we could simple remove the assertions.

## Why is it important?
We have observed two different error messages in the Docker daemon for the same operation of copying a directory to a path that does not exist in the container.

Running the test on my `Mac M1`, where the Docker info is:

```
2022/10/22 00:15:50 github.com/testcontainers/testcontainers-go - Connected to docker:
    Server Version: 20.10.17
    API Version: 1.41
    Operating System: Docker Desktop
    Total Memory: 7951 MB
```

I get the same error message from the daemon than before these changes:

```
"can't copy ./testresources to container: Error: No such container:path"
```

But when running the test the Github actions, where we use `Ubuntu:latest` as build machines and the Docker info returns:
```
22022/10/21 22:11:26 github.com/testcontainers/testcontainers-go - Connected to docker:
    Server Version: 20.10.18+azure-
    API Version: 1.41
    Operating System: Ubuntu 20.04.5 LTS
    Total Memory: 6944 MB
```

we see that the error message for the very same operation is:

```
can't copy ./testresources to container: Error response from daemon: Could not find the file /parent-does-not-exist in container 81700aee9f0ab62c05dbbaa89798a8ab4f7843f54d7288b2a5a6360b2af19e90: failed to create container
```

For that reason we are adding these changes, checking the error message in parts, not the entire string.

I've done a super quick search on Github looking for changes in the daemon responses on errors, but I could not find anything yet, but I probably need more time to find the original changes. In any case, I consider the different server version relevant for the changes.

Besides that, the fix for an upcoming release will be of interest.

Finally, the test failure is blocking other PRs in a non-deterministic manner: there are times where the GHA are passing and failing, probably because we are using `ubuntu:latest`. I wonder if Github infra is deterministic about the builder machines 🤔 

## Related issues
- Blocks #476

