### PR TITLE
fix: update code snippet for Docker Auth

### DIFF
--- a/docker_test.go
+++ b/docker_test.go
@@ -1131,6 +1131,7 @@ func Test_BuildContainerFromDockerfileWithBuildLog(t *testing.T) {
 	ctx := context.Background()
 	t.Log("got ctx, creating container request")
 
+	// fromDockerfile {
 	req := ContainerRequest{
 		FromDockerfile: FromDockerfile{
 			Context:       "./testresources",
@@ -1138,6 +1139,7 @@ func Test_BuildContainerFromDockerfileWithBuildLog(t *testing.T) {
 			PrintBuildLog: true,
 		},
 	}
+	// }
 
 	genContainerReq := GenericContainerRequest{
 		ProviderType:     providerType,

--- a/docs/features/docker_auth.md
+++ b/docs/features/docker_auth.md
@@ -23,14 +23,7 @@ req := ContainerRequest{
 
 In the case you are building an image from the Dockerfile, the authentication will be automatically retrieved from the Docker config, so you don't need to pass it explicitly:
 
-```go
-req := ContainerRequest{
-	FromDockerfile: testcontainers.FromDockerfile{
-		Context: "/path/to/build/context",
-		Dockerfile: "CustomDockerfile",
-		BuildArgs: map[string]*string {
-			"FOO": "BAR",
-		},
-	},
-}
-```
+<!--codeinclude-->
+[Building From a Dockerfile does not need Auth credentials anymore](../../docker_test.go) inside_block:fromDockerfile
+<!--/codeinclude-->
+

--- a/docs/features/docker_auth.md
+++ b/docs/features/docker_auth.md
@@ -17,9 +17,7 @@ _Testcontainers for Go_ will automatically discover the credentials for a given 
 
 ```go
 req := ContainerRequest{
-	FromDockerfile: testcontainers.FromDockerfile{
-		Image: "myregistry.com/myimage:latest",
-	},
+	Image: "myregistry.com/myimage:latest",
 }
 ```
 


### PR DESCRIPTION
- docs: fix snippet for containerRequest and private registries
- docs: use codeinclude

<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
It updates the code snippet used in the Docker Auth section of the docs, which was wrong.

At the same time, it uses a `codeinclude` snippet.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
Fix the code snippet, ensuring it comes from a real code block, instead of being a plain text that could be easily outdated.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Caused by #869

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
