### PR TITLE
docs: networking basics

### DIFF
--- a/docker_test.go
+++ b/docker_test.go
@@ -5,8 +5,8 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+
 	// Import mysql into the scope of this package (required)
-	_ "github.com/go-sql-driver/mysql"
 	"io"
 	"io/ioutil"
 	"math/rand"
@@ -17,6 +17,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	_ "github.com/go-sql-driver/mysql"
 
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/strslice"
@@ -54,6 +56,7 @@ func init() {
 	}
 }
 
+// testNetworkAliases {
 func TestContainerAttachedToNewNetwork(t *testing.T) {
 	aliases := []string{"alias1", "alias2", "alias3"}
 	networkName := "new-network"
@@ -130,6 +133,8 @@ func TestContainerAttachedToNewNetwork(t *testing.T) {
 		t.Errorf("Expected an IP address, got %v", networkIP)
 	}
 }
+
+// }
 
 func TestContainerWithHostNetworkOptions(t *testing.T) {
 	absPath, err := filepath.Abs("./testresources/nginx-highport.conf")
@@ -981,6 +986,7 @@ func TestContainerCreationWaitsForLogContextTimeout(t *testing.T) {
 }
 
 func TestContainerCreationWaitsForLog(t *testing.T) {
+	// exposePorts {
 	ctx := context.Background()
 	req := ContainerRequest{
 		Image:        "docker.io/mysql:latest",
@@ -996,13 +1002,18 @@ func TestContainerCreationWaitsForLog(t *testing.T) {
 		ContainerRequest: req,
 		Started:          true,
 	})
+	// }
 
 	require.NoError(t, err)
 	terminateContainerOnEnd(t, ctx, mysqlC)
 
+	// containerHost {
 	host, _ := mysqlC.Host(ctx)
+	// }
+	// mappedPort {
 	p, _ := mysqlC.MappedPort(ctx, "3306/tcp")
 	port := p.Int()
+	// }
 	connectionString := fmt.Sprintf("%s:%s@tcp(%s:%d)/%s?tls=skip-verify",
 		"root", "password", host, port, "database")
 
@@ -1368,6 +1379,7 @@ func TestContainerCreationWaitsForLogAndPort(t *testing.T) {
 	require.NoError(t, err)
 	terminateContainerOnEnd(t, ctx, mysqlC)
 
+	// buildingAddresses {
 	host, _ := mysqlC.Host(ctx)
 	p, _ := mysqlC.MappedPort(ctx, "3306/tcp")
 	port := p.Int()
@@ -1378,6 +1390,7 @@ func TestContainerCreationWaitsForLogAndPort(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	// }
 
 	defer db.Close()
 

--- a/docs/features/networking.md
+++ b/docs/features/networking.md
@@ -1,0 +1,56 @@
+# Networking and communicating with containers
+
+## Exposing container ports to the host
+
+It is common to want to connect to a container from your test process, running on the test 'host' machine.
+For example, you may be testing some code that needs to connect to a backend or data store container.
+
+Generally, each required port needs to be explicitly exposed. For example, we can specify one or more ports as follows:
+
+<!--codeinclude-->
+[Exposing ports](../../docker_test.go) inside_block:exposePorts
+<!--/codeinclude-->
+
+Note that this exposed port number is from the *perspective of the container*. 
+
+*From the host's perspective* Testcontainers actually exposes this on a random free port.
+This is by design, to avoid port collisions that may arise with locally running software or in between parallel test runs.
+
+Because there is this layer of indirection, it is necessary to ask Testcontainers for the actual mapped port at runtime.
+This can be done using the `getMappedPort` method, which takes the original (container) port as an argument:
+
+<!--codeinclude-->
+[Retrieving actual ports at runtime](../../docker_test.go) inside_block:mappedPort
+<!--/codeinclude-->
+
+!!! warning
+    Because the randomised port mapping happens during container startup, the container must be running at the time `MappedPort` is called. 
+    You may need to ensure that the startup order of components in your tests caters for this.
+
+## Getting the container host
+
+When running with a local Docker daemon, exposed ports will usually be reachable on `localhost`.
+However, in some CI environments they may instead be reachable on a different host.
+
+As such, Testcontainers provides a convenience method to obtain an address on which the container should be reachable from the host machine.
+
+<!--codeinclude-->
+[Getting the container host](../../docker_test.go) inside_block:containerHost
+<!--/codeinclude-->
+
+It is normally advisable to use `Host` and `MappedPort` together when constructing addresses - for example:
+
+<!--codeinclude-->
+[Getting the container host and mapped port](../../docker_test.go) inside_block:buildingAddresses
+<!--/codeinclude-->
+
+## Advanced networking
+
+Docker provides the ability for you to create custom networks and place containers on one or more networks. Then, communication can occur between networked containers without the need of exposing ports through the host. With Testcontainers, you can do this as well. 
+
+!!! tip
+    Note that _Testcontainers for Go_ allows a container to be on multiple networks including network aliases.
+
+<!--codeinclude-->
+[Creating custom networks](../../docker_test.go) inside_block:testNetworkAliases
+<!--/codeinclude-->

--- a/docs/features/networking.md
+++ b/docs/features/networking.md
@@ -32,7 +32,7 @@ This can be done using the `MappedPort` function, which takes the original (cont
 When running with a local Docker daemon, exposed ports will usually be reachable on `localhost`.
 However, in some CI environments they may instead be reachable on a different host.
 
-As such, Testcontainers provides a convenience method to obtain an address on which the container should be reachable from the host machine.
+As such, Testcontainers provides a convenience function to obtain an address on which the container should be reachable from the host machine.
 
 <!--codeinclude-->
 [Getting the container host](../../docker_test.go) inside_block:containerHost

--- a/docs/features/networking.md
+++ b/docs/features/networking.md
@@ -17,7 +17,7 @@ Note that this exposed port number is from the *perspective of the container*.
 This is by design, to avoid port collisions that may arise with locally running software or in between parallel test runs.
 
 Because there is this layer of indirection, it is necessary to ask Testcontainers for the actual mapped port at runtime.
-This can be done using the `getMappedPort` method, which takes the original (container) port as an argument:
+This can be done using the `MappedPort` function, which takes the original (container) port as an argument:
 
 <!--codeinclude-->
 [Retrieving actual ports at runtime](../../docker_test.go) inside_block:mappedPort

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -30,6 +30,7 @@ nav:
           - quickstart/gotest.md
     - Features:
           - features/creating_container.md
+          - features/networking.md
           - features/garbage_collector.md
           - features/build_from_dockerfile.md
           - features/docker_compose.md


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
It documents the networking basics:
- exposing ports to the host
- getting container host
- advanced networking such as creating networks and attaching containers to them, including aliases

It uses the `codeinclude` mkdocs plugin, to embed code snippets demonstrating each feature.

This docs page is basically a copy from the Java one, but removing the section that explains how to bind a host port to the container.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
Docs, docs, docs!!


<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes #607 

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
