### PR TITLE
chore: skip CI builds when updating the docs

### DIFF
--- a/.github/workflows/bigtable-example.yml
+++ b/.github/workflows/bigtable-example.yml
@@ -1,6 +1,16 @@
 name: Bigtable example pipeline
 
-on: [push, pull_request]
+on:
+  push:
+    paths-ignore:
+    - 'mkdocs.yml'
+    - 'docs/**'
+    - 'README.md'
+  pull_request:
+    paths-ignore:
+    - 'mkdocs.yml'
+    - 'docs/**'
+    - 'README.md'
 
 concurrency:
   group: "${{ github.workflow }}-${{ github.head_ref || github.sha }}"

--- a/.github/workflows/ci-reaper-off.yml
+++ b/.github/workflows/ci-reaper-off.yml
@@ -1,6 +1,16 @@
 name: Reaper-Off pipeline
 
-on: [push, pull_request]
+on:
+  push:
+    paths-ignore:
+    - 'mkdocs.yml'
+    - 'docs/**'
+    - 'README.md'
+  pull_request:
+    paths-ignore:
+    - 'mkdocs.yml'
+    - 'docs/**'
+    - 'README.md'
 
 concurrency:
   group: "${{ github.workflow }}-${{ github.head_ref || github.sha }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,16 @@
 name: Main pipeline
 
-on: [push, pull_request]
+on:
+  push:
+    paths-ignore:
+    - 'mkdocs.yml'
+    - 'docs/**'
+    - 'README.md'
+  pull_request:
+    paths-ignore:
+    - 'mkdocs.yml'
+    - 'docs/**'
+    - 'README.md'
 
 concurrency:
   group: "${{ github.workflow }}-${{ github.head_ref || github.sha }}"

--- a/.github/workflows/cockroachdb-example.yml
+++ b/.github/workflows/cockroachdb-example.yml
@@ -1,6 +1,16 @@
 name: Cockroachdb example pipeline
 
-on: [push, pull_request]
+on:
+  push:
+    paths-ignore:
+    - 'mkdocs.yml'
+    - 'docs/**'
+    - 'README.md'
+  pull_request:
+    paths-ignore:
+    - 'mkdocs.yml'
+    - 'docs/**'
+    - 'README.md'
 
 concurrency:
   group: "${{ github.workflow }}-${{ github.head_ref || github.sha }}"

--- a/.github/workflows/consul-example.yml
+++ b/.github/workflows/consul-example.yml
@@ -1,6 +1,16 @@
 name: Consul example pipeline
 
-on: [push, pull_request]
+on:
+  push:
+    paths-ignore:
+    - 'mkdocs.yml'
+    - 'docs/**'
+    - 'README.md'
+  pull_request:
+    paths-ignore:
+    - 'mkdocs.yml'
+    - 'docs/**'
+    - 'README.md'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.sha }}

--- a/.github/workflows/datastore-example.yml
+++ b/.github/workflows/datastore-example.yml
@@ -1,6 +1,16 @@
 name: Datastore example pipeline
 
-on: [push, pull_request]
+on:
+  push:
+    paths-ignore:
+    - 'mkdocs.yml'
+    - 'docs/**'
+    - 'README.md'
+  pull_request:
+    paths-ignore:
+    - 'mkdocs.yml'
+    - 'docs/**'
+    - 'README.md'
 
 concurrency:
   group: "${{ github.workflow }}-${{ github.head_ref || github.sha }}"

--- a/.github/workflows/firestore-example.yml
+++ b/.github/workflows/firestore-example.yml
@@ -1,6 +1,16 @@
 name: Firestore example pipeline
 
-on: [push, pull_request]
+on:
+  push:
+    paths-ignore:
+    - 'mkdocs.yml'
+    - 'docs/**'
+    - 'README.md'
+  pull_request:
+    paths-ignore:
+    - 'mkdocs.yml'
+    - 'docs/**'
+    - 'README.md'
 
 concurrency:
   group: "${{ github.workflow }}-${{ github.head_ref || github.sha }}"

--- a/.github/workflows/module-compose.yml
+++ b/.github/workflows/module-compose.yml
@@ -1,6 +1,16 @@
 name: Compose module pipeline
 
-on: [push, pull_request]
+on:
+  push:
+    paths-ignore:
+    - 'mkdocs.yml'
+    - 'docs/**'
+    - 'README.md'
+  pull_request:
+    paths-ignore:
+    - 'mkdocs.yml'
+    - 'docs/**'
+    - 'README.md'
 
 jobs:
   test-compose:

--- a/.github/workflows/module-couchbase.yml
+++ b/.github/workflows/module-couchbase.yml
@@ -1,6 +1,16 @@
 name: Couchbase module pipeline
 
-on: [push, pull_request]
+on:
+  push:
+    paths-ignore:
+    - 'mkdocs.yml'
+    - 'docs/**'
+    - 'README.md'
+  pull_request:
+    paths-ignore:
+    - 'mkdocs.yml'
+    - 'docs/**'
+    - 'README.md'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.sha }}

--- a/.github/workflows/module-localstack.yml
+++ b/.github/workflows/module-localstack.yml
@@ -1,6 +1,16 @@
 name: LocalStack module pipeline
 
-on: [push, pull_request]
+on:
+  push:
+    paths-ignore:
+    - 'mkdocs.yml'
+    - 'docs/**'
+    - 'README.md'
+  pull_request:
+    paths-ignore:
+    - 'mkdocs.yml'
+    - 'docs/**'
+    - 'README.md'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.sha }}

--- a/.github/workflows/module-mysql.yml
+++ b/.github/workflows/module-mysql.yml
@@ -1,6 +1,16 @@
 name: MySQL module pipeline
 
-on: [push, pull_request]
+on:
+  push:
+    paths-ignore:
+    - 'mkdocs.yml'
+    - 'docs/**'
+    - 'README.md'
+  pull_request:
+    paths-ignore:
+    - 'mkdocs.yml'
+    - 'docs/**'
+    - 'README.md'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.sha }}

--- a/.github/workflows/module-neo4j.yml
+++ b/.github/workflows/module-neo4j.yml
@@ -1,6 +1,16 @@
 name: Neo4j module pipeline
 
-on: [push, pull_request]
+on:
+  push:
+    paths-ignore:
+    - 'mkdocs.yml'
+    - 'docs/**'
+    - 'README.md'
+  pull_request:
+    paths-ignore:
+    - 'mkdocs.yml'
+    - 'docs/**'
+    - 'README.md'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.sha }}

--- a/.github/workflows/module-postgres.yml
+++ b/.github/workflows/module-postgres.yml
@@ -1,6 +1,16 @@
 name: Postgres module pipeline
 
-on: [push, pull_request]
+on:
+  push:
+    paths-ignore:
+    - 'mkdocs.yml'
+    - 'docs/**'
+    - 'README.md'
+  pull_request:
+    paths-ignore:
+    - 'mkdocs.yml'
+    - 'docs/**'
+    - 'README.md'
 
 concurrency:
   group: "${{ github.workflow }}-${{ github.head_ref || github.sha }}"

--- a/.github/workflows/module-pulsar.yml
+++ b/.github/workflows/module-pulsar.yml
@@ -1,6 +1,16 @@
 name: Pulsar module pipeline
 
-on: [push, pull_request]
+on:
+  push:
+    paths-ignore:
+    - 'mkdocs.yml'
+    - 'docs/**'
+    - 'README.md'
+  pull_request:
+    paths-ignore:
+    - 'mkdocs.yml'
+    - 'docs/**'
+    - 'README.md'
 
 concurrency:
   group: "${{ github.workflow }}-${{ github.head_ref || github.sha }}"

--- a/.github/workflows/module-vault.yml
+++ b/.github/workflows/module-vault.yml
@@ -1,6 +1,16 @@
 name: vault module pipeline
 
-on: [push, pull_request]
+on:
+  push:
+    paths-ignore:
+    - 'mkdocs.yml'
+    - 'docs/**'
+    - 'README.md'
+  pull_request:
+    paths-ignore:
+    - 'mkdocs.yml'
+    - 'docs/**'
+    - 'README.md'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.sha }}

--- a/.github/workflows/mongodb-example.yml
+++ b/.github/workflows/mongodb-example.yml
@@ -1,6 +1,16 @@
 name: MongoDB example pipeline
 
-on: [push, pull_request]
+on:
+  push:
+    paths-ignore:
+    - 'mkdocs.yml'
+    - 'docs/**'
+    - 'README.md'
+  pull_request:
+    paths-ignore:
+    - 'mkdocs.yml'
+    - 'docs/**'
+    - 'README.md'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.sha }}

--- a/.github/workflows/nginx-example.yml
+++ b/.github/workflows/nginx-example.yml
@@ -1,6 +1,16 @@
 name: Nginx example pipeline
 
-on: [push, pull_request]
+on:
+  push:
+    paths-ignore:
+    - 'mkdocs.yml'
+    - 'docs/**'
+    - 'README.md'
+  pull_request:
+    paths-ignore:
+    - 'mkdocs.yml'
+    - 'docs/**'
+    - 'README.md'
 
 concurrency:
   group: "${{ github.workflow }}-${{ github.head_ref || github.sha }}"

--- a/.github/workflows/pubsub-example.yml
+++ b/.github/workflows/pubsub-example.yml
@@ -1,6 +1,16 @@
 name: Pubsub example pipeline
 
-on: [push, pull_request]
+on:
+  push:
+    paths-ignore:
+    - 'mkdocs.yml'
+    - 'docs/**'
+    - 'README.md'
+  pull_request:
+    paths-ignore:
+    - 'mkdocs.yml'
+    - 'docs/**'
+    - 'README.md'
 
 concurrency:
   group: "${{ github.workflow }}-${{ github.head_ref || github.sha }}"

--- a/.github/workflows/redis-example.yml
+++ b/.github/workflows/redis-example.yml
@@ -1,6 +1,16 @@
 name: Redis example pipeline
 
-on: [push, pull_request]
+on:
+  push:
+    paths-ignore:
+    - 'mkdocs.yml'
+    - 'docs/**'
+    - 'README.md'
+  pull_request:
+    paths-ignore:
+    - 'mkdocs.yml'
+    - 'docs/**'
+    - 'README.md'
 
 concurrency:
   group: "${{ github.workflow }}-${{ github.head_ref || github.sha }}"

--- a/.github/workflows/spanner-example.yml
+++ b/.github/workflows/spanner-example.yml
@@ -1,6 +1,16 @@
 name: Spanner example pipeline
 
-on: [push, pull_request]
+on:
+  push:
+    paths-ignore:
+    - 'mkdocs.yml'
+    - 'docs/**'
+    - 'README.md'
+  pull_request:
+    paths-ignore:
+    - 'mkdocs.yml'
+    - 'docs/**'
+    - 'README.md'
 
 concurrency:
   group: "${{ github.workflow }}-${{ github.head_ref || github.sha }}"

--- a/.github/workflows/toxiproxy-example.yml
+++ b/.github/workflows/toxiproxy-example.yml
@@ -1,6 +1,16 @@
 name: Toxiproxy example pipeline
 
-on: [push, pull_request]
+on:
+  push:
+    paths-ignore:
+    - 'mkdocs.yml'
+    - 'docs/**'
+    - 'README.md'
+  pull_request:
+    paths-ignore:
+    - 'mkdocs.yml'
+    - 'docs/**'
+    - 'README.md'
 
 concurrency:
   group: "${{ github.workflow }}-${{ github.head_ref || github.sha }}"

--- a/modulegen/_template/ci.yml.tmpl
+++ b/modulegen/_template/ci.yml.tmpl
@@ -1,6 +1,16 @@
 {{ $lower := ToLower }}name: {{ Title }} {{ ExampleType }} pipeline
 
-on: [push, pull_request]
+on:
+  push:
+    paths-ignore:
+    - 'mkdocs.yml'
+    - 'docs/**'
+    - 'README.md'
+  pull_request:
+    paths-ignore:
+    - 'mkdocs.yml'
+    - 'docs/**'
+    - 'README.md'
 
 concurrency:
   group: {{ "${{ github.workflow }}-${{ github.head_ref || github.sha }}" }}

--- a/modulegen/main_test.go
+++ b/modulegen/main_test.go
@@ -465,12 +465,12 @@ func assertExampleGithubWorkflowContent(t *testing.T, example Example, exampleWo
 
 	data := strings.Split(string(content), "\n")
 	assert.Equal(t, "name: "+title+" "+example.Type()+" pipeline", data[0])
-	assert.Equal(t, "  test-"+lower+":", data[9])
-	assert.Equal(t, "          go-version: ${{ matrix.go-version }}", data[19])
-	assert.Equal(t, "        working-directory: ./"+example.ParentDir()+"/"+lower, data[26])
-	assert.Equal(t, "        working-directory: ./"+example.ParentDir()+"/"+lower, data[30])
-	assert.Equal(t, "        working-directory: ./"+example.ParentDir()+"/"+lower, data[34])
-	assert.Equal(t, "          paths: \"**/TEST-"+lower+"*.xml\"", data[44])
+	assert.Equal(t, "  test-"+lower+":", data[19])
+	assert.Equal(t, "          go-version: ${{ matrix.go-version }}", data[29])
+	assert.Equal(t, "        working-directory: ./"+example.ParentDir()+"/"+lower, data[36])
+	assert.Equal(t, "        working-directory: ./"+example.ParentDir()+"/"+lower, data[40])
+	assert.Equal(t, "        working-directory: ./"+example.ParentDir()+"/"+lower, data[44])
+	assert.Equal(t, "          paths: \"**/TEST-"+lower+"*.xml\"", data[54])
 }
 
 // assert content go.mod


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
This PR adds a filter when listening to push/pull_request events on the GH workflows, to ignore the events when the changeset includes only files in those paths.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
With the raise of modules and the ability to run in multiple versions, we are seeing hundreds of GH actions being executed under the testcontainers GH org... and there are [limits](https://docs.github.com/en/actions/learn-github-actions/usage-limits-billing-and-administration#usage-limits) that we are hitting everyday (20 concurrent jobs) specially when dependabot wants to play with us.

With this change we expect to mitigate that issue, and only run the CI jobs with tests for code, not for docs (they are already rendered by Netlify)

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->


<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
