### PR TITLE
chore: do not force SSL disabled in the connection string

### DIFF
--- a/docs/modules/postgres.md
+++ b/docs/modules/postgres.md
@@ -84,8 +84,8 @@ the Postgres container exposes a `WithWaitStrategy` option to set a custom wait 
 
 #### ConnectionString
 
-This method returns the connection string to connect to the Postgres container, using the default `5432` port and SSL disabled.
-It's possible to pass extra parameters to the connection string, e.g. `application_name=myapp`, in a variadic way.
+This method returns the connection string to connect to the Postgres container, using the default `5432` port.
+It's possible to pass extra parameters to the connection string, e.g. `sslmode=disable` or `application_name=myapp`, in a variadic way.
 
 <!--codeinclude-->
 [Get connection string](../../modules/postgres/postgres_test.go) inside_block:connectionString

--- a/modules/postgres/postgres.go
+++ b/modules/postgres/postgres.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
-	"strings"
 	"time"
 
 	"github.com/testcontainers/testcontainers-go"
@@ -40,13 +39,10 @@ func (c *PostgresContainer) ConnectionString(ctx context.Context, args ...string
 
 	extraArgs := ""
 	for _, arg := range args {
-		if strings.HasPrefix(arg, "sslmode=") {
-			continue
-		}
 		extraArgs += " " + arg
 	}
 
-	connStr := fmt.Sprintf("host=%s port=%s user=%s password=%s dbname=%s sslmode=disable %s", host, containerPort.Port(), c.user, c.password, c.dbName, extraArgs)
+	connStr := fmt.Sprintf("host=%s port=%s user=%s password=%s dbname=%s %s", host, containerPort.Port(), c.user, c.password, c.dbName, extraArgs)
 	return connStr, nil
 }
 

--- a/modules/postgres/postgres_test.go
+++ b/modules/postgres/postgres_test.go
@@ -72,7 +72,8 @@ func TestPostgres(t *testing.T) {
 			})
 
 			// connectionString {
-			connStr, err := container.ConnectionString(ctx, "application_name=test")
+			// explicitly set sslmode=disable because the container is not configured to use TLS
+			connStr, err := container.ConnectionString(ctx, "sslmode=disable", "application_name=test")
 			assert.NoError(t, err)
 			// }
 
@@ -162,7 +163,8 @@ func TestWithConfigFile(t *testing.T) {
 		}
 	})
 
-	connStr, err := container.ConnectionString(ctx)
+	// explicitly set sslmode=disable because the container is not configured to use TLS
+	connStr, err := container.ConnectionString(ctx, "sslmode=disable")
 	assert.NoError(t, err)
 
 	db, err := sql.Open("postgres", connStr)
@@ -194,7 +196,8 @@ func TestWithInitScript(t *testing.T) {
 		}
 	})
 
-	connStr, err := container.ConnectionString(ctx)
+	// explicitly set sslmode=disable because the container is not configured to use TLS
+	connStr, err := container.ConnectionString(ctx, "sslmode=disable")
 	assert.NoError(t, err)
 
 	db, err := sql.Open("postgres", connStr)


### PR DESCRIPTION

<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
It removes the hardcoded `sslmode=disable` parameter from the connection string, as it could be the case where users set up an instance with SSL enabled.
In the tests for the module, it's disabled on purpose for simplicity.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
Let the users decide

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Completes #945

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
