### PR TITLE
feat: allow setting custom IP address for container

### DIFF
--- a/container.go
+++ b/container.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/pkg/archive"
 	"github.com/docker/go-connections/nat"
 
@@ -120,6 +121,7 @@ type ContainerRequest struct {
 	ShmSize         int64    // Amount of memory shared with the host (in bytes)
 	CapAdd          []string // Add Linux capabilities
 	CapDrop         []string // Drop Linux capabilities
+	IPAMConfig      *network.EndpointIPAMConfig
 }
 
 type (

--- a/docker.go
+++ b/docker.go
@@ -279,7 +279,6 @@ func (c *DockerContainer) inspectContainer(ctx context.Context) (*types.Containe
 // Logs will fetch both STDOUT and STDERR from the current container. Returns a
 // ReadCloser and leaves it up to the caller to extract what it wants.
 func (c *DockerContainer) Logs(ctx context.Context) (io.ReadCloser, error) {
-
 	const streamHeaderSize = 8
 
 	options := types.ContainerLogsOptions{
@@ -812,7 +811,7 @@ func NewDockerProvider(provOpts ...DockerProviderOption) (*DockerProvider, error
 }
 
 func logDockerServerInfo(ctx context.Context, client client.APIClient, logger Logging) {
-	infoMessage := `%v - Connected to docker: 
+	infoMessage := `%v - Connected to docker:
   Server Version: %v
   API Version: %v
   Operating System: %v
@@ -1035,7 +1034,7 @@ func (p *DockerProvider) CreateContainer(ctx context.Context, req ContainerReque
 		if err != nil {
 			return nil, err
 		}
-		for p, _ := range image.ContainerConfig.ExposedPorts {
+		for p := range image.ContainerConfig.ExposedPorts {
 			exposedPorts = append(exposedPorts, string(p))
 		}
 	}
@@ -1087,8 +1086,9 @@ func (p *DockerProvider) CreateContainer(ctx context.Context, req ContainerReque
 		})
 		if err == nil {
 			endpointSetting := network.EndpointSettings{
-				Aliases:   req.NetworkAliases[attachContainerTo],
-				NetworkID: nw.ID,
+				Aliases:    req.NetworkAliases[attachContainerTo],
+				NetworkID:  nw.ID,
+				IPAMConfig: req.IPAMConfig,
 			}
 			endpointConfigs[attachContainerTo] = &endpointSetting
 		}


### PR DESCRIPTION
this PR adds option to specify custom IP for a container

some prerequisites are needed, but those are regular as with doing the same with docker or docker compose
this is possible to use only when using user defined subnets, but error message is quite clear if anyone tries to use it without.

reason why i need this feature is quite simple:
I have some complex tests where I need to know in advance IP addressees of some containers before starting anything. 

However I can only do that currently by starting the containers, getting the IPs of all containers, stopping it, clearing data, setting all IPs in configs of multiple containers and then start containers again and proceed with test

so the test itself can be much simpler if I can define all addresses in advance, create configs, build containers with already known IPs and just focus on actual testing of a feature. 
Reason why IP needs to be fixed (and not hostname or some discovery ) is due to protocols used and for example security (and I do something similar not only in tests)
Also its much easier to set the "wrong" IP and test implementation where security is good enough to not allow that.

I also added test where i test both creating container in custom subnet + creating container with custom IP (for test is just next available IP) in same network.