### PR TITLE
bug(892): include godog in replace block of compose gomod

### DIFF
--- a/docs/features/docker_compose.md
+++ b/docs/features/docker_compose.md
@@ -22,7 +22,7 @@ go get github.com/testcontainers/testcontainers-go/modules/compose
 	```
 	replace (
 
-            github.com/cucumber/godog => github.com/laurazard/godog v0.0.0-20220922095256-4c4b17abdae7
+		github.com/cucumber/godog => github.com/laurazard/godog v0.0.0-20220922095256-4c4b17abdae7
 
 		// For k8s dependencies, we use a replace directive, to prevent them being
 		// upgraded to the version specified in containerd, which is not relevant to the

--- a/docs/features/docker_compose.md
+++ b/docs/features/docker_compose.md
@@ -21,6 +21,9 @@ go get github.com/testcontainers/testcontainers-go/modules/compose
 
 	```
 	replace (
+
+            github.com/cucumber/godog => github.com/laurazard/godog v0.0.0-20220922095256-4c4b17abdae7
+
 		// For k8s dependencies, we use a replace directive, to prevent them being
 		// upgraded to the version specified in containerd, which is not relevant to the
 		// version needed.

--- a/modules/compose/go.mod
+++ b/modules/compose/go.mod
@@ -3,6 +3,7 @@ module github.com/testcontainers/testcontainers-go/modules/compose
 go 1.18
 
 replace (
+	github.com/cucumber/godog => github.com/laurazard/godog v0.0.0-20220922095256-4c4b17abdae7
 	github.com/testcontainers/testcontainers-go => ../..
 
 	golang.org/x/oauth2 => golang.org/x/oauth2 v0.0.0-20221014153046-6fdb5e3db783


### PR DESCRIPTION
## What does this PR do?

Fixes https://github.com/testcontainers/testcontainers-go/issues/892

## Why is it important?

Without this change folk can't pull and use the latest compose module v0.18

## Related issues

- Closes #892

## How to test this PR

Run:
`go clean --modcache` then `go mod tidy`

Without this change it'll break with the below:
`go: github.com/cucumber/godog@v0.0.0-00010101000000-000000000000: invalid version: unknown revision 000000000000`

With this change dependancies should sync.
