### PR TITLE
chore: check dependabot dependencies weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,96 +3,96 @@ updates:
     - package-ecosystem: gomod
       directory: /
       schedule:
-        interval: daily
+        interval: weekly
       open-pull-requests-limit: 3
       rebase-strategy: disabled
     - package-ecosystem: gomod
       directory: /modules/compose
       schedule:
-        interval: daily
+        interval: weekly
       open-pull-requests-limit: 3
       rebase-strategy: disabled
     - package-ecosystem: gomod
       directory: /examples/bigtable
       schedule:
-        interval: daily
+        interval: weekly
       open-pull-requests-limit: 3
       rebase-strategy: disabled
     - package-ecosystem: gomod
       directory: /examples/cockroachdb
       schedule:
-        interval: daily
+        interval: weekly
       open-pull-requests-limit: 3
       rebase-strategy: disabled
     - package-ecosystem: gomod
       directory: /examples/consul
       schedule:
-        interval: daily
+        interval: weekly
       open-pull-requests-limit: 3
       rebase-strategy: disabled
     - package-ecosystem: gomod
       directory: /examples/datastore
       schedule:
-        interval: daily
+        interval: weekly
       open-pull-requests-limit: 3
       rebase-strategy: disabled
     - package-ecosystem: gomod
       directory: /examples/firestore
       schedule:
-        interval: daily
+        interval: weekly
       open-pull-requests-limit: 3
       rebase-strategy: disabled
     - package-ecosystem: gomod
       directory: /examples/mongodb
       schedule:
-        interval: daily
+        interval: weekly
       open-pull-requests-limit: 3
       rebase-strategy: disabled
     - package-ecosystem: gomod
       directory: /examples/mysql
       schedule:
-        interval: daily
+        interval: weekly
       open-pull-requests-limit: 3
       rebase-strategy: disabled
     - package-ecosystem: gomod
       directory: /examples/nginx
       schedule:
-        interval: daily
+        interval: weekly
       open-pull-requests-limit: 3
       rebase-strategy: disabled
     - package-ecosystem: gomod
       directory: /examples/postgres
       schedule:
-        interval: daily
+        interval: weekly
       open-pull-requests-limit: 3
       rebase-strategy: disabled
     - package-ecosystem: gomod
       directory: /examples/pubsub
       schedule:
-        interval: daily
+        interval: weekly
       open-pull-requests-limit: 3
       rebase-strategy: disabled
     - package-ecosystem: gomod
       directory: /examples/pulsar
       schedule:
-        interval: daily
+        interval: weekly
       open-pull-requests-limit: 3
       rebase-strategy: disabled
     - package-ecosystem: gomod
       directory: /examples/redis
       schedule:
-        interval: daily
+        interval: weekly
       open-pull-requests-limit: 3
       rebase-strategy: disabled
     - package-ecosystem: gomod
       directory: /examples/spanner
       schedule:
-        interval: daily
+        interval: weekly
       open-pull-requests-limit: 3
       rebase-strategy: disabled
     - package-ecosystem: gomod
       directory: /examples/toxiproxy
       schedule:
-        interval: daily
+        interval: weekly
       open-pull-requests-limit: 3
       rebase-strategy: disabled

--- a/examples/dependabot.go
+++ b/examples/dependabot.go
@@ -33,7 +33,7 @@ func NewUpdate(example string) Update {
 		PackageEcosystem:      "gomod",
 		RebaseStrategy:        "disabled",
 		Schedule: Schedule{
-			Interval: "daily",
+			Interval: "weekly",
 		},
 	}
 }

--- a/examples/dependabot_test.go
+++ b/examples/dependabot_test.go
@@ -61,6 +61,8 @@ func TestExamplesHasDependabotEntry(t *testing.T) {
 		for _, exampleUpdate := range exampleUpdates {
 			dependabotDir := "/examples/" + strings.ToLower(example.Name())
 
+			assert.Equal(t, exampleUpdate.Schedule.Interval, "weekly")
+
 			if dependabotDir == exampleUpdate.Directory {
 				found = true
 				continue


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
It updates dependabot's descriptor and the code generator to use a weekly schedule for dependabot updates.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
We want to reduce the overhead of merging dependabot's updates, which could lead to have as many PRs as example modules exist in the project.

We currently mitigate this issue combining PRs that are related, but we still suffer when the dependencies are bumping multiple versions in the same week.

With this PR we expect to have this overhead, at most, once a week instead of multiple times a week.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->


<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
