### PR TITLE
docs: Rename the MkDocs site name to match other Testcontainers languages

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,4 @@
-# Testcontainers-go
+# Testcontainers
 
 ![Testcontainers logo](./logo.png)
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,4 +1,4 @@
-site_name: Testcontainers-Go
+site_name: Testcontainers for Go
 plugins:
     - search
     - codeinclude


### PR DESCRIPTION
## What does this PR do?

Aligns the Testcontainers OSS naming conventions with the MKDocs Go documentation.

## Why is it important?

Creates a more unified appearance for Testcontainers language documentations. The Java and .NET implementation are following the same conventions.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
\- 

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->