### PR TITLE
fix: update modules path in generator

### DIFF
--- a/modulegen/_template/ci.yml.tmpl
+++ b/modulegen/_template/ci.yml.tmpl
@@ -24,15 +24,15 @@ jobs:
         uses: actions/checkout@v3
 
       - name: modVerify
-        working-directory: ./examples/{{ $lower }}
+        working-directory: ./{{ ParentDir }}/{{ $lower }}
         run: go mod verify
 
       - name: modTidy
-        working-directory: ./examples/{{ $lower }}
+        working-directory: ./{{ ParentDir }}/{{ $lower }}
         run: make tools-tidy
 
       - name: gotestsum
-        working-directory: ./examples/{{ $lower }}
+        working-directory: ./{{ ParentDir }}/{{ $lower }}
         run: make test-unit
 
       - name: Run checker

--- a/modulegen/_template/docs_example.md.tmpl
+++ b/modulegen/_template/docs_example.md.tmpl
@@ -1,9 +1,9 @@
 {{ $lower := ToLower }}{{ $title := Title }}# {{ $title }}
 
 {{ codeinclude "<!--codeinclude-->" }}
-[Creating a {{ $title }} container](../../examples/{{ $lower }}/{{ $lower }}.go)
+[Creating a {{ $title }} container](../../{{ ParentDir }}/{{ $lower }}/{{ $lower }}.go)
 {{ codeinclude "<!--/codeinclude-->" }}
 
 {{ codeinclude "<!--codeinclude-->" }}
-[Test for a {{ $title }} container](../../examples/{{ $lower }}/{{ $lower }}_test.go)
+[Test for a {{ $title }} container](../../{{ ParentDir }}/{{ $lower }}/{{ $lower }}_test.go)
 {{ codeinclude "<!--/codeinclude-->" }}

--- a/modulegen/_template/tools.go.tmpl
+++ b/modulegen/_template/tools.go.tmpl
@@ -1,7 +1,7 @@
 //go:build tools
 // +build tools
 
-// This package contains the tool dependencies of the {{ Title }} example.
+// This package contains the tool dependencies of the {{ Title }} {{ ExampleType }}.
 
 package tools
 

--- a/modulegen/main.go
+++ b/modulegen/main.go
@@ -175,6 +175,7 @@ func generate(example Example, rootDir string) error {
 		"Entrypoint":    func() string { return example.Entrypoint() },
 		"ContainerName": func() string { return example.ContainerName() },
 		"ExampleType":   func() string { return example.Type() },
+		"ParentDir":     func() string { return example.ParentDir() },
 		"ToLower":       func() string { return example.Lower() },
 		"Title":         func() string { return example.Title() },
 		"codeinclude":   func(s string) template.HTML { return template.HTML(s) }, // escape HTML comments for codeinclude

--- a/modulegen/main_test.go
+++ b/modulegen/main_test.go
@@ -391,18 +391,13 @@ func assertExampleGithubWorkflowContent(t *testing.T, example Example, exampleWo
 	lower := example.Lower()
 	title := example.Title()
 
-	exampleType := "example"
-	if example.IsModule {
-		exampleType = "module"
-	}
-
 	data := strings.Split(string(content), "\n")
-	assert.Equal(t, "name: "+title+" "+exampleType+" pipeline", data[0])
+	assert.Equal(t, "name: "+title+" "+example.Type()+" pipeline", data[0])
 	assert.Equal(t, "  test-"+lower+":", data[9])
 	assert.Equal(t, "          go-version: ${{ matrix.go-version }}", data[19])
-	assert.Equal(t, "        working-directory: ./examples/"+lower, data[26])
-	assert.Equal(t, "        working-directory: ./examples/"+lower, data[30])
-	assert.Equal(t, "        working-directory: ./examples/"+lower, data[34])
+	assert.Equal(t, "        working-directory: ./"+example.ParentDir()+"/"+lower, data[26])
+	assert.Equal(t, "        working-directory: ./"+example.ParentDir()+"/"+lower, data[30])
+	assert.Equal(t, "        working-directory: ./"+example.ParentDir()+"/"+lower, data[34])
 	assert.Equal(t, "          paths: \"**/TEST-"+lower+"*.xml\"", data[44])
 }
 

--- a/modulegen/main_test.go
+++ b/modulegen/main_test.go
@@ -345,10 +345,10 @@ func assertExampleDocContent(t *testing.T, example Example, exampleDocFile strin
 	data := strings.Split(string(content), "\n")
 	assert.Equal(t, data[0], "# "+title)
 	assert.Equal(t, data[2], "<!--codeinclude-->")
-	assert.Equal(t, data[3], "[Creating a "+title+" container](../../examples/"+lower+"/"+lower+".go)")
+	assert.Equal(t, data[3], "[Creating a "+title+" container](../../"+example.ParentDir()+"/"+lower+"/"+lower+".go)")
 	assert.Equal(t, data[4], "<!--/codeinclude-->")
 	assert.Equal(t, data[6], "<!--codeinclude-->")
-	assert.Equal(t, data[7], "[Test for a "+title+" container](../../examples/"+lower+"/"+lower+"_test.go)")
+	assert.Equal(t, data[7], "[Test for a "+title+" container](../../"+example.ParentDir()+"/"+lower+"/"+lower+"_test.go)")
 	assert.Equal(t, data[8], "<!--/codeinclude-->")
 }
 

--- a/modulegen/main_test.go
+++ b/modulegen/main_test.go
@@ -457,6 +457,6 @@ func assertToolsGoContent(t *testing.T, example Example, tools string) {
 	assert.Nil(t, err)
 
 	data := strings.Split(string(content), "\n")
-	assert.Equal(t, data[3], "// This package contains the tool dependencies of the "+example.Title()+" example.")
+	assert.Equal(t, data[3], "// This package contains the tool dependencies of the "+example.Title()+" "+example.Type()+".")
 	assert.Equal(t, data[5], "package tools")
 }


### PR DESCRIPTION
- fix: update tests for gh workflow modules
- fix: update tests for docs and modules
- fix: support passing the parent dir
- fix: update tools.go

<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
This PR fixes the generated code for modules in the following places:
- the GH workflow, where the path was hardcoded to use `examples`.
- the website docs for the module, where the path was also hardcoded to use `examples`.
- the tools.go file, where the commet used `example` type
 
<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
The generated code, although valid in terms of the compiler, generates metadata that is incorrect. E.g. it's not possible to render the website because certain paths don't exist. At the same time, the GH workflow would fail because the path is also incorrect.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Discovered while testing #876

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
