### PR TITLE
fix: support parallel execution of reusable containers

### DIFF
--- a/generic.go
+++ b/generic.go
@@ -58,7 +58,7 @@ func GenericContainer(ctx context.Context, req GenericContainerRequest) (Contain
 
 	var c Container
 	if req.Reuse {
-		// we must protect the reusability of the container in the case it's invoke
+		// we must protect the reusability of the container in the case it's invoked
 		// in a parallel execution, via ParallelContainers or t.Parallel()
 		reuseContainerMx.Lock()
 		defer reuseContainerMx.Unlock()

--- a/generic.go
+++ b/generic.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync"
 )
 
 var (
+	reuseContainerMx  sync.Mutex
 	ErrReuseEmptyName = errors.New("with reuse option a container name mustn't be empty")
 )
 
@@ -56,6 +58,11 @@ func GenericContainer(ctx context.Context, req GenericContainerRequest) (Contain
 
 	var c Container
 	if req.Reuse {
+		// we must protect the reusability of the container in the case it's invoke
+		// in a parallel execution, via ParallelContainers or t.Parallel()
+		reuseContainerMx.Lock()
+		defer reuseContainerMx.Unlock()
+
 		c, err = provider.ReuseOrCreateContainer(ctx, req.ContainerRequest)
 	} else {
 		c, err = provider.CreateContainer(ctx, req.ContainerRequest)

--- a/parallel_test.go
+++ b/parallel_test.go
@@ -2,9 +2,12 @@ package testcontainers
 
 import (
 	"context"
+	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go/wait"
 )
 
 func TestParallelContainers(t *testing.T) {
@@ -118,5 +121,52 @@ func TestParallelContainers(t *testing.T) {
 				t.Fatalf("expected containers: %d, got: %d\n", tc.resLen, len(res))
 			}
 		})
+	}
+}
+
+func TestParallelContainersWithReuse(t *testing.T) {
+	const (
+		postgresPort     = 5432
+		postgresPassword = "test"
+		postgresUser     = "test"
+		postgresDb       = "test"
+	)
+
+	natPort := fmt.Sprintf("%d/tcp", postgresPort)
+
+	req := GenericContainerRequest{
+		ContainerRequest: ContainerRequest{
+			Image:        "postgis/postgis",
+			Name:         "test-postgres",
+			ExposedPorts: []string{natPort},
+			Env: map[string]string{
+				"POSTGRES_PASSWORD": postgresPassword,
+				"POSTGRES_USER":     postgresUser,
+				"POSTGRES_DATABASE": postgresDb,
+			},
+			WaitingFor: wait.ForLog("database system is ready to accept connections").
+				WithPollInterval(100 * time.Millisecond).
+				WithOccurrence(2),
+		},
+		Started: true,
+		Reuse:   true,
+	}
+
+	parallelRequest := ParallelContainerRequest{
+		req,
+		req,
+		req,
+	}
+
+	ctx := context.Background()
+
+	res, err := ParallelContainers(ctx, parallelRequest, ParallelContainersOptions{})
+	if err != nil {
+		e, _ := err.(ParallelContainersError)
+		t.Fatalf("expected errors: %d, got: %d\n", 0, len(e.Errors))
+	}
+
+	for _, c := range res {
+		defer c.Terminate(ctx)
 	}
 }


### PR DESCRIPTION
## What does this PR do?
It adds a sync.Mutex lock/unlock when a reusable container is created, including a test that demonstrates the bug

In the original bug report (#592), a repro snippet was added, although I preferred a different test that leverages our `testcontainers.ParallelContainers` API, adding code coverage to the library. 

## Why is it important?
Thanks to @mhatch-nxcr, who reported this bug in #592, we demonstrated that the implementation of the reusable containers was not complete in terms of a parallel execution of tests creating containers with the library. The bug report found a race condition while checking the Docker client to find containers with the same name when called from a goroutine (i.e. running multiple Test functions including `t.Parallel()` or our `ParallelContainers` function).

Internally, when we are checking if we need to reuse a container by its name, the library calls the Docker client with a `findContainerByName` function of the DockerProvider. At the moment this `findContainerByName` function was called by any goroutine, no container was already created with the reusable container name, and in consequence the Docker client responded with a list of zero containers, which was expected. Therefore we had to look up the stack call to identify what code was calling that method, until we found that we needed synchronization at the moment the first container was created. That's why we are adding the `lock/unlock` only for the `req.Reuse` if/else branch.

**Before the changes**
```mermaid
graph TD
    B(Test execution)
    B --> C{Parallel creation}
    C -->|ReuseContainer| D[Name: reusable]
    C -->|ReuseContainer| E[Name: reusable]
    C -->|ReuseContainer| F[Name: reusable]
    D -->|findContainerByName| G[Docker client]
    E -->|findContainerByName| G[Docker client]
    F -->|findContainerByName| G[Docker client]
    G -->|filter:name=reusable| H["len(List)"]
```

**After the changes**
```mermaid
graph TD
    B(Test execution)
    B --> C{Parallel creation}
    C --> I[sync.Mutex]
    I -->|ReuseContainer| D[Name: reusable]
    I -->|ReuseContainer| E[Name: reusable]
    I -->|ReuseContainer| F[Name: reusable]
    D -->|findContainerByName| G[Docker client]
    E -->|findContainerByName| G[Docker client]
    F -->|findContainerByName| G[Docker client]
    G -->|filter:name=reusable| H["len(List)"]
```
## How to test this
Run the first commit of this PR with and without the second commit.

## Related issues
- Fixes #592


