### PR TITLE
Allow numerical characters in example names/titles

### DIFF
--- a/docs/modules/index.md
+++ b/docs/modules/index.md
@@ -20,16 +20,16 @@ We have provided a command line tool to generate the scaffolding for the code of
 
 ### Command line flags
 
-| Flag | Type | Required | Description |
-|------|------|----------|-------------|
-| -name | string | Yes | Name of the module, use camel-case when needed. Only alphabetical characters are allowed. |
-| -image | string | Yes | Fully-qualified name of the Docker image to be used by the module (i.e. 'docker.io/org/project:tag') |
-| -title | string | No | A variant of the name supporting mixed casing (i.e. 'MongoDB'). Only alphabetical characters are allowed. |
-| -as-module | bool | No | If set, the module will be generated as a Go module, under the modules directory. Otherwise, it will be generated as a subdirectory of the examples directory. |
+| Flag       | Type   | Required | Description                                                                                                                                                    |
+|------------|--------|----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| -name      | string | Yes      | Name of the module, use camel-case when needed. Only alphanumerical characters are allowed (leading character must be a letter).                               |
+| -image     | string | Yes      | Fully-qualified name of the Docker image to be used by the module (i.e. 'docker.io/org/project:tag')                                                           |
+| -title     | string | No       | A variant of the name supporting mixed casing (i.e. 'MongoDB'). Only alphanumerical characters are allowed (leading character must be a letter).               |
+| -as-module | bool   | No       | If set, the module will be generated as a Go module, under the modules directory. Otherwise, it will be generated as a subdirectory of the examples directory. |
 
 ### What is this tool not doing?
 
-- If the module name does not contain alphabetical characters, it will exit the generation.
+- If the module name or title does not contain alphanumerical characters, it will exit the generation.
 - If the module already exists, it will exit without updating the existing files.
 
 ### How to run the tool

--- a/modulegen/main.go
+++ b/modulegen/main.go
@@ -97,11 +97,11 @@ func (e *Example) Type() string {
 
 func (e *Example) Validate() error {
 	if !regexp.MustCompile(`^[A-Za-z][A-Za-z0-9]*$`).MatchString(e.Name) {
-		return fmt.Errorf("invalid name: %s. Only alphanumerical characters are allowed", e.Name)
+		return fmt.Errorf("invalid name: %s. Only alphanumerical characters are allowed (leading character must be a letter)", e.Name)
 	}
 
 	if !regexp.MustCompile(`^[A-Za-z][A-Za-z0-9]*$`).MatchString(e.TitleName) {
-		return fmt.Errorf("invalid title: %s. Only alphanumerical characters are allowed", e.TitleName)
+		return fmt.Errorf("invalid title: %s. Only alphanumerical characters are allowed (leading character must be a letter)", e.TitleName)
 	}
 
 	return nil

--- a/modulegen/main.go
+++ b/modulegen/main.go
@@ -96,12 +96,12 @@ func (e *Example) Type() string {
 }
 
 func (e *Example) Validate() error {
-	if !regexp.MustCompile(`^[A-Za-z]+$`).MatchString(e.Name) {
-		return fmt.Errorf("invalid name: %s. Only alphabetical characters are allowed", e.Name)
+	if !regexp.MustCompile(`^[A-Za-z][A-Za-z0-9]*$`).MatchString(e.Name) {
+		return fmt.Errorf("invalid name: %s. Only alphanumerical characters are allowed", e.Name)
 	}
 
-	if !regexp.MustCompile(`^[A-Za-z]+$`).MatchString(e.TitleName) {
-		return fmt.Errorf("invalid title: %s. Only alphabetical characters are allowed", e.TitleName)
+	if !regexp.MustCompile(`^[A-Za-z][A-Za-z0-9]*$`).MatchString(e.TitleName) {
+		return fmt.Errorf("invalid title: %s. Only alphanumerical characters are allowed", e.TitleName)
 	}
 
 	return nil

--- a/modulegen/main_test.go
+++ b/modulegen/main_test.go
@@ -113,7 +113,7 @@ func TestExample_Validate(outer *testing.T) {
 				Name:      "Amazing DB 4 The Win",
 				TitleName: "AmazingDB",
 			},
-			expectedErr: errors.New("invalid name: Amazing DB 4 The Win. Only alphanumerical characters are allowed"),
+			expectedErr: errors.New("invalid name: Amazing DB 4 The Win. Only alphanumerical characters are allowed (leading character must be a letter)"),
 		},
 		{
 			name: "non-alphanumerical characters in title",
@@ -121,7 +121,23 @@ func TestExample_Validate(outer *testing.T) {
 				Name:      "AmazingDB",
 				TitleName: "Amazing DB 4 The Win",
 			},
-			expectedErr: errors.New("invalid title: Amazing DB 4 The Win. Only alphanumerical characters are allowed"),
+			expectedErr: errors.New("invalid title: Amazing DB 4 The Win. Only alphanumerical characters are allowed (leading character must be a letter)"),
+		},
+		{
+			name: "leading numerical character in name",
+			example: Example{
+				Name:      "1AmazingDB",
+				TitleName: "AmazingDB",
+			},
+			expectedErr: errors.New("invalid name: 1AmazingDB. Only alphanumerical characters are allowed (leading character must be a letter)"),
+		},
+		{
+			name: "leading numerical character in title",
+			example: Example{
+				Name:      "AmazingDB",
+				TitleName: "1AmazingDB",
+			},
+			expectedErr: errors.New("invalid title: 1AmazingDB. Only alphanumerical characters are allowed (leading character must be a letter)"),
 		},
 	}
 

--- a/modulegen/main_test.go
+++ b/modulegen/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -73,6 +74,60 @@ func TestExample(t *testing.T) {
 			assert.Equal(t, test.expectedTitle, example.Title())
 			assert.Equal(t, test.expectedContainerName, example.ContainerName())
 			assert.Equal(t, test.expectedEntrypoint, example.Entrypoint())
+		})
+	}
+}
+
+func TestExample_Validate(outer *testing.T) {
+	outer.Parallel()
+
+	tests := []struct {
+		name        string
+		example     Example
+		expectedErr error
+	}{
+		{
+			name: "only alphabetical characters in name/title",
+			example: Example{
+				Name:      "AmazingDB",
+				TitleName: "AmazingDB",
+			},
+		},
+		{
+			name: "alphanumerical characters in name",
+			example: Example{
+				Name:      "AmazingDB4tw",
+				TitleName: "AmazingDB",
+			},
+		},
+		{
+			name: "alphanumerical characters in title",
+			example: Example{
+				Name:      "AmazingDB",
+				TitleName: "AmazingDB4tw",
+			},
+		},
+		{
+			name: "non-alphanumerical characters in name",
+			example: Example{
+				Name:      "Amazing DB 4 The Win",
+				TitleName: "AmazingDB",
+			},
+			expectedErr: errors.New("invalid name: Amazing DB 4 The Win. Only alphanumerical characters are allowed"),
+		},
+		{
+			name: "non-alphanumerical characters in title",
+			example: Example{
+				Name:      "AmazingDB",
+				TitleName: "Amazing DB 4 The Win",
+			},
+			expectedErr: errors.New("invalid title: Amazing DB 4 The Win. Only alphanumerical characters are allowed"),
+		},
+	}
+
+	for _, test := range tests {
+		outer.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.expectedErr, test.example.Validate())
 		})
 	}
 }
@@ -190,8 +245,8 @@ func TestGenerate(t *testing.T) {
 	assert.Nil(t, err)
 
 	example := Example{
-		Name:      "foodb",
-		TitleName: "FooDB",
+		Name:      "foodb4tw",
+		TitleName: "FooDB4TheWin",
 		IsModule:  false,
 		Image:     "docker.io/example/foodb:latest",
 		TCVersion: "v0.0.0-test",


### PR DESCRIPTION
## What does this PR do?

This PR relaxes the requirement around example names and titles.
Names and titles cannot currently include any numbers, which is too limiting.

## Why is it important?

This is important for products where numbers are included... like Neo4j :)

## Related issues

This is a prerequisite for the Neo4j work initially discussed in #636, and isolated in #921.

## How to test this PR

```
cd modulegen
go run . --name neo4j --image "docker.io/neo4j:5.5" --title Neo4j
```

This should now work.
