### PR TITLE
fix: proper sorting of dependabot updates when generating a module

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,24 +7,6 @@ updates:
       open-pull-requests-limit: 3
       rebase-strategy: disabled
     - package-ecosystem: gomod
-      directory: /modulegen
-      schedule:
-        interval: weekly
-      open-pull-requests-limit: 3
-      rebase-strategy: disabled
-    - package-ecosystem: gomod
-      directory: /modules/compose
-      schedule:
-        interval: weekly
-      open-pull-requests-limit: 3
-      rebase-strategy: disabled
-    - package-ecosystem: gomod
-      directory: /modules/localstack
-      schedule:
-        interval: weekly
-      open-pull-requests-limit: 3
-      rebase-strategy: disabled
-    - package-ecosystem: gomod
       directory: /examples/bigtable
       schedule:
         interval: weekly
@@ -104,6 +86,24 @@ updates:
       rebase-strategy: disabled
     - package-ecosystem: gomod
       directory: /examples/toxiproxy
+      schedule:
+        interval: weekly
+      open-pull-requests-limit: 3
+      rebase-strategy: disabled
+    - package-ecosystem: gomod
+      directory: /modulegen
+      schedule:
+        interval: weekly
+      open-pull-requests-limit: 3
+      rebase-strategy: disabled
+    - package-ecosystem: gomod
+      directory: /modules/compose
+      schedule:
+        interval: weekly
+      open-pull-requests-limit: 3
+      rebase-strategy: disabled
+    - package-ecosystem: gomod
+      directory: /modules/localstack
       schedule:
         interval: weekly
       open-pull-requests-limit: 3

--- a/modulegen/_template/go.mod.tmpl
+++ b/modulegen/_template/go.mod.tmpl
@@ -1,4 +1,4 @@
-{{ $lower := ToLower }}module github.com/testcontainers/testcontainers-go/examples/{{ $lower }}
+{{ $lower := ToLower }}module github.com/testcontainers/testcontainers-go/{{ ParentDir }}/{{ $lower }}
 
 go 1.18
 

--- a/modulegen/_template/go.mod.tmpl
+++ b/modulegen/_template/go.mod.tmpl
@@ -3,7 +3,7 @@
 go 1.18
 
 require (
-	github.com/testcontainers/testcontainers-go v{{ .TCVersion }}
+	github.com/testcontainers/testcontainers-go {{ .TCVersion }}
 	gotest.tools/gotestsum v1.8.2
 )
 

--- a/modulegen/main.go
+++ b/modulegen/main.go
@@ -255,14 +255,13 @@ func generateDependabotUpdates(rootDir string, example Example) error {
 
 	dependabotExampleUpdates := dependabotConfig.Updates
 
-	// make sure the main module is the first element in the list of examples,
-	// the compose module is the second element
-	exampleUpdates := make(Updates, len(dependabotExampleUpdates)-2)
+	// make sure the main module is the first element in the list of examples
+	exampleUpdates := make(Updates, len(dependabotExampleUpdates)-1)
 	j := 0
 
 	for _, exampleUpdate := range dependabotExampleUpdates {
-		// filter out the index.md file
-		if exampleUpdate.Directory != "/" && exampleUpdate.Directory != "/modules/compose" {
+		// filter out the root module
+		if exampleUpdate.Directory != "/" {
 			exampleUpdates[j] = exampleUpdate
 			j++
 		}
@@ -272,7 +271,7 @@ func generateDependabotUpdates(rootDir string, example Example) error {
 	sort.Sort(exampleUpdates)
 
 	// prepend the main and compose modules
-	exampleUpdates = append([]Update{dependabotExampleUpdates[0], dependabotExampleUpdates[1]}, exampleUpdates...)
+	exampleUpdates = append([]Update{dependabotExampleUpdates[0]}, exampleUpdates...)
 
 	dependabotConfig.Updates = exampleUpdates
 

--- a/modulegen/main_test.go
+++ b/modulegen/main_test.go
@@ -407,7 +407,7 @@ func assertGoModContent(t *testing.T, example Example, goModFile string) {
 	assert.Nil(t, err)
 
 	data := strings.Split(string(content), "\n")
-	assert.Equal(t, "module github.com/testcontainers/testcontainers-go/examples/"+example.Lower(), data[0])
+	assert.Equal(t, "module github.com/testcontainers/testcontainers-go/"+example.ParentDir()+"/"+example.Lower(), data[0])
 	assert.Equal(t, "\tgithub.com/testcontainers/testcontainers-go v"+example.TCVersion, data[5])
 }
 

--- a/modulegen/main_test.go
+++ b/modulegen/main_test.go
@@ -406,7 +406,7 @@ func assertGoModContent(t *testing.T, example Example, goModFile string) {
 
 	data := strings.Split(string(content), "\n")
 	assert.Equal(t, "module github.com/testcontainers/testcontainers-go/"+example.ParentDir()+"/"+example.Lower(), data[0])
-	assert.Equal(t, "\tgithub.com/testcontainers/testcontainers-go v"+example.TCVersion, data[5])
+	assert.Equal(t, "\tgithub.com/testcontainers/testcontainers-go "+example.TCVersion, data[5])
 }
 
 // assert content Makefile

--- a/modulegen/main_test.go
+++ b/modulegen/main_test.go
@@ -330,8 +330,6 @@ func assertDependabotExamplesUpdates(t *testing.T, example Example, originalConf
 
 	// first item is the main module
 	assert.Equal(t, "/", examples[0].Directory, examples)
-	// second item is the modulegen module
-	assert.Equal(t, "/modulegen", examples[1].Directory, examples)
 }
 
 // assert content example file in the docs


### PR DESCRIPTION

<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
This PR fixes the generated code for modules:

- the module dir in Go module file was hardcoded to `examples`: now it is modules or examples, depending on the module type.
- alphabetically sorts dependabot configs, which simplifies the code generation
- modifies the generator to properly sort dependabot updates
- fixes the go mod file, where it was prepending 'v' to version

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
Make the code generation experience even smoother, as there is no need to manually update any file

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Discovered while tesing #876
- Continues #877

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
