### PR TITLE
chore: support for titles in examples

### DIFF
--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -23,10 +23,11 @@ We have provided a command line tool to generate the scaffolding for the code of
 |------|------|----------|-------------|
 | -name | string | Yes | Name of the example, use camel-case when needed. Only alphabetical characters are allowed. |
 | -image | string | Yes | Fully-qualified name of the Docker image to be used by the example (i.e. 'docker.io/org/project:tag') |
+| -title | string | No | A variant of the Name including uppercase characters (i.e. 'MongoDB'). Only alphabetical characters are allowed. |
 
 ### What is this tool not doing?
 
-- If the example name does not contain alphabeticall characters, it will exit the generation.
+- If the example name does not contain alphabetical characters, it will exit the generation.
 - If the example already exists, it will exit without updating the existing files.
 
 ### How to run the tool
@@ -34,7 +35,7 @@ We have provided a command line tool to generate the scaffolding for the code of
 From the [`examples` directory]({{repo_url}}/tree/main/examples), please run:
 
 ```shell
-go run . --name ${NAME_OF_YOUR_EXAMPLE} --image "${REGISTRY}/${EXAMPLE}:${TAG}"
+go run . --name ${NAME_OF_YOUR_EXAMPLE} --image "${REGISTRY}/${EXAMPLE}:${TAG}" --title ${TITLE_OF_YOUR_EXAMPLE}
 ```
 
 ## Update Go dependencies in the examples

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -23,7 +23,7 @@ We have provided a command line tool to generate the scaffolding for the code of
 |------|------|----------|-------------|
 | -name | string | Yes | Name of the example, use camel-case when needed. Only alphabetical characters are allowed. |
 | -image | string | Yes | Fully-qualified name of the Docker image to be used by the example (i.e. 'docker.io/org/project:tag') |
-| -title | string | No | A variant of the Name including uppercase characters (i.e. 'MongoDB'). Only alphabetical characters are allowed. |
+| -title | string | No | A variant of the name supporting mixed casing (i.e. 'MongoDB'). Only alphabetical characters are allowed. |
 
 ### What is this tool not doing?
 

--- a/examples/_template/Makefile.tmpl
+++ b/examples/_template/Makefile.tmpl
@@ -1,4 +1,4 @@
-{{ $lower := .Name | ToLower }}include ../../commons-test.mk
+{{ $lower := ToLower }}include ../../commons-test.mk
 
 .PHONY: test
 test:

--- a/examples/_template/ci.yml.tmpl
+++ b/examples/_template/ci.yml.tmpl
@@ -1,4 +1,4 @@
-{{ $lower := .Name | ToLower }}{{ $title := .Name | Title }}name: {{ $title }} example pipeline
+{{ $lower := ToLower }}name: {{ Title }} example pipeline
 
 on: [push, pull_request]
 

--- a/examples/_template/docs_example.md.tmpl
+++ b/examples/_template/docs_example.md.tmpl
@@ -1,4 +1,4 @@
-{{ $lower := .Name | ToLower }}{{ $title := .Name | Title }}# {{ $title }}
+{{ $lower := ToLower }}{{ $title := Title }}# {{ $title }}
 
 {{ codeinclude "<!--codeinclude-->" }}
 [Creating a {{ $title }} container](../../examples/{{ $lower }}/{{ $lower }}.go)

--- a/examples/_template/example.go.tmpl
+++ b/examples/_template/example.go.tmpl
@@ -1,4 +1,4 @@
-{{ $lower := .Name | ToLower }}{{ $title := .Name | Title }}package {{ $lower }}
+{{ $lower := ToLower }}{{ $title := Title }}{{ $lowerTitle := ToLowerTitle }}package {{ $lower }}
 
 import (
 	"context"
@@ -6,13 +6,13 @@ import (
 	"github.com/testcontainers/testcontainers-go"
 )
 
-// {{ $lower }}Container represents the {{ .Name }} container type used in the module
-type {{ $lower }}Container struct {
+// {{ $lowerTitle }}Container represents the {{ $title }} container type used in the module
+type {{ $lowerTitle }}Container struct {
 	testcontainers.Container
 }
 
-// setup{{ $title }} creates an instance of the {{ .Name }} container type
-func setup{{ $title }}(ctx context.Context) (*{{ $lower }}Container, error) {
+// setup{{ $title }} creates an instance of the {{ $title }} container type
+func setup{{ $title }}(ctx context.Context) (*{{ $lowerTitle }}Container, error) {
 	req := testcontainers.ContainerRequest{
 		Image: "{{ .Image }}",
 	}
@@ -24,5 +24,5 @@ func setup{{ $title }}(ctx context.Context) (*{{ $lower }}Container, error) {
 		return nil, err
 	}
 
-	return &{{ $lower }}Container{Container: container}, nil
+	return &{{ $lowerTitle }}Container{Container: container}, nil
 }

--- a/examples/_template/example_test.go.tmpl
+++ b/examples/_template/example_test.go.tmpl
@@ -1,4 +1,4 @@
-{{ $lower := .Name | ToLower }}{{ $title := .Name | Title }}package {{ $lower }}
+{{ $lower := ToLower }}{{ $title := Title }}package {{ $lower }}
 
 import (
 	"context"

--- a/examples/_template/go.mod.tmpl
+++ b/examples/_template/go.mod.tmpl
@@ -1,4 +1,4 @@
-{{ $lower := .Name | ToLower }}module github.com/testcontainers/testcontainers-go/examples/{{ $lower }}
+{{ $lower := ToLower }}module github.com/testcontainers/testcontainers-go/examples/{{ $lower }}
 
 go 1.18
 

--- a/examples/_template/tools.go.tmpl
+++ b/examples/_template/tools.go.tmpl
@@ -1,7 +1,7 @@
 //go:build tools
 // +build tools
 
-// This package contains the tool dependencies of the {{ .Name }} example.
+// This package contains the tool dependencies of the {{ Title }} example.
 
 package tools
 

--- a/examples/main.go
+++ b/examples/main.go
@@ -26,14 +26,14 @@ var templates = []string{
 
 func init() {
 	flag.StringVar(&nameVar, "name", "", "Name of the example. Only alphabetical characters are allowed.")
-	flag.StringVar(&nameTitleVar, "title", "", "(Optional) Title of the example name, used to override the name in the case initials are present (Mongodb -> MongoDB). Use camel-case when needed. Only alphabetical characters are allowed.")
+	flag.StringVar(&nameTitleVar, "title", "", "(Optional) Title of the example name, used to override the name in the case of mixed casing (Mongodb -> MongoDB). Use camel-case when needed. Only alphabetical characters are allowed.")
 	flag.StringVar(&imageVar, "image", "", "Fully-qualified name of the Docker image to be used by the example")
 }
 
 type Example struct {
 	Image     string // fully qualified name of the Docker image
 	Name      string
-	TitleName string // title of the name: i.e. "mongodb" -> "MongoDB"
+	TitleName string // title of the name: e.g. "mongodb" -> "MongoDB"
 	TCVersion string // Testcontainers for Go version
 }
 

--- a/examples/main.go
+++ b/examples/main.go
@@ -9,12 +9,15 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+	"unicode"
+	"unicode/utf8"
 
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
 )
 
 var nameVar string
+var nameTitleVar string
 var imageVar string
 
 var templates = []string{
@@ -22,13 +25,15 @@ var templates = []string{
 }
 
 func init() {
-	flag.StringVar(&nameVar, "name", "", "Name of the example, use camel-case when needed. Only alphabetical characters are allowed.")
+	flag.StringVar(&nameVar, "name", "", "Name of the example. Only alphabetical characters are allowed.")
+	flag.StringVar(&nameTitleVar, "title", "", "(Optional) Title of the example name, used to override the name in the case initials are present (Mongodb -> MongoDB). Use camel-case when needed. Only alphabetical characters are allowed.")
 	flag.StringVar(&imageVar, "image", "", "Fully-qualified name of the Docker image to be used by the example")
 }
 
 type Example struct {
 	Image     string // fully qualified name of the Docker image
 	Name      string
+	TitleName string // title of the name: i.e. "mongodb" -> "MongoDB"
 	TCVersion string // Testcontainers for Go version
 }
 
@@ -36,8 +41,33 @@ func (e *Example) Lower() string {
 	return strings.ToLower(e.Name)
 }
 
-func (e *Example) Title() string {
+func (e *Example) LowerTitle() string {
+	if e.TitleName != "" {
+		r, n := utf8.DecodeRuneInString(e.TitleName)
+		return string(unicode.ToLower(r)) + e.TitleName[n:]
+	}
+
 	return cases.Title(language.Und, cases.NoLower).String(e.Lower())
+}
+
+func (e *Example) Title() string {
+	if e.TitleName != "" {
+		return e.TitleName
+	}
+
+	return cases.Title(language.Und, cases.NoLower).String(e.Lower())
+}
+
+func (e *Example) Validate() error {
+	if !regexp.MustCompile(`^[A-Za-z]+$`).MatchString(e.Name) {
+		return fmt.Errorf("invalid name: %s. Only alphabetical characters are allowed", e.Name)
+	}
+
+	if !regexp.MustCompile(`^[A-Za-z]+$`).MatchString(e.TitleName) {
+		return fmt.Errorf("invalid title: %s. Only alphabetical characters are allowed", e.TitleName)
+	}
+
+	return nil
 }
 
 func main() {
@@ -68,7 +98,14 @@ func main() {
 		os.Exit(1)
 	}
 
-	err = generate(Example{Name: nameVar, Image: imageVar, TCVersion: mkdocsConfig.Extra.LatestVersion}, rootDir)
+	example := Example{
+		Image:     imageVar,
+		Name:      nameVar,
+		TitleName: nameTitleVar,
+		TCVersion: mkdocsConfig.Extra.LatestVersion,
+	}
+
+	err = generate(example, rootDir)
 	if err != nil {
 		fmt.Printf(">> error generating the example: %v\n", err)
 		os.Exit(1)
@@ -76,8 +113,8 @@ func main() {
 }
 
 func generate(example Example, rootDir string) error {
-	if !regexp.MustCompile(`^[A-Za-z]+$`).MatchString(example.Name) {
-		return fmt.Errorf("invalid name: %s. Only alphabetical characters are allowed", example.Name)
+	if err := example.Validate(); err != nil {
+		return err
 	}
 
 	githubWorkflowsDir := filepath.Join(rootDir, ".github", "workflows")
@@ -85,9 +122,10 @@ func generate(example Example, rootDir string) error {
 	docsDir := filepath.Join(rootDir, "docs", "examples")
 
 	funcMap := template.FuncMap{
-		"ToLower":     strings.ToLower,
-		"Title":       cases.Title(language.Und, cases.NoLower).String,
-		"codeinclude": func(s string) template.HTML { return template.HTML(s) }, // escape HTML comments for codeinclude
+		"ToLower":      func() string { return example.Lower() },
+		"Title":        func() string { return example.Title() },
+		"ToLowerTitle": func() string { return example.LowerTitle() },
+		"codeinclude":  func(s string) template.HTML { return template.HTML(s) }, // escape HTML comments for codeinclude
 	}
 
 	// create the example dir


### PR DESCRIPTION

<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
This PR is adding a flag to the examples generator so that it's possible to define a camelcase version of the name to be used when initials are present.

It will allow creating an example but overriding the default name with a custom title that follows the same rules that a name, i.e. alphabetical
characters, only. The only difference is that it allows uppercase chars that will be used when certain initials are needed in uppercase: i.e.
mongodb and MongoDB (before this changes it was Mongodb).

This title will be used here:
- the CI descriptor, as its name
- the H1 heading in the docs page for the example
- the struct for the example, which is now exampleDBContainer
- the setupExample function name, which is now setupExampleDB

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
As detected [here](https://github.com/testcontainers/testcontainers-go/pull/723#discussion_r1061705712) a technology with initials generated examples not 100% accurate,
forcing users of the generator to add a second commit polishing certain names.

This PR simplifies the creation of those examples including initials (MongoDB, QuestDB...).

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Discovered while reviewing #723

## How to test this PR
<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->
```shell
go run . --name questdb --image "questdb/questdb:latest" --title QuestDB
```

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
