### PR TITLE
Improve datastore, firestore, pubsub and spanner tests

### DIFF
--- a/examples/datastore/datastore_test.go
+++ b/examples/datastore/datastore_test.go
@@ -3,6 +3,9 @@ package datastore
 import (
 	"cloud.google.com/go/datastore"
 	"context"
+	"google.golang.org/api/option"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 	"testing"
 )
 
@@ -25,8 +28,12 @@ func TestDatastore(t *testing.T) {
 		}
 	})
 
-	t.Setenv("DATASTORE_EMULATOR_HOST", container.URI)
-	dsClient, err := datastore.NewClient(ctx, "test-project")
+	options := []option.ClientOption{
+		option.WithEndpoint(container.URI),
+		option.WithoutAuthentication(),
+		option.WithGRPCDialOption(grpc.WithTransportCredentials(insecure.NewCredentials())),
+	}
+	dsClient, err := datastore.NewClient(ctx, "test-project", options...)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/examples/pubsub/pubsub_test.go
+++ b/examples/pubsub/pubsub_test.go
@@ -3,6 +3,9 @@ package pubsub
 import (
 	"cloud.google.com/go/pubsub"
 	"context"
+	"google.golang.org/api/option"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 	"testing"
 )
 
@@ -21,8 +24,12 @@ func TestPubsub(t *testing.T) {
 		}
 	})
 
-	t.Setenv("PUBSUB_EMULATOR_HOST", container.URI)
-	client, err := pubsub.NewClient(ctx, "my-project-id")
+	conn, err := grpc.Dial(container.URI, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	options := []option.ClientOption{option.WithGRPCConn(conn)}
+	client, err := pubsub.NewClient(ctx, "my-project-id", options...)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Avoid use of env vars due to will not allow running parallel tests.
Use `options` instead to set the container address.
