### PR TITLE
chore: bump minimal compile version of GO to 1.19

### DIFF
--- a/.github/workflows/bigtable-example.yml
+++ b/.github/workflows/bigtable-example.yml
@@ -10,7 +10,7 @@ jobs:
   test-bigtable:
     strategy:
       matrix:
-        go-version: [1.18.x, 1.x]
+        go-version: [1.19.x, 1.x]
     runs-on: "ubuntu-latest"
     steps:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.18.x, 1.x]
+        go-version: [1.19.x, 1.x]
         platform: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/.github/workflows/cockroachdb-example.yml
+++ b/.github/workflows/cockroachdb-example.yml
@@ -10,7 +10,7 @@ jobs:
   test-cockroachdb:
     strategy:
       matrix:
-        go-version: [1.18.x, 1.x]
+        go-version: [1.19.x, 1.x]
     runs-on: "ubuntu-latest"
     steps:
 

--- a/.github/workflows/consul-example.yml
+++ b/.github/workflows/consul-example.yml
@@ -10,7 +10,7 @@ jobs:
   test-consul:
     strategy:
       matrix:
-        go-version: [1.18.x, 1.x]
+        go-version: [1.19.x, 1.x]
     runs-on: "ubuntu-latest"
     steps:
 

--- a/.github/workflows/datastore-example.yml
+++ b/.github/workflows/datastore-example.yml
@@ -10,7 +10,7 @@ jobs:
   test-datastore:
     strategy:
       matrix:
-        go-version: [1.18.x, 1.x]
+        go-version: [1.19.x, 1.x]
     runs-on: "ubuntu-latest"
     steps:
 

--- a/.github/workflows/firestore-example.yml
+++ b/.github/workflows/firestore-example.yml
@@ -10,7 +10,7 @@ jobs:
   test-firestore:
     strategy:
       matrix:
-        go-version: [1.18.x, 1.x]
+        go-version: [1.19.x, 1.x]
     runs-on: "ubuntu-latest"
     steps:
 

--- a/.github/workflows/module-compose.yml
+++ b/.github/workflows/module-compose.yml
@@ -6,7 +6,7 @@ jobs:
   test-compose:
     strategy:
       matrix:
-        go-version: [1.18.x, 1.x]
+        go-version: [1.19.x, 1.x]
     runs-on: "ubuntu-latest"
     steps:
 

--- a/.github/workflows/module-localstack.yml
+++ b/.github/workflows/module-localstack.yml
@@ -10,7 +10,7 @@ jobs:
   test-localstack:
     strategy:
       matrix:
-        go-version: [1.18.x, 1.x]
+        go-version: [1.19.x, 1.x]
     runs-on: "ubuntu-latest"
     steps:
 

--- a/.github/workflows/module-pulsar.yml
+++ b/.github/workflows/module-pulsar.yml
@@ -10,7 +10,7 @@ jobs:
   test-pulsar:
     strategy:
       matrix:
-        go-version: [1.18.x, 1.x]
+        go-version: [1.19.x, 1.x]
     runs-on: "ubuntu-latest"
     steps:
 

--- a/.github/workflows/mongodb-example.yml
+++ b/.github/workflows/mongodb-example.yml
@@ -10,7 +10,7 @@ jobs:
   test-mongodb:
     strategy:
       matrix:
-        go-version: [1.18.x, 1.x]
+        go-version: [1.19.x, 1.x]
     runs-on: "ubuntu-latest"
     steps:
 

--- a/.github/workflows/mysql-example.yml
+++ b/.github/workflows/mysql-example.yml
@@ -10,7 +10,7 @@ jobs:
   test-mysql:
     strategy:
       matrix:
-        go-version: [1.18.x, 1.x]
+        go-version: [1.19.x, 1.x]
     runs-on: "ubuntu-latest"
     steps:
 

--- a/.github/workflows/nginx-example.yml
+++ b/.github/workflows/nginx-example.yml
@@ -10,7 +10,7 @@ jobs:
   test-nginx:
     strategy:
       matrix:
-        go-version: [1.18.x, 1.x]
+        go-version: [1.19.x, 1.x]
     runs-on: "ubuntu-latest"
     steps:
 

--- a/.github/workflows/postgres-example.yml
+++ b/.github/workflows/postgres-example.yml
@@ -10,7 +10,7 @@ jobs:
   test-postgres:
     strategy:
       matrix:
-        go-version: [1.18.x, 1.x]
+        go-version: [1.19.x, 1.x]
     runs-on: "ubuntu-latest"
     steps:
 

--- a/.github/workflows/pubsub-example.yml
+++ b/.github/workflows/pubsub-example.yml
@@ -10,7 +10,7 @@ jobs:
   test-pubsub:
     strategy:
       matrix:
-        go-version: [1.18.x, 1.x]
+        go-version: [1.19.x, 1.x]
     runs-on: "ubuntu-latest"
     steps:
 

--- a/.github/workflows/redis-example.yml
+++ b/.github/workflows/redis-example.yml
@@ -10,7 +10,7 @@ jobs:
   test-redis:
     strategy:
       matrix:
-        go-version: [1.18.x, 1.x]
+        go-version: [1.19.x, 1.x]
     runs-on: "ubuntu-latest"
     steps:
 

--- a/.github/workflows/spanner-example.yml
+++ b/.github/workflows/spanner-example.yml
@@ -10,7 +10,7 @@ jobs:
   test-spanner:
     strategy:
       matrix:
-        go-version: [1.18.x, 1.x]
+        go-version: [1.19.x, 1.x]
     runs-on: "ubuntu-latest"
     steps:
 

--- a/.github/workflows/toxiproxy-example.yml
+++ b/.github/workflows/toxiproxy-example.yml
@@ -10,7 +10,7 @@ jobs:
   test-toxiproxy:
     strategy:
       matrix:
-        go-version: [1.18.x, 1.x]
+        go-version: [1.19.x, 1.x]
     runs-on: "ubuntu-latest"
     steps:
 

--- a/examples/bigtable/go.mod
+++ b/examples/bigtable/go.mod
@@ -1,6 +1,6 @@
 module github.com/testcontainers/testcontainers-go/examples/bigtable
 
-go 1.18
+go 1.19
 
 require (
 	cloud.google.com/go/bigtable v1.18.1

--- a/examples/cockroachdb/go.mod
+++ b/examples/cockroachdb/go.mod
@@ -1,6 +1,6 @@
 module github.com/testcontainers/testcontainers-go/examples/cockroachdb
 
-go 1.18
+go 1.19
 
 require (
 	github.com/google/uuid v1.3.0

--- a/examples/consul/go.mod
+++ b/examples/consul/go.mod
@@ -1,6 +1,6 @@
 module github.com/testcontainers/testcontainers-go/examples/consul
 
-go 1.18
+go 1.19
 
 require (
 	github.com/hashicorp/consul/api v1.19.1

--- a/examples/datastore/go.mod
+++ b/examples/datastore/go.mod
@@ -1,6 +1,6 @@
 module github.com/testcontainers/testcontainers-go/examples/datastore
 
-go 1.18
+go 1.19
 
 require (
 	cloud.google.com/go/datastore v1.10.0

--- a/examples/firestore/go.mod
+++ b/examples/firestore/go.mod
@@ -1,6 +1,6 @@
 module github.com/testcontainers/testcontainers-go/examples/firestore
 
-go 1.18
+go 1.19
 
 require (
 	cloud.google.com/go/firestore v1.9.0

--- a/examples/mongodb/go.mod
+++ b/examples/mongodb/go.mod
@@ -1,6 +1,6 @@
 module github.com/testcontainers/testcontainers-go/examples/mongodb
 
-go 1.18
+go 1.19
 
 require (
 	github.com/testcontainers/testcontainers-go v0.18.0

--- a/examples/mysql/go.mod
+++ b/examples/mysql/go.mod
@@ -1,6 +1,6 @@
 module github.com/testcontainers/testcontainers-go/examples/mysql
 
-go 1.18
+go 1.19
 
 require (
 	github.com/go-sql-driver/mysql v1.7.0

--- a/examples/nginx/go.mod
+++ b/examples/nginx/go.mod
@@ -1,6 +1,6 @@
 module github.com/testcontainers/testcontainers-go/examples/nginx
 
-go 1.18
+go 1.19
 
 require (
 	github.com/testcontainers/testcontainers-go v0.18.0

--- a/examples/postgres/go.mod
+++ b/examples/postgres/go.mod
@@ -1,6 +1,6 @@
 module github.com/testcontainers/testcontainers-go/examples/postgres
 
-go 1.18
+go 1.19
 
 require (
 	github.com/docker/go-connections v0.4.0

--- a/examples/pubsub/go.mod
+++ b/examples/pubsub/go.mod
@@ -1,6 +1,6 @@
 module github.com/testcontainers/testcontainers-go/examples/pubsub
 
-go 1.18
+go 1.19
 
 require (
 	cloud.google.com/go/pubsub v1.28.0

--- a/examples/redis/go.mod
+++ b/examples/redis/go.mod
@@ -1,6 +1,6 @@
 module github.com/testcontainers/testcontainers-go/examples/redis
 
-go 1.18
+go 1.19
 
 require (
 	github.com/go-redis/redis/v8 v8.11.5

--- a/examples/spanner/go.mod
+++ b/examples/spanner/go.mod
@@ -1,6 +1,6 @@
 module github.com/testcontainers/testcontainers-go/examples/spanner
 
-go 1.18
+go 1.19
 
 require (
 	cloud.google.com/go/spanner v1.44.0

--- a/examples/toxiproxy/go.mod
+++ b/examples/toxiproxy/go.mod
@@ -1,6 +1,6 @@
 module github.com/testcontainers/testcontainers-go/examples/toxiproxy
 
-go 1.18
+go 1.19
 
 require (
 	github.com/Shopify/toxiproxy/v2 v2.5.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/testcontainers/testcontainers-go
 
-go 1.18
+go 1.19
 
 require (
 	github.com/cenkalti/backoff/v4 v4.2.0

--- a/modulegen/_template/ci.yml.tmpl
+++ b/modulegen/_template/ci.yml.tmpl
@@ -10,7 +10,7 @@ jobs:
   test-{{ $lower }}:
     strategy:
       matrix:
-        go-version: [1.18.x, 1.x]
+        go-version: [1.19.x, 1.x]
     runs-on: "ubuntu-latest"
     steps:
 

--- a/modulegen/_template/go.mod.tmpl
+++ b/modulegen/_template/go.mod.tmpl
@@ -1,6 +1,6 @@
 {{ $lower := ToLower }}module github.com/testcontainers/testcontainers-go/{{ ParentDir }}/{{ $lower }}
 
-go 1.18
+go 1.19
 
 require (
 	github.com/testcontainers/testcontainers-go {{ .TCVersion }}

--- a/modulegen/go.mod
+++ b/modulegen/go.mod
@@ -1,6 +1,6 @@
 module github.com/testcontainers/testcontainers-go/modulegen
 
-go 1.18
+go 1.19
 
 require (
 	github.com/stretchr/testify v1.8.2

--- a/modules/compose/go.mod
+++ b/modules/compose/go.mod
@@ -1,6 +1,6 @@
 module github.com/testcontainers/testcontainers-go/modules/compose
 
-go 1.18
+go 1.19
 
 replace (
 	github.com/cucumber/godog => github.com/laurazard/godog v0.0.0-20220922095256-4c4b17abdae7

--- a/modules/localstack/go.mod
+++ b/modules/localstack/go.mod
@@ -1,6 +1,6 @@
 module github.com/testcontainers/testcontainers-go/modules/localstack
 
-go 1.18
+go 1.19
 
 require (
 	github.com/aws/aws-sdk-go v1.44.211

--- a/modules/pulsar/go.mod
+++ b/modules/pulsar/go.mod
@@ -1,6 +1,6 @@
 module github.com/testcontainers/testcontainers-go/modules/pulsar
 
-go 1.18
+go 1.19
 
 require (
 	github.com/apache/pulsar-client-go v0.9.0

--- a/wait/testdata/go.mod
+++ b/wait/testdata/go.mod
@@ -1,3 +1,3 @@
 module httptest
 
-go 1.18
+go 1.19


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
It bumps the minimal version for compiling testcontainers-go from 1.18 to 1.19

- in all the modules: example modules and Go modules
- in all the CI workflows

It includes the code generation tool and its templates.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
According to https://endoflife.date/go, 1.18 EOL support expired on 01 Feb 2023.

Besides that, Github actions workers now use Go 1.20 when using Go 1.x, so we were testing 1.18 and 1.20 but not 1.19. With this change, the version window is correct again.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes #923

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
