### PR TITLE
feat: support for wait.ForExec with response matcher

### DIFF
--- a/docs/features/wait/exec.md
+++ b/docs/features/wait/exec.md
@@ -4,16 +4,12 @@ The exec wait strategy will check the exit code of a process to be executed in t
 
 - the command and arguments to be executed, as an array of strings.
 - a function to match a specific exit code, with the default matching `0`.
+- the output response matcher as a function.
 - the startup timeout to be used in seconds, default is 60 seconds.
 - the poll interval to be used in milliseconds, default is 100 milliseconds.
 
-## Match an exit code
+## Match an exit code and a response matcher
 
-```golang
-req := ContainerRequest{
-	Image:        "docker.io/nginx:alpine",
-	WaitingFor: wait.NewExecStrategy([]string{"git", "version"}).WithExitCodeMatcher(func(exitCode int) bool {
-		return exitCode == 10
-	}),
-}
-```
+<!--codeinclude-->
+[Waiting for a command matching an exit code and response](../../../wait/exec_test.go) inside_block:waitForExecExitCodeResponse
+<!--/codeinclude-->


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
It adds `WithResponseMatcher` to the wait.ForExec strategy, so that it behaves as in the wait.ForHTTP strategy.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
Provide support for the use case where we want to run a command in a container, and verify the output of that command.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Discovered while testing #994 

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
