### PR TITLE
docs: document tc_host inside the networking section

### DIFF
--- a/docs/features/networking.md
+++ b/docs/features/networking.md
@@ -44,6 +44,8 @@ It is normally advisable to use `Host` and `MappedPort` together when constructi
 [Getting the container host and mapped port](../../docker_test.go) inside_block:buildingAddresses
 <!--/codeinclude-->
 
+Setting the `TC_HOST` environment variable overrides the host of the docker daemon where the container port is exposed. For example, `TC_HOST=172.17.0.1`.
+
 ## Advanced networking
 
 Docker provides the ability for you to create custom networks and place containers on one or more networks. Then, communication can occur between networked containers without the need of exposing ports through the host. With Testcontainers, you can do this as well. 

--- a/docs/features/networking.md
+++ b/docs/features/networking.md
@@ -44,7 +44,8 @@ It is normally advisable to use `Host` and `MappedPort` together when constructi
 [Getting the container host and mapped port](../../docker_test.go) inside_block:buildingAddresses
 <!--/codeinclude-->
 
-Setting the `TC_HOST` environment variable overrides the host of the docker daemon where the container port is exposed. For example, `TC_HOST=172.17.0.1`.
+!!! info
+    Setting the `TC_HOST` environment variable overrides the host of the docker daemon where the container port is exposed. For example, `TC_HOST=172.17.0.1`.
 
 ## Advanced networking
 


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?

Document the `TC_HOST` environment variable in the container networking section.

## Why is it important?

Our CI Kubernetes runners were incorrectly returning `localhost` via the `Host` call. After going through the `docker.go` code I noticed there is a manual override via the `TC_HOST` ENV variable. Document this so it's more visible in the future. 
