### PR TITLE
Prevent custom reaper image from causing Ryuk warning

### DIFF
--- a/reaper.go
+++ b/reaper.go
@@ -65,10 +65,11 @@ func NewReaper(ctx context.Context, sessionID string, provider ReaperProvider, r
 		Labels: map[string]string{
 			TestcontainerLabelIsReaper: "true",
 		},
-		SkipReaper: true,
-		Mounts:     Mounts(BindMount(dockerHost, "/var/run/docker.sock")),
-		AutoRemove: true,
-		WaitingFor: wait.ForListeningPort(listeningPort),
+		SkipReaper:  true,
+		Mounts:      Mounts(BindMount(dockerHost, "/var/run/docker.sock")),
+		AutoRemove:  true,
+		WaitingFor:  wait.ForListeningPort(listeningPort),
+		ReaperImage: reaperImage(reaperImageName),
 	}
 
 	// include reaper-specific labels to the reaper container

--- a/reaper_test.go
+++ b/reaper_test.go
@@ -44,6 +44,7 @@ func createContainerRequest(customize func(ContainerRequest) ContainerRequest) C
 		AutoRemove:  true,
 		WaitingFor:  wait.ForListeningPort(nat.Port("8080/tcp")),
 		NetworkMode: "bridge",
+		ReaperImage: "reaperImage",
 	}
 	if customize == nil {
 		return req


### PR DESCRIPTION
 - A custom provided ReaperImage would trigger the "Ryuk has been disabled for the container" warning when starting the Reaper image itself because the image name is used to detect if the container is the reaper container.

## What does this PR do?
 - This passes the selected ReaperImage as the ReaperImage when creating the Reaper ContainerRequest to ensure that it matches as the reaper image and prevents the incorrect warning.

## Why is it important?

Configuring a custom ReaperImage currently leads to an inaccurate warning 
```go
	network, err := testcontainers.GenericNetwork(ctx, testcontainers.GenericNetworkRequest{
		NetworkRequest: testcontainers.NetworkRequest{
			Name:           networkName,
			CheckDuplicate: true,
			ReaperImage:    "some-other-reaper-image", 
		},
	})
```
=>

```
	**********************************************************************************************
	Ryuk has been disabled for the container. This can cause unexpected behavior in your environment.
	More on this: https://golang.testcontainers.org/features/garbage_collector/
	**********************************************************************************************
```	