### PR TITLE
README: update `nginxC.Terminate`

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,8 +69,8 @@ func TestIntegrationNginxLatestReturn(t *testing.T) {
 
 	// Clean up the container after the test is complete
 	defer func() {
-		if err := nginxC.terminate(ctx); err != nil {
-			t.Fatalf("failed to terminate container: %w", err)
+		if err := nginxC.Terminate(ctx); err != nil {
+			t.Fatalf("failed to terminate container: %v", err)
 		}
 	}()
 


### PR DESCRIPTION
This is a documentation enhancement.

## What does this PR do?

Fix an outdated method in README.md

Environment: `go 1.19.3`, `testcontainers-go v0.15.0`.

## Why is it important?

Most users would grab this example for test. So, it should work out of the box.

## Related issues

Too tiny to create an issue.