### PR TITLE
chore: simplify env vars for localstack module

### DIFF
--- a/modules/localstack/localstack.go
+++ b/modules/localstack/localstack.go
@@ -49,12 +49,7 @@ func StartContainer(ctx context.Context, overrideReq OverrideContainerRequestOpt
 		Binds:        []string{fmt.Sprintf("%s:/var/run/docker.sock", testcontainersdocker.ExtractDockerHost(ctx))},
 		WaitingFor:   wait.ForHTTP("/_localstack/health").WithPort("4566/tcp").WithStartupTimeout(120 * time.Second),
 		ExposedPorts: []string{fmt.Sprintf("%d/tcp", defaultPort)},
-		Env: map[string]string{
-			"AWS_ACCESS_KEY_ID":     defaultAccessKeyID,
-			"AWS_SECRET_ACCESS_KEY": defaultSecretAccessKey,
-			"AWS_SESSION_TOKEN":     defaultToken,
-			"DEFAULT_REGION":        defaultRegion,
-		},
+		Env:          map[string]string{},
 	}
 	// }
 

--- a/modules/localstack/localstack_test.go
+++ b/modules/localstack/localstack_test.go
@@ -98,7 +98,6 @@ func TestStart(t *testing.T) {
 		ctx,
 		OverrideContainerRequest(testcontainers.ContainerRequest{
 			Image: fmt.Sprintf("localstack/localstack:%s", defaultVersion),
-			Env:   map[string]string{"SERVICES": "s3,sqs,kinesis"},
 		}),
 	)
 	// }

--- a/modules/localstack/v1/s3_test.go
+++ b/modules/localstack/v1/s3_test.go
@@ -61,18 +61,7 @@ func TestS3(t *testing.T) {
 	ctx := context.Background()
 
 	// localStackCreateContainer {
-	container, err := localstack.StartContainer(
-		ctx,
-		localstack.OverrideContainerRequest(testcontainers.ContainerRequest{
-			Env: map[string]string{
-				"AWS_ACCESS_KEY_ID":     accesskey,
-				"AWS_SECRET_ACCESS_KEY": secretkey,
-				"AWS_SESSION_TOKEN":     token,
-				"AWS_DEFAULT_REGION":    region,
-				"SERVICES":              "s3,sqs,cloudwatchlogs,kms",
-			}},
-		),
-	)
+	container, err := localstack.StartContainer(ctx, localstack.NoopOverrideContainerRequest)
 	require.Nil(t, err)
 	// }
 

--- a/modules/localstack/v2/s3_test.go
+++ b/modules/localstack/v2/s3_test.go
@@ -71,18 +71,7 @@ func s3Client(ctx context.Context, l *localstack.LocalStackContainer) (*s3.Clien
 func TestS3(t *testing.T) {
 	ctx := context.Background()
 
-	container, err := localstack.StartContainer(
-		ctx,
-		localstack.OverrideContainerRequest(testcontainers.ContainerRequest{
-			Env: map[string]string{
-				"AWS_ACCESS_KEY_ID":     accesskey,
-				"AWS_SECRET_ACCESS_KEY": secretkey,
-				"AWS_SESSION_TOKEN":     token,
-				"AWS_DEFAULT_REGION":    region,
-				"SERVICES":              "s3,sqs,cloudwatchlogs,kms",
-			}},
-		),
-	)
+	container, err := localstack.StartContainer(ctx, localstack.NoopOverrideContainerRequest)
 	require.Nil(t, err)
 
 	s3Client, err := s3Client(ctx, container)


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
It removes the usage of AWS_ env vars for the localstack module, as they are deprecated in the upstream project. 

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
KISS

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Relates https://github.com/localstack/docs/pull/486

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
