### PR TITLE
chore: support for multiple lifecycles defined by the user

### DIFF
--- a/container.go
+++ b/container.go
@@ -121,7 +121,7 @@ type ContainerRequest struct {
 	ConfigModifier          func(*container.Config)                    // Modifier for the config before container creation
 	HostConfigModifier      func(*container.HostConfig)                // Modifier for the host config before container creation
 	EnpointSettingsModifier func(map[string]*network.EndpointSettings) // Modifier for the network settings before container creation
-	LifecycleHooks          ContainerLifecycleHooks                    // define hooks to be executed during container lifecycle
+	LifecycleHooks          []ContainerLifecycleHooks                  // define hooks to be executed during container lifecycle
 }
 
 // containerOptions functional options for a container

--- a/docker.go
+++ b/docker.go
@@ -1052,7 +1052,7 @@ func (p *DockerProvider) CreateContainer(ctx context.Context, req ContainerReque
 					for _, f := range req.Files {
 						err := c.CopyFileToContainer(ctx, f.HostFilePath, f.ContainerFilePath, f.FileMode)
 						if err != nil {
-							return fmt.Errorf("can't copy %s to container %s: %w", f.HostFilePath, c.GetContainerID(), err)
+							return fmt.Errorf("can't copy %s to container: %w", f.HostFilePath, err)
 						}
 					}
 

--- a/docs/features/creating_container.md
+++ b/docs/features/creating_container.md
@@ -89,7 +89,9 @@ func TestIntegrationNginxLatestReturn(t *testing.T) {
 
 ### Lifecycle hooks
 
-_Testcontainers for Go_ allows you to define your own lifecycle hooks for better control over your containers. You just need to define functions that return an error and receive the Go context as first argument, and a `ContainerRequest` for the `Creating` hook, and a `Container` for the rest of them. The `testcontainers.ContainerLifecycleHooks` struct has the following methods:
+_Testcontainers for Go_ allows you to define your own lifecycle hooks for better control over your containers. You just need to define functions that return an error and receive the Go context as first argument, and a `ContainerRequest` for the `Creating` hook, and a `Container` for the rest of them. You'll be able to pass multiple lifecycle hooks at the `ContainerRequest` as an array of `testcontainers.ContainerLifecycleHooks`.
+
+The `testcontainers.ContainerLifecycleHooks` struct has the following methods:
 
 * `Creating` - called before the container is created
 * `Created` - called after the container is created

--- a/docs/features/creating_container.md
+++ b/docs/features/creating_container.md
@@ -89,23 +89,25 @@ func TestIntegrationNginxLatestReturn(t *testing.T) {
 
 ### Lifecycle hooks
 
-_Testcontainers for Go_ allows you to define your own lifecycle hooks for better control over your containers. You just need to define functions that return an error and receive the Go context as first argument, and a `ContainerRequest` for the `Creating` hook, and a `Container` for the rest of them. You'll be able to pass multiple lifecycle hooks at the `ContainerRequest` as an array of `testcontainers.ContainerLifecycleHooks`.
+_Testcontainers for Go_ allows you to define your own lifecycle hooks for better control over your containers. You just need to define functions that return an error and receive the Go context as first argument, and a `ContainerRequest` for the `Creating` hook, and a `Container` for the rest of them as second argument.
 
-The `testcontainers.ContainerLifecycleHooks` struct has the following methods:
+You'll be able to pass multiple lifecycle hooks at the `ContainerRequest` as an array of `testcontainers.ContainerLifecycleHooks`, which will be processed one by one in the order they are passed.
 
-* `Creating` - called before the container is created
-* `Created` - called after the container is created
-* `Starting` - called before the container is started
-* `Started` - called after the container is started
-* `Stopping` - called before the container is stopped
-* `Stopped` - called after the container is stopped
-* `Terminating` - called before the container is terminated
-* `Terminated` - called after the container is terminated
+The `testcontainers.ContainerLifecycleHooks` struct defines the following lifecycle hooks, each of them backed by an array of functions representing the hooks:
+
+* `PreCreates` - hooks that are executed before the container is created
+* `PostCreates` - hooks that are executed after the container is created
+* `PreStarts` - hooks that are executed before the container is started
+* `PostStarts` - hooks that are executed after the container is started
+* `PreStops` - hooks that are executed before the container is stopped
+* `PostStops` - hooks that are executed after the container is stopped
+* `PreTerminates` - hooks that are executed before the container is terminated
+* `PostTerminates` - hooks that are executed after the container is terminated
 
 In the following example, we are going to create a container using all the lifecycle hooks, all of them printing a message when any of the lifecycle hooks is called:
 
 <!--codeinclude-->
-[Extending container with life cycle hooks](../../lifecycle_test.go) inside_block:reqWithLifecycleHooks
+[Extending container with lifecycle hooks](../../lifecycle_test.go) inside_block:reqWithLifecycleHooks
 <!--/codeinclude-->
 
 #### Default Logging Hook

--- a/docs/features/creating_container.md
+++ b/docs/features/creating_container.md
@@ -108,6 +108,14 @@ In the following example, we are going to create a container using all the lifec
 [Extending container with life cycle hooks](../../lifecycle_test.go) inside_block:reqWithLifecycleHooks
 <!--/codeinclude-->
 
+#### Default Logging Hook
+
+_Testcontainers for Go_ comes with a default logging hook that will print a log message for each container lifecycle event. You can enable it by passing the `testcontainers.DefaultLoggingHook` option to the `ContainerRequest`, passing a reference to the container logger like this:
+
+<!--codeinclude-->
+[Extending container with life cycle hooks](../../lifecycle_test.go) inside_block:reqWithDefaultLogginHook
+<!--/codeinclude-->
+
 ### Advanced Settings
 
 The aforementioned `GenericContainer` function and the `ContainerRequest` struct represent a straightforward manner to configure the containers, but you could need to create your containers with more advance settings regarding the config, host config and endpoint settings Docker types. For those more advance settings, _Testcontainers for Go_ offers a way to fully customize the container request and those internal Docker types. These customisations, called _modifiers_, will be applied just before the internal call to the Docker client to create the container.

--- a/lifecycle.go
+++ b/lifecycle.go
@@ -42,6 +42,63 @@ type ContainerLifecycleHooks struct {
 	PostTerminates []ContainerHook
 }
 
+var DefaultLoggingHook = func(logger Logging) ContainerLifecycleHooks {
+	shortContainerID := func(c Container) string {
+		return c.GetContainerID()[:12]
+	}
+
+	return ContainerLifecycleHooks{
+		PreCreates: []ContainerRequestHook{
+			func(ctx context.Context, req ContainerRequest) error {
+				logger.Printf("🐳 Creating container for image %s", req.Image)
+				return nil
+			},
+		},
+		PostCreates: []ContainerHook{
+			func(ctx context.Context, c Container) error {
+				logger.Printf("✅ Container created: %s", shortContainerID(c))
+				return nil
+			},
+		},
+		PreStarts: []ContainerHook{
+			func(ctx context.Context, c Container) error {
+				logger.Printf("🐳 Starting container: %s", shortContainerID(c))
+				return nil
+			},
+		},
+		PostStarts: []ContainerHook{
+			func(ctx context.Context, c Container) error {
+				logger.Printf("✅ Container started: %s", shortContainerID(c))
+				return nil
+			},
+		},
+		PreStops: []ContainerHook{
+			func(ctx context.Context, c Container) error {
+				logger.Printf("🐳 Stopping container: %s", shortContainerID(c))
+				return nil
+			},
+		},
+		PostStops: []ContainerHook{
+			func(ctx context.Context, c Container) error {
+				logger.Printf("✋ Container stopped: %s", shortContainerID(c))
+				return nil
+			},
+		},
+		PreTerminates: []ContainerHook{
+			func(ctx context.Context, c Container) error {
+				logger.Printf("🐳 Terminating container: %s", shortContainerID(c))
+				return nil
+			},
+		},
+		PostTerminates: []ContainerHook{
+			func(ctx context.Context, c Container) error {
+				logger.Printf("🚫 Container terminated: %s", shortContainerID(c))
+				return nil
+			},
+		},
+	}
+}
+
 // creatingHook is a hook that will be called before a container is created.
 func (req ContainerRequest) creatingHook(ctx context.Context) error {
 	for _, lifecycleHooks := range req.LifecycleHooks {

--- a/lifecycle.go
+++ b/lifecycle.go
@@ -42,6 +42,102 @@ type ContainerLifecycleHooks struct {
 	PostTerminates []ContainerHook
 }
 
+// creatingHook is a hook that will be called before a container is created.
+func (req ContainerRequest) creatingHook(ctx context.Context) error {
+	for _, lifecycleHooks := range req.LifecycleHooks {
+		err := lifecycleHooks.Creating(ctx)(req)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// createdHook is a hook that will be called after a container is created
+func (c *DockerContainer) createdHook(ctx context.Context) error {
+	for _, lifecycleHooks := range c.lifecycleHooks {
+		err := containerHookFn(ctx, lifecycleHooks.PostCreates)(c)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// startingHook is a hook that will be called before a container is started
+func (c *DockerContainer) startingHook(ctx context.Context) error {
+	for _, lifecycleHooks := range c.lifecycleHooks {
+		err := containerHookFn(ctx, lifecycleHooks.PreStarts)(c)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// startedHook is a hook that will be called after a container is started
+func (c *DockerContainer) startedHook(ctx context.Context) error {
+	for _, lifecycleHooks := range c.lifecycleHooks {
+		err := containerHookFn(ctx, lifecycleHooks.PostStarts)(c)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// stoppingHook is a hook that will be called before a container is stopped
+func (c *DockerContainer) stoppingHook(ctx context.Context) error {
+	for _, lifecycleHooks := range c.lifecycleHooks {
+		err := containerHookFn(ctx, lifecycleHooks.PreStops)(c)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// stoppedHook is a hook that will be called after a container is stopped
+func (c *DockerContainer) stoppedHook(ctx context.Context) error {
+	for _, lifecycleHooks := range c.lifecycleHooks {
+		err := containerHookFn(ctx, lifecycleHooks.PostStops)(c)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// terminatingHook is a hook that will be called before a container is terminated
+func (c *DockerContainer) terminatingHook(ctx context.Context) error {
+	for _, lifecycleHooks := range c.lifecycleHooks {
+		err := containerHookFn(ctx, lifecycleHooks.PreTerminates)(c)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// terminatedHook is a hook that will be called after a container is terminated
+func (c *DockerContainer) terminatedHook(ctx context.Context) error {
+	for _, lifecycleHooks := range c.lifecycleHooks {
+		err := containerHookFn(ctx, lifecycleHooks.PostTerminates)(c)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 // Creating is a hook that will be called before a container is created.
 func (c ContainerLifecycleHooks) Creating(ctx context.Context) func(req ContainerRequest) error {
 	return func(req ContainerRequest) error {

--- a/lifecycle_test.go
+++ b/lifecycle_test.go
@@ -481,6 +481,39 @@ func TestLifecycleHooks_WithDefaultLogger(t *testing.T) {
 	require.Equal(t, 10, len(dl.data))
 }
 
+func TestLifecycleHooks_WithMultipleHooks(t *testing.T) {
+	ctx := context.Background()
+
+	dl := inMemoryLogger{}
+
+	req := ContainerRequest{
+		Image: nginxAlpineImage,
+		LifecycleHooks: []ContainerLifecycleHooks{
+			DefaultLoggingHook(&dl),
+			DefaultLoggingHook(&dl),
+		},
+	}
+
+	c, err := GenericContainer(ctx, GenericContainerRequest{
+		ContainerRequest: req,
+		Started:          true,
+	})
+	require.Nil(t, err)
+	require.NotNil(t, c)
+
+	duration := 1 * time.Second
+	err = c.Stop(ctx, &duration)
+	require.Nil(t, err)
+
+	err = c.Start(ctx)
+	require.Nil(t, err)
+
+	err = c.Terminate(ctx)
+	require.Nil(t, err)
+
+	require.Equal(t, 20, len(dl.data))
+}
+
 func lifecycleHooksIsHonouredFn(t *testing.T, ctx context.Context, container Container, prints []string) {
 	require.Equal(t, 20, len(prints))
 

--- a/lifecycle_test.go
+++ b/lifecycle_test.go
@@ -303,165 +303,172 @@ func TestPreCreateModifierHook(t *testing.T) {
 }
 
 func TestLifecycleHooks(t *testing.T) {
-	// reqWithLifecycleHooks {
-	prints := []string{}
-
-	req := ContainerRequest{
-		Image: nginxAlpineImage,
-		LifecycleHooks: ContainerLifecycleHooks{
-			PreCreates: []ContainerRequestHook{
-				func(ctx context.Context, req ContainerRequest) error {
-					prints = append(prints, fmt.Sprintf("pre-create hook 1: %#v", req))
-					return nil
-				},
-				func(ctx context.Context, req ContainerRequest) error {
-					prints = append(prints, fmt.Sprintf("pre-create hook 2: %#v", req))
-					return nil
-				},
-			},
-			PostCreates: []ContainerHook{
-				func(ctx context.Context, c Container) error {
-					prints = append(prints, fmt.Sprintf("post-create hook 1: %#v", c))
-					return nil
-				},
-				func(ctx context.Context, c Container) error {
-					prints = append(prints, fmt.Sprintf("post-create hook 2: %#v", c))
-					return nil
-				},
-			},
-			PreStarts: []ContainerHook{
-				func(ctx context.Context, c Container) error {
-					prints = append(prints, fmt.Sprintf("pre-start hook 1: %#v", c))
-					return nil
-				},
-				func(ctx context.Context, c Container) error {
-					prints = append(prints, fmt.Sprintf("pre-start hook 2: %#v", c))
-					return nil
-				},
-			},
-			PostStarts: []ContainerHook{
-				func(ctx context.Context, c Container) error {
-					prints = append(prints, fmt.Sprintf("post-start hook 1: %#v", c))
-					return nil
-				},
-				func(ctx context.Context, c Container) error {
-					prints = append(prints, fmt.Sprintf("post-start hook 2: %#v", c))
-					return nil
-				},
-			},
-			PreStops: []ContainerHook{
-				func(ctx context.Context, c Container) error {
-					prints = append(prints, fmt.Sprintf("pre-stop hook 1: %#v", c))
-					return nil
-				},
-				func(ctx context.Context, c Container) error {
-					prints = append(prints, fmt.Sprintf("pre-stop hook 2: %#v", c))
-					return nil
-				},
-			},
-			PostStops: []ContainerHook{
-				func(ctx context.Context, c Container) error {
-					prints = append(prints, fmt.Sprintf("post-stop hook 1: %#v", c))
-					return nil
-				},
-				func(ctx context.Context, c Container) error {
-					prints = append(prints, fmt.Sprintf("post-stop hook 2: %#v", c))
-					return nil
-				},
-			},
-			PreTerminates: []ContainerHook{
-				func(ctx context.Context, c Container) error {
-					prints = append(prints, fmt.Sprintf("pre-terminate hook 1: %#v", c))
-					return nil
-				},
-				func(ctx context.Context, c Container) error {
-					prints = append(prints, fmt.Sprintf("pre-terminate hook 2: %#v", c))
-					return nil
-				},
-			},
-			PostTerminates: []ContainerHook{
-				func(ctx context.Context, c Container) error {
-					prints = append(prints, fmt.Sprintf("post-terminate hook 1: %#v", c))
-					return nil
-				},
-				func(ctx context.Context, c Container) error {
-					prints = append(prints, fmt.Sprintf("post-terminate hook 2: %#v", c))
-					return nil
-				},
-			},
+	tests := []struct {
+		name  string
+		reuse bool
+	}{
+		{
+			name:  "GenericContainer",
+			reuse: false,
+		},
+		{
+			name:  "ReuseContainer",
+			reuse: true,
 		},
 	}
-	// }
 
-	lifecycleHooksIsHonouredFn := func(t *testing.T, ctx context.Context, container Container) {
-		duration := 1 * time.Second
-		err := container.Stop(ctx, &duration)
-		require.Nil(t, err)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			prints := []string{}
+			ctx := context.Background()
+			// reqWithLifecycleHooks {
+			req := ContainerRequest{
+				Image: nginxAlpineImage,
+				LifecycleHooks: []ContainerLifecycleHooks{
+					{
+						PreCreates: []ContainerRequestHook{
+							func(ctx context.Context, req ContainerRequest) error {
+								prints = append(prints, fmt.Sprintf("pre-create hook 1: %#v", req))
+								return nil
+							},
+							func(ctx context.Context, req ContainerRequest) error {
+								prints = append(prints, fmt.Sprintf("pre-create hook 2: %#v", req))
+								return nil
+							},
+						},
+						PostCreates: []ContainerHook{
+							func(ctx context.Context, c Container) error {
+								prints = append(prints, fmt.Sprintf("post-create hook 1: %#v", c))
+								return nil
+							},
+							func(ctx context.Context, c Container) error {
+								prints = append(prints, fmt.Sprintf("post-create hook 2: %#v", c))
+								return nil
+							},
+						},
+						PreStarts: []ContainerHook{
+							func(ctx context.Context, c Container) error {
+								prints = append(prints, fmt.Sprintf("pre-start hook 1: %#v", c))
+								return nil
+							},
+							func(ctx context.Context, c Container) error {
+								prints = append(prints, fmt.Sprintf("pre-start hook 2: %#v", c))
+								return nil
+							},
+						},
+						PostStarts: []ContainerHook{
+							func(ctx context.Context, c Container) error {
+								prints = append(prints, fmt.Sprintf("post-start hook 1: %#v", c))
+								return nil
+							},
+							func(ctx context.Context, c Container) error {
+								prints = append(prints, fmt.Sprintf("post-start hook 2: %#v", c))
+								return nil
+							},
+						},
+						PreStops: []ContainerHook{
+							func(ctx context.Context, c Container) error {
+								prints = append(prints, fmt.Sprintf("pre-stop hook 1: %#v", c))
+								return nil
+							},
+							func(ctx context.Context, c Container) error {
+								prints = append(prints, fmt.Sprintf("pre-stop hook 2: %#v", c))
+								return nil
+							},
+						},
+						PostStops: []ContainerHook{
+							func(ctx context.Context, c Container) error {
+								prints = append(prints, fmt.Sprintf("post-stop hook 1: %#v", c))
+								return nil
+							},
+							func(ctx context.Context, c Container) error {
+								prints = append(prints, fmt.Sprintf("post-stop hook 2: %#v", c))
+								return nil
+							},
+						},
+						PreTerminates: []ContainerHook{
+							func(ctx context.Context, c Container) error {
+								prints = append(prints, fmt.Sprintf("pre-terminate hook 1: %#v", c))
+								return nil
+							},
+							func(ctx context.Context, c Container) error {
+								prints = append(prints, fmt.Sprintf("pre-terminate hook 2: %#v", c))
+								return nil
+							},
+						},
+						PostTerminates: []ContainerHook{
+							func(ctx context.Context, c Container) error {
+								prints = append(prints, fmt.Sprintf("post-terminate hook 1: %#v", c))
+								return nil
+							},
+							func(ctx context.Context, c Container) error {
+								prints = append(prints, fmt.Sprintf("post-terminate hook 2: %#v", c))
+								return nil
+							},
+						},
+					},
+				},
+			}
+			// }
 
-		err = container.Start(ctx)
-		require.Nil(t, err)
+			if tt.reuse {
+				req.Name = "reuse-container"
+			}
 
-		err = container.Terminate(ctx)
-		require.Nil(t, err)
+			c, err := GenericContainer(ctx, GenericContainerRequest{
+				ContainerRequest: req,
+				Reuse:            tt.reuse,
+				Started:          true,
+			})
+			require.Nil(t, err)
+			require.NotNil(t, c)
 
-		require.Equal(t, 20, len(prints))
+			duration := 1 * time.Second
+			err = c.Stop(ctx, &duration)
+			require.Nil(t, err)
 
-		assert.True(t, strings.HasPrefix(prints[0], "pre-create hook 1: "))
-		assert.True(t, strings.HasPrefix(prints[1], "pre-create hook 2: "))
+			err = c.Start(ctx)
+			require.Nil(t, err)
 
-		assert.True(t, strings.HasPrefix(prints[2], "post-create hook 1: "))
-		assert.True(t, strings.HasPrefix(prints[3], "post-create hook 2: "))
+			err = c.Terminate(ctx)
+			require.Nil(t, err)
 
-		assert.True(t, strings.HasPrefix(prints[4], "pre-start hook 1: "))
-		assert.True(t, strings.HasPrefix(prints[5], "pre-start hook 2: "))
-
-		assert.True(t, strings.HasPrefix(prints[6], "post-start hook 1: "))
-		assert.True(t, strings.HasPrefix(prints[7], "post-start hook 2: "))
-
-		assert.True(t, strings.HasPrefix(prints[8], "pre-stop hook 1: "))
-		assert.True(t, strings.HasPrefix(prints[9], "pre-stop hook 2: "))
-
-		assert.True(t, strings.HasPrefix(prints[10], "post-stop hook 1: "))
-		assert.True(t, strings.HasPrefix(prints[11], "post-stop hook 2: "))
-
-		assert.True(t, strings.HasPrefix(prints[12], "pre-start hook 1: "))
-		assert.True(t, strings.HasPrefix(prints[13], "pre-start hook 2: "))
-
-		assert.True(t, strings.HasPrefix(prints[14], "post-start hook 1: "))
-		assert.True(t, strings.HasPrefix(prints[15], "post-start hook 2: "))
-
-		assert.True(t, strings.HasPrefix(prints[16], "pre-terminate hook 1: "))
-		assert.True(t, strings.HasPrefix(prints[17], "pre-terminate hook 2: "))
-
-		assert.True(t, strings.HasPrefix(prints[18], "post-terminate hook 1: "))
-		assert.True(t, strings.HasPrefix(prints[19], "post-terminate hook 2: "))
+			lifecycleHooksIsHonouredFn(t, ctx, c, prints)
+		})
 	}
-	t.Run("GenericContainer", func(t *testing.T) {
-		ctx := context.Background()
-		c, err := GenericContainer(ctx, GenericContainerRequest{
-			ContainerRequest: req,
-			Started:          true,
-		})
-		require.Nil(t, err)
-		require.NotNil(t, c)
 
-		lifecycleHooksIsHonouredFn(t, ctx, c)
-	})
+}
 
-	t.Run("ReuseContainer", func(t *testing.T) {
-		ctx := context.Background()
+func lifecycleHooksIsHonouredFn(t *testing.T, ctx context.Context, container Container, prints []string) {
+	require.Equal(t, 20, len(prints))
 
-		req.Name = "reuse-container"
+	assert.True(t, strings.HasPrefix(prints[0], "pre-create hook 1: "))
+	assert.True(t, strings.HasPrefix(prints[1], "pre-create hook 2: "))
 
-		c, err := GenericContainer(ctx, GenericContainerRequest{
-			ContainerRequest: req,
-			Reuse:            true,
-			Started:          true,
-		})
-		require.Nil(t, err)
-		require.NotNil(t, c)
+	assert.True(t, strings.HasPrefix(prints[2], "post-create hook 1: "))
+	assert.True(t, strings.HasPrefix(prints[3], "post-create hook 2: "))
 
-		lifecycleHooksIsHonouredFn(t, ctx, c)
-	})
+	assert.True(t, strings.HasPrefix(prints[4], "pre-start hook 1: "))
+	assert.True(t, strings.HasPrefix(prints[5], "pre-start hook 2: "))
 
+	assert.True(t, strings.HasPrefix(prints[6], "post-start hook 1: "))
+	assert.True(t, strings.HasPrefix(prints[7], "post-start hook 2: "))
+
+	assert.True(t, strings.HasPrefix(prints[8], "pre-stop hook 1: "))
+	assert.True(t, strings.HasPrefix(prints[9], "pre-stop hook 2: "))
+
+	assert.True(t, strings.HasPrefix(prints[10], "post-stop hook 1: "))
+	assert.True(t, strings.HasPrefix(prints[11], "post-stop hook 2: "))
+
+	assert.True(t, strings.HasPrefix(prints[12], "pre-start hook 1: "))
+	assert.True(t, strings.HasPrefix(prints[13], "pre-start hook 2: "))
+
+	assert.True(t, strings.HasPrefix(prints[14], "post-start hook 1: "))
+	assert.True(t, strings.HasPrefix(prints[15], "post-start hook 2: "))
+
+	assert.True(t, strings.HasPrefix(prints[16], "pre-terminate hook 1: "))
+	assert.True(t, strings.HasPrefix(prints[17], "pre-terminate hook 2: "))
+
+	assert.True(t, strings.HasPrefix(prints[18], "post-terminate hook 1: "))
+	assert.True(t, strings.HasPrefix(prints[19], "post-terminate hook 2: "))
 }


### PR DESCRIPTION
- chore: support for multiple container life cycles
- chore: define a default logging hook
- chore: extract copying files to the postCreate hook

<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
In this PR we are updating the lifecycle field of the container request to accept an array of lifecycles structs.

With this in mind, a user could define custom lifecycles to be appended to the list of container lifecycles, which the library will execute in the order they are passed.

Therefore, given two lifecycles in a container request this will be the execution order:

1. lifecycle-1
  1.1 pre-create
  1.2 post-create
  1.3 pre-start
  1.4 post-start
  1.5 pre-stop
  1.6 post-stop
  1.7 pre-terminate
  1.8 post-terminate
2. lifecycle-2
  2.1 pre-create
  2.2 post-create
  2.3 pre-start
  2.4 post-start
  2.5 pre-stop
  2.6 post-stop
  2.7 pre-terminate
  2.8 post-terminate

Besides that, we are refactoring library code to wrap into into functions to leverage the lifecycle, injecting them at the right lifecycle event:

- pre-creation hook will be always prepended to the lifecycles at the container request 
- copying the files from the request to a container has been converted into a post-creation hook

Finally, we are providing with a default logger hook, which leverages the internal logger of the container to print out messages on each lifecycle hook.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
Support for multiple lifecycle hook that could be decoupled from the library, and provide a simple to use manner of logging the events.

Examples: a lifecycle that sends OpenTelemetry traces.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Continues #1036

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
