### PR TITLE
feat: use an interface for container customization in modules

### DIFF
--- a/docs/modules/couchbase.md
+++ b/docs/modules/couchbase.md
@@ -14,22 +14,8 @@ go get github.com/testcontainers/testcontainers-go/modules/couchbase
 
 ## Usage example
 
-1. The **StartContainer** function is the main entry point to create a new CouchbaseContainer instance. 
-It takes a context and zero or more Option values to configure the container. 
-It creates a new container instance, initializes the couchbase cluster, and creates buckets. 
-If successful, it returns the **CouchbaseContainer** instance.
-
 <!--codeinclude-->
 [Start Couchbase](../../modules/couchbase/couchbase_test.go) inside_block:withBucket
-<!--/codeinclude-->
-
-2. The **ConnectionString** method returns the connection string to connect to the Couchbase container instance. 
-It returns a string with the format `couchbase://<host>:<port>`.
-The **Username** method returns the username of the Couchbase administrator. 
-The **Password** method returns the password of the Couchbase administrator.
-
-<!--codeinclude-->
-[Connect to Couchbase](../../modules/couchbase/couchbase_test.go) inside_block:connectToCluster
 <!--/codeinclude-->
 
 ## Module Reference
@@ -37,11 +23,33 @@ The **Password** method returns the password of the Couchbase administrator.
 The Couchbase module exposes one entrypoint function to create the Couchbase container, and this function receives two parameters:
 
 ```golang
-func StartContainer(ctx context.Context, opts ...Option) (*CouchbaseContainer, error)
+func RunContainer(ctx context.Context, opts ...testcontainers.ContainerCustomizer) (*CouchbaseContainer, error)
 ```
 
 - `context.Context`, the Go context.
-- `Option`, a variad argument for passing options.
+- `testcontainers.ContainerCustomizer`, a variadic argument for passing options.
+
+Once the container is started, it will perform the following operations, **in this particular order**:
+
+* Wait until the node is online, waiting for the `/pools` endpoint in the management port to return a 200 HTTP status code.
+* Check for Enterprise services, sending a GET request to the `/pools` endpoint in the management port. If the response contains the `isEnterprise` key set to `false`, it will check if the Analytics or the Eventing services are enabled. If so, it will raise an error.
+* Rename the node, sending a POST request to the `/node/controller/rename` endpoint in the management port.
+* Initialize the services, sending a POST request to the `/node/controller/setupServices` endpoint in the management port, passing as body of the request the list of enabled services.
+* Set the memory quotas, sending a POST request to the `/pools/default` endpoint in the management port, passing as body of the request the memory quota for each enabled service.
+* Configure the Admin user, sending a POST request to the `/settings/web` endpoint in the management port, passing as body of the request the username and password of the admin user.
+* Configure the external ports, sending a POST request to the `/node/controller/setupAlternateAddresses/external` endpoint in the management port, passing as body of the request the external mapped ports for each enabled service.
+* If the `Index` service is enabled, configure the indexer, sending a POST request to the `/settings/indexes` endpoint in the management port, passing as body of the request the defined storage mode. If the Community Edition is used, it will make sure the storage mode is `forestdb`. If the Enterprise Edition is used, it will make sure the storage mode is not `forestdb`, changing to `memory_optimized` in that case.
+* Finally, it will wait for all nodes to be healthy. Depending of the enabled services, it will use a different wait strategy to check if the node is healthy:
+	- It will wait for the `/pools/default` endpoint in the management port to return a 200 HTTP status code and the response body to contain the `healthy` key set to `true`.
+	- If the `Query` service is enabled, it will wait for the `/admin/ping` endpoint in the query port to return a 200 HTTP status code.
+	- If the `Analytics` service is enabled, it will wait for the `/admin/ping` endpoint in the analytics port to return a 200 HTTP status code.
+	- If the `Eventing` service is enabled, it will wait for the `/api/v1/config` endpoint in the eventing port to return a 200 HTTP status code.
+
+### Container Ports
+
+<!--codeinclude-->
+[Container Ports](../../modules/couchbase/couchbase.go) inside_block:containerPorts
+<!--/codeinclude-->
 
 ### Container Options
 
@@ -60,19 +68,15 @@ By default, the container will use the following Docker image:
 
 #### Credentials
 
-If you need to change the default credentials for the admin user, you can use `WithCredentials(user, password)` with a valid username and password.
+If you need to change the default credentials for the admin user, you can use `WithAdminCredentials(user, password)` with a valid username and password.
 
 !!!info
 	The default username is `Administrator` and the default password is `password`.
 
-#### Bucket
+#### Buckets
 
-When creating a new Couchbase container, you can create one or more buckets. The module provides a `NewBucket` function to create a new bucket, where
-you can pass the bucket name.
-
-<!--codeinclude-->
-[Adding a new bucket](../../modules/couchbase/couchbase_test.go) inside_block:withBucket
-<!--/codeinclude-->
+When creating a new Couchbase container, you can create one or more buckets. The module provides with a `WithBuckets` function that accepts an array of buckets to be created.
+To create a new bucket, the module exposes a `NewBucket` function, where you can pass the bucket name.
 
 It's possible to customize a newly created bucket, using the following options:
 
@@ -81,15 +85,9 @@ It's possible to customize a newly created bucket, using the following options:
 - `WithFlushEnabled`: sets whether the bucket should be flushed when the container is stopped.
 - `WithPrimaryIndex`: sets whether the primary index should be created for this bucket.
 
-```go
-bucket := NewBucket(
-	"bucketName",
-	WithQuota(100),
-	WithReplicas(1),
-	WithFlushEnabled(true),
-	WithPrimaryIndex(true),
-)
-```
+<!--codeinclude-->
+[Adding a new bucket](../../modules/couchbase/couchbase_test.go) inside_block:withBucket
+<!--/codeinclude-->
 
 #### Index Storage
 
@@ -108,9 +106,38 @@ By default, the container will start with the following services: `kv`, `n1ql`, 
 
 !!!warning
 	When running the Enterprise Edition of Couchbase Server, the module provides two functions to enable or disable services:
-	`WithAnalyticsService` and `WithEventingService`. Else, it will throw an error and the container won't be created.
+	`WithServiceAnalytics` and `WithServiceEventing`. Else, it will throw an error and the container won't be created.
 
 <!--codeinclude-->
 [Docker images](../../modules/couchbase/couchbase_test.go) inside_block:dockerImages
 <!--/codeinclude-->
 
+### Container Methods
+
+#### ConnectionString
+
+The `ConnectionString` method returns the connection string to connect to the Couchbase container instance. 
+It returns a string with the format `couchbase://<host>:<port>`.
+The **Username** method returns the username of the Couchbase administrator. 
+The **Password** method returns the password of the Couchbase administrator.
+
+<!--codeinclude-->
+[Connect to Couchbase](../../modules/couchbase/couchbase_test.go) inside_block:connectToCluster
+<!--/codeinclude-->
+
+#### Username
+
+The `Username` method returns the username of the Couchbase administrator. 
+The **Password** method returns the password of the Couchbase administrator.
+
+<!--codeinclude-->
+[Connect to Couchbase using Credentials](../../modules/couchbase/couchbase_test.go) inside_block:getCredentials
+<!--/codeinclude-->
+
+#### Password
+
+The `Password` method returns the password of the Couchbase administrator.
+
+<!--codeinclude-->
+[Connect to Couchbase using Credentials](../../modules/couchbase/couchbase_test.go) inside_block:getCredentials
+<!--/codeinclude-->

--- a/docs/modules/couchbase.md
+++ b/docs/modules/couchbase.md
@@ -69,6 +69,7 @@ By default, the container will use the following Docker image:
 #### Credentials
 
 If you need to change the default credentials for the admin user, you can use `WithAdminCredentials(user, password)` with a valid username and password.
+When the password has less than 6 characters, the container won't be created and the `RunContainer` function will throw an error.
 
 !!!info
 	The default username is `Administrator` and the default password is `password`.
@@ -118,8 +119,6 @@ By default, the container will start with the following services: `kv`, `n1ql`, 
 
 The `ConnectionString` method returns the connection string to connect to the Couchbase container instance. 
 It returns a string with the format `couchbase://<host>:<port>`.
-The **Username** method returns the username of the Couchbase administrator. 
-The **Password** method returns the password of the Couchbase administrator.
 
 <!--codeinclude-->
 [Connect to Couchbase](../../modules/couchbase/couchbase_test.go) inside_block:connectToCluster
@@ -128,7 +127,6 @@ The **Password** method returns the password of the Couchbase administrator.
 #### Username
 
 The `Username` method returns the username of the Couchbase administrator. 
-The **Password** method returns the password of the Couchbase administrator.
 
 <!--codeinclude-->
 [Connect to Couchbase using Credentials](../../modules/couchbase/couchbase_test.go) inside_block:getCredentials

--- a/docs/modules/index.md
+++ b/docs/modules/index.md
@@ -55,11 +55,28 @@ We are going to propose a set of steps to follow when adding types and methods t
 
 - Make sure a public `Container` type exists for the module. This type have to use composition to embed the `testcontainers.Container` type, inheriting all the methods from it.
 - Make sure a `RunContainer` function exists and is public. This function is the entrypoint to the module and will define the initial values for a `testcontainers.GenericContainerRequest` struct, including the image, the default exposed ports, wait strategies, etc. Therefore, the function must initialise the container request with the default values.
-- Define container options for the module. We consider that a best practice for the options is to return a function that returns a modified `testcontainers.GenericContainerRequest` type, and for that, the library already provides with a `testcontainers.CustomizeRequestOption` type representing this function signature.
+- Define container options for the module leveraging the `testcontainers.ContainerCustomizer` interface, that has one single method: `Customize(req *GenericContainerRequest)`.
+- We consider that a best practice for the options is define a function using the `With` prefix, that returns a function returning a modified `testcontainers.GenericContainerRequest` type. For that, the library already provides with a `testcontainers.CustomizeRequestOption` type implementing the `ContainerCustomizer` interface, and we encourage you use this type for creating your own customizer functions.
+- At the same time, you could need to create your own container customizers for your module. Make sure they implement the `testcontainers.ContainerCustomizer` interface.
 - The options will be passed to the `RunContainer` function as variadic arguments after the Go context, and they will be processed right after defining the initial `testcontainers.GenericContainerRequest` struct using a for loop.
 
 ```golang
-func RunContainer(ctx context.Context, opts ...testcontainers.CustomizeRequestOption) (*Container, error) {...}
+func RunContainer(ctx context.Context, opts ...testcontainers.ContainerCustomizer) (*Container, error) {
+    req := testcontainers.ContainerRequest{
+        Image: "my-image",
+        ...
+    }
+    genericContainerReq := testcontainers.GenericContainerRequest{
+        ContainerRequest: req,
+        Started:          true,
+    }
+    ...
+    for _, opt := range opts {
+        req = opt.Customize(&genericContainerReq)
+    }
+    ...
+    container, err := testcontainers.GenericContainer(ctx, genericContainerReq)
+}
 ```
 
 - If needed, define public methods to extract information from the running container, using the `Container` type as receiver. E.g. a connection string to access a database:
@@ -73,7 +90,7 @@ func (c *Container) ConnectionString(ctx context.Context) (string, error) {...}
 
 ### ContainerRequest options
 
-In order to simplify the creation of the container for a given module, `Testcontainers for Go` provides with a set of `testcontainers.CustomizeRequestOption` functions to customise the container request for the module. These options are:
+In order to simplify the creation of the container for a given module, `Testcontainers for Go` provides with a set of `testcontainers.CustomizeRequestOption` functions to customize the container request for the module. These options are:
 
 - `testcontainers.CustomizeRequest`: a function that merges the default options with the ones provided by the user. Recommended for completely customising the container request.
 - `testcontainers.WithImage`: a function that sets the image for the container request.

--- a/docs/modules/localstack.md
+++ b/docs/modules/localstack.md
@@ -39,11 +39,16 @@ For further reference on the SDK v1, please check out the AWS docs [here](https:
 
 For further reference on the SDK v2, please check out the AWS docs [here](https://aws.github.io/aws-sdk-go-v2/docs/getting-started)
 
-## `HOSTNAME_EXTERNAL` and hostname-sensitive services
+## Accessing hostname-sensitive services
 
 Some Localstack APIs, such as SQS, require the container to be aware of the hostname that it is accessible on - for example, for construction of queue URLs in responses.
 
-Testcontainers will inform Localstack of the best hostname automatically, using the `HOSTNAME_EXTERNAL` environment variable:
+Testcontainers will inform Localstack of the best hostname automatically, using the an environment variable for that:
+
+* for Localstack versions 0.10.0 and above, the `HOSTNAME_EXTERNAL` environment variable will be set to hostname in the container request.
+* for Localstack versions 2.0.0 and above, the `LOCALSTACK_HOST` environment variable will be set to the hostname in the container request.
+
+Once the variable is set:
 
 * when running the Localstack container directly without a custom network defined, it is expected that all calls to the container will be from the test host. As such, the container address will be used (typically localhost or the address where the Docker daemon is running).
 

--- a/docs/modules/localstack.md
+++ b/docs/modules/localstack.md
@@ -64,21 +64,33 @@ Testcontainers will inform Localstack of the best hostname automatically, using 
 The LocalStack module exposes one single function to create the LocalStack container, and this function receives two parameters:
 
 ```golang
-func StartContainer(ctx context.Context, overrideReq OverrideContainerRequestOption) (*LocalStackContainer, error)
+func RunContainer(ctx context.Context, opts ...testcontainers.ContainerCustomizer) (*LocalStackContainer, error)
 ```
 
 - `context.Context`
-- `OverrideContainerRequestOption`
+- `testcontainers.ContainerCustomizer`
 
-### OverrideContainerRequestOption
+### Container Options
 
-The `OverrideContainerRequestOption` functional option represents a way to override the default LocalStack container request:
+When starting the Localstack container, you can pass options in a variadic way to configure it.
+
+#### Set Image
+
+By default, the image used is `localstack:1.4.0`.  If you need to use a different image, you can use `testcontainers.WithImage` option.
 
 <!--codeinclude-->
-[Default container request](../../modules/localstack/localstack.go) inside_block:defaultContainerRequest
+[Custom Image](../../modules/localstack/localstack_test.go) inside_block:withImage
 <!--/codeinclude-->
 
-With simply passing your own instance of an `OverrideContainerRequestOption` type to the `StartContainer` function, you'll be able to configure the LocalStack container with your own needs, as this new container request will be merged with the original one.
+#### Customize the container request
+
+It's possible to entirely override the default LocalStack container request:
+
+<!--codeinclude-->
+[Customize container request](../../modules/localstack/localstack_test.go) inside_block:withCustomContainerRequest
+<!--/codeinclude-->
+
+With simply passing the `testcontainers.CustomizeRequest` functional option to the `RunContainer` function, you'll be able to configure the LocalStack container with your own needs, as this new container request will be merged with the original one.
 
 In the following example you check how it's possible to set certain environment variables that are needed by the tests, the most important of them the AWS services you want to use. Besides, the container runs in a separate Docker network with an alias:
 
@@ -86,10 +98,10 @@ In the following example you check how it's possible to set certain environment 
 [Overriding the default container request](../../modules/localstack/localstack_test.go) inside_block:withNetwork
 <!--/codeinclude-->
 
-If you do not need to override the container request, you can pass `nil` or the `NoopOverrideContainerRequest` instance, which is exposed as a helper for this reason.
+If you do not need to override the container request, you can simply pass the Go context to the `RunContainer` function.
 
 <!--codeinclude-->
-[Skip overriding the default container request](../../modules/localstack/localstack_test.go) inside_block:noopOverrideContainerRequest
+[Skip overriding the default container request](../../modules/localstack/localstack_test.go) inside_block:noOverrideContainerRequest
 <!--/codeinclude-->
 
 ## Testing the module

--- a/docs/modules/localstack.md
+++ b/docs/modules/localstack.md
@@ -72,8 +72,8 @@ The LocalStack module exposes one single function to create the LocalStack conta
 func RunContainer(ctx context.Context, opts ...testcontainers.ContainerCustomizer) (*LocalStackContainer, error)
 ```
 
-- `context.Context`
-- `testcontainers.ContainerCustomizer`
+- `context.Context`, the Go context.
+- `testcontainers.ContainerCustomizer`, a variadic argument for passing options.
 
 ### Container Options
 

--- a/docs/modules/mysql.md
+++ b/docs/modules/mysql.md
@@ -19,11 +19,11 @@ go get github.com/testcontainers/testcontainers-go/modules/mysql
 The MySQL module exposes one entrypoint function to create the container, and this function receives two parameters:
 
 ```golang
-func RunContainer(ctx context.Context, opts ...testcontainers.CustomizeRequestOption) (*MySQLContainer, error) {
+func RunContainer(ctx context.Context, opts ...testcontainers.ContainerCustomizer) (*MySQLContainer, error) {
 ```
 
 - `context.Context`, the Go context.
-- `testcontainers.CustomizeRequestOption`, a variad argument for passing options.
+- `testcontainers.ContainerCustomizer`, a variad argument for passing options.
 
 ## Container Options
 

--- a/docs/modules/mysql.md
+++ b/docs/modules/mysql.md
@@ -23,7 +23,7 @@ func RunContainer(ctx context.Context, opts ...testcontainers.ContainerCustomize
 ```
 
 - `context.Context`, the Go context.
-- `testcontainers.ContainerCustomizer`, a variad argument for passing options.
+- `testcontainers.ContainerCustomizer`, a variadic argument for passing options.
 
 ## Container Options
 

--- a/docs/modules/postgres.md
+++ b/docs/modules/postgres.md
@@ -19,11 +19,11 @@ go get github.com/testcontainers/testcontainers-go/modules/postgres
 The Postgres module exposes one entrypoint function to create the Postgres container, and this function receives two parameters:
 
 ```golang
-func RunContainer(ctx context.Context, opts ...testcontainers.CustomizeRequestOption) (*PostgresContainer, error)
+func RunContainer(ctx context.Context, opts ...testcontainers.ContainerCustomizer) (*PostgresContainer, error)
 ```
 
 - `context.Context`, the Go context.
-- `testcontainers.CustomizeRequestOption`, a variadic argument for passing options.
+- `testcontainers.ContainerCustomizer`, a variadic argument for passing options.
 
 ### Container Options
 

--- a/docs/modules/pulsar.md
+++ b/docs/modules/pulsar.md
@@ -22,24 +22,29 @@ Create a `Pulsar` container to use it in your tests:
 
 where the `tt.opts` are the options to configure the container. See the [Container Options](#container-options) section for more details.
 
-Then you can retrieve the broker and the admin url:
+## Module Reference
 
-<!--codeinclude-->
-[Get broker and admin urls](../../modules/pulsar/pulsar_test.go) inside_block:getPulsarURLs
-<!--/codeinclude-->
+The Redis module exposes one entrypoint function to create the containerr, and this function receives two parameters:
 
-## Container Options
+```golang
+func RunContainer(ctx context.Context, opts ...testcontainers.ContainerCustomizer) (*Container, error)
+```
+
+- `context.Context`, the Go context.
+- `testcontainers.ContainerCustomizer`, a variadic argument for passing options.
+
+### Container Options
 
 When starting the Pulsar container, you can pass options in a variadic way to configure it.
 
-### Pulsar Image
+#### Pulsar Image
 If you need to set a different Pulsar image you can use the `testcontainers.WithImage`.
 
 <!--codeinclude-->
 [Set Pulsar image](../../modules/pulsar/pulsar_test.go) inside_block:setPulsarImage
 <!--/codeinclude-->
 
-### Pulsar Configuration
+#### Pulsar Configuration
 If you need to set Pulsar configuration variables you can use the `WithPulsarEnv` to set Pulsar environment variables: the `PULSAR_PREFIX_` prefix will be automatically added for you.
 
 For example, if you want to enable `brokerDeduplicationEnabled`:
@@ -50,7 +55,7 @@ For example, if you want to enable `brokerDeduplicationEnabled`:
 
 It will result in the `PULSAR_PREFIX_brokerDeduplicationEnabled=true` environment variable being set in the container request.
 
-### Pulsar IO
+#### Pulsar IO
 
 If you need to test Pulsar IO framework you can enable the Pulsar Functions Worker with the `WithFunctionsWorker` option:
 
@@ -58,7 +63,7 @@ If you need to test Pulsar IO framework you can enable the Pulsar Functions Work
 [Create a Pulsar container with functions worker](../../modules/pulsar/pulsar_test.go) inside_block:withFunctionsWorker
 <!--/codeinclude-->
 
-### Pulsar Transactions
+#### Pulsar Transactions
 
 If you need to test Pulsar Transactions you can enable the transactions feature:
 
@@ -66,7 +71,7 @@ If you need to test Pulsar Transactions you can enable the transactions feature:
 [Create a Pulsar container with transactions](../../modules/pulsar/pulsar_test.go) inside_block:withTransactions
 <!--/codeinclude-->
 
-### Log consumers
+#### Log consumers
 If you need to collect the logs from the Pulsar container, you can add your own LogConsumer with the `WithLogConsumers` function, which accepts a variadic argument of LogConsumers.
 
 <!--codeinclude-->
@@ -84,7 +89,7 @@ An example of a LogConsumer could be the following:
 
 If you want to know more about LogConsumers, please check the [Following Container Logs](../features/follow_logs.md) documentation.
 
-## Advanced configuration
+#### Advanced configuration
 
 In the case you need a more advanced configuration regarding the config, host config and endpoint settings Docker types, you can leverage the modifier functions that are available in
 the ContainerRequest. The Pulsar container exposes a way to interact with those modifiers in a simple manner, using the aforementioned options in the `RunContainer` function:
@@ -94,3 +99,19 @@ the ContainerRequest. The Pulsar container exposes a way to interact with those 
 <!--/codeinclude-->
 
 Please check out the [Advanced Settings](../features/creating_container.md#advanced-settings) for creating containers documentation.
+
+### Container methods
+
+Once you have a Pulsar container, then you can retrieve the broker and the admin url:
+
+#### Admin URL
+
+<!--codeinclude-->
+[Get admin url](../../modules/pulsar/pulsar_test.go) inside_block:getAdminURL
+<!--/codeinclude-->
+
+#### Broker URL
+
+<!--codeinclude-->
+[Get broker url](../../modules/pulsar/pulsar_test.go) inside_block:getBrokerURL
+<!--/codeinclude-->

--- a/docs/modules/redis.md
+++ b/docs/modules/redis.md
@@ -19,11 +19,11 @@ go get github.com/testcontainers/testcontainers-go/modules/redis
 The Redis module exposes one entrypoint function to create the containerr, and this function receives two parameters:
 
 ```golang
-func RunContainer(ctx context.Context, opts ...testcontainers.CustomizeRequestOption) (*RedisContainer, error)
+func RunContainer(ctx context.Context, opts ...testcontainers.ContainerCustomizer) (*RedisContainer, error)
 ```
 
 - `context.Context`, the Go context.
-- `testcontainers.CustomizeRequestOption`, a variad argument for passing options.
+- `testcontainers.ContainerCustomizer`, a variad argument for passing options.
 
 ### Container Options
 

--- a/docs/modules/redis.md
+++ b/docs/modules/redis.md
@@ -23,7 +23,7 @@ func RunContainer(ctx context.Context, opts ...testcontainers.ContainerCustomize
 ```
 
 - `context.Context`, the Go context.
-- `testcontainers.ContainerCustomizer`, a variad argument for passing options.
+- `testcontainers.ContainerCustomizer`, a variadic argument for passing options.
 
 ### Container Options
 

--- a/generic.go
+++ b/generic.go
@@ -27,9 +27,19 @@ type GenericContainerRequest struct {
 	Reuse            bool         // reuse an existing container if it exists or create a new one. a container name mustn't be empty
 }
 
+// ContainerCustomizer is an interface that can be used to configure the Testcontainers container
+// request. The passed request will be merged with the default one.
+type ContainerCustomizer interface {
+	Customize(req *GenericContainerRequest)
+}
+
 // CustomizeRequestOption is a type that can be used to configure the Testcontainers container request.
 // The passed request will be merged with the default one.
 type CustomizeRequestOption func(req *GenericContainerRequest)
+
+func (opt CustomizeRequestOption) Customize(req *GenericContainerRequest) {
+	opt(req)
+}
 
 // CustomizeRequest returns a function that can be used to merge the passed container request with the one that is used by the container.
 // Slices and Maps will be appended.

--- a/modulegen/_template/docs_example.md.tmpl
+++ b/modulegen/_template/docs_example.md.tmpl
@@ -23,11 +23,11 @@ go get github.com/testcontainers/testcontainers-go/{{ ParentDir }}/{{ $lower }}
 The {{ $title }} module exposes one entrypoint function to create the {{ $title }} container, and this function receives two parameters:
 
 ```golang
-func RunContainer(ctx context.Context, opts ...testcontainers.CustomizeRequestOption) (*{{ $title }}Container, error)
+func RunContainer(ctx context.Context, opts ...testcontainers.ContainerCustomizer) (*{{ $title }}Container, error)
 ```
 
 - `context.Context`, the Go context.
-- `testcontainers.CustomizeRequestOption`, a variadic argument for passing options.
+- `testcontainers.ContainerCustomizer`, a variadic argument for passing options.
 
 ### Container Options
 

--- a/modulegen/_template/example.go.tmpl
+++ b/modulegen/_template/example.go.tmpl
@@ -12,19 +12,21 @@ type {{ $containerName }} struct {
 }
 
 // {{ $entrypoint }} creates an instance of the {{ $title }} container type
-func {{ $entrypoint }}(ctx context.Context, opts ...testcontainers.CustomizeRequestOption) (*{{ $containerName }}, error) {
+func {{ $entrypoint }}(ctx context.Context, opts ...testcontainers.ContainerCustomizer) (*{{ $containerName }}, error) {
 	req := testcontainers.ContainerRequest{
 		Image: "{{ .Image }}",
 	}
 
-	for _, opt := range opts {
-		opt(&req)
-	}
-
-	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
+	genericContainerReq := testcontainers.GenericContainerRequest{
 		ContainerRequest: req,
 		Started:          true,
-	})
+	}
+
+	for _, opt := range opts {
+		opt.Customize(&genericContainerReq)
+	}
+
+	container, err := testcontainers.GenericContainer(ctx, genericContainerReq)
 	if err != nil {
 		return nil, err
 	}

--- a/modulegen/main_test.go
+++ b/modulegen/main_test.go
@@ -453,9 +453,9 @@ func assertExampleContent(t *testing.T, example Example, exampleFile string) {
 	assert.Equal(t, data[8], "// "+containerName+" represents the "+exampleName+" container type used in the module")
 	assert.Equal(t, data[9], "type "+containerName+" struct {")
 	assert.Equal(t, data[13], "// "+entrypoint+" creates an instance of the "+exampleName+" container type")
-	assert.Equal(t, data[14], "func "+entrypoint+"(ctx context.Context, opts ...testcontainers.CustomizeRequestOption) (*"+containerName+", error) {")
+	assert.Equal(t, data[14], "func "+entrypoint+"(ctx context.Context, opts ...testcontainers.ContainerCustomizer) (*"+containerName+", error) {")
 	assert.Equal(t, data[16], "\t\tImage: \""+example.Image+"\",")
-	assert.Equal(t, data[31], "\treturn &"+containerName+"{Container: container}, nil")
+	assert.Equal(t, data[33], "\treturn &"+containerName+"{Container: container}, nil")
 }
 
 // assert content GitHub workflow for the example

--- a/modules/couchbase/couchbase.go
+++ b/modules/couchbase/couchbase.go
@@ -17,6 +17,7 @@ import (
 	"github.com/tidwall/gjson"
 )
 
+// containerPorts {
 const (
 	MGMT_PORT     = "8091"
 	MGMT_SSL_PORT = "18091"
@@ -39,6 +40,8 @@ const (
 	KV_PORT     = "11210"
 	KV_SSL_PORT = "11207"
 )
+
+// }
 
 // initialServices is the list of services that are enabled by default
 var initialServices = []Service{kv, query, search, index}
@@ -374,11 +377,8 @@ func (c *CouchbaseContainer) waitUntilAllNodesAreHealthy(ctx context.Context) er
 				return false
 			}
 			status := gjson.Get(string(response), "nodes.0.status")
-			if status.String() != "healthy" {
-				return false
-			}
 
-			return true
+			return status.String() == "healthy"
 		}))
 
 	if contains(c.config.enabledServices, query) {

--- a/modules/couchbase/couchbase.go
+++ b/modules/couchbase/couchbase.go
@@ -51,7 +51,7 @@ type CouchbaseContainer struct {
 // StartContainer creates an instance of the Couchbase container type
 func StartContainer(ctx context.Context, opts ...Option) (*CouchbaseContainer, error) {
 	config := &Config{
-		enabledServices: []service{kv, query, search, index},
+		enabledServices: []Service{kv, query, search, index},
 		username:        "Administrator",
 		password:        "password",
 		// defaultImage {
@@ -581,7 +581,7 @@ func (c *CouchbaseContainer) checkAllServicesEnabled(rawConfig []byte) bool {
 	return true
 }
 
-func exposePorts(enabledServices []service) []string {
+func exposePorts(enabledServices []Service) []string {
 	exposedPorts := []string{MGMT_PORT + "/tcp", MGMT_SSL_PORT + "/tcp"}
 
 	for _, service := range enabledServices {
@@ -593,7 +593,7 @@ func exposePorts(enabledServices []service) []string {
 	return exposedPorts
 }
 
-func contains(services []service, service service) bool {
+func contains(services []Service, service Service) bool {
 	for _, s := range services {
 		if s.identifier == service.identifier {
 			return true

--- a/modules/couchbase/couchbase_test.go
+++ b/modules/couchbase/couchbase_test.go
@@ -22,13 +22,11 @@ const (
 func TestStartContainer(t *testing.T) {
 	ctx := context.Background()
 
-	// withBucket {
 	bucketName := "testBucket"
 	container, err := tccouchbase.StartContainer(ctx, tccouchbase.WithImageName(communityEdition), tccouchbase.WithBucket(tccouchbase.NewBucket(bucketName)))
 	if err != nil {
 		t.Fatal(err)
 	}
-	// }
 
 	// Clean up the container after the test is complete
 	t.Cleanup(func() {

--- a/modules/couchbase/couchbase_test.go
+++ b/modules/couchbase/couchbase_test.go
@@ -106,10 +106,24 @@ func TestWithCredentials(t *testing.T) {
 	bucketName := "testBucket"
 	_, err := tccouchbase.RunContainer(ctx,
 		testcontainers.WithImage(communityEdition),
-		tccouchbase.WithAdminCredentials("testcontainers", "cool!"),
+		tccouchbase.WithAdminCredentials("testcontainers", "testcontainers.IS.cool!"),
 		tccouchbase.WithBuckets(tccouchbase.NewBucket(bucketName)))
 
 	if err != nil {
+		t.Errorf("Expected error to be [%v] , got nil", err)
+	}
+}
+
+func TestWithCredentials_Password_LessThan_6(t *testing.T) {
+	ctx := context.Background()
+
+	bucketName := "testBucket"
+	_, err := tccouchbase.RunContainer(ctx,
+		testcontainers.WithImage(communityEdition),
+		tccouchbase.WithAdminCredentials("testcontainers", "12345"),
+		tccouchbase.WithBuckets(tccouchbase.NewBucket(bucketName)))
+
+	if err == nil {
 		t.Errorf("Expected error to be [%v] , got nil", err)
 	}
 }

--- a/modules/couchbase/options.go
+++ b/modules/couchbase/options.go
@@ -5,7 +5,7 @@ type Option func(*Config)
 
 // Config is the configuration for the Couchbase container, that will be stored in the container itself.
 type Config struct {
-	enabledServices  []service
+	enabledServices  []Service
 	username         string
 	password         string
 	isEnterprise     bool

--- a/modules/couchbase/options.go
+++ b/modules/couchbase/options.go
@@ -1,21 +1,25 @@
 package couchbase
 
+import "github.com/testcontainers/testcontainers-go"
+
 // Option is a function that configures the Couchbase container.
+// Deprecated: Use the With* functions instead.
 type Option func(*Config)
 
 // Config is the configuration for the Couchbase container, that will be stored in the container itself.
 type Config struct {
 	enabledServices  []Service
-	username         string
-	password         string
+	username         string // Deprecated: Use WithAdminCredentials instead.
+	password         string // Deprecated: Use WithAdminCredentials instead.
 	isEnterprise     bool
-	buckets          []bucket
-	imageName        string
-	indexStorageMode indexStorageMode
+	buckets          []bucket         // Deprecated: Use WithBuckets instead.
+	imageName        string           // Deprecated: Use WithImage instead.
+	indexStorageMode indexStorageMode // Deprecated: Use WithIndexStorage instead.
 }
 
 // WithEnterpriseService enables the eventing service in the container.
 // Only available in the Enterprise Edition of Couchbase Server.
+// Deprecated: Use WithServiceEventing instead.
 func WithEventingService() Option {
 	return func(c *Config) {
 		c.enabledServices = append(c.enabledServices, eventing)
@@ -24,13 +28,32 @@ func WithEventingService() Option {
 
 // WithAnalyticsService enables the analytics service in the container.
 // Only available in the Enterprise Edition of Couchbase Server.
+// Deprecated: Use WithServiceAnalytics instead.
 func WithAnalyticsService() Option {
 	return func(c *Config) {
 		c.enabledServices = append(c.enabledServices, analytics)
 	}
 }
 
+type credentialsCustomizer struct {
+	username string
+	password string
+}
+
+func (c credentialsCustomizer) Customize(req *testcontainers.GenericContainerRequest) {
+	// NOOP, we want to simply transfer the credentials to the container
+}
+
+// WithAdminCredentials sets the username and password for the administrator user.
+func WithAdminCredentials(username, password string) credentialsCustomizer {
+	return credentialsCustomizer{
+		username: username,
+		password: password,
+	}
+}
+
 // WithCredentials sets the username and password for the administrator user.
+// Deprecated: Use WithAdminCredentials instead.
 func WithCredentials(username, password string) Option {
 	return func(c *Config) {
 		c.username = username
@@ -39,20 +62,53 @@ func WithCredentials(username, password string) Option {
 }
 
 // WithBucket adds a bucket to the container.
+// Deprecated: Use WithBuckets instead.
 func WithBucket(bucket bucket) Option {
 	return func(c *Config) {
 		c.buckets = append(c.buckets, bucket)
 	}
 }
 
+type bucketCustomizer struct {
+	buckets []bucket
+}
+
+func (c bucketCustomizer) Customize(req *testcontainers.GenericContainerRequest) {
+	// NOOP, we want to simply transfer the buckets to the container
+}
+
+// WithBucket adds buckets to the couchbase container
+func WithBuckets(bucket ...bucket) bucketCustomizer {
+	return bucketCustomizer{
+		buckets: bucket,
+	}
+}
+
 // WithImageName allows to override the default image name.
+// Deprecated: Use testcontainers.WithImage instead.
 func WithImageName(imageName string) Option {
 	return func(c *Config) {
 		c.imageName = imageName
 	}
 }
 
+type indexStorageCustomizer struct {
+	mode indexStorageMode
+}
+
+func (c indexStorageCustomizer) Customize(req *testcontainers.GenericContainerRequest) {
+	// NOOP, we want to simply transfer the index storage mode to the container
+}
+
+// WithBucket adds buckets to the couchbase container
+func WithIndexStorage(indexStorageMode indexStorageMode) indexStorageCustomizer {
+	return indexStorageCustomizer{
+		mode: indexStorageMode,
+	}
+}
+
 // WithIndexStorageMode sets the storage mode to be used in the cluster.
+// Deprecated: Use WithIndexStorage instead.
 func WithIndexStorageMode(indexStorageMode indexStorageMode) Option {
 	return func(c *Config) {
 		c.indexStorageMode = indexStorageMode

--- a/modules/couchbase/service.go
+++ b/modules/couchbase/service.go
@@ -1,46 +1,46 @@
 package couchbase
 
-type service struct {
+type Service struct {
 	identifier     string
 	minimumQuotaMb int
 	ports          []string
 }
 
-func (s service) hasQuota() bool {
+func (s Service) hasQuota() bool {
 	return s.minimumQuotaMb > 0
 }
 
 var (
-	kv = service{
+	kv = Service{
 		identifier:     "kv",
 		minimumQuotaMb: 256,
 		ports:          []string{KV_PORT, KV_SSL_PORT, VIEW_PORT, VIEW_SSL_PORT},
 	}
 
-	query = service{
+	query = Service{
 		identifier:     "n1ql",
 		minimumQuotaMb: 0,
 		ports:          []string{QUERY_PORT, QUERY_SSL_PORT},
 	}
 
-	search = service{
+	search = Service{
 		identifier:     "fts",
 		minimumQuotaMb: 256,
 		ports:          []string{SEARCH_PORT, SEARCH_SSL_PORT},
 	}
 
-	index = service{
+	index = Service{
 		identifier:     "index",
 		minimumQuotaMb: 256,
 	}
 
-	analytics = service{
+	analytics = Service{
 		identifier:     "cbas",
 		minimumQuotaMb: 256,
 		ports:          []string{ANALYTICS_PORT, ANALYTICS_SSL_PORT},
 	}
 
-	eventing = service{
+	eventing = Service{
 		identifier:     "eventing",
 		minimumQuotaMb: 256,
 		ports:          []string{EVENTING_PORT, EVENTING_SSL_PORT},

--- a/modules/localstack/go.mod
+++ b/modules/localstack/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/credentials v1.13.18
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.31.0
 	github.com/docker/go-connections v0.4.0
-	github.com/imdario/mergo v0.3.14
 	github.com/stretchr/testify v1.8.2
 	github.com/testcontainers/testcontainers-go v0.19.0
 	golang.org/x/mod v0.9.0
@@ -47,6 +46,7 @@ require (
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
 	github.com/google/uuid v1.3.0 // indirect
+	github.com/imdario/mergo v0.3.14 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/klauspost/compress v1.15.9 // indirect
 	github.com/magiconair/properties v1.8.7 // indirect

--- a/modules/localstack/types.go
+++ b/modules/localstack/types.go
@@ -1,9 +1,6 @@
 package localstack
 
 import (
-	"fmt"
-
-	"github.com/imdario/mergo"
 	"github.com/testcontainers/testcontainers-go"
 )
 
@@ -15,26 +12,39 @@ type LocalStackContainer struct {
 // LocalStackContainerRequest represents the LocalStack container request type used in the module
 // to configure the container
 type LocalStackContainerRequest struct {
-	testcontainers.ContainerRequest
+	testcontainers.GenericContainerRequest
 }
 
 // OverrideContainerRequestOption is a type that can be used to configure the Testcontainers container request.
 // The passed request will be merged with the default one.
+// Deprecated: use testcontainers.ContainerCustomizer instead
 type OverrideContainerRequestOption func(req testcontainers.ContainerRequest) testcontainers.ContainerRequest
 
 // NoopOverrideContainerRequest returns a helper function that does not override the container request
+// Deprecated: use testcontainers.ContainerCustomizer instead
 var NoopOverrideContainerRequest = func(req testcontainers.ContainerRequest) testcontainers.ContainerRequest {
 	return req
 }
 
+func (opt OverrideContainerRequestOption) Customize(req *testcontainers.GenericContainerRequest) {
+	req.ContainerRequest = opt(req.ContainerRequest)
+}
+
 // OverrideContainerRequest returns a function that can be used to merge the passed container request with one that is created by the LocalStack container
+// Deprecated: use testcontainers.CustomizeRequest instead
 func OverrideContainerRequest(r testcontainers.ContainerRequest) func(req testcontainers.ContainerRequest) testcontainers.ContainerRequest {
+	destContainerReq := testcontainers.GenericContainerRequest{
+		ContainerRequest: r,
+	}
+
 	return func(req testcontainers.ContainerRequest) testcontainers.ContainerRequest {
-		if err := mergo.Merge(&req, r, mergo.WithOverride); err != nil {
-			fmt.Printf("error merging container request %v. Keeping the default one: %v", err, req)
-			return req
+		srcContainerReq := testcontainers.GenericContainerRequest{
+			ContainerRequest: req,
 		}
 
-		return req
+		opt := testcontainers.CustomizeRequest(destContainerReq)
+		opt.Customize(&srcContainerReq)
+
+		return srcContainerReq.ContainerRequest
 	}
 }

--- a/modules/localstack/v1/s3_test.go
+++ b/modules/localstack/v1/s3_test.go
@@ -62,7 +62,7 @@ func TestS3(t *testing.T) {
 	ctx := context.Background()
 
 	// localStackCreateContainer {
-	container, err := localstack.StartContainer(ctx, localstack.NoopOverrideContainerRequest)
+	container, err := localstack.RunContainer(ctx)
 	require.Nil(t, err)
 	// }
 

--- a/modules/localstack/v2/s3_test.go
+++ b/modules/localstack/v2/s3_test.go
@@ -72,7 +72,7 @@ func s3Client(ctx context.Context, l *localstack.LocalStackContainer) (*s3.Clien
 func TestS3(t *testing.T) {
 	ctx := context.Background()
 
-	container, err := localstack.StartContainer(ctx, localstack.NoopOverrideContainerRequest)
+	container, err := localstack.RunContainer(ctx)
 	require.Nil(t, err)
 
 	s3Client, err := s3Client(ctx, container)

--- a/modules/neo4j/config.go
+++ b/modules/neo4j/config.go
@@ -92,7 +92,7 @@ func addSetting(req *testcontainers.GenericContainerRequest, key string, newVal 
 	if oldVal, found := req.Env[normalizedKey]; found {
 		// make sure AUTH is not overwritten by a setting
 		if key == "AUTH" {
-			req.Logger.Printf("setting %q is not permitted, WithAdminPassword as already been set\n", normalizedKey)
+			req.Logger.Printf("setting %q is not permitted, WithAdminPassword has already been set\n", normalizedKey)
 			return
 		}
 

--- a/modules/neo4j/neo4j.go
+++ b/modules/neo4j/neo4j.go
@@ -38,7 +38,7 @@ func (c Neo4jContainer) BoltUrl(ctx context.Context) (string, error) {
 }
 
 // RunContainer creates an instance of the Neo4j container type
-func RunContainer(ctx context.Context, options ...testcontainers.CustomizeRequestOption) (*Neo4jContainer, error) {
+func RunContainer(ctx context.Context, options ...testcontainers.ContainerCustomizer) (*Neo4jContainer, error) {
 	httpPort, _ := nat.NewPort("tcp", defaultHttpPort)
 	request := testcontainers.ContainerRequest{
 		Image: fmt.Sprintf("docker.io/%s:%s", defaultImageName, defaultTag),
@@ -72,7 +72,7 @@ func RunContainer(ctx context.Context, options ...testcontainers.CustomizeReques
 	}
 
 	for _, option := range options {
-		option(&genericContainerReq)
+		option.Customize(&genericContainerReq)
 	}
 
 	err := validate(&genericContainerReq)

--- a/modules/postgres/postgres.go
+++ b/modules/postgres/postgres.go
@@ -110,7 +110,7 @@ func WithUsername(user string) testcontainers.CustomizeRequestOption {
 }
 
 // RunContainer creates an instance of the postgres container type
-func RunContainer(ctx context.Context, opts ...testcontainers.CustomizeRequestOption) (*PostgresContainer, error) {
+func RunContainer(ctx context.Context, opts ...testcontainers.ContainerCustomizer) (*PostgresContainer, error) {
 	req := testcontainers.ContainerRequest{
 		Image: defaultPostgresImage,
 		Env: map[string]string{
@@ -128,7 +128,7 @@ func RunContainer(ctx context.Context, opts ...testcontainers.CustomizeRequestOp
 	}
 
 	for _, opt := range opts {
-		opt(&genericContainerReq)
+		opt.Customize(&genericContainerReq)
 	}
 
 	container, err := testcontainers.GenericContainer(ctx, genericContainerReq)

--- a/modules/pulsar/pulsar.go
+++ b/modules/pulsar/pulsar.go
@@ -124,7 +124,7 @@ func WithTransactions() testcontainers.CustomizeRequestOption {
 //		- the Pulsar admin API ("/admin/v2/clusters") to be ready on port 8080/tcp and return the response `["standalone"]`
 // 		- the log message "Successfully updated the policies on namespace public/default"
 // - command: "/bin/bash -c /pulsar/bin/apply-config-from-env.py /pulsar/conf/standalone.conf && bin/pulsar standalone --no-functions-worker -nss"
-func RunContainer(ctx context.Context, opts ...testcontainers.CustomizeRequestOption) (*Container, error) {
+func RunContainer(ctx context.Context, opts ...testcontainers.ContainerCustomizer) (*Container, error) {
 	req := testcontainers.ContainerRequest{
 		Image:        defaultPulsarImage,
 		Env:          map[string]string{},
@@ -139,7 +139,7 @@ func RunContainer(ctx context.Context, opts ...testcontainers.CustomizeRequestOp
 	}
 
 	for _, opt := range opts {
-		opt(&genericContainerReq)
+		opt.Customize(&genericContainerReq)
 	}
 
 	c, err := testcontainers.GenericContainer(ctx, genericContainerReq)

--- a/modules/pulsar/pulsar_test.go
+++ b/modules/pulsar/pulsar_test.go
@@ -44,7 +44,7 @@ func TestPulsar(t *testing.T) {
 
 	tests := []struct {
 		name         string
-		opts         []testcontainers.CustomizeRequestOption
+		opts         []testcontainers.ContainerCustomizer
 		logConsumers []testcontainers.LogConsumer
 	}{
 		{
@@ -52,7 +52,7 @@ func TestPulsar(t *testing.T) {
 		},
 		{
 			name: "with modifiers",
-			opts: []testcontainers.CustomizeRequestOption{
+			opts: []testcontainers.ContainerCustomizer{
 				// setPulsarImage {
 				testcontainers.WithImage("docker.io/apachepulsar/pulsar:2.10.2"),
 				// }
@@ -78,7 +78,7 @@ func TestPulsar(t *testing.T) {
 		},
 		{
 			name: "with functions worker",
-			opts: []testcontainers.CustomizeRequestOption{
+			opts: []testcontainers.ContainerCustomizer{
 				// withFunctionsWorker {
 				testcontainerspulsar.WithFunctionsWorker(),
 				// }
@@ -86,7 +86,7 @@ func TestPulsar(t *testing.T) {
 		},
 		{
 			name: "with transactions",
-			opts: []testcontainers.CustomizeRequestOption{
+			opts: []testcontainers.ContainerCustomizer{
 				// withTransactions {
 				testcontainerspulsar.WithTransactions(),
 				// }

--- a/modules/pulsar/pulsar_test.go
+++ b/modules/pulsar/pulsar_test.go
@@ -119,10 +119,12 @@ func TestPulsar(t *testing.T) {
 			}
 			// }
 
-			// getPulsarURLs {
+			// getBrokerURL {
 			brokerURL, err := c.BrokerURL(ctx)
 			require.Nil(t, err)
+			// }
 
+			// getAdminURL {
 			serviceURL, err := c.HTTPServiceURL(ctx)
 			require.Nil(t, err)
 			// }

--- a/modules/redis/redis.go
+++ b/modules/redis/redis.go
@@ -47,7 +47,7 @@ func (c *RedisContainer) ConnectionString(ctx context.Context) (string, error) {
 }
 
 // RunContainer creates an instance of the Redis container type
-func RunContainer(ctx context.Context, opts ...testcontainers.CustomizeRequestOption) (*RedisContainer, error) {
+func RunContainer(ctx context.Context, opts ...testcontainers.ContainerCustomizer) (*RedisContainer, error) {
 	req := testcontainers.ContainerRequest{
 		Image:        defaultImage,
 		ExposedPorts: []string{"6379/tcp"},
@@ -60,7 +60,7 @@ func RunContainer(ctx context.Context, opts ...testcontainers.CustomizeRequestOp
 	}
 
 	for _, opt := range opts {
-		opt(&genericContainerReq)
+		opt.Customize(&genericContainerReq)
 	}
 
 	container, err := testcontainers.GenericContainer(ctx, genericContainerReq)

--- a/modules/vault/vault.go
+++ b/modules/vault/vault.go
@@ -22,7 +22,7 @@ type VaultContainer struct {
 }
 
 // RunContainer creates an instance of the vault container type
-func RunContainer(ctx context.Context, opts ...testcontainers.CustomizeRequestOption) (*VaultContainer, error) {
+func RunContainer(ctx context.Context, opts ...testcontainers.ContainerCustomizer) (*VaultContainer, error) {
 	req := testcontainers.ContainerRequest{
 		Image:        defaultImageName,
 		ExposedPorts: []string{defaultPort + "/tcp"},
@@ -41,7 +41,7 @@ func RunContainer(ctx context.Context, opts ...testcontainers.CustomizeRequestOp
 	}
 
 	for _, opt := range opts {
-		opt(&genericContainerReq)
+		opt.Customize(&genericContainerReq)
 	}
 
 	container, err := testcontainers.GenericContainer(ctx, genericContainerReq)

--- a/modules/vault/vault_test.go
+++ b/modules/vault/vault_test.go
@@ -28,7 +28,7 @@ var (
 
 func TestMain(m *testing.M) {
 	var err error
-	opts := []testcontainers.CustomizeRequestOption{
+	opts := []testcontainers.ContainerCustomizer{
 		// WithImageName {
 		testcontainers.WithImage("hashicorp/vault:1.13.0"),
 		// }

--- a/testcontainer.go
+++ b/testcontainer.go
@@ -1,0 +1,1 @@
+package testcontainers


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
This PR leverages a new interface for container customization: `ContainerCustomizer`, which has one single method: `Customize`.

Therefore we are adding a polymorphic behaviour for customization, which opens the gate to module authors to create an in-module struct implementing the interface and pass it as a customizer.

As a result, we are updating all existing modules to follow this design.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
Accepting interfaces as options allow users to define their own customizers, making it more flexible the creation of modules.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Continues #1036 #1037

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


