### PR TITLE
feat: provide container lifecycle hooks

### DIFF
--- a/container.go
+++ b/container.go
@@ -121,6 +121,7 @@ type ContainerRequest struct {
 	ConfigModifier          func(*container.Config)                    // Modifier for the config before container creation
 	HostConfigModifier      func(*container.HostConfig)                // Modifier for the host config before container creation
 	EnpointSettingsModifier func(map[string]*network.EndpointSettings) // Modifier for the network settings before container creation
+	LifecycleHooks          ContainerLifecycleHooks                    // define hooks to be executed during container lifecycle
 }
 
 // containerOptions functional options for a container

--- a/docs/features/creating_container.md
+++ b/docs/features/creating_container.md
@@ -87,6 +87,25 @@ func TestIntegrationNginxLatestReturn(t *testing.T) {
 }
 ```
 
+### Lifecycle callbacks
+
+_Testcontainers for Go_ allows you to define your own lifecycle callbacks for better control over your containers. You just need to define functions that return an error and implement the `testcontainers.Lifecycle` interface. The `testcontainers.Lifecycle` interface has the following methods:
+
+* `Creating` - called before the container is created
+* `Created` - called after the container is created
+* `Starting` - called before the container is started
+* `Started` - called after the container is started
+* `Stopping` - called before the container is stopped
+* `Stopped` - called after the container is stopped
+* `Terminating` - called before the container is terminated
+* `Terminated` - called after the container is terminated
+
+In the following example, we are going to create a container with a lifecycle callback that will print a message when any of the lifecycle hooks is called:
+
+<!--codeinclude--> 
+[Extending container with life cycle hooks](../../lifecycle_test.go) inside_block:lifecycleHooks
+<!--/codeinclude-->
+
 ### Advanced Settings
 
 The aforementioned `GenericContainer` function and the `ContainerRequest` struct represent a straightforward manner to configure the containers, but you could need to create your containers with more advance settings regarding the config, host config and endpoint settings Docker types. For those more advance settings, _Testcontainers for Go_ offers a way to fully customize the container request and those internal Docker types. These customisations, called _modifiers_, will be applied just before the internal call to the Docker client to create the container.

--- a/docs/features/creating_container.md
+++ b/docs/features/creating_container.md
@@ -87,9 +87,9 @@ func TestIntegrationNginxLatestReturn(t *testing.T) {
 }
 ```
 
-### Lifecycle callbacks
+### Lifecycle hooks
 
-_Testcontainers for Go_ allows you to define your own lifecycle callbacks for better control over your containers. You just need to define functions that return an error and implement the `testcontainers.Lifecycle` interface. The `testcontainers.Lifecycle` interface has the following methods:
+_Testcontainers for Go_ allows you to define your own lifecycle hooks for better control over your containers. You just need to define functions that return an error and receive the Go context as first argument, and a `ContainerRequest` for the `Creating` hook, and a `Container` for the rest of them. The `testcontainers.ContainerLifecycleHooks` struct has the following methods:
 
 * `Creating` - called before the container is created
 * `Created` - called after the container is created
@@ -100,7 +100,7 @@ _Testcontainers for Go_ allows you to define your own lifecycle callbacks for be
 * `Terminating` - called before the container is terminated
 * `Terminated` - called after the container is terminated
 
-In the following example, we are going to create a container with a lifecycle callback that will print a message when any of the lifecycle hooks is called:
+In the following example, we are going to create a container using all the lifecycle hooks, all of them printing a message when any of the lifecycle hooks is called:
 
 <!--codeinclude--> 
 [Extending container with life cycle hooks](../../lifecycle_test.go) inside_block:lifecycleHooks

--- a/docs/features/creating_container.md
+++ b/docs/features/creating_container.md
@@ -102,8 +102,8 @@ _Testcontainers for Go_ allows you to define your own lifecycle hooks for better
 
 In the following example, we are going to create a container using all the lifecycle hooks, all of them printing a message when any of the lifecycle hooks is called:
 
-<!--codeinclude--> 
-[Extending container with life cycle hooks](../../lifecycle_test.go) inside_block:lifecycleHooks
+<!--codeinclude-->
+[Extending container with life cycle hooks](../../lifecycle_test.go) inside_block:reqWithLifecycleHooks
 <!--/codeinclude-->
 
 ### Advanced Settings

--- a/lifecycle_test.go
+++ b/lifecycle_test.go
@@ -306,112 +306,106 @@ func TestLifecycleHooks(t *testing.T) {
 	// lifecycleHooks {
 	prints := []string{}
 
-	req := ContainerRequest{
-		Image: nginxAlpineImage,
-		LifecycleHooks: ContainerLifecycleHooks{
-			PreCreates: []ContainerRequestHook{
-				func(ctx context.Context, req ContainerRequest) error {
-					prints = append(prints, fmt.Sprintf("pre-create hook 1: %#v", req))
-					return nil
-				},
-				func(ctx context.Context, req ContainerRequest) error {
-					prints = append(prints, fmt.Sprintf("pre-create hook 2: %#v", req))
-					return nil
-				},
+	lifecycleHooks := ContainerLifecycleHooks{
+		PreCreates: []ContainerRequestHook{
+			func(ctx context.Context, req ContainerRequest) error {
+				prints = append(prints, fmt.Sprintf("pre-create hook 1: %#v", req))
+				return nil
 			},
-			PostCreates: []ContainerHook{
-				func(ctx context.Context, c Container) error {
-					prints = append(prints, fmt.Sprintf("post-create hook 1: %#v", c))
-					return nil
-				},
-				func(ctx context.Context, c Container) error {
-					prints = append(prints, fmt.Sprintf("post-create hook 2: %#v", c))
-					return nil
-				},
+			func(ctx context.Context, req ContainerRequest) error {
+				prints = append(prints, fmt.Sprintf("pre-create hook 2: %#v", req))
+				return nil
 			},
-			PreStarts: []ContainerHook{
-				func(ctx context.Context, c Container) error {
-					prints = append(prints, fmt.Sprintf("pre-start hook 1: %#v", c))
-					return nil
-				},
-				func(ctx context.Context, c Container) error {
-					prints = append(prints, fmt.Sprintf("pre-start hook 2: %#v", c))
-					return nil
-				},
+		},
+		PostCreates: []ContainerHook{
+			func(ctx context.Context, c Container) error {
+				prints = append(prints, fmt.Sprintf("post-create hook 1: %#v", c))
+				return nil
 			},
-			PostStarts: []ContainerHook{
-				func(ctx context.Context, c Container) error {
-					prints = append(prints, fmt.Sprintf("post-start hook 1: %#v", c))
-					return nil
-				},
-				func(ctx context.Context, c Container) error {
-					prints = append(prints, fmt.Sprintf("post-start hook 2: %#v", c))
-					return nil
-				},
+			func(ctx context.Context, c Container) error {
+				prints = append(prints, fmt.Sprintf("post-create hook 2: %#v", c))
+				return nil
 			},
-			PreStops: []ContainerHook{
-				func(ctx context.Context, c Container) error {
-					prints = append(prints, fmt.Sprintf("pre-stop hook 1: %#v", c))
-					return nil
-				},
-				func(ctx context.Context, c Container) error {
-					prints = append(prints, fmt.Sprintf("pre-stop hook 2: %#v", c))
-					return nil
-				},
+		},
+		PreStarts: []ContainerHook{
+			func(ctx context.Context, c Container) error {
+				prints = append(prints, fmt.Sprintf("pre-start hook 1: %#v", c))
+				return nil
 			},
-			PostStops: []ContainerHook{
-				func(ctx context.Context, c Container) error {
-					prints = append(prints, fmt.Sprintf("post-stop hook 1: %#v", c))
-					return nil
-				},
-				func(ctx context.Context, c Container) error {
-					prints = append(prints, fmt.Sprintf("post-stop hook 2: %#v", c))
-					return nil
-				},
+			func(ctx context.Context, c Container) error {
+				prints = append(prints, fmt.Sprintf("pre-start hook 2: %#v", c))
+				return nil
 			},
-			PreTerminates: []ContainerHook{
-				func(ctx context.Context, c Container) error {
-					prints = append(prints, fmt.Sprintf("pre-terminate hook 1: %#v", c))
-					return nil
-				},
-				func(ctx context.Context, c Container) error {
-					prints = append(prints, fmt.Sprintf("pre-terminate hook 2: %#v", c))
-					return nil
-				},
+		},
+		PostStarts: []ContainerHook{
+			func(ctx context.Context, c Container) error {
+				prints = append(prints, fmt.Sprintf("post-start hook 1: %#v", c))
+				return nil
 			},
-			PostTerminates: []ContainerHook{
-				func(ctx context.Context, c Container) error {
-					prints = append(prints, fmt.Sprintf("post-terminate hook 1: %#v", c))
-					return nil
-				},
-				func(ctx context.Context, c Container) error {
-					prints = append(prints, fmt.Sprintf("post-terminate hook 2: %#v", c))
-					return nil
-				},
+			func(ctx context.Context, c Container) error {
+				prints = append(prints, fmt.Sprintf("post-start hook 2: %#v", c))
+				return nil
+			},
+		},
+		PreStops: []ContainerHook{
+			func(ctx context.Context, c Container) error {
+				prints = append(prints, fmt.Sprintf("pre-stop hook 1: %#v", c))
+				return nil
+			},
+			func(ctx context.Context, c Container) error {
+				prints = append(prints, fmt.Sprintf("pre-stop hook 2: %#v", c))
+				return nil
+			},
+		},
+		PostStops: []ContainerHook{
+			func(ctx context.Context, c Container) error {
+				prints = append(prints, fmt.Sprintf("post-stop hook 1: %#v", c))
+				return nil
+			},
+			func(ctx context.Context, c Container) error {
+				prints = append(prints, fmt.Sprintf("post-stop hook 2: %#v", c))
+				return nil
+			},
+		},
+		PreTerminates: []ContainerHook{
+			func(ctx context.Context, c Container) error {
+				prints = append(prints, fmt.Sprintf("pre-terminate hook 1: %#v", c))
+				return nil
+			},
+			func(ctx context.Context, c Container) error {
+				prints = append(prints, fmt.Sprintf("pre-terminate hook 2: %#v", c))
+				return nil
+			},
+		},
+		PostTerminates: []ContainerHook{
+			func(ctx context.Context, c Container) error {
+				prints = append(prints, fmt.Sprintf("post-terminate hook 1: %#v", c))
+				return nil
+			},
+			func(ctx context.Context, c Container) error {
+				prints = append(prints, fmt.Sprintf("post-terminate hook 2: %#v", c))
+				return nil
 			},
 		},
 	}
+
+	req := ContainerRequest{
+		Image:          nginxAlpineImage,
+		LifecycleHooks: lifecycleHooks,
+	}
 	// }
 
-	ctx := context.Background()
-	c, err := GenericContainer(ctx, GenericContainerRequest{
-		ContainerRequest: req,
-		Started:          true,
-	})
-	require.Nil(t, err)
-	require.NotNil(t, c)
+	lifecycleHooksIsHonouredFn := func(t *testing.T, ctx context.Context, container Container) {
+		duration := 1 * time.Second
+		err := container.Stop(ctx, &duration)
+		require.Nil(t, err)
 
-	duration := 1 * time.Second
-	err = c.Stop(ctx, &duration)
-	require.Nil(t, err)
+		err = container.Start(ctx)
+		require.Nil(t, err)
 
-	err = c.Start(ctx)
-	require.Nil(t, err)
+		err = container.Terminate(ctx)
+		require.Nil(t, err)
 
-	err = c.Terminate(ctx)
-	require.Nil(t, err)
-
-	t.Run("Lifecycle is honoured", func(t *testing.T) {
 		require.Equal(t, 20, len(prints))
 
 		assert.True(t, strings.HasPrefix(prints[0], "pre-create hook 1: "))
@@ -443,5 +437,33 @@ func TestLifecycleHooks(t *testing.T) {
 
 		assert.True(t, strings.HasPrefix(prints[18], "post-terminate hook 1: "))
 		assert.True(t, strings.HasPrefix(prints[19], "post-terminate hook 2: "))
+	}
+	t.Run("GenericContainer", func(t *testing.T) {
+		ctx := context.Background()
+		c, err := GenericContainer(ctx, GenericContainerRequest{
+			ContainerRequest: req,
+			Started:          true,
+		})
+		require.Nil(t, err)
+		require.NotNil(t, c)
+
+		lifecycleHooksIsHonouredFn(t, ctx, c)
 	})
+
+	t.Run("ReuseContainer", func(t *testing.T) {
+		ctx := context.Background()
+
+		req.Name = "reuse-container"
+
+		c, err := GenericContainer(ctx, GenericContainerRequest{
+			ContainerRequest: req,
+			Reuse:            true,
+			Started:          true,
+		})
+		require.Nil(t, err)
+		require.NotNil(t, c)
+
+		lifecycleHooksIsHonouredFn(t, ctx, c)
+	})
+
 }

--- a/lifecycle_test.go
+++ b/lifecycle_test.go
@@ -402,9 +402,11 @@ func TestLifecycleHooks(t *testing.T) {
 	require.NotNil(t, c)
 
 	duration := 1 * time.Second
-	c.Stop(ctx, &duration)
+	err = c.Stop(ctx, &duration)
+	require.Nil(t, err)
 
-	c.Start(ctx)
+	err = c.Start(ctx)
+	require.Nil(t, err)
 
 	err = c.Terminate(ctx)
 	require.Nil(t, err)

--- a/lifecycle_test.go
+++ b/lifecycle_test.go
@@ -303,95 +303,93 @@ func TestPreCreateModifierHook(t *testing.T) {
 }
 
 func TestLifecycleHooks(t *testing.T) {
-	// lifecycleHooks {
+	// reqWithLifecycleHooks {
 	prints := []string{}
 
-	lifecycleHooks := ContainerLifecycleHooks{
-		PreCreates: []ContainerRequestHook{
-			func(ctx context.Context, req ContainerRequest) error {
-				prints = append(prints, fmt.Sprintf("pre-create hook 1: %#v", req))
-				return nil
-			},
-			func(ctx context.Context, req ContainerRequest) error {
-				prints = append(prints, fmt.Sprintf("pre-create hook 2: %#v", req))
-				return nil
-			},
-		},
-		PostCreates: []ContainerHook{
-			func(ctx context.Context, c Container) error {
-				prints = append(prints, fmt.Sprintf("post-create hook 1: %#v", c))
-				return nil
-			},
-			func(ctx context.Context, c Container) error {
-				prints = append(prints, fmt.Sprintf("post-create hook 2: %#v", c))
-				return nil
-			},
-		},
-		PreStarts: []ContainerHook{
-			func(ctx context.Context, c Container) error {
-				prints = append(prints, fmt.Sprintf("pre-start hook 1: %#v", c))
-				return nil
-			},
-			func(ctx context.Context, c Container) error {
-				prints = append(prints, fmt.Sprintf("pre-start hook 2: %#v", c))
-				return nil
-			},
-		},
-		PostStarts: []ContainerHook{
-			func(ctx context.Context, c Container) error {
-				prints = append(prints, fmt.Sprintf("post-start hook 1: %#v", c))
-				return nil
-			},
-			func(ctx context.Context, c Container) error {
-				prints = append(prints, fmt.Sprintf("post-start hook 2: %#v", c))
-				return nil
-			},
-		},
-		PreStops: []ContainerHook{
-			func(ctx context.Context, c Container) error {
-				prints = append(prints, fmt.Sprintf("pre-stop hook 1: %#v", c))
-				return nil
-			},
-			func(ctx context.Context, c Container) error {
-				prints = append(prints, fmt.Sprintf("pre-stop hook 2: %#v", c))
-				return nil
-			},
-		},
-		PostStops: []ContainerHook{
-			func(ctx context.Context, c Container) error {
-				prints = append(prints, fmt.Sprintf("post-stop hook 1: %#v", c))
-				return nil
-			},
-			func(ctx context.Context, c Container) error {
-				prints = append(prints, fmt.Sprintf("post-stop hook 2: %#v", c))
-				return nil
-			},
-		},
-		PreTerminates: []ContainerHook{
-			func(ctx context.Context, c Container) error {
-				prints = append(prints, fmt.Sprintf("pre-terminate hook 1: %#v", c))
-				return nil
-			},
-			func(ctx context.Context, c Container) error {
-				prints = append(prints, fmt.Sprintf("pre-terminate hook 2: %#v", c))
-				return nil
-			},
-		},
-		PostTerminates: []ContainerHook{
-			func(ctx context.Context, c Container) error {
-				prints = append(prints, fmt.Sprintf("post-terminate hook 1: %#v", c))
-				return nil
-			},
-			func(ctx context.Context, c Container) error {
-				prints = append(prints, fmt.Sprintf("post-terminate hook 2: %#v", c))
-				return nil
-			},
-		},
-	}
-
 	req := ContainerRequest{
-		Image:          nginxAlpineImage,
-		LifecycleHooks: lifecycleHooks,
+		Image: nginxAlpineImage,
+		LifecycleHooks: ContainerLifecycleHooks{
+			PreCreates: []ContainerRequestHook{
+				func(ctx context.Context, req ContainerRequest) error {
+					prints = append(prints, fmt.Sprintf("pre-create hook 1: %#v", req))
+					return nil
+				},
+				func(ctx context.Context, req ContainerRequest) error {
+					prints = append(prints, fmt.Sprintf("pre-create hook 2: %#v", req))
+					return nil
+				},
+			},
+			PostCreates: []ContainerHook{
+				func(ctx context.Context, c Container) error {
+					prints = append(prints, fmt.Sprintf("post-create hook 1: %#v", c))
+					return nil
+				},
+				func(ctx context.Context, c Container) error {
+					prints = append(prints, fmt.Sprintf("post-create hook 2: %#v", c))
+					return nil
+				},
+			},
+			PreStarts: []ContainerHook{
+				func(ctx context.Context, c Container) error {
+					prints = append(prints, fmt.Sprintf("pre-start hook 1: %#v", c))
+					return nil
+				},
+				func(ctx context.Context, c Container) error {
+					prints = append(prints, fmt.Sprintf("pre-start hook 2: %#v", c))
+					return nil
+				},
+			},
+			PostStarts: []ContainerHook{
+				func(ctx context.Context, c Container) error {
+					prints = append(prints, fmt.Sprintf("post-start hook 1: %#v", c))
+					return nil
+				},
+				func(ctx context.Context, c Container) error {
+					prints = append(prints, fmt.Sprintf("post-start hook 2: %#v", c))
+					return nil
+				},
+			},
+			PreStops: []ContainerHook{
+				func(ctx context.Context, c Container) error {
+					prints = append(prints, fmt.Sprintf("pre-stop hook 1: %#v", c))
+					return nil
+				},
+				func(ctx context.Context, c Container) error {
+					prints = append(prints, fmt.Sprintf("pre-stop hook 2: %#v", c))
+					return nil
+				},
+			},
+			PostStops: []ContainerHook{
+				func(ctx context.Context, c Container) error {
+					prints = append(prints, fmt.Sprintf("post-stop hook 1: %#v", c))
+					return nil
+				},
+				func(ctx context.Context, c Container) error {
+					prints = append(prints, fmt.Sprintf("post-stop hook 2: %#v", c))
+					return nil
+				},
+			},
+			PreTerminates: []ContainerHook{
+				func(ctx context.Context, c Container) error {
+					prints = append(prints, fmt.Sprintf("pre-terminate hook 1: %#v", c))
+					return nil
+				},
+				func(ctx context.Context, c Container) error {
+					prints = append(prints, fmt.Sprintf("pre-terminate hook 2: %#v", c))
+					return nil
+				},
+			},
+			PostTerminates: []ContainerHook{
+				func(ctx context.Context, c Container) error {
+					prints = append(prints, fmt.Sprintf("post-terminate hook 1: %#v", c))
+					return nil
+				},
+				func(ctx context.Context, c Container) error {
+					prints = append(prints, fmt.Sprintf("post-terminate hook 2: %#v", c))
+					return nil
+				},
+			},
+		},
 	}
 	// }
 

--- a/lifecycle_test.go
+++ b/lifecycle_test.go
@@ -2,7 +2,10 @@ package testcontainers
 
 import (
 	"context"
+	"fmt"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/mount"
@@ -296,5 +299,147 @@ func TestPreCreateModifierHook(t *testing.T) {
 			inputNetworkingConfig.EndpointsConfig[networkName].NetworkID,
 			"Networking config's network ID should be retrieved from Docker",
 		)
+	})
+}
+
+func TestLifecycleHooks(t *testing.T) {
+	// lifecycleHooks {
+	prints := []string{}
+
+	req := ContainerRequest{
+		Image: nginxAlpineImage,
+		LifecycleHooks: ContainerLifecycleHooks{
+			PreCreates: []ContainerRequestHook{
+				func(ctx context.Context, req ContainerRequest) error {
+					prints = append(prints, fmt.Sprintf("pre-create hook 1: %#v", req))
+					return nil
+				},
+				func(ctx context.Context, req ContainerRequest) error {
+					prints = append(prints, fmt.Sprintf("pre-create hook 2: %#v", req))
+					return nil
+				},
+			},
+			PostCreates: []ContainerHook{
+				func(ctx context.Context, c Container) error {
+					prints = append(prints, fmt.Sprintf("post-create hook 1: %#v", c))
+					return nil
+				},
+				func(ctx context.Context, c Container) error {
+					prints = append(prints, fmt.Sprintf("post-create hook 2: %#v", c))
+					return nil
+				},
+			},
+			PreStarts: []ContainerHook{
+				func(ctx context.Context, c Container) error {
+					prints = append(prints, fmt.Sprintf("pre-start hook 1: %#v", c))
+					return nil
+				},
+				func(ctx context.Context, c Container) error {
+					prints = append(prints, fmt.Sprintf("pre-start hook 2: %#v", c))
+					return nil
+				},
+			},
+			PostStarts: []ContainerHook{
+				func(ctx context.Context, c Container) error {
+					prints = append(prints, fmt.Sprintf("post-start hook 1: %#v", c))
+					return nil
+				},
+				func(ctx context.Context, c Container) error {
+					prints = append(prints, fmt.Sprintf("post-start hook 2: %#v", c))
+					return nil
+				},
+			},
+			PreStops: []ContainerHook{
+				func(ctx context.Context, c Container) error {
+					prints = append(prints, fmt.Sprintf("pre-stop hook 1: %#v", c))
+					return nil
+				},
+				func(ctx context.Context, c Container) error {
+					prints = append(prints, fmt.Sprintf("pre-stop hook 2: %#v", c))
+					return nil
+				},
+			},
+			PostStops: []ContainerHook{
+				func(ctx context.Context, c Container) error {
+					prints = append(prints, fmt.Sprintf("post-stop hook 1: %#v", c))
+					return nil
+				},
+				func(ctx context.Context, c Container) error {
+					prints = append(prints, fmt.Sprintf("post-stop hook 2: %#v", c))
+					return nil
+				},
+			},
+			PreTerminates: []ContainerHook{
+				func(ctx context.Context, c Container) error {
+					prints = append(prints, fmt.Sprintf("pre-terminate hook 1: %#v", c))
+					return nil
+				},
+				func(ctx context.Context, c Container) error {
+					prints = append(prints, fmt.Sprintf("pre-terminate hook 2: %#v", c))
+					return nil
+				},
+			},
+			PostTerminates: []ContainerHook{
+				func(ctx context.Context, c Container) error {
+					prints = append(prints, fmt.Sprintf("post-terminate hook 1: %#v", c))
+					return nil
+				},
+				func(ctx context.Context, c Container) error {
+					prints = append(prints, fmt.Sprintf("post-terminate hook 2: %#v", c))
+					return nil
+				},
+			},
+		},
+	}
+	// }
+
+	ctx := context.Background()
+	c, err := GenericContainer(ctx, GenericContainerRequest{
+		ContainerRequest: req,
+		Started:          true,
+	})
+	require.Nil(t, err)
+	require.NotNil(t, c)
+
+	duration := 1 * time.Second
+	c.Stop(ctx, &duration)
+
+	c.Start(ctx)
+
+	err = c.Terminate(ctx)
+	require.Nil(t, err)
+
+	t.Run("Lifecycle is honoured", func(t *testing.T) {
+		require.Equal(t, 20, len(prints))
+
+		assert.True(t, strings.HasPrefix(prints[0], "pre-create hook 1: "))
+		assert.True(t, strings.HasPrefix(prints[1], "pre-create hook 2: "))
+
+		assert.True(t, strings.HasPrefix(prints[2], "post-create hook 1: "))
+		assert.True(t, strings.HasPrefix(prints[3], "post-create hook 2: "))
+
+		assert.True(t, strings.HasPrefix(prints[4], "pre-start hook 1: "))
+		assert.True(t, strings.HasPrefix(prints[5], "pre-start hook 2: "))
+
+		assert.True(t, strings.HasPrefix(prints[6], "post-start hook 1: "))
+		assert.True(t, strings.HasPrefix(prints[7], "post-start hook 2: "))
+
+		assert.True(t, strings.HasPrefix(prints[8], "pre-stop hook 1: "))
+		assert.True(t, strings.HasPrefix(prints[9], "pre-stop hook 2: "))
+
+		assert.True(t, strings.HasPrefix(prints[10], "post-stop hook 1: "))
+		assert.True(t, strings.HasPrefix(prints[11], "post-stop hook 2: "))
+
+		assert.True(t, strings.HasPrefix(prints[12], "pre-start hook 1: "))
+		assert.True(t, strings.HasPrefix(prints[13], "pre-start hook 2: "))
+
+		assert.True(t, strings.HasPrefix(prints[14], "post-start hook 1: "))
+		assert.True(t, strings.HasPrefix(prints[15], "post-start hook 2: "))
+
+		assert.True(t, strings.HasPrefix(prints[16], "pre-terminate hook 1: "))
+		assert.True(t, strings.HasPrefix(prints[17], "pre-terminate hook 2: "))
+
+		assert.True(t, strings.HasPrefix(prints[18], "post-terminate hook 1: "))
+		assert.True(t, strings.HasPrefix(prints[19], "post-terminate hook 2: "))
 	})
 }


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
This PR opens the gates to the extension of a container, defining lifecycle hooks that can be leveraged by the consumers of the library to extend how a container is defined.

We have defined 8 lifecycle hooks:

1. Creating, executed right before the container is actually created by the Docker engine
2. Created, executed right after the container is created by the Docker engine
3. Starting, executed right before the container enters the Running state
4. Started, executed right after the container enters the Running state
5. Stopping, executed right before the container is stopped
6. Stopped, executed right after the container is stopper
7. Terminating, executed right before the container is terminated, removed from the Docker engine
8. Terminated, executed right after the container is terminated

For that, we are defining two types of hooks: one getting access to the container request (which defines the container), and the second getting access to the running container created by the aforementioned request. 

Each hook will be backed by an array of functions that returns an error and receive the Go context as first argument plus a second argument:
1) the container request for the `Creating` hook, as the representation of the container type does not exist at this moment.
2) the container for the rest of the hooks, as the representation of the container type has just been created.

If a hook returns an error, then the lifecycle will be stopped at that moment. For that reason, I'm not using `defer` to execute the Post hooks.

To add the hooks, we have defined a `LifecycleHooks` fiels in the ContainerRequest struct, so that it's possible to define how the container will behave when requesting a container.

With this implementation users would be able to define as many functions as they need to customize the container, e.g. passing an array of functions to the PreCreates field of the lifecycle, and/or an array of functions to the PostStarts field of the lifecycle. I've provided with a test demonstrating how it's possible to leverage the lifecycle: the tests adds a "log entry" everytime the life cycle hooks are called, and we assert that the life cycle is honoured (creating > created > starting > started > stopping > stopped > starting > started > terminating > terminated)

Finally, the docs have been updated to include the lifecycle hooks explanation in the "Create Container" section. Render URL here: https://deploy-preview-1036--testcontainers-go.netlify.app/features/creating_container/#lifecycle-hooks

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
As a user of the library creating a container, I want to be able to execute code just before/after the container is created/started/stopped/terminated.


<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->


<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


## Follow-ups
I'd like to identify all code that happens out of the lifecycle hooks defined here but acting as a hook, wrapping them into hooks that will be part of the lifecycle
