### PR TITLE
fix: do not create garbage in examples nav bar

### DIFF
--- a/examples/main.go
+++ b/examples/main.go
@@ -145,11 +145,13 @@ func generate(example Example, rootDir string) error {
 
 	// make sure the index.md is the first element in the list of examples in the nav
 	examplesNav := make([]string, len(mkdocsExamplesNav)-1)
+	j := 0
 
 	for _, exampleNav := range mkdocsExamplesNav {
 		// filter out the index.md file
-		if !strings.HasSuffix("index.md", exampleNav) {
-			examplesNav = append(examplesNav, exampleNav)
+		if !strings.HasSuffix(exampleNav, "index.md") {
+			examplesNav[j] = exampleNav
+			j++
 		}
 	}
 

--- a/examples/main_test.go
+++ b/examples/main_test.go
@@ -68,6 +68,9 @@ func TestGenerate(t *testing.T) {
 	err = copyInitialConfig(t, rootTmp)
 	assert.Nil(t, err)
 
+	originalConfig, err := readMkdocsConfig(rootTmp)
+	assert.Nil(t, err)
+
 	example := Example{
 		Name:      "foo",
 		Image:     "docker.io/example/foo:latest",
@@ -109,7 +112,7 @@ func TestGenerate(t *testing.T) {
 	assertGoModContent(t, example, filepath.Join(generatedTemplatesDir, "go.mod"))
 	assertMakefileContent(t, example, filepath.Join(generatedTemplatesDir, "Makefile"))
 	assertToolsGoContent(t, example, filepath.Join(generatedTemplatesDir, "tools", "tools.go"))
-	assertMkdocsExamplesNav(t, example, rootTmp)
+	assertMkdocsExamplesNav(t, example, originalConfig, rootTmp)
 }
 
 // assert content example file in the docs
@@ -197,12 +200,15 @@ func assertMakefileContent(t *testing.T, example Example, makefile string) {
 }
 
 // assert content in the Examples nav from mkdocs.yml
-func assertMkdocsExamplesNav(t *testing.T, example Example, rootDir string) {
+func assertMkdocsExamplesNav(t *testing.T, example Example, originalConfig *MkDocsConfig, rootDir string) {
 	config, err := readMkdocsConfig(rootDir)
 	assert.Nil(t, err)
 
-	// the example should be in the nav
 	examples := config.Nav[3].Examples
+
+	assert.Equal(t, len(originalConfig.Nav[3].Examples)+1, len(examples))
+
+	// the example should be in the nav
 	found := false
 	for _, ex := range examples {
 		markdownExample := "examples/" + example.Lower() + ".md"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,71 +1,71 @@
 site_name: Testcontainers for Go
 plugins:
-    - search
-    - codeinclude
-    - markdownextradata
+- search
+- codeinclude
+- markdownextradata
 theme:
-    name: 'material'
-    palette:
-        scheme: testcontainers
-    font:
-        text: Roboto
-        code: Roboto Mono
-    logo: 'logo.svg'
-    favicon: 'favicon.ico'
+  name: material
+  palette:
+    scheme: testcontainers
+  font:
+    text: Roboto
+    code: Roboto Mono
+  logo: logo.svg
+  favicon: favicon.ico
 extra_css:
-    - 'css/extra.css'
-repo_name: 'testcontainers-go'
-repo_url: 'https://github.com/testcontainers/testcontainers-go'
+- css/extra.css
+repo_name: testcontainers-go
+repo_url: https://github.com/testcontainers/testcontainers-go
 markdown_extensions:
-    - admonition
-    - codehilite:
-          linenums: False
-    - pymdownx.superfences
-    - pymdownx.tabbed:
-        alternate_style: true
-    - pymdownx.snippets
+- admonition
+- codehilite:
+    linenums: false
+- pymdownx.superfences
+- pymdownx.tabbed:
+    alternate_style: true
+- pymdownx.snippets
 nav:
-    - Home: index.md
-    - Quickstart:
-          - quickstart/gotest.md
-    - Features:
-          - features/creating_container.md
-          - features/networking.md
-          - features/garbage_collector.md
-          - features/build_from_dockerfile.md
-          - features/docker_compose.md
-          - features/follow_logs.md
-          - features/override_container_command.md
-          - features/copy_file.md
-          - Wait Strategies:
-            - Introduction: features/wait/introduction.md
-            - Exec: features/wait/exec.md
-            - Exit: features/wait/exit.md
-            - Health: features/wait/health.md
-            - HostPort: features/wait/host_port.md
-            - HTTP: features/wait/http.md
-            - Log: features/wait/log.md
-            - Multi: features/wait/multi.md
-            - SQL: features/wait/sql.md
-    - Examples:
-          - examples/index.md
-          - examples/cockroachdb.md
-          - examples/datastore.md
-          - examples/firestore.md
-          - examples/nginx.md
-          - examples/redis.md
-          - examples/pubsub.md
-          - examples/pulsar.md
-          - examples/spanner.md
-          - examples/toxiproxy.md
-    - System Requirements:
-          - system_requirements/index.md
-          - system_requirements/using_colima.md
-          - system_requirements/using_podman.md
-    - Contributing:
-          - contributing.md
-          - contributing_docs.md
-    - Getting help: getting_help.md
+- Home: index.md
+- Quickstart:
+  - quickstart/gotest.md
+- Features:
+  - features/creating_container.md
+  - features/networking.md
+  - features/garbage_collector.md
+  - features/build_from_dockerfile.md
+  - features/docker_compose.md
+  - features/follow_logs.md
+  - features/override_container_command.md
+  - features/copy_file.md
+  - Wait Strategies:
+    - Introduction: features/wait/introduction.md
+    - Exec: features/wait/exec.md
+    - Exit: features/wait/exit.md
+    - Health: features/wait/health.md
+    - HostPort: features/wait/host_port.md
+    - HTTP: features/wait/http.md
+    - Log: features/wait/log.md
+    - Multi: features/wait/multi.md
+    - SQL: features/wait/sql.md
+- Examples:
+  - examples/index.md
+  - examples/cockroachdb.md
+  - examples/datastore.md
+  - examples/firestore.md
+  - examples/nginx.md
+  - examples/redis.md
+  - examples/pubsub.md
+  - examples/pulsar.md
+  - examples/spanner.md
+  - examples/toxiproxy.md
+- System Requirements:
+  - system_requirements/index.md
+  - system_requirements/using_colima.md
+  - system_requirements/using_podman.md
+- Contributing:
+  - contributing.md
+  - contributing_docs.md
+- Getting help: getting_help.md
 edit_uri: edit/main/docs/
 extra:
-    latest_version: 0.16.0
+  latest_version: 0.16.0


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
It fixes how the nav bar for the examples is generated, not appending the examples to the "non"-empty array that the generator created to define the examples nav bar.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
It added empty elements to the nav bar, that the user must remove before submitting the example

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- 

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
