### PR TITLE
chore: prepare for 0.15.0 release

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -60,4 +60,4 @@ nav:
     - Getting help: getting_help.md
 edit_uri: edit/main/docs/
 extra:
-    latest_version: 0.14.0
+    latest_version: 0.15.0

--- a/wait/sql.go
+++ b/wait/sql.go
@@ -12,7 +12,7 @@ import (
 const defaultForSqlQuery = "SELECT 1"
 
 //ForSQL constructs a new waitForSql strategy for the given driver
-func ForSQL(port nat.Port, driver string, url func(string, nat.Port) string) *waitForSql {
+func ForSQL(port nat.Port, driver string, url func(host string, port nat.Port) string) *waitForSql {
 	return &waitForSql{
 		Port:           port,
 		URL:            url,


### PR DESCRIPTION
## What does this PR do?
It bumps the version of the library in the docs site, and adds named parameters in a function of the public API.

## Why is it important?
Keep docs up-to-date, and increase the readability of that function while consuming it.



