### PR TITLE
fix: tune release script

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -140,7 +140,7 @@ function gitState() {
 }
 
 function gitUnstash() {
-  gitFn unstash
+  gitFn stash pop
 }
 
 # This function is used to create a tag for the module.

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -97,9 +97,9 @@ function curlGolangProxy() {
   fi
 
   # e.g.:
-  #   github.com/testcontainers/testcontainers-go/v0.0.1
-  #   github.com/testcontainers/testcontainers-go/modules/mongodb/v0.0.1
-  curl "https://proxy.golang.org/${module_path}/@v/${module_version}"
+  #   github.com/testcontainers/testcontainers-go/v0.0.1.info
+  #   github.com/testcontainers/testcontainers-go/modules/mongodb/v0.0.1.info
+  curl "https://proxy.golang.org/${module_path}/@v/${module_version}.info"
 }
 
 # This function reads the version.go file and extracts the current version.


### PR DESCRIPTION
- fix: unstash does not exist
- fix: use the right IRL endpoint for go proxy

<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
It fixes two parts of the release script:

- replaces `git unstash` :facepalm: with `git stash pop`
- appends the `.info` suffix to the Go proxy URL

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
Otherwise it's not possible to perform the release

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Caused by #776

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
