### PR TITLE
chore: use a fixed version of MySQL

### DIFF
--- a/docker_test.go
+++ b/docker_test.go
@@ -39,6 +39,7 @@ import (
 )
 
 const (
+	mysqlImage       = "docker.io/mysql:8.0.30"
 	nginxImage       = "docker.io/nginx"
 	nginxAlpineImage = "docker.io/nginx:alpine"
 	nginxDefaultPort = "80/tcp"
@@ -968,7 +969,7 @@ func TestContainerCreationTimesOutWithHttp(t *testing.T) {
 func TestContainerCreationWaitsForLogContextTimeout(t *testing.T) {
 	ctx := context.Background()
 	req := ContainerRequest{
-		Image:        "docker.io/mysql:latest",
+		Image:        mysqlImage,
 		ExposedPorts: []string{"3306/tcp", "33060/tcp"},
 		Env: map[string]string{
 			"MYSQL_ROOT_PASSWORD": "password",
@@ -991,7 +992,7 @@ func TestContainerCreationWaitsForLog(t *testing.T) {
 	// exposePorts {
 	ctx := context.Background()
 	req := ContainerRequest{
-		Image:        "docker.io/mysql:latest",
+		Image:        mysqlImage,
 		ExposedPorts: []string{"3306/tcp", "33060/tcp"},
 		Env: map[string]string{
 			"MYSQL_ROOT_PASSWORD": "password",
@@ -1304,7 +1305,7 @@ func Test_BuildContainerFromDockerfileWithBuildLog(t *testing.T) {
 func TestContainerCreationWaitsForLogAndPortContextTimeout(t *testing.T) {
 	ctx := context.Background()
 	req := ContainerRequest{
-		Image:        "docker.io/mysql:latest",
+		Image:        mysqlImage,
 		ExposedPorts: []string{"3306/tcp", "33060/tcp"},
 		Env: map[string]string{
 			"MYSQL_ROOT_PASSWORD": "password",
@@ -1363,7 +1364,7 @@ func TestContainerCreationWaitingForHostPortWithoutBashThrowsAnError(t *testing.
 func TestContainerCreationWaitsForLogAndPort(t *testing.T) {
 	ctx := context.Background()
 	req := ContainerRequest{
-		Image:        "docker.io/mysql:latest",
+		Image:        mysqlImage,
 		ExposedPorts: []string{"3306/tcp", "33060/tcp"},
 		Env: map[string]string{
 			"MYSQL_ROOT_PASSWORD": "password",

--- a/docs/features/wait/log.md
+++ b/docs/features/wait/log.md
@@ -9,7 +9,7 @@ The Log wait strategy will check if a string occurs in the container logs for a 
 
 ```golang
 req := ContainerRequest{
-    Image:        "docker.io/mysql:latest",
+    Image:        "docker.io/mysql:8.0.30",
     ExposedPorts: []string{"3306/tcp", "33060/tcp"},
     Env: map[string]string{
         "MYSQL_ROOT_PASSWORD": "password",

--- a/docs/features/wait/multi.md
+++ b/docs/features/wait/multi.md
@@ -6,7 +6,7 @@ The Multi wait strategy will hold a list of wait strategies, in order to wait fo
 
 ```golang
 req := ContainerRequest{
-    Image:        "docker.io/mysql:latest",
+    Image:        "docker.io/mysql:8.0.30",
     ExposedPorts: []string{"3306/tcp", "33060/tcp"},
     Env: map[string]string{
         "MYSQL_ROOT_PASSWORD": "password",


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
It extracts the mysql docker image string to a constant in the tests, using a fixed version (8.0.30) instead of latest.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
Consistency in the code. I'm also seeing certain unstability in the tests consuming the MySQL image when running them in the CI:

```
goroutine 1743 [sleep]:
time.Sleep(0x5f5e100)
	/opt/hostedtoolcache/go/1.18.7/x64/src/runtime/time.go:194 +0x12e
github.com/testcontainers/testcontainers-go/wait.(*LogStrategy).WaitUntilReady(0xc000846270, {0x2220b20?, 0xc0008be060?}, {0x2223870, 0xc0005f9a40})
	/home/runner/work/testcontainers-go/testcontainers-go/wait/log.go:99 +0x165
github.com/testcontainers/testcontainers-go/wait.(*MultiStrategy).WaitUntilReady(0xc000699520, {0x2220ae8?, 0xc000136000?}, {0x2223870, 0xc0005f9a40})
	/home/runner/work/testcontainers-go/testcontainers-go/wait/all.go:41 +0x12e
github.com/testcontainers/testcontainers-go.(*DockerContainer).Start(0xc0005f9a40, {0x2220ae8, 0xc000136000})
	/home/runner/work/testcontainers-go/testcontainers-go/docker.go:187 +0x248
github.com/testcontainers/testcontainers-go.GenericContainer({_, _}, {{{{0x0, 0x0}, {0x0, 0x0}, {0x0, 0x0}, 0x0, 0x0, ...}, ...}, ...})
	/home/runner/work/testcontainers-go/testcontainers-go/generic.go:75 +0x3d4
github.com/testcontainers/testcontainers-go.TestContainerCreationWaitsForLogAndPortContextTimeout(0xc00077bd40)
	/home/runner/work/testcontainers-go/testcontainers-go/docker_test.go:1318 +0x3af
testing.tRunner(0xc00077bd40, 0x200df68)
	/opt/hostedtoolcache/go/1.18.7/x64/src/testing/testing.go:1439 +0x102
created by testing.(*T).Run
	/opt/hostedtoolcache/go/1.18.7/x64/src/testing/testing.go:1486 +0x35f
```
 
<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- 

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
