### PR TITLE
chore: reduce concurrent builds

### DIFF
--- a/.github/workflows/bigtable-example.yml
+++ b/.github/workflows/bigtable-example.yml
@@ -2,6 +2,10 @@ name: Bigtable example pipeline
 
 on: [push, pull_request]
 
+concurrency:
+  group: "${{ github.workflow }}-${{ github.head_ref || github.sha }}"
+  cancel-in-progress: true
+
 jobs:
   test-bigtable:
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,10 @@ name: Main pipeline
 
 on: [push, pull_request]
 
+concurrency:
+  group: "${{ github.workflow }}-${{ github.head_ref || github.sha }}"
+  cancel-in-progress: true
+
 jobs:
   test:
     strategy:

--- a/.github/workflows/cockroachdb-example.yml
+++ b/.github/workflows/cockroachdb-example.yml
@@ -2,6 +2,10 @@ name: Cockroachdb example pipeline
 
 on: [push, pull_request]
 
+concurrency:
+  group: "${{ github.workflow }}-${{ github.head_ref || github.sha }}"
+  cancel-in-progress: true
+
 jobs:
   test-cockroachdb:
     strategy:

--- a/.github/workflows/datastore-example.yml
+++ b/.github/workflows/datastore-example.yml
@@ -2,6 +2,10 @@ name: Datastore example pipeline
 
 on: [push, pull_request]
 
+concurrency:
+  group: "${{ github.workflow }}-${{ github.head_ref || github.sha }}"
+  cancel-in-progress: true
+
 jobs:
   test-datastore:
     strategy:

--- a/.github/workflows/firestore-example.yml
+++ b/.github/workflows/firestore-example.yml
@@ -2,6 +2,10 @@ name: Firestore example pipeline
 
 on: [push, pull_request]
 
+concurrency:
+  group: "${{ github.workflow }}-${{ github.head_ref || github.sha }}"
+  cancel-in-progress: true
+
 jobs:
   test-firestore:
     strategy:

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -7,6 +7,10 @@ on:
       - main
   pull_request:
 
+concurrency:
+  group: "${{ github.workflow }}-${{ github.head_ref || github.sha }}"
+  cancel-in-progress: true
+
 permissions:
   contents: read
   # Optional: allow read access to pull request. Use with `only-new-issues` option.

--- a/.github/workflows/mysql-example.yml
+++ b/.github/workflows/mysql-example.yml
@@ -2,6 +2,10 @@ name: Mysql example pipeline
 
 on: [push, pull_request]
 
+concurrency:
+  group: "${{ github.workflow }}-${{ github.head_ref || github.sha }}"
+  cancel-in-progress: true
+
 jobs:
   test-mysql:
     strategy:

--- a/.github/workflows/nginx-example.yml
+++ b/.github/workflows/nginx-example.yml
@@ -2,6 +2,10 @@ name: Nginx example pipeline
 
 on: [push, pull_request]
 
+concurrency:
+  group: "${{ github.workflow }}-${{ github.head_ref || github.sha }}"
+  cancel-in-progress: true
+
 jobs:
   test-nginx:
     strategy:

--- a/.github/workflows/postgres-example.yml
+++ b/.github/workflows/postgres-example.yml
@@ -2,6 +2,10 @@ name: Postgres example pipeline
 
 on: [push, pull_request]
 
+concurrency:
+  group: "${{ github.workflow }}-${{ github.head_ref || github.sha }}"
+  cancel-in-progress: true
+
 jobs:
   test-postgres:
     strategy:

--- a/.github/workflows/pubsub-example.yml
+++ b/.github/workflows/pubsub-example.yml
@@ -2,6 +2,10 @@ name: Pubsub example pipeline
 
 on: [push, pull_request]
 
+concurrency:
+  group: "${{ github.workflow }}-${{ github.head_ref || github.sha }}"
+  cancel-in-progress: true
+
 jobs:
   test-pubsub:
     strategy:

--- a/.github/workflows/pulsar-example.yml
+++ b/.github/workflows/pulsar-example.yml
@@ -2,6 +2,10 @@ name: Pulsar example pipeline
 
 on: [push, pull_request]
 
+concurrency:
+  group: "${{ github.workflow }}-${{ github.head_ref || github.sha }}"
+  cancel-in-progress: true
+
 jobs:
   test-pulsar:
     strategy:

--- a/.github/workflows/redis-example.yml
+++ b/.github/workflows/redis-example.yml
@@ -2,6 +2,10 @@ name: Redis example pipeline
 
 on: [push, pull_request]
 
+concurrency:
+  group: "${{ github.workflow }}-${{ github.head_ref || github.sha }}"
+  cancel-in-progress: true
+
 jobs:
   test-redis:
     strategy:

--- a/.github/workflows/spanner-example.yml
+++ b/.github/workflows/spanner-example.yml
@@ -2,6 +2,10 @@ name: Spanner example pipeline
 
 on: [push, pull_request]
 
+concurrency:
+  group: "${{ github.workflow }}-${{ github.head_ref || github.sha }}"
+  cancel-in-progress: true
+
 jobs:
   test-spanner:
     strategy:

--- a/.github/workflows/toxiproxy-example.yml
+++ b/.github/workflows/toxiproxy-example.yml
@@ -2,6 +2,10 @@ name: Toxiproxy example pipeline
 
 on: [push, pull_request]
 
+concurrency:
+  group: "${{ github.workflow }}-${{ github.head_ref || github.sha }}"
+  cancel-in-progress: true
+
 jobs:
   test-toxiproxy:
     strategy:

--- a/examples/_template/ci.yml.tmpl
+++ b/examples/_template/ci.yml.tmpl
@@ -2,6 +2,10 @@
 
 on: [push, pull_request]
 
+concurrency:
+  group: {{ "${{ github.workflow }}-${{ github.head_ref || github.sha }}" }}
+  cancel-in-progress: true
+
 jobs:
   test-{{ $lower }}:
     strategy:

--- a/examples/main_test.go
+++ b/examples/main_test.go
@@ -205,12 +205,12 @@ func assertExampleGithubWorkflowContent(t *testing.T, example Example, exampleWo
 
 	data := strings.Split(string(content), "\n")
 	assert.Equal(t, "name: "+title+" example pipeline", data[0])
-	assert.Equal(t, "  test-"+lower+":", data[5])
-	assert.Equal(t, "          go-version: ${{ matrix.go-version }}", data[15])
-	assert.Equal(t, "        working-directory: ./examples/"+lower, data[22])
+	assert.Equal(t, "  test-"+lower+":", data[9])
+	assert.Equal(t, "          go-version: ${{ matrix.go-version }}", data[19])
 	assert.Equal(t, "        working-directory: ./examples/"+lower, data[26])
 	assert.Equal(t, "        working-directory: ./examples/"+lower, data[30])
-	assert.Equal(t, "          paths: \"**/TEST-"+lower+"*.xml\"", data[40])
+	assert.Equal(t, "        working-directory: ./examples/"+lower, data[34])
+	assert.Equal(t, "          paths: \"**/TEST-"+lower+"*.xml\"", data[44])
 }
 
 // assert content go.mod


### PR DESCRIPTION

<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
It will avoid multiple pushes to have concurrent builds, aborting running builds in the followins scenarios:
- for PRs, a new commit will abort running builds for the workflow
- for branches, because it will use the SHA commit as discriminator, a new commit won't abort the running builds

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
Taking a look at https://docs.github.com/en/actions/learn-github-actions/usage-limits-billing-and-administration, it seems there is a max number of concurrent builds per organization.

@kiview, we should consider this for any project spanning multiple builds (per lang, per module, per OS...).

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- 

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
