### PR TITLE
chore: bump version in mkdocs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -62,4 +62,4 @@ nav:
     - Getting help: getting_help.md
 edit_uri: edit/main/docs/
 extra:
-    latest_version: 0.15.0
+    latest_version: 0.16.0


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
It bumps the version in mkdocs to the latest_version

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
TBH I'm not sure if this extra value is used by mkdocs to render the docs site. According to their docs: https://www.mkdocs.org/user-guide/configuration/#extra

> A set of key-value pairs, where the values can be any valid YAML construct, that will be passed to the template. This allows for great flexibility when creating custom themes.
>
> For example, if you are using a theme that supports displaying the project version, you can pass it to the theme like this:

```yml
extra:
    version: 1.0
```

But I cannot see any occurrence of the `latest_version` key.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->


<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
