### PR TITLE
fix: generated code must compile

### DIFF
--- a/modulegen/_template/example_test.go.tmpl
+++ b/modulegen/_template/example_test.go.tmpl
@@ -8,7 +8,7 @@ import (
 func Test{{ $title }}(t *testing.T) {
 	ctx := context.Background()
 
-	container, err := setup{{ $title }}(ctx)
+	container, err := RunContainer(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/modulegen/main.go
+++ b/modulegen/main.go
@@ -149,15 +149,19 @@ func main() {
 		os.Exit(1)
 	}
 
-	cmd := exec.Command("go", "mod", "tidy")
-	cmd.Dir = filepath.Join(rootDir, example.ParentDir(), example.Lower())
-	err = cmd.Run()
+	cmdDir := filepath.Join(rootDir, example.ParentDir(), example.Lower())
+	err = runGoCommand(cmdDir, "mod", "tidy")
 	if err != nil {
 		fmt.Printf(">> error synchronizing the dependencies: %v\n", err)
 		os.Exit(1)
 	}
+	err = runGoCommand(cmdDir, "vet", "./...")
+	if err != nil {
+		fmt.Printf(">> error checking generated code: %v\n", err)
+		os.Exit(1)
+	}
 
-	fmt.Println("Please go to", cmd.Dir, "directory to check the results, where 'go mod tidy' was executed to synchronize the dependencies")
+	fmt.Println("Please go to", cmdDir, "directory to check the results, where 'go mod tidy' and 'go vet' was executed to synchronize the dependencies")
 	fmt.Println("Commit the modified files and submit a pull request to include them into the project")
 	fmt.Println("Thanks!")
 }
@@ -315,4 +319,10 @@ func generateMkdocs(rootDir string, example Example) error {
 	}
 
 	return writeMkdocsConfig(rootDir, mkdocsConfig)
+}
+
+func runGoCommand(cmdDir string, args ...string) error {
+	cmd := exec.Command("go", args...)
+	cmd.Dir = cmdDir
+	return cmd.Run()
 }

--- a/modulegen/main_test.go
+++ b/modulegen/main_test.go
@@ -435,7 +435,7 @@ func assertExampleTestContent(t *testing.T, example Example, exampleTestFile str
 	data := strings.Split(string(content), "\n")
 	assert.Equal(t, data[0], "package "+example.Lower())
 	assert.Equal(t, data[7], "func Test"+example.Title()+"(t *testing.T) {")
-	assert.Equal(t, data[10], "\tcontainer, err := setup"+example.Title()+"(ctx)")
+	assert.Equal(t, data[10], "\tcontainer, err := RunContainer(ctx)")
 }
 
 // assert content example


### PR DESCRIPTION
- fix: update template for tests
- chore: run go vet when generating code

<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
This PR adds a check at the end of the generated code to run `go vet` in the generated module, updating the template generating the default test file for the new functions of the module design.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
The template included code for the old behaviour, and now the generated code compiles, running the check at the end of the code generation.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Caused by #1016 #1042

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
