### PR TITLE
docs: add permalink to mkdocs headings

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -25,6 +25,8 @@ markdown_extensions:
     - pymdownx.tabbed:
         alternate_style: true
     - pymdownx.snippets
+    - toc:
+        permalink: true
 nav:
     - Home: index.md
     - Quickstart: quickstart.md


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
It adds a configuration to mkdocs to render a permalink next to each section from the table of contents. See https://squidfunk.github.io/mkdocs-material/setup/extensions/python-markdown/?h=toc#+toc.permalink

Render URL: https://deploy-preview-1032--testcontainers-go.netlify.app/

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
It's possible to get the permalink from the TOC (right sidenav) but many times it's handy to copy a permalink from the content itself.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->


<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
