### PR TITLE
fix: close response body in http strategy

### DIFF
--- a/wait/http.go
+++ b/wait/http.go
@@ -217,11 +217,11 @@ func (ws *HTTPStrategy) WaitUntilReady(ctx context.Context, target StrategyTarge
 				continue
 			}
 			if ws.StatusCodeMatcher != nil && !ws.StatusCodeMatcher(resp.StatusCode) {
-				resp.Body.Close()
+				_ = resp.Body.Close()
 				continue
 			}
 			if ws.ResponseMatcher != nil && !ws.ResponseMatcher(resp.Body) {
-				resp.Body.Close()
+				_ = resp.Body.Close()
 				continue
 			}
 			if err := resp.Body.Close(); err != nil {

--- a/wait/http.go
+++ b/wait/http.go
@@ -217,9 +217,11 @@ func (ws *HTTPStrategy) WaitUntilReady(ctx context.Context, target StrategyTarge
 				continue
 			}
 			if ws.StatusCodeMatcher != nil && !ws.StatusCodeMatcher(resp.StatusCode) {
+				resp.Body.Close()
 				continue
 			}
 			if ws.ResponseMatcher != nil && !ws.ResponseMatcher(resp.Body) {
+				resp.Body.Close()
 				continue
 			}
 			if err := resp.Body.Close(); err != nil {


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?

From to the documentation:
> If the returned error is nil, the Response will contain a non-nil body
which the user is expected to close.

Close the response body according to the documentation.

## Why is it important?

Failed requests (due to wrong response or status code) were leaving open connections.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- None, afaik

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
