### PR TITLE
chore: always close Docker client

### DIFF
--- a/docker.go
+++ b/docker.go
@@ -822,6 +822,7 @@ func NewDockerProvider(provOpts ...DockerProviderOption) (*DockerProvider, error
 		if err != nil {
 			return nil, err
 		}
+		defer c.Close()
 	}
 
 	p := &DockerProvider{

--- a/docker.go
+++ b/docker.go
@@ -765,7 +765,7 @@ func NewDockerClient() (cli *client.Client, host string, tcConfig TestContainers
 
 	host = tcConfig.Host
 
-	opts := []client.Opt{client.FromEnv}
+	opts := []client.Opt{client.FromEnv, client.WithAPIVersionNegotiation()}
 	if host != "" {
 		opts = append(opts, client.WithHost(host))
 
@@ -795,8 +795,6 @@ func NewDockerClient() (cli *client.Client, host string, tcConfig TestContainers
 		return nil, "", TestContainersConfig{}, err
 	}
 
-	cli.NegotiateAPIVersion(context.Background())
-
 	return cli, host, tcConfig, nil
 }
 
@@ -820,13 +818,12 @@ func NewDockerProvider(provOpts ...DockerProviderOption) (*DockerProvider, error
 	_, err = c.Ping(context.TODO())
 	if err != nil {
 		// fallback to environment
-		c, err = client.NewClientWithOpts(client.FromEnv)
+		c, err = client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
 		if err != nil {
 			return nil, err
 		}
 	}
 
-	c.NegotiateAPIVersion(context.Background())
 	p := &DockerProvider{
 		DockerProviderOptions: o,
 		host:                  host,

--- a/docker.go
+++ b/docker.go
@@ -818,7 +818,7 @@ func NewDockerProvider(provOpts ...DockerProviderOption) (*DockerProvider, error
 	_, err = c.Ping(context.TODO())
 	if err != nil {
 		// fallback to environment
-		c, err = client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
+		c, err = testcontainersdocker.NewClient(context.Background())
 		if err != nil {
 			return nil, err
 		}

--- a/docker_auth.go
+++ b/docker_auth.go
@@ -38,6 +38,7 @@ func defaultRegistry(ctx context.Context) string {
 	if err != nil {
 		return testcontainersdocker.IndexDockerIO
 	}
+	defer p.Close()
 
 	info, err := p.client.Info(ctx)
 	if err != nil {

--- a/docker_test.go
+++ b/docker_test.go
@@ -370,6 +370,7 @@ func TestContainerStartsWithoutTheReaper(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer client.Close()
 
 	var container Container
 	container, err = GenericContainer(ctx, GenericContainerRequest{
@@ -404,6 +405,7 @@ func TestContainerStartsWithTheReaper(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer client.Close()
 
 	_, err = GenericContainer(ctx, GenericContainerRequest{
 		ProviderType: providerType,
@@ -642,6 +644,7 @@ func TestContainerTerminationRemovesDockerImage(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
+		defer client.Close()
 
 		container, err := GenericContainer(ctx, GenericContainerRequest{
 			ProviderType: providerType,
@@ -673,6 +676,7 @@ func TestContainerTerminationRemovesDockerImage(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
+		defer client.Close()
 
 		req := ContainerRequest{
 			FromDockerfile: FromDockerfile{
@@ -2194,6 +2198,7 @@ func TestDockerContainerResources(t *testing.T) {
 
 	c, err := testcontainersdocker.NewClient(ctx)
 	require.NoError(t, err)
+	defer c.Close()
 
 	containerID := nginxC.GetContainerID()
 
@@ -2245,6 +2250,8 @@ func TestContainerWithReaperNetwork(t *testing.T) {
 
 	cli, err := testcontainersdocker.NewClient(ctx)
 	assert.Nil(t, err)
+	defer cli.Close()
+
 	cnt, err := cli.ContainerInspect(ctx, containerId)
 	assert.Nil(t, err)
 	assert.Equal(t, 2, len(cnt.NetworkSettings.Networks))

--- a/docker_test.go
+++ b/docker_test.go
@@ -2399,6 +2399,7 @@ func TestProviderHasConfig(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer provider.Close()
 
 	assert.NotNil(t, provider.Config(), "expecting DockerProvider to provide the configuration")
 }
@@ -2505,6 +2506,7 @@ func TestDockerProviderFindContainerByName(t *testing.T) {
 	ctx := context.Background()
 	provider, err := NewDockerProvider(WithLogger(TestLogger(t)))
 	require.NoError(t, err)
+	defer provider.Close()
 
 	c1, err := GenericContainer(ctx, GenericContainerRequest{
 		ProviderType: providerType,

--- a/docker_test.go
+++ b/docker_test.go
@@ -28,7 +28,6 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
-	"github.com/docker/docker/client"
 
 	"github.com/testcontainers/testcontainers-go/internal/testcontainersdocker"
 	"github.com/testcontainers/testcontainers-go/wait"
@@ -367,7 +366,7 @@ func TestContainerReturnItsContainerID(t *testing.T) {
 
 func TestContainerStartsWithoutTheReaper(t *testing.T) {
 	ctx := context.Background()
-	client, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
+	client, err := testcontainersdocker.NewClient(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -401,7 +400,7 @@ func TestContainerStartsWithoutTheReaper(t *testing.T) {
 
 func TestContainerStartsWithTheReaper(t *testing.T) {
 	ctx := context.Background()
-	client, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
+	client, err := testcontainersdocker.NewClient(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -639,7 +638,7 @@ func TestContainerTerminationWithoutReaper(t *testing.T) {
 func TestContainerTerminationRemovesDockerImage(t *testing.T) {
 	t.Run("if not built from Dockerfile", func(t *testing.T) {
 		ctx := context.Background()
-		client, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
+		client, err := testcontainersdocker.NewClient(ctx)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -670,7 +669,7 @@ func TestContainerTerminationRemovesDockerImage(t *testing.T) {
 
 	t.Run("if built from Dockerfile", func(t *testing.T) {
 		ctx := context.Background()
-		client, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
+		client, err := testcontainersdocker.NewClient(ctx)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -2193,7 +2192,7 @@ func TestDockerContainerResources(t *testing.T) {
 	require.NoError(t, err)
 	terminateContainerOnEnd(t, ctx, nginxC)
 
-	c, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
+	c, err := testcontainersdocker.NewClient(ctx)
 	require.NoError(t, err)
 
 	containerID := nginxC.GetContainerID()
@@ -2244,7 +2243,7 @@ func TestContainerWithReaperNetwork(t *testing.T) {
 
 	containerId := nginxC.GetContainerID()
 
-	cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
+	cli, err := testcontainersdocker.NewClient(ctx)
 	assert.Nil(t, err)
 	cnt, err := cli.ContainerInspect(ctx, containerId)
 	assert.Nil(t, err)
@@ -2277,7 +2276,7 @@ func TestContainerCapAdd(t *testing.T) {
 	require.NoError(t, err)
 	terminateContainerOnEnd(t, ctx, nginx)
 
-	dockerClient, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
+	dockerClient, err := testcontainersdocker.NewClient(ctx)
 	require.NoError(t, err)
 	defer dockerClient.Close()
 

--- a/docker_test.go
+++ b/docker_test.go
@@ -367,11 +367,11 @@ func TestContainerReturnItsContainerID(t *testing.T) {
 
 func TestContainerStartsWithoutTheReaper(t *testing.T) {
 	ctx := context.Background()
-	client, err := client.NewClientWithOpts(client.FromEnv)
+	client, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
 	if err != nil {
 		t.Fatal(err)
 	}
-	client.NegotiateAPIVersion(ctx)
+
 	var container Container
 	container, err = GenericContainer(ctx, GenericContainerRequest{
 		ProviderType: providerType,
@@ -401,11 +401,11 @@ func TestContainerStartsWithoutTheReaper(t *testing.T) {
 
 func TestContainerStartsWithTheReaper(t *testing.T) {
 	ctx := context.Background()
-	client, err := client.NewClientWithOpts(client.FromEnv)
+	client, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
 	if err != nil {
 		t.Fatal(err)
 	}
-	client.NegotiateAPIVersion(ctx)
+
 	_, err = GenericContainer(ctx, GenericContainerRequest{
 		ProviderType: providerType,
 		ContainerRequest: ContainerRequest{
@@ -639,11 +639,11 @@ func TestContainerTerminationWithoutReaper(t *testing.T) {
 func TestContainerTerminationRemovesDockerImage(t *testing.T) {
 	t.Run("if not built from Dockerfile", func(t *testing.T) {
 		ctx := context.Background()
-		client, err := client.NewClientWithOpts(client.FromEnv)
+		client, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
 		if err != nil {
 			t.Fatal(err)
 		}
-		client.NegotiateAPIVersion(ctx)
+
 		container, err := GenericContainer(ctx, GenericContainerRequest{
 			ProviderType: providerType,
 			ContainerRequest: ContainerRequest{
@@ -670,11 +670,11 @@ func TestContainerTerminationRemovesDockerImage(t *testing.T) {
 
 	t.Run("if built from Dockerfile", func(t *testing.T) {
 		ctx := context.Background()
-		client, err := client.NewClientWithOpts(client.FromEnv)
+		client, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
 		if err != nil {
 			t.Fatal(err)
 		}
-		client.NegotiateAPIVersion(ctx)
+
 		req := ContainerRequest{
 			FromDockerfile: FromDockerfile{
 				Context: "./testresources",
@@ -1799,7 +1799,6 @@ func TestContainerCustomPlatformImage(t *testing.T) {
 		dockerCli, _, _, err := NewDockerClient()
 		require.NoError(t, err)
 
-		dockerCli.NegotiateAPIVersion(ctx)
 		ctr, err := dockerCli.ContainerInspect(ctx, c.GetContainerID())
 		assert.NoError(t, err)
 
@@ -2194,10 +2193,9 @@ func TestDockerContainerResources(t *testing.T) {
 	require.NoError(t, err)
 	terminateContainerOnEnd(t, ctx, nginxC)
 
-	c, err := client.NewClientWithOpts(client.FromEnv)
+	c, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
 	require.NoError(t, err)
 
-	c.NegotiateAPIVersion(ctx)
 	containerID := nginxC.GetContainerID()
 
 	resp, err := c.ContainerInspect(ctx, containerID)

--- a/internal/testcontainersdocker/client.go
+++ b/internal/testcontainersdocker/client.go
@@ -1,0 +1,16 @@
+package testcontainersdocker
+
+import (
+	"context"
+
+	"github.com/docker/docker/client"
+)
+
+// NewClient returns a new docker client with the default options
+func NewClient(ctx context.Context, ops ...client.Opt) (*client.Client, error) {
+	if len(ops) == 0 {
+		ops = []client.Opt{client.FromEnv, client.WithAPIVersionNegotiation()}
+	}
+
+	return client.NewClientWithOpts(ops...)
+}

--- a/lifecycle_test.go
+++ b/lifecycle_test.go
@@ -18,6 +18,7 @@ func TestPreCreateModifierHook(t *testing.T) {
 
 	provider, err := NewDockerProvider()
 	require.Nil(t, err)
+	defer provider.Close()
 
 	t.Run("No exposed ports", func(t *testing.T) {
 		// reqWithModifiers {

--- a/logconsumer_test.go
+++ b/logconsumer_test.go
@@ -231,13 +231,11 @@ func TestContainerLogWithErrClosed(t *testing.T) {
 		t.Fatal("get endpoint:", err)
 	}
 
-	client, err := client.NewClientWithOpts(client.WithHost(remoteDocker))
+	client, err := client.NewClientWithOpts(client.WithHost(remoteDocker), client.WithAPIVersionNegotiation())
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer client.Close()
-
-	client.NegotiateAPIVersion(ctx)
 
 	provider := &DockerProvider{client: client, DockerProviderOptions: &DockerProviderOptions{GenericProviderOptions: &GenericProviderOptions{Logger: TestLogger(t)}}}
 

--- a/logconsumer_test.go
+++ b/logconsumer_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/docker/docker/client"
 
+	"github.com/testcontainers/testcontainers-go/internal/testcontainersdocker"
 	"github.com/testcontainers/testcontainers-go/wait"
 )
 
@@ -231,7 +232,9 @@ func TestContainerLogWithErrClosed(t *testing.T) {
 		t.Fatal("get endpoint:", err)
 	}
 
-	client, err := client.NewClientWithOpts(client.WithHost(remoteDocker), client.WithAPIVersionNegotiation())
+	opts := []client.Opt{client.WithHost(remoteDocker), client.WithAPIVersionNegotiation()}
+
+	client, err := testcontainersdocker.NewClient(ctx, opts...)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/modules/compose/compose_local.go
+++ b/modules/compose/compose_local.go
@@ -14,10 +14,10 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
-	"github.com/docker/docker/client"
 	"gopkg.in/yaml.v3"
 
 	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/internal/testcontainersdocker"
 	"github.com/testcontainers/testcontainers-go/wait"
 )
 
@@ -125,7 +125,7 @@ func (dc *LocalDockerCompose) containerNameFromServiceName(service, separator st
 }
 
 func (dc *LocalDockerCompose) applyStrategyToRunningContainer() error {
-	cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
+	cli, err := testcontainersdocker.NewClient(context.Background())
 	if err != nil {
 		return err
 	}

--- a/modules/compose/compose_local.go
+++ b/modules/compose/compose_local.go
@@ -129,6 +129,7 @@ func (dc *LocalDockerCompose) applyStrategyToRunningContainer() error {
 	if err != nil {
 		return err
 	}
+	defer cli.Close()
 
 	for k := range dc.WaitStrategyMap {
 		containerName := dc.containerNameFromServiceName(k.service, "_")

--- a/modules/compose/compose_local.go
+++ b/modules/compose/compose_local.go
@@ -125,12 +125,10 @@ func (dc *LocalDockerCompose) containerNameFromServiceName(service, separator st
 }
 
 func (dc *LocalDockerCompose) applyStrategyToRunningContainer() error {
-	cli, err := client.NewClientWithOpts(client.FromEnv)
+	cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
 	if err != nil {
 		return err
 	}
-
-	cli.NegotiateAPIVersion(context.Background())
 
 	for k := range dc.WaitStrategyMap {
 		containerName := dc.containerNameFromServiceName(k.service, "_")

--- a/modules/compose/compose_local.go
+++ b/modules/compose/compose_local.go
@@ -158,6 +158,8 @@ func (dc *LocalDockerCompose) applyStrategyToRunningContainer() error {
 		if err != nil {
 			return fmt.Errorf("unable to create new Docker Provider: %w", err)
 		}
+		defer dockerProvider.Close()
+
 		dockercontainer := &testcontainers.DockerContainer{ID: container.ID, WaitingFor: strategy}
 		dockercontainer.SetLogger(dc.Logger)
 		dockercontainer.SetProvider(dockerProvider)

--- a/modules/compose/compose_test.go
+++ b/modules/compose/compose_test.go
@@ -3,6 +3,7 @@ package compose
 import (
 	"context"
 	"fmt"
+	"path/filepath"
 	"regexp"
 	"strings"
 	"testing"
@@ -95,7 +96,7 @@ func ExampleLocalDockerCompose_WithEnv() {
 }
 
 func TestLocalDockerCompose(t *testing.T) {
-	path := "./testresources/docker-compose-simple.yml"
+	path := filepath.Join("testresources", "docker-compose-simple.yml")
 
 	identifier := strings.ToLower(uuid.New().String())
 
@@ -112,7 +113,7 @@ func TestLocalDockerCompose(t *testing.T) {
 	checkIfError(t, err)
 }
 func TestDockerComposeStrategyForInvalidService(t *testing.T) {
-	path := "./testresources/docker-compose-simple.yml"
+	path := filepath.Join("testresources", "docker-compose-simple.yml")
 
 	identifier := strings.ToLower(uuid.New().String())
 
@@ -135,7 +136,7 @@ func TestDockerComposeStrategyForInvalidService(t *testing.T) {
 }
 
 func TestDockerComposeWithWaitLogStrategy(t *testing.T) {
-	path := "./testresources/docker-compose-complex.yml"
+	path := filepath.Join("testresources", "docker-compose-complex.yml")
 
 	identifier := strings.ToLower(uuid.New().String())
 
@@ -159,7 +160,7 @@ func TestDockerComposeWithWaitLogStrategy(t *testing.T) {
 }
 
 func TestDockerComposeWithWaitForService(t *testing.T) {
-	path := "./testresources/docker-compose-simple.yml"
+	path := filepath.Join("testresources", "docker-compose-simple.yml")
 
 	identifier := strings.ToLower(uuid.New().String())
 
@@ -184,7 +185,7 @@ func TestDockerComposeWithWaitForService(t *testing.T) {
 }
 
 func TestDockerComposeWithWaitForShortLifespanService(t *testing.T) {
-	path := "./testresources/docker-compose-short-lifespan.yml"
+	path := filepath.Join("testresources", "docker-compose-short-lifespan.yml")
 
 	identifier := strings.ToLower(uuid.New().String())
 
@@ -209,7 +210,7 @@ func TestDockerComposeWithWaitForShortLifespanService(t *testing.T) {
 }
 
 func TestDockerComposeWithWaitHTTPStrategy(t *testing.T) {
-	path := "./testresources/docker-compose-simple.yml"
+	path := filepath.Join("testresources", "docker-compose-simple.yml")
 
 	identifier := strings.ToLower(uuid.New().String())
 
@@ -234,7 +235,7 @@ func TestDockerComposeWithWaitHTTPStrategy(t *testing.T) {
 }
 
 func TestDockerComposeWithContainerName(t *testing.T) {
-	path := "./testresources/docker-compose-container-name.yml"
+	path := filepath.Join("testresources", "docker-compose-container-name.yml")
 
 	identifier := strings.ToLower(uuid.New().String())
 
@@ -259,7 +260,7 @@ func TestDockerComposeWithContainerName(t *testing.T) {
 }
 
 func TestDockerComposeWithWaitStrategy_NoExposedPorts(t *testing.T) {
-	path := "./testresources/docker-compose-no-exposed-ports.yml"
+	path := filepath.Join("testresources", "docker-compose-no-exposed-ports.yml")
 
 	identifier := strings.ToLower(uuid.New().String())
 
@@ -281,7 +282,7 @@ func TestDockerComposeWithWaitStrategy_NoExposedPorts(t *testing.T) {
 }
 
 func TestDockerComposeWithMultipleWaitStrategies(t *testing.T) {
-	path := "./testresources/docker-compose-complex.yml"
+	path := filepath.Join("testresources", "docker-compose-complex.yml")
 
 	identifier := strings.ToLower(uuid.New().String())
 
@@ -305,7 +306,7 @@ func TestDockerComposeWithMultipleWaitStrategies(t *testing.T) {
 }
 
 func TestDockerComposeWithFailedStrategy(t *testing.T) {
-	path := "./testresources/docker-compose-simple.yml"
+	path := filepath.Join("testresources", "docker-compose-simple.yml")
 
 	identifier := strings.ToLower(uuid.New().String())
 
@@ -332,7 +333,7 @@ func TestDockerComposeWithFailedStrategy(t *testing.T) {
 }
 
 func TestLocalDockerComposeComplex(t *testing.T) {
-	path := "./testresources/docker-compose-complex.yml"
+	path := filepath.Join("testresources", "docker-compose-complex.yml")
 
 	identifier := strings.ToLower(uuid.New().String())
 
@@ -354,7 +355,7 @@ func TestLocalDockerComposeComplex(t *testing.T) {
 }
 
 func TestLocalDockerComposeWithEnvironment(t *testing.T) {
-	path := "./testresources/docker-compose-simple.yml"
+	path := filepath.Join("testresources", "docker-compose-simple.yml")
 
 	identifier := strings.ToLower(uuid.New().String())
 
@@ -385,9 +386,9 @@ func TestLocalDockerComposeWithEnvironment(t *testing.T) {
 
 func TestLocalDockerComposeWithMultipleComposeFiles(t *testing.T) {
 	composeFiles := []string{
-		"testresources/docker-compose-simple.yml",
-		"testresources/docker-compose-postgres.yml",
-		"testresources/docker-compose-override.yml",
+		filepath.Join("testresources", "docker-compose-simple.yml"),
+		filepath.Join("testresources", "docker-compose-postgres.yml"),
+		filepath.Join("testresources", "docker-compose-override.yml"),
 	}
 
 	identifier := strings.ToLower(uuid.New().String())
@@ -422,7 +423,7 @@ func TestLocalDockerComposeWithMultipleComposeFiles(t *testing.T) {
 }
 
 func TestLocalDockerComposeWithVolume(t *testing.T) {
-	path := "./testresources/docker-compose-volume.yml"
+	path := filepath.Join("testresources", "docker-compose-volume.yml")
 
 	identifier := strings.ToLower(uuid.New().String())
 

--- a/modules/localstack/localstack.go
+++ b/modules/localstack/localstack.go
@@ -111,6 +111,7 @@ func configureDockerHost(req *LocalStackContainerRequest) (reason string, err er
 	if err != nil {
 		return
 	}
+	defer dockerProvider.Close()
 
 	var daemonHost string
 	daemonHost, err = dockerProvider.DaemonHost(context.Background())

--- a/modules/localstack/localstack_test.go
+++ b/modules/localstack/localstack_test.go
@@ -50,6 +50,7 @@ func TestConfigureDockerHost(t *testing.T) {
 	t.Run("HOSTNAME_EXTERNAL matches the daemon host because there are no aliases", func(t *testing.T) {
 		dockerProvider, err := testcontainers.NewDockerProvider()
 		assert.Nil(t, err)
+		defer dockerProvider.Close()
 
 		// because the daemon host could be a remote one, we need to get it from the provider
 		expectedDaemonHost, err := dockerProvider.DaemonHost(context.Background())

--- a/modules/localstack/v1/s3_test.go
+++ b/modules/localstack/v1/s3_test.go
@@ -38,6 +38,7 @@ func awsSession(ctx context.Context, l *localstack.LocalStackContainer) (*sessio
 	if err != nil {
 		return &session.Session{}, err
 	}
+	defer provider.Close()
 
 	host, err := provider.DaemonHost(ctx)
 	if err != nil {

--- a/modules/localstack/v2/s3_test.go
+++ b/modules/localstack/v2/s3_test.go
@@ -35,6 +35,7 @@ func s3Client(ctx context.Context, l *localstack.LocalStackContainer) (*s3.Clien
 	if err != nil {
 		return nil, err
 	}
+	defer provider.Close()
 
 	host, err := provider.DaemonHost(ctx)
 	if err != nil {

--- a/modules/pulsar/pulsar.go
+++ b/modules/pulsar/pulsar.go
@@ -47,6 +47,7 @@ func (c *Container) resolveURL(ctx context.Context, port nat.Port) (string, erro
 	if err != nil {
 		return "", err
 	}
+	defer provider.Close()
 
 	host, err := provider.DaemonHost(ctx)
 	if err != nil {

--- a/provider.go
+++ b/provider.go
@@ -81,6 +81,7 @@ func (f GenericProviderOptionFunc) ApplyGenericTo(opts *GenericProviderOptions) 
 
 // ContainerProvider allows the creation of containers on an arbitrary system
 type ContainerProvider interface {
+	Close() error                                                                // close the provider
 	CreateContainer(context.Context, ContainerRequest) (Container, error)        // create a container without starting it
 	ReuseOrCreateContainer(context.Context, ContainerRequest) (Container, error) // reuses a container if it exists or creates a container without starting
 	RunContainer(context.Context, ContainerRequest) (Container, error)           // create a container and start it

--- a/provider.go
+++ b/provider.go
@@ -1,0 +1,160 @@
+package testcontainers
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/testcontainers/testcontainers-go/internal/testcontainersdocker"
+)
+
+// possible provider types
+const (
+	ProviderDocker ProviderType = iota // Docker is default = 0
+	ProviderPodman
+)
+
+type (
+	// ProviderType is an enum for the possible providers
+	ProviderType int
+
+	// GenericProviderOptions defines options applicable to all providers
+	GenericProviderOptions struct {
+		Logger         Logging
+		DefaultNetwork string
+	}
+
+	// GenericProviderOption defines a common interface to modify GenericProviderOptions
+	// These options can be passed to GetProvider in a variadic way to customize the returned GenericProvider instance
+	GenericProviderOption interface {
+		ApplyGenericTo(opts *GenericProviderOptions)
+	}
+
+	// GenericProviderOptionFunc is a shorthand to implement the GenericProviderOption interface
+	GenericProviderOptionFunc func(opts *GenericProviderOptions)
+
+	// DockerProviderOptions defines options applicable to DockerProvider
+	DockerProviderOptions struct {
+		defaultBridgeNetworkName string
+		*GenericProviderOptions
+	}
+
+	// DockerProviderOption defines a common interface to modify DockerProviderOptions
+	// These can be passed to NewDockerProvider in a variadic way to customize the returned DockerProvider instance
+	DockerProviderOption interface {
+		ApplyDockerTo(opts *DockerProviderOptions)
+	}
+
+	// DockerProviderOptionFunc is a shorthand to implement the DockerProviderOption interface
+	DockerProviderOptionFunc func(opts *DockerProviderOptions)
+)
+
+func (f DockerProviderOptionFunc) ApplyDockerTo(opts *DockerProviderOptions) {
+	f(opts)
+}
+
+func Generic2DockerOptions(opts ...GenericProviderOption) []DockerProviderOption {
+	converted := make([]DockerProviderOption, 0, len(opts))
+	for _, o := range opts {
+		switch c := o.(type) {
+		case DockerProviderOption:
+			converted = append(converted, c)
+		default:
+			converted = append(converted, DockerProviderOptionFunc(func(opts *DockerProviderOptions) {
+				o.ApplyGenericTo(opts.GenericProviderOptions)
+			}))
+		}
+	}
+
+	return converted
+}
+
+func WithDefaultBridgeNetwork(bridgeNetworkName string) DockerProviderOption {
+	return DockerProviderOptionFunc(func(opts *DockerProviderOptions) {
+		opts.defaultBridgeNetworkName = bridgeNetworkName
+	})
+}
+
+func (f GenericProviderOptionFunc) ApplyGenericTo(opts *GenericProviderOptions) {
+	f(opts)
+}
+
+// ContainerProvider allows the creation of containers on an arbitrary system
+type ContainerProvider interface {
+	CreateContainer(context.Context, ContainerRequest) (Container, error)        // create a container without starting it
+	ReuseOrCreateContainer(context.Context, ContainerRequest) (Container, error) // reuses a container if it exists or creates a container without starting
+	RunContainer(context.Context, ContainerRequest) (Container, error)           // create a container and start it
+	Health(context.Context) error
+	Config() TestContainersConfig
+}
+
+// GetProvider provides the provider implementation for a certain type
+func (t ProviderType) GetProvider(opts ...GenericProviderOption) (GenericProvider, error) {
+	opt := &GenericProviderOptions{
+		Logger: Logger,
+	}
+
+	for _, o := range opts {
+		o.ApplyGenericTo(opt)
+	}
+
+	switch t {
+	case ProviderDocker:
+		providerOptions := append(Generic2DockerOptions(opts...), WithDefaultBridgeNetwork(Bridge))
+		provider, err := NewDockerProvider(providerOptions...)
+		if err != nil {
+			return nil, fmt.Errorf("%w, failed to create Docker provider", err)
+		}
+		return provider, nil
+	case ProviderPodman:
+		providerOptions := append(Generic2DockerOptions(opts...), WithDefaultBridgeNetwork(Podman))
+		provider, err := NewDockerProvider(providerOptions...)
+		if err != nil {
+			return nil, fmt.Errorf("%w, failed to create Docker provider", err)
+		}
+		return provider, nil
+	}
+	return nil, errors.New("unknown provider")
+}
+
+// NewDockerProvider creates a Docker provider with the EnvClient
+func NewDockerProvider(provOpts ...DockerProviderOption) (*DockerProvider, error) {
+	o := &DockerProviderOptions{
+		GenericProviderOptions: &GenericProviderOptions{
+			Logger: Logger,
+		},
+	}
+
+	for idx := range provOpts {
+		provOpts[idx].ApplyDockerTo(o)
+	}
+
+	c, host, tcConfig, err := NewDockerClient()
+	if err != nil {
+		return nil, err
+	}
+
+	_, err = c.Ping(context.TODO())
+	if err != nil {
+		// fallback to environment
+		c, err = testcontainersdocker.NewClient(context.Background())
+		if err != nil {
+			return nil, err
+		}
+		defer c.Close()
+	}
+
+	p := &DockerProvider{
+		DockerProviderOptions: o,
+		host:                  host,
+		client:                c,
+		config:                tcConfig,
+	}
+
+	// log docker server info only once
+	logOnce.Do(func() {
+		LogDockerServerInfo(context.Background(), p.client, p.Logger)
+	})
+
+	return p, nil
+}


### PR DESCRIPTION
<!--
- chore: simplify how to negotiate the API version
- chore: use filepath in compose tests
- chore: unify how to internally retrieve a Docker client
- chore: defer closing the internal Docker client
- chore: extract provider code to a separate file
- chor: always Close the Docker client
-->

<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
This PR improves how the Docker client is handled:

- it simplifies how the API version is negotiated when retrieving a Docker client: instead of forcing a call to the `NegotiateAPIVersion(ctx)` method, it's passed as a client Opt when getting the new client.
- it unifies how a Docker client is retrieved, creating an internal function to it. There, we will centralise the creation of the Docker client.
- it also adds a `Close` method to the DockerProvider struct. With it, we have identified the usages of the DockerProvider, and its underlying Docker client, to close the client and avoid leaking Docker connections.

As part of the PR we are moving the provider related code to a separate Go file, and identified that all `compose_test.go` paths were not using `filepath` to create cross-OS paths.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
It makes sure that we are not leaking Docker client connections, making sure it's closed everywhere, also providing a way to close the Docker Provider wrapper.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes #321

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


## Follow-ups
@Eun I'm not adding the test you provided in the original issue because I dit not see any difference running it against this branch or main (without the closes). Do you think we must add them to be covered? My only concern would be plugin the leak detector to the TestMain (`goleak.VerifyTestMain(m)`, see https://pkg.go.dev/go.uber.org/goleak#readme-quick-start):

> Instead of checking for leaks at the end of every test, goleak can also be run at the end of every test package by creating a TestMain function for your package.

<!-- Optional

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
