### PR TITLE
Revert "chore: render logos from the base location (#995)"

### DIFF
--- a/docs/theme/partials/nav.html
+++ b/docs/theme/partials/nav.html
@@ -58,22 +58,22 @@
                 <ul>
                     <li>
                         <a href="https://slack.testcontainers.org/" target="_blank">
-                            <img src="icons/slack.svg" alt="Slack" width="30" height="31">
+                            <img src="/icons/slack.svg" alt="Slack" width="30" height="31">
                         </a>
                     </li>
                     <li>
                         <a href="https://github.com/testcontainers" target="_blank">
-                            <img src="icons/github.svg" alt="GitHub" width="30" height="31">
+                            <img src="/icons/github.svg" alt="GitHub" width="30" height="31">
                         </a>
                     </li>
                     <li>
                         <a href="https://stackoverflow.com/questions/tagged/testcontainers" target="_blank">
-                            <img src="icons/stackoverflow.svg" alt="StackOverflow" width="26" height="31">
+                            <img src="/icons/stackoverflow.svg" alt="StackOverflow" width="26" height="31">
                         </a>
                     </li>
                     <li>
                         <a href="https://twitter.com/testcontainers" target="_blank">
-                            <img src="icons/twitter.svg" alt="Twitter" width="37" height="31">
+                            <img src="/icons/twitter.svg" alt="Twitter" width="37" height="31">
                         </a>
                     </li>
                 </ul>


### PR DESCRIPTION

<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
This reverts commit b89457c21b4cb87dbd4471276687648dbe52ff37.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
For some reason, Netlify renders the icons properly in the preview URL, but does not (404 NotFound) for the production URL.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Reverts #995

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
