### PR TITLE
Reorder docs language links

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -7,8 +7,8 @@
     <a href="https://testcontainers.org" class="card-grid-item"><img src="language-logos/java.svg"/>Java</a>
     <a class="card-grid-item"><img src="language-logos/go.svg"/>Go</a>
     <a href="https://dotnet.testcontainers.org/" class="card-grid-item"><img src="language-logos/dotnet.svg"/>.NET</a>
-    <a href="https://testcontainers-python.readthedocs.io/en/latest/" class="card-grid-item"><img src="language-logos/python.svg"/>Python</a>
     <a href="https://node.testcontainers.org/" class="card-grid-item"><img src="language-logos/nodejs.svg"/>Node.js</a></a>
+    <a href="https://testcontainers-python.readthedocs.io/en/latest/" class="card-grid-item"><img src="language-logos/python.svg"/>Python</a>
     <a href="https://docs.rs/testcontainers/latest/testcontainers/" class="card-grid-item"><img src="language-logos/rust.svg"/>Rust</a>
     <a href="https://github.com/testcontainers/testcontainers-hs" class="card-grid-item"><img src="language-logos/haskell.svg"/>Haskell</a>
 </div>


### PR DESCRIPTION
## What is this PR doing?
It's reordering the supported langs in the docs site, to have NodeJS before Python.

## Why is it important?
Consistency in the order of the languages