### PR TITLE
chore: support running MySQL compose in ARM

### DIFF
--- a/modules/compose/testresources/docker-compose-complex.yml
+++ b/modules/compose/testresources/docker-compose-complex.yml
@@ -5,7 +5,7 @@ services:
     ports:
      - "9080:80"
   mysql:
-    image: docker.io/mysql:5.7
+    image: docker.io/mysql:8
     environment:
       - MYSQL_DATABASE=db
       - MYSQL_ROOT_PASSWORD=my-secret-pw


### PR DESCRIPTION

<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
It bumps the version of the MySQL docker image, from 5.7 to 8.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
mysql:5.7 does not have an ARM flavor, which makes impossible to run the tests locally on a Mac M1

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->


<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
