### PR TITLE
docs: wording in project name

### DIFF
--- a/docs/features/build_from_dockerfile.md
+++ b/docs/features/build_from_dockerfile.md
@@ -58,7 +58,7 @@ fromDockerfile := testcontainers.FromDockerfile{
 }
 ```
 
-**Please Note** if you specify a `ContextArchive` this will cause Testcontainers-go to ignore the path passed
+**Please Note** if you specify a `ContextArchive` this will cause _Testcontainers for Go_ to ignore the path passed
 in to `Context`.
 
 ## Images requiring auth

--- a/docs/quickstart/gotest.md
+++ b/docs/quickstart/gotest.md
@@ -1,4 +1,4 @@
-Testcontainers-go plays well with the native `go test` framework.
+_Testcontainers for Go_ plays well with the native `go test` framework.
 
 The ideal use case is for integration or end to end tests. It helps you to spin
 up and manage the dependencies life cycle via Docker.


### PR DESCRIPTION
## What does this PR do?
It uses "Testcontainers for Go" in the docs

## Why is it important?
Because the umbrella project is "Testcontainers", and this library is the implementation for the Go language.
