### PR TITLE
chore: bump testcontainers-go in Go modules

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -22,6 +22,7 @@ Once the version file is correct in the repository:
 
         BUMP_TYPE="major" ./scripts/release.sh
 
+- The script will update the `go.mod` files for each Go modules and example modules under the examples and modules directories, updating the version of the testcontainers-go dependency to the recently created tag.
 - The script will create a commit in the **main** branch.
 - The script will push the git the main branch including the tags to the upstream repository, https://github.com/testcontainers/testcontainers-go
 
@@ -29,52 +30,102 @@ An example execution, with dry-run mode enabled:
 
 ```
 $ ./scripts/release.sh
-git tag v0.18.0
-git tag examples/bigtable/v0.18.0
-git tag examples/cockroachdb/v0.18.0
-git tag examples/consul/v0.18.0
-git tag examples/datastore/v0.18.0
-git tag examples/firestore/v0.18.0
-git tag examples/mongodb/v0.18.0
-git tag examples/mysql/v0.18.0
-git tag examples/nginx/v0.18.0
-git tag examples/postgres/v0.18.0
-git tag examples/pubsub/v0.18.0
-git tag examples/pulsar/v0.18.0
-git tag examples/redis/v0.18.0
-git tag examples/spanner/v0.18.0
-git tag examples/toxiproxy/v0.18.0
-git tag modules/compose/v0.18.0
-git tag modules/localstack/v0.18.0
+git tag v0.19.0
+git tag examples/bigtable/v0.19.0
+git tag examples/cockroachdb/v0.19.0
+git tag examples/consul/v0.19.0
+git tag examples/datastore/v0.19.0
+git tag examples/firestore/v0.19.0
+git tag examples/mongodb/v0.19.0
+git tag examples/mysql/v0.19.0
+git tag examples/nginx/v0.19.0
+git tag examples/postgres/v0.19.0
+git tag examples/pubsub/v0.19.0
+git tag examples/pulsar/v0.19.0
+git tag examples/redis/v0.19.0
+git tag examples/spanner/v0.19.0
+git tag examples/toxiproxy/v0.19.0
+git tag modules/compose/v0.19.0
+git tag modules/localstack/v0.19.0
 git stash
 git checkout main
-Producing a minor bump of the version, from v0.18.0 to 0.19.0
-sed "s/const Version = ".*"/const Version = "0.19.0"/g" /Users/mdelapenya/sourcecode/src/github.com/testcontainers/testcontainers-go/internal/version.go > /Users/mdelapenya/sourcecode/src/github.com/testcontainers/testcontainers-go/internal/version.go.tmp
+sed "s/const Version = ".*"/const Version = "0.20.0"/g" /Users/mdelapenya/sourcecode/src/github.com/testcontainers/testcontainers-go/internal/version.go > /Users/mdelapenya/sourcecode/src/github.com/testcontainers/testcontainers-go/internal/version.go.tmp
 mv /Users/mdelapenya/sourcecode/src/github.com/testcontainers/testcontainers-go/internal/version.go.tmp /Users/mdelapenya/sourcecode/src/github.com/testcontainers/testcontainers-go/internal/version.go
-sed "s/latest_version: .*/latest_version: v0.18.0/g" /Users/mdelapenya/sourcecode/src/github.com/testcontainers/testcontainers-go/mkdocs.yml > /Users/mdelapenya/sourcecode/src/github.com/testcontainers/testcontainers-go/mkdocs.yml.tmp
+sed "s/latest_version: .*/latest_version: v0.19.0/g" /Users/mdelapenya/sourcecode/src/github.com/testcontainers/testcontainers-go/mkdocs.yml > /Users/mdelapenya/sourcecode/src/github.com/testcontainers/testcontainers-go/mkdocs.yml.tmp
 mv /Users/mdelapenya/sourcecode/src/github.com/testcontainers/testcontainers-go/mkdocs.yml.tmp /Users/mdelapenya/sourcecode/src/github.com/testcontainers/testcontainers-go/mkdocs.yml
+sed "s/testcontainers-go .*/testcontainers-go v0.19.0/g" examples/bigtable/go.mod > examples/bigtable/go.mod.tmp
+mv examples/bigtable/go.mod.tmp examples/bigtable/go.mod
+sed "s/testcontainers-go .*/testcontainers-go v0.19.0/g" examples/cockroachdb/go.mod > examples/cockroachdb/go.mod.tmp
+mv examples/cockroachdb/go.mod.tmp examples/cockroachdb/go.mod
+sed "s/testcontainers-go .*/testcontainers-go v0.19.0/g" examples/consul/go.mod > examples/consul/go.mod.tmp
+mv examples/consul/go.mod.tmp examples/consul/go.mod
+sed "s/testcontainers-go .*/testcontainers-go v0.19.0/g" examples/datastore/go.mod > examples/datastore/go.mod.tmp
+mv examples/datastore/go.mod.tmp examples/datastore/go.mod
+sed "s/testcontainers-go .*/testcontainers-go v0.19.0/g" examples/firestore/go.mod > examples/firestore/go.mod.tmp
+mv examples/firestore/go.mod.tmp examples/firestore/go.mod
+sed "s/testcontainers-go .*/testcontainers-go v0.19.0/g" examples/mongodb/go.mod > examples/mongodb/go.mod.tmp
+mv examples/mongodb/go.mod.tmp examples/mongodb/go.mod
+sed "s/testcontainers-go .*/testcontainers-go v0.19.0/g" examples/mysql/go.mod > examples/mysql/go.mod.tmp
+mv examples/mysql/go.mod.tmp examples/mysql/go.mod
+sed "s/testcontainers-go .*/testcontainers-go v0.19.0/g" examples/nginx/go.mod > examples/nginx/go.mod.tmp
+mv examples/nginx/go.mod.tmp examples/nginx/go.mod
+sed "s/testcontainers-go .*/testcontainers-go v0.19.0/g" examples/postgres/go.mod > examples/postgres/go.mod.tmp
+mv examples/postgres/go.mod.tmp examples/postgres/go.mod
+sed "s/testcontainers-go .*/testcontainers-go v0.19.0/g" examples/pubsub/go.mod > examples/pubsub/go.mod.tmp
+mv examples/pubsub/go.mod.tmp examples/pubsub/go.mod
+sed "s/testcontainers-go .*/testcontainers-go v0.19.0/g" examples/pulsar/go.mod > examples/pulsar/go.mod.tmp
+mv examples/pulsar/go.mod.tmp examples/pulsar/go.mod
+sed "s/testcontainers-go .*/testcontainers-go v0.19.0/g" examples/redis/go.mod > examples/redis/go.mod.tmp
+mv examples/redis/go.mod.tmp examples/redis/go.mod
+sed "s/testcontainers-go .*/testcontainers-go v0.19.0/g" examples/spanner/go.mod > examples/spanner/go.mod.tmp
+mv examples/spanner/go.mod.tmp examples/spanner/go.mod
+sed "s/testcontainers-go .*/testcontainers-go v0.19.0/g" examples/toxiproxy/go.mod > examples/toxiproxy/go.mod.tmp
+mv examples/toxiproxy/go.mod.tmp examples/toxiproxy/go.mod
+go mod tidy
+go mod tidy
+go mod tidy
+go mod tidy
+go mod tidy
+go mod tidy
+go mod tidy
+go mod tidy
+go mod tidy
+go mod tidy
+go mod tidy
+go mod tidy
+go mod tidy
+go mod tidy
+go mod tidy
+sed "s/testcontainers-go .*/testcontainers-go v0.19.0/g" modules/compose/go.mod > modules/compose/go.mod.tmp
+mv modules/compose/go.mod.tmp modules/compose/go.mod
+sed "s/testcontainers-go .*/testcontainers-go v0.19.0/g" modules/localstack/go.mod > modules/localstack/go.mod.tmp
+mv modules/localstack/go.mod.tmp modules/localstack/go.mod
+go mod tidy
+go mod tidy
 git add /Users/mdelapenya/sourcecode/src/github.com/testcontainers/testcontainers-go/internal/version.go
 git add /Users/mdelapenya/sourcecode/src/github.com/testcontainers/testcontainers-go/mkdocs.yml
-git commit -m chore: prepare for next minor development cycle (0.19.0)
+git add examples/**/go.mod
+git add modules/**/go.mod
+git commit -m chore: prepare for next minor development cycle (0.20.0)
 git push origin main --tags
-git unstash
-curl https://proxy.golang.org/github.com/testcontainers/testcontainers-go/@v/v0.18.0
-curl https://proxy.golang.org/github.com/testcontainers/testcontainers-go/examples/bigtable/@v/v0.18.0
-curl https://proxy.golang.org/github.com/testcontainers/testcontainers-go/examples/cockroachdb/@v/v0.18.0
-curl https://proxy.golang.org/github.com/testcontainers/testcontainers-go/examples/consul/@v/v0.18.0
-curl https://proxy.golang.org/github.com/testcontainers/testcontainers-go/examples/datastore/@v/v0.18.0
-curl https://proxy.golang.org/github.com/testcontainers/testcontainers-go/examples/firestore/@v/v0.18.0
-curl https://proxy.golang.org/github.com/testcontainers/testcontainers-go/examples/mongodb/@v/v0.18.0
-curl https://proxy.golang.org/github.com/testcontainers/testcontainers-go/examples/mysql/@v/v0.18.0
-curl https://proxy.golang.org/github.com/testcontainers/testcontainers-go/examples/nginx/@v/v0.18.0
-curl https://proxy.golang.org/github.com/testcontainers/testcontainers-go/examples/postgres/@v/v0.18.0
-curl https://proxy.golang.org/github.com/testcontainers/testcontainers-go/examples/pubsub/@v/v0.18.0
-curl https://proxy.golang.org/github.com/testcontainers/testcontainers-go/examples/pulsar/@v/v0.18.0
-curl https://proxy.golang.org/github.com/testcontainers/testcontainers-go/examples/redis/@v/v0.18.0
-curl https://proxy.golang.org/github.com/testcontainers/testcontainers-go/examples/spanner/@v/v0.18.0
-curl https://proxy.golang.org/github.com/testcontainers/testcontainers-go/examples/toxiproxy/@v/v0.18.0
-curl https://proxy.golang.org/github.com/testcontainers/testcontainers-go/modules/compose/@v/v0.18.0
-curl https://proxy.golang.org/github.com/testcontainers/testcontainers-go/modules/localstack/@v/v0.18.0
+git stash pop
+curl https://proxy.golang.org/github.com/testcontainers/testcontainers-go/@v/v0.19.0
+curl https://proxy.golang.org/github.com/testcontainers/testcontainers-go/examples/bigtable/@v/v0.19.0
+curl https://proxy.golang.org/github.com/testcontainers/testcontainers-go/examples/cockroachdb/@v/v0.19.0
+curl https://proxy.golang.org/github.com/testcontainers/testcontainers-go/examples/consul/@v/v0.19.0
+curl https://proxy.golang.org/github.com/testcontainers/testcontainers-go/examples/datastore/@v/v0.19.0
+curl https://proxy.golang.org/github.com/testcontainers/testcontainers-go/examples/firestore/@v/v0.19.0
+curl https://proxy.golang.org/github.com/testcontainers/testcontainers-go/examples/mongodb/@v/v0.19.0
+curl https://proxy.golang.org/github.com/testcontainers/testcontainers-go/examples/mysql/@v/v0.19.0
+curl https://proxy.golang.org/github.com/testcontainers/testcontainers-go/examples/nginx/@v/v0.19.0
+curl https://proxy.golang.org/github.com/testcontainers/testcontainers-go/examples/postgres/@v/v0.19.0
+curl https://proxy.golang.org/github.com/testcontainers/testcontainers-go/examples/pubsub/@v/v0.19.0
+curl https://proxy.golang.org/github.com/testcontainers/testcontainers-go/examples/pulsar/@v/v0.19.0
+curl https://proxy.golang.org/github.com/testcontainers/testcontainers-go/examples/redis/@v/v0.19.0
+curl https://proxy.golang.org/github.com/testcontainers/testcontainers-go/examples/spanner/@v/v0.19.0
+curl https://proxy.golang.org/github.com/testcontainers/testcontainers-go/examples/toxiproxy/@v/v0.19.0
+curl https://proxy.golang.org/github.com/testcontainers/testcontainers-go/modules/compose/@v/v0.19.0
+curl https://proxy.golang.org/github.com/testcontainers/testcontainers-go/modules/localstack/@v/v0.19.0
 ```
 
 Right after that, you have to:

--- a/examples/bigtable/go.mod
+++ b/examples/bigtable/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	cloud.google.com/go/bigtable v1.18.1
-	github.com/testcontainers/testcontainers-go v0.17.0
+	github.com/testcontainers/testcontainers-go v0.18.0
 	google.golang.org/api v0.110.0
 	google.golang.org/grpc v1.53.0
 	gotest.tools/gotestsum v1.9.0

--- a/examples/cockroachdb/go.mod
+++ b/examples/cockroachdb/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/google/uuid v1.3.0
 	github.com/jackc/pgx/v4 v4.18.0
 	github.com/stretchr/testify v1.8.1
-	github.com/testcontainers/testcontainers-go v0.17.0
+	github.com/testcontainers/testcontainers-go v0.18.0
 	gotest.tools/gotestsum v1.9.0
 )
 

--- a/examples/consul/go.mod
+++ b/examples/consul/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/hashicorp/consul/api v1.18.0
-	github.com/testcontainers/testcontainers-go v0.17.0
+	github.com/testcontainers/testcontainers-go v0.18.0
 	gotest.tools/gotestsum v1.9.0
 )
 

--- a/examples/datastore/go.mod
+++ b/examples/datastore/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	cloud.google.com/go/datastore v1.10.0
-	github.com/testcontainers/testcontainers-go v0.17.0
+	github.com/testcontainers/testcontainers-go v0.18.0
 	google.golang.org/api v0.110.0
 	google.golang.org/grpc v1.53.0
 	gotest.tools/gotestsum v1.9.0

--- a/examples/firestore/go.mod
+++ b/examples/firestore/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	cloud.google.com/go/firestore v1.9.0
-	github.com/testcontainers/testcontainers-go v0.17.0
+	github.com/testcontainers/testcontainers-go v0.18.0
 	google.golang.org/api v0.110.0
 	google.golang.org/grpc v1.53.0
 	gotest.tools/gotestsum v1.9.0

--- a/examples/mongodb/go.mod
+++ b/examples/mongodb/go.mod
@@ -3,7 +3,7 @@ module github.com/testcontainers/testcontainers-go/examples/mongodb
 go 1.18
 
 require (
-	github.com/testcontainers/testcontainers-go v0.17.0
+	github.com/testcontainers/testcontainers-go v0.18.0
 	go.mongodb.org/mongo-driver v1.11.2
 	gotest.tools/gotestsum v1.9.0
 )

--- a/examples/mysql/go.mod
+++ b/examples/mysql/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/go-sql-driver/mysql v1.7.0
-	github.com/testcontainers/testcontainers-go v0.17.0
+	github.com/testcontainers/testcontainers-go v0.18.0
 	gotest.tools/gotestsum v1.9.0
 )
 

--- a/examples/nginx/go.mod
+++ b/examples/nginx/go.mod
@@ -3,7 +3,7 @@ module github.com/testcontainers/testcontainers-go/examples/nginx
 go 1.18
 
 require (
-	github.com/testcontainers/testcontainers-go v0.17.0
+	github.com/testcontainers/testcontainers-go v0.18.0
 	gotest.tools/gotestsum v1.9.0
 )
 

--- a/examples/postgres/go.mod
+++ b/examples/postgres/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/docker/go-connections v0.4.0
 	github.com/lib/pq v0.0.0-20150723085316-0dad96c0b94f
 	github.com/stretchr/testify v1.8.1
-	github.com/testcontainers/testcontainers-go v0.17.0
+	github.com/testcontainers/testcontainers-go v0.18.0
 	gotest.tools/gotestsum v1.9.0
 )
 

--- a/examples/pubsub/go.mod
+++ b/examples/pubsub/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	cloud.google.com/go/pubsub v1.28.0
-	github.com/testcontainers/testcontainers-go v0.17.0
+	github.com/testcontainers/testcontainers-go v0.18.0
 	google.golang.org/api v0.110.0
 	google.golang.org/grpc v1.53.0
 	gotest.tools/gotestsum v1.9.0

--- a/examples/pulsar/go.mod
+++ b/examples/pulsar/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/apache/pulsar-client-go v0.9.0
-	github.com/testcontainers/testcontainers-go v0.17.0
+	github.com/testcontainers/testcontainers-go v0.18.0
 	gotest.tools/gotestsum v1.9.0
 )
 

--- a/examples/redis/go.mod
+++ b/examples/redis/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/go-redis/redis/v8 v8.11.5
 	github.com/google/uuid v1.3.0
 	github.com/stretchr/testify v1.8.1
-	github.com/testcontainers/testcontainers-go v0.17.0
+	github.com/testcontainers/testcontainers-go v0.18.0
 	gotest.tools/gotestsum v1.9.0
 )
 

--- a/examples/spanner/go.mod
+++ b/examples/spanner/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	cloud.google.com/go/spanner v1.44.0
-	github.com/testcontainers/testcontainers-go v0.17.0
+	github.com/testcontainers/testcontainers-go v0.18.0
 	google.golang.org/api v0.110.0
 	google.golang.org/genproto v0.0.0-20230209215440-0dfe4f8abfcc
 	google.golang.org/grpc v1.53.0

--- a/examples/toxiproxy/go.mod
+++ b/examples/toxiproxy/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/Shopify/toxiproxy/v2 v2.5.0
 	github.com/go-redis/redis/v8 v8.11.5
 	github.com/google/uuid v1.3.0
-	github.com/testcontainers/testcontainers-go v0.17.0
+	github.com/testcontainers/testcontainers-go v0.18.0
 	gotest.tools/gotestsum v1.9.0
 )
 

--- a/modules/compose/go.mod
+++ b/modules/compose/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/docker/docker v23.0.0+incompatible
 	github.com/google/uuid v1.3.0
 	github.com/stretchr/testify v1.8.1
-	github.com/testcontainers/testcontainers-go v0.17.0
+	github.com/testcontainers/testcontainers-go v0.18.0
 	golang.org/x/sync v0.1.0
 	gopkg.in/yaml.v3 v3.0.1
 	gotest.tools/gotestsum v1.9.0

--- a/modules/localstack/go.mod
+++ b/modules/localstack/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/docker/go-connections v0.4.0
 	github.com/imdario/mergo v0.3.13
 	github.com/stretchr/testify v1.8.1
-	github.com/testcontainers/testcontainers-go v0.17.0
+	github.com/testcontainers/testcontainers-go v0.18.0
 	golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4
 	gotest.tools/gotestsum v1.9.0
 )


### PR DESCRIPTION
- chore: bump version of modules
- chore: also bump the modules in the release script

<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
This PR bumps the testcontainers-go dependency in all the Go modules and examples to use the latest released version: 0.18.0

Besides that, it updates the release script to perform the same: bump the testcontainers-go dependency across all Go modules and examples.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
Keep modules up-to-date at the moment we perform a release.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Continues #776 and #839

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
