### PR TITLE
Remove created volumes when taking down a compose stack

### DIFF
--- a/compose_api.go
+++ b/compose_api.go
@@ -157,6 +157,7 @@ func (d *dockerCompose) Down(ctx context.Context, opts ...StackDownOption) error
 	options := stackDownOptions{
 		DownOptions: api.DownOptions{
 			Project: d.project,
+			Volumes: true,
 		},
 	}
 

--- a/compose_api_test.go
+++ b/compose_api_test.go
@@ -7,7 +7,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
+	"github.com/docker/docker/api/types/filters"
 
 	"github.com/testcontainers/testcontainers-go/wait"
 )
@@ -363,6 +365,29 @@ func TestDockerComposeAPIWithVolume(t *testing.T) {
 
 	err = compose.Up(ctx, Wait(true))
 	assert.NoError(t, err, "compose.Up()")
+}
+
+func TestDockerComposeAPICleanupVolumesOnDown(t *testing.T) {
+	identifier := uuid.New().String()
+	stackFiles := WithStackFiles("./testresources/docker-compose-volume.yml")
+	compose, err := NewDockerComposeWith(stackFiles, StackIdentifier(identifier))
+	assert.NoError(t, err, "NewDockerCompose()")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	err = compose.Up(ctx, Wait(true))
+	assert.NoError(t, err, "compose.Up()")
+
+	err = compose.Down(context.Background(), RemoveOrphans(true), RemoveImagesLocal)
+ 	assert.NoError(t, err, "compose.Down()")
+
+	volumeListFilters := filters.NewArgs()
+	volumeListFilters.Add("name", fmt.Sprintf("%s_mydata", identifier))
+	volumeList, err := compose.dockerClient.VolumeList(ctx, volumeListFilters)
+	assert.NoError(t, err, "compose.dockerClient.VolumeList()")
+
+	assert.Equal(t, 0, len(volumeList.Volumes), "Volumes are not cleaned up")
 }
 
 func TestDockerComposeAPIWithBuild(t *testing.T) {


### PR DESCRIPTION
## What does this PR do?

Cleans up orphaned volumes when taking down a Docker Compose stack.

## Why is it important?

Cleaning up after your tests is important.

## Related issues

- Closes #644 
