### PR TITLE
fix: move to the right dir to git commit when releasing

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -142,6 +142,9 @@ function gitFn() {
 # This function is used to commit the version.go file.
 function gitCommitVersion() {
   local newVersion="${1}" 
+
+  cd "${ROOT_DIR}"
+
   gitFn add "${VERSION_FILE}"
   gitFn add "${MKDOCS_FILE}"
   gitFn add "examples/**/go.*"


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
It fixes the release script to move to the parent directory before executing `git add`.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
It did not find the changes produced by the build script.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->


<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
