### PR TITLE
Fix race condition while initializing docker client

### DIFF
--- a/docker.go
+++ b/docker.go
@@ -784,21 +784,19 @@ func (p *DockerProvider) SetClient(c client.APIClient) {
 var _ ContainerProvider = (*DockerProvider)(nil)
 
 func NewDockerClient() (cli *client.Client, err error) {
-	tcConfig = ReadConfig()
-
-	host := tcConfig.Host
-
+	tcConfig := ReadConfig()
 	opts := []client.Opt{client.FromEnv, client.WithAPIVersionNegotiation()}
-	if host != "" {
-		opts = append(opts, client.WithHost(host))
 
-		// for further informacion, read https://docs.docker.com/engine/security/protect-access/
+	if tcConfig.Host != "" {
+		opts = append(opts, client.WithHost(tcConfig.Host))
+
+		// For further information, read https://docs.docker.com/engine/security/protect-access/.
 		if tcConfig.TLSVerify == 1 {
-			cacertPath := filepath.Join(tcConfig.CertPath, "ca.pem")
+			caCertPath := filepath.Join(tcConfig.CertPath, "ca.pem")
 			certPath := filepath.Join(tcConfig.CertPath, "cert.pem")
 			keyPath := filepath.Join(tcConfig.CertPath, "key.pem")
 
-			opts = append(opts, client.WithTLSClientConfig(cacertPath, certPath, keyPath))
+			opts = append(opts, client.WithTLSClientConfig(caCertPath, certPath, keyPath))
 		}
 	}
 
@@ -813,9 +811,8 @@ func NewDockerClient() (cli *client.Client, err error) {
 		return nil, err
 	}
 
-	_, err = cli.Ping(context.TODO())
-	if err != nil {
-		// fallback to environment
+	if _, err = cli.Ping(context.Background()); err != nil {
+		// Fallback to environment.
 		cli, err = testcontainersdocker.NewClient(context.Background())
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?

After updating the dependencies in my project from `v0.19.0` to `v0.20.0`, I get this error while running the tests

```
==================
WARNING: DATA RACE
Read at 0x00010366fa60 by goroutine 27:
  github.com/testcontainers/testcontainers-go.ReadConfig()
      /go/src/github.com/nhatthm/testcontainers-go-extra/vendor/github.com/testcontainers/testcontainers-go/config.go:45 +0x5c
  github.com/testcontainers/testcontainers-go.NewDockerClient()
      /go/src/github.com/nhatthm/testcontainers-go-extra/vendor/github.com/testcontainers/testcontainers-go/docker.go:787 +0x30
  github.com/testcontainers/testcontainers-go.NewDockerProvider()
      /go/src/github.com/nhatthm/testcontainers-go-extra/vendor/github.com/testcontainers/testcontainers-go/provider.go:139 +0x1e4
  github.com/testcontainers/testcontainers-go.ProviderType.GetProvider()
      /go/src/github.com/nhatthm/testcontainers-go-extra/vendor/github.com/testcontainers/testcontainers-go/provider.go:111 +0x55c
  github.com/testcontainers/testcontainers-go.GenericContainer()
      /go/src/github.com/nhatthm/testcontainers-go-extra/vendor/github.com/testcontainers/testcontainers-go/generic.go:125 +0x110
  go.nhat.io/testcontainers-extra.StartGenericContainer()
      /go/src/github.com/nhatthm/testcontainers-go-extra/container.go:47 +0x2a8
  go.nhat.io/testcontainers-extra.StartGenericContainers.func1()
      /go/src/github.com/nhatthm/testcontainers-go-extra/container.go:83 +0xcc
  go.nhat.io/testcontainers-extra.StartGenericContainers.func2()
      /go/src/github.com/nhatthm/testcontainers-go-extra/container.go:95 +0xa4

Previous write at 0x00010366fa60 by goroutine 15:
  github.com/testcontainers/testcontainers-go.NewDockerClient()
      /go/src/github.com/nhatthm/testcontainers-go-extra/vendor/github.com/testcontainers/testcontainers-go/docker.go:787 +0x78
  github.com/testcontainers/testcontainers-go.NewDockerProvider()
      /go/src/github.com/nhatthm/testcontainers-go-extra/vendor/github.com/testcontainers/testcontainers-go/provider.go:139 +0x1e4
  github.com/testcontainers/testcontainers-go.ProviderType.GetProvider()
      /go/src/github.com/nhatthm/testcontainers-go-extra/vendor/github.com/testcontainers/testcontainers-go/provider.go:111 +0x55c
  github.com/testcontainers/testcontainers-go.GenericContainer()
      /go/src/github.com/nhatthm/testcontainers-go-extra/vendor/github.com/testcontainers/testcontainers-go/generic.go:125 +0x110
  go.nhat.io/testcontainers-extra.StartGenericContainer()
      /go/src/github.com/nhatthm/testcontainers-go-extra/container.go:47 +0x2a8
  go.nhat.io/testcontainers-extra_test.TestStartGenericContainer_NamePrefixAndSuffix()
      /go/src/github.com/nhatthm/testcontainers-go-extra/container_test.go:119 +0xf8
  testing.tRunner()
      /opt/homebrew/opt/go/libexec/src/testing/testing.go:1576 +0x188
  testing.(*T).Run.func1()
      /opt/homebrew/opt/go/libexec/src/testing/testing.go:1629 +0x40
```

The root cause is `tcConfig = ReadConfig()`, `tcConfig` is a private global variable and is initialized in the `ReadConfig()`. The one in `NewDockerClient()` should be a local variable instead.

## Why is it important?

The testcontainers should be running without a race condition

## Related issues

n/a

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
