### PR TITLE
chore: update Docker labels for containers

### DIFF
--- a/docker.go
+++ b/docker.go
@@ -33,6 +33,7 @@ import (
 	specs "github.com/opencontainers/image-spec/specs-go/v1"
 
 	tcexec "github.com/testcontainers/testcontainers-go/exec"
+	"github.com/testcontainers/testcontainers-go/internal"
 	"github.com/testcontainers/testcontainers-go/internal/testcontainersdocker"
 	"github.com/testcontainers/testcontainers-go/internal/testcontainerssession"
 	"github.com/testcontainers/testcontainers-go/wait"
@@ -1464,7 +1465,9 @@ func (p *DockerProvider) getDefaultNetwork(ctx context.Context, cli client.APICl
 			Driver:     Bridge,
 			Attachable: true,
 			Labels: map[string]string{
-				TestcontainerLabel: "true",
+				TestcontainerLabel:                "true",
+				testcontainersdocker.LabelLang:    "go",
+				testcontainersdocker.LabelVersion: internal.Version,
 			},
 		})
 

--- a/docker_test.go
+++ b/docker_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/client"
 
+	"github.com/testcontainers/testcontainers-go/internal/testcontainersdocker"
 	"github.com/testcontainers/testcontainers-go/wait"
 )
 
@@ -378,7 +379,7 @@ func TestContainerStartsWithoutTheReaper(t *testing.T) {
 	terminateContainerOnEnd(t, ctx, container)
 
 	resp, err := client.ContainerList(ctx, types.ContainerListOptions{
-		Filters: filters.NewArgs(filters.Arg("label", fmt.Sprintf("%s=%s", TestcontainerLabelSessionID, container.SessionID()))),
+		Filters: filters.NewArgs(filters.Arg("label", fmt.Sprintf("%s=%s", testcontainersdocker.LabelSessionID, container.SessionID()))),
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -408,7 +409,7 @@ func TestContainerStartsWithTheReaper(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	filtersJSON := fmt.Sprintf(`{"label":{"%s":true}}`, TestcontainerLabelIsReaper)
+	filtersJSON := fmt.Sprintf(`{"label":{"%s":true}}`, testcontainersdocker.LabelReaper)
 	f, err := filters.FromJSON(filtersJSON)
 	if err != nil {
 		t.Fatal(err)

--- a/internal/testcontainersdocker/labels.go
+++ b/internal/testcontainersdocker/labels.go
@@ -1,0 +1,9 @@
+package testcontainersdocker
+
+const (
+	LabelBase      = "org.testcontainers"
+	LabelLang      = LabelBase + ".lang"
+	LabelReaper    = LabelBase + ".reaper"
+	LabelSessionID = LabelBase + ".sessionId"
+	LabelVersion   = LabelBase + ".version"
+)

--- a/internal/version.go
+++ b/internal/version.go
@@ -1,0 +1,3 @@
+package internal
+
+const Version = "0.18.0"

--- a/reaper.go
+++ b/reaper.go
@@ -11,14 +11,18 @@ import (
 
 	"github.com/docker/go-connections/nat"
 
+	"github.com/testcontainers/testcontainers-go/internal"
 	"github.com/testcontainers/testcontainers-go/internal/testcontainersdocker"
 	"github.com/testcontainers/testcontainers-go/wait"
 )
 
 const (
-	TestcontainerLabel          = "org.testcontainers.golang"
+	// Deprecated: it has been replaced by the internal testcontainersdocker.LabelLang
+	TestcontainerLabel = "org.testcontainers.golang"
+	// Deprecated: it has been replaced by the internal testcontainersdocker.LabelSessionID
 	TestcontainerLabelSessionID = TestcontainerLabel + ".sessionId"
-	TestcontainerLabelIsReaper  = TestcontainerLabel + ".reaper"
+	// Deprecated: it has been replaced by the internal testcontainersdocker.LabelReaper
+	TestcontainerLabelIsReaper = TestcontainerLabel + ".reaper"
 
 	ReaperDefaultImage = "docker.io/testcontainers/ryuk:0.3.4"
 )
@@ -88,7 +92,8 @@ func newReaper(ctx context.Context, sessionID string, provider ReaperProvider, o
 		ExposedPorts: []string{string(listeningPort)},
 		NetworkMode:  Bridge,
 		Labels: map[string]string{
-			TestcontainerLabelIsReaper: "true",
+			TestcontainerLabelIsReaper:       "true",
+			testcontainersdocker.LabelReaper: "true",
 		},
 		SkipReaper:    true,
 		RegistryCred:  reaperOpts.RegistryCredentials,
@@ -103,7 +108,7 @@ func newReaper(ctx context.Context, sessionID string, provider ReaperProvider, o
 
 	// include reaper-specific labels to the reaper container
 	for k, v := range reaper.Labels() {
-		if k == TestcontainerLabelSessionID {
+		if k == TestcontainerLabelSessionID || k == testcontainersdocker.LabelSessionID {
 			continue
 		}
 		req.Labels[k] = v
@@ -191,8 +196,11 @@ func (r *Reaper) Connect() (chan bool, error) {
 // Labels returns the container labels to use so that this Reaper cleans them up
 func (r *Reaper) Labels() map[string]string {
 	return map[string]string{
-		TestcontainerLabel:          "true",
-		TestcontainerLabelSessionID: r.SessionID,
+		TestcontainerLabel:                  "true",
+		TestcontainerLabelSessionID:         r.SessionID,
+		testcontainersdocker.LabelLang:      "go",
+		testcontainersdocker.LabelVersion:   internal.Version,
+		testcontainersdocker.LabelSessionID: r.SessionID,
 	}
 }
 

--- a/reaper_test.go
+++ b/reaper_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/docker/go-connections/nat"
 	"github.com/stretchr/testify/assert"
+	"github.com/testcontainers/testcontainers-go/internal"
 	"github.com/testcontainers/testcontainers-go/internal/testcontainersdocker"
 	"github.com/testcontainers/testcontainers-go/wait"
 )
@@ -37,8 +38,11 @@ func createContainerRequest(customize func(ContainerRequest) ContainerRequest) C
 		ReaperImage:  "reaperImage",
 		ExposedPorts: []string{"8080/tcp"},
 		Labels: map[string]string{
-			TestcontainerLabel:         "true",
-			TestcontainerLabelIsReaper: "true",
+			TestcontainerLabel:                "true",
+			TestcontainerLabelIsReaper:        "true",
+			testcontainersdocker.LabelReaper:  "true",
+			testcontainersdocker.LabelLang:    "go",
+			testcontainersdocker.LabelVersion: internal.Version,
 		},
 		SkipReaper:  true,
 		Mounts:      Mounts(BindMount("/var/run/docker.sock", "/var/run/docker.sock")),


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
This PR adds a Go file in the internal package with the constants representing the Docker labels that will be applied to all the containers produced by this library.

We are deprecating the old ones, as they were part of the public API, and using the new ones internally (production and test code). We are keeping the usage of the old labels for backwards compatibility in the case any of our users was using the old labels.

For the version of the library, which we do not want to expose at this moment, it lives in the internal package.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
It will allow us to identify containers created by testcontainers for Go in a more consistent manner.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->


<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
