### PR TITLE
chore: bump testcontainers-go to 0.17.0 in examples

### DIFF
--- a/examples/bigtable/go.mod
+++ b/examples/bigtable/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	cloud.google.com/go/bigtable v1.18.1
-	github.com/testcontainers/testcontainers-go v0.16.0
+	github.com/testcontainers/testcontainers-go v0.17.0
 	google.golang.org/api v0.105.0
 	google.golang.org/grpc v1.51.0
 	gotest.tools/gotestsum v1.8.2

--- a/examples/cockroachdb/go.mod
+++ b/examples/cockroachdb/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/google/uuid v1.3.0
 	github.com/jackc/pgx/v4 v4.17.2
 	github.com/stretchr/testify v1.8.1
-	github.com/testcontainers/testcontainers-go v0.16.0
+	github.com/testcontainers/testcontainers-go v0.17.0
 	gotest.tools/gotestsum v1.8.2
 )
 

--- a/examples/datastore/go.mod
+++ b/examples/datastore/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	cloud.google.com/go/datastore v1.10.0
-	github.com/testcontainers/testcontainers-go v0.16.0
+	github.com/testcontainers/testcontainers-go v0.17.0
 	google.golang.org/api v0.105.0
 	google.golang.org/grpc v1.51.0
 	gotest.tools/gotestsum v1.8.2

--- a/examples/firestore/go.mod
+++ b/examples/firestore/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	cloud.google.com/go/firestore v1.9.0
-	github.com/testcontainers/testcontainers-go v0.16.0
+	github.com/testcontainers/testcontainers-go v0.17.0
 	google.golang.org/api v0.105.0
 	google.golang.org/grpc v1.51.0
 	gotest.tools/gotestsum v1.8.2

--- a/examples/mysql/go.mod
+++ b/examples/mysql/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/go-sql-driver/mysql v1.7.0
-	github.com/testcontainers/testcontainers-go v0.16.0
+	github.com/testcontainers/testcontainers-go v0.17.0
 	gotest.tools/gotestsum v1.8.2
 )
 

--- a/examples/nginx/go.mod
+++ b/examples/nginx/go.mod
@@ -3,7 +3,7 @@ module github.com/testcontainers/testcontainers-go/examples/nginx
 go 1.18
 
 require (
-	github.com/testcontainers/testcontainers-go v0.16.0
+	github.com/testcontainers/testcontainers-go v0.17.0
 	gotest.tools/gotestsum v1.8.2
 )
 

--- a/examples/postgres/go.mod
+++ b/examples/postgres/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/docker/go-connections v0.4.0
 	github.com/lib/pq v0.0.0-20150723085316-0dad96c0b94f
 	github.com/stretchr/testify v1.8.1
-	github.com/testcontainers/testcontainers-go v0.16.0
+	github.com/testcontainers/testcontainers-go v0.17.0
 	gotest.tools/gotestsum v1.8.2
 )
 

--- a/examples/pubsub/go.mod
+++ b/examples/pubsub/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	cloud.google.com/go/pubsub v1.28.0
-	github.com/testcontainers/testcontainers-go v0.16.0
+	github.com/testcontainers/testcontainers-go v0.17.0
 	google.golang.org/api v0.105.0
 	google.golang.org/grpc v1.51.0
 	gotest.tools/gotestsum v1.8.2

--- a/examples/pulsar/go.mod
+++ b/examples/pulsar/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/apache/pulsar-client-go v0.9.0
-	github.com/testcontainers/testcontainers-go v0.16.0
+	github.com/testcontainers/testcontainers-go v0.17.0
 	gotest.tools/gotestsum v1.8.2
 )
 

--- a/examples/redis/go.mod
+++ b/examples/redis/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/go-redis/redis/v8 v8.11.5
 	github.com/google/uuid v1.3.0
 	github.com/stretchr/testify v1.8.1
-	github.com/testcontainers/testcontainers-go v0.16.0
+	github.com/testcontainers/testcontainers-go v0.17.0
 	gotest.tools/gotestsum v1.8.2
 )
 

--- a/examples/spanner/go.mod
+++ b/examples/spanner/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	cloud.google.com/go/spanner v1.42.0
-	github.com/testcontainers/testcontainers-go v0.16.0
+	github.com/testcontainers/testcontainers-go v0.17.0
 	google.golang.org/api v0.105.0
 	google.golang.org/genproto v0.0.0-20221206210731-b1a01be3a5f6
 	google.golang.org/grpc v1.51.0

--- a/examples/toxiproxy/go.mod
+++ b/examples/toxiproxy/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/Shopify/toxiproxy/v2 v2.5.0
 	github.com/go-redis/redis/v8 v8.11.5
 	github.com/google/uuid v1.3.0
-	github.com/testcontainers/testcontainers-go v0.16.0
+	github.com/testcontainers/testcontainers-go v0.17.0
 	gotest.tools/gotestsum v1.8.2
 )
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -70,4 +70,4 @@ nav:
     - Getting help: getting_help.md
 edit_uri: edit/main/docs/
 extra:
-    latest_version: 0.16.0
+    latest_version: 0.17.0


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
It bumps all example modules to tc-go 0.17.0
<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
Keep example modules up-to-date
<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->


<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
