### PR TITLE
fix: nil pointer dereference in HealthStrategy

### DIFF
--- a/wait/health.go
+++ b/wait/health.go
@@ -2,6 +2,7 @@ package wait
 
 import (
 	"context"
+	"github.com/docker/docker/api/types"
 	"time"
 )
 
@@ -76,7 +77,7 @@ func (ws *HealthStrategy) WaitUntilReady(ctx context.Context, target StrategyTar
 			if err != nil {
 				return err
 			}
-			if state.Health.Status != "healthy" {
+			if state.Health == nil || state.Health.Status != types.Healthy {
 				time.Sleep(ws.PollInterval)
 				continue
 			}

--- a/wait/health_test.go
+++ b/wait/health_test.go
@@ -1,0 +1,80 @@
+package wait
+
+import (
+	"context"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/go-connections/nat"
+	tcexec "github.com/testcontainers/testcontainers-go/exec"
+)
+
+type healthStrategyTarget struct {
+	Health *types.Health
+}
+
+func (st healthStrategyTarget) Host(ctx context.Context) (string, error) {
+	return "", nil
+}
+
+func (st healthStrategyTarget) Ports(ctx context.Context) (nat.PortMap, error) {
+	return nil, nil
+}
+
+func (st healthStrategyTarget) MappedPort(ctx context.Context, n nat.Port) (nat.Port, error) {
+	return n, nil
+}
+
+func (st healthStrategyTarget) Logs(ctx context.Context) (io.ReadCloser, error) {
+	return nil, nil
+}
+
+func (st healthStrategyTarget) Exec(ctx context.Context, cmd []string, options ...tcexec.ProcessOption) (int, io.Reader, error) {
+	return 0, nil, nil
+}
+
+func (st healthStrategyTarget) State(ctx context.Context) (*types.ContainerState, error) {
+	return &types.ContainerState{Health: st.Health}, nil
+}
+
+func TestWaitForHealthTimesOutForUnhealthy(t *testing.T) {
+	target := healthStrategyTarget{Health: &types.Health{Status: types.Unhealthy}}
+	wg := NewHealthStrategy().WithStartupTimeout(100 * time.Millisecond)
+	err := wg.WaitUntilReady(context.Background(), target)
+
+	if err != nil && err == context.DeadlineExceeded {
+		return
+	}
+	t.Fatal(err)
+}
+
+func TestWaitForHealthSucceeds(t *testing.T) {
+	target := healthStrategyTarget{Health: &types.Health{Status: types.Healthy}}
+	wg := NewHealthStrategy().WithStartupTimeout(100 * time.Millisecond)
+	err := wg.WaitUntilReady(context.Background(), target)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestWaitForHealthWithNil(t *testing.T) {
+	target := &healthStrategyTarget{Health: nil}
+	wg := NewHealthStrategy().
+		WithStartupTimeout(500 * time.Millisecond).
+		WithPollInterval(100 * time.Millisecond)
+
+	go func(target *healthStrategyTarget) {
+		// wait a bit to simulate startup time and give check time to at least
+		// try a few times with a nil Health
+		time.Sleep(200 * time.Millisecond)
+		target.Health = &types.Health{Status: types.Healthy}
+	}(target)
+
+	err := wg.WaitUntilReady(context.Background(), target)
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/wait/health_test.go
+++ b/wait/health_test.go
@@ -58,9 +58,7 @@ func TestWaitForHealthSucceeds(t *testing.T) {
 	wg := NewHealthStrategy().WithStartupTimeout(100 * time.Millisecond)
 	err := wg.WaitUntilReady(context.Background(), target)
 
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.Nil(t, err)
 }
 
 // TestWaitForHealthWithNil checks that an initial `nil` Health will not casue a panic,

--- a/wait/health_test.go
+++ b/wait/health_test.go
@@ -48,10 +48,8 @@ func TestWaitForHealthTimesOutForUnhealthy(t *testing.T) {
 	wg := NewHealthStrategy().WithStartupTimeout(100 * time.Millisecond)
 	err := wg.WaitUntilReady(context.Background(), target)
 
-	if err != nil && err == context.DeadlineExceeded {
-		return
-	}
-	t.Fatal(err)
+	assert.NotNil(t, err)
+	assert.True(t, errors.Is(err, context.DeadlineExceeded))
 }
 
 // TestWaitForHealthSucceeds ensures that a healthy container always succeeds.

--- a/wait/health_test.go
+++ b/wait/health_test.go
@@ -81,9 +81,7 @@ func TestWaitForHealthWithNil(t *testing.T) {
 	}(target)
 
 	err := wg.WaitUntilReady(context.Background(), target)
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.Nil(t, err)
 }
 
 // TestWaitFailsForNilHealth checks that Health always nil fails (but will NOT cause a panic)

--- a/wait/health_test.go
+++ b/wait/health_test.go
@@ -2,6 +2,8 @@ package wait
 
 import (
 	"context"
+	"errors"
+	"github.com/stretchr/testify/assert"
 	"io"
 	"testing"
 	"time"
@@ -92,9 +94,6 @@ func TestWaitFailsForNilHealth(t *testing.T) {
 		WithPollInterval(100 * time.Millisecond)
 
 	err := wg.WaitUntilReady(context.Background(), target)
-	if err != nil && err == context.DeadlineExceeded {
-		return
-	}
-	// Any error, or success will cause this test to fail
-	t.Fatal(err)
+	assert.NotNil(t, err)
+	assert.True(t, errors.Is(err, context.DeadlineExceeded))
 }


### PR DESCRIPTION
## What does this PR do?

Fixes a panic caused by a `nil` pointer dereference in the `HealthStrategy.WaitUntilReady` function.
See Issue #801 

## Why is it important?
Anyone using the `HealthStrategy` for their tests would see them failing with the panic.

## Related issues

- Closes #801

## How to test this PR
I have added the following tests, to cover the various scenarios:
```
PASS wait.TestWaitForHealthTimesOutForUnhealthy (0.20s)
PASS wait.TestWaitForHealthSucceeds (0.00s)
PASS wait.TestWaitForHealthWithNil (0.30s)
```
The `TestWaitForHealthWithNil` test will cause the panic with the original code, but it does not after the PR is applied.