### PR TITLE
docs: add intel as user

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -30,6 +30,7 @@ examples as well. Check it out at
 
 * [Elastic](https://www.elastic.co) - Testing of the APM Server, and E2E testing for Beats
 * [Telegraf](https://www.influxdata.com/time-series-platform/telegraf/) - Integration testing the plugin-driven server agent for collecting & reporting metrics
+* [Intel](https://intel.com/) - Reference implementation design E2E testing for microservice-based solutions
 
 ## License
 


### PR DESCRIPTION
Signed-off-by: Samantha Coyle <sam@diagrid.io>

<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?

Update docs section to include Intel as using pkg.

## Why is it important?

Maintain accurate account of testcontainers-go users.

## Related issues

None

## How to test this PR

Verify doc updates.

