### PR TITLE
ci(lint): enable misspell and gci linters

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -35,7 +35,7 @@ jobs:
 
           # Optional: golangci-lint command line arguments.
           # args: --issues-exit-code=0
-          args: --timeout=3m
+          args: --verbose
 
           # Optional: show only new issues if it's a pull request. The default value is `false`.
           # only-new-issues: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,6 +2,8 @@ linters:
   enable:
     - gci
     - gofmt
+    - misspell
+
 
 linters-settings:
   gci:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,3 +1,14 @@
 linters:
   enable:
+    - gci
     - gofmt
+
+linters-settings:
+  gci:
+    sections:
+    - standard
+    - default
+    - prefix(github.com/testcontainters)
+
+run:
+  timeout: 3m

--- a/container.go
+++ b/container.go
@@ -13,7 +13,6 @@ import (
 	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/pkg/archive"
 	"github.com/docker/go-connections/nat"
-
 	tcexec "github.com/testcontainers/testcontainers-go/exec"
 	"github.com/testcontainers/testcontainers-go/internal/testcontainersdocker"
 	"github.com/testcontainers/testcontainers-go/wait"

--- a/container_test.go
+++ b/container_test.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-
 	"github.com/testcontainers/testcontainers-go/wait"
 )
 

--- a/docker.go
+++ b/docker.go
@@ -18,12 +18,11 @@ import (
 	"sync"
 	"time"
 
-	"github.com/docker/docker/api/types/filters"
-
 	"github.com/cenkalti/backoff/v4"
 	"github.com/containerd/containerd/platforms"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/client"
 	"github.com/docker/docker/errdefs"
@@ -32,7 +31,6 @@ import (
 	"github.com/google/uuid"
 	"github.com/moby/term"
 	specs "github.com/opencontainers/image-spec/specs-go/v1"
-
 	tcexec "github.com/testcontainers/testcontainers-go/exec"
 	"github.com/testcontainers/testcontainers-go/internal"
 	"github.com/testcontainers/testcontainers-go/internal/testcontainersdocker"

--- a/docker_mounts.go
+++ b/docker_mounts.go
@@ -33,7 +33,7 @@ type DockerBindMountSource struct {
 	*mount.BindOptions
 
 	// HostPath is the path mounted into the container
-	// the same host path might be mounted to multiple locations withing a single container
+	// the same host path might be mounted to multiple locations within a single container
 	HostPath string
 }
 

--- a/docker_test.go
+++ b/docker_test.go
@@ -4,9 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
-
 	"io"
+	"log"
 	"math/rand"
 	"net/http"
 	"os"
@@ -16,19 +15,15 @@ import (
 	"testing"
 	"time"
 
+	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/strslice"
+	"github.com/docker/docker/api/types/volume"
+	"github.com/docker/docker/errdefs"
 	"github.com/docker/go-units"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	"github.com/docker/docker/errdefs"
-
-	"github.com/docker/docker/api/types/volume"
-
-	"github.com/docker/docker/api/types"
-	"github.com/docker/docker/api/types/filters"
-
 	"github.com/testcontainers/testcontainers-go/internal/testcontainersdocker"
 	"github.com/testcontainers/testcontainers-go/wait"
 )

--- a/generic_test.go
+++ b/generic_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-
 	"github.com/testcontainers/testcontainers-go/wait"
 )
 

--- a/logconsumer_test.go
+++ b/logconsumer_test.go
@@ -10,11 +10,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/docker/docker/client"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	"github.com/docker/docker/client"
-
 	"github.com/testcontainers/testcontainers-go/internal/testcontainersdocker"
 	"github.com/testcontainers/testcontainers-go/wait"
 )

--- a/mounts.go
+++ b/mounts.go
@@ -34,7 +34,7 @@ type ContainerMountSource interface {
 // Optionally mount.BindOptions might be added for advanced scenarios
 type GenericBindMountSource struct {
 	// HostPath is the path mounted into the container
-	// the same host path might be mounted to multiple locations withing a single container
+	// the same host path might be mounted to multiple locations within a single container
 	HostPath string
 }
 

--- a/network.go
+++ b/network.go
@@ -3,9 +3,8 @@ package testcontainers
 import (
 	"context"
 
-	"github.com/docker/docker/api/types/network"
-
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/network"
 )
 
 // NetworkProvider allows the creation of networks on an arbitrary system

--- a/network_test.go
+++ b/network_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/docker/docker/api/types/network"
 	"github.com/stretchr/testify/assert"
-
 	"github.com/testcontainers/testcontainers-go/wait"
 )
 

--- a/reaper.go
+++ b/reaper.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/go-connections/nat"
-
 	"github.com/testcontainers/testcontainers-go/internal"
 	"github.com/testcontainers/testcontainers-go/internal/testcontainersdocker"
 	"github.com/testcontainers/testcontainers-go/wait"

--- a/wait/exec_test.go
+++ b/wait/exec_test.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/go-connections/nat"
-
 	"github.com/testcontainers/testcontainers-go"
 	tcexec "github.com/testcontainers/testcontainers-go/exec"
 	"github.com/testcontainers/testcontainers-go/wait"

--- a/wait/health_test.go
+++ b/wait/health_test.go
@@ -71,7 +71,7 @@ func TestWaitForHealthSucceeds(t *testing.T) {
 	assert.Nil(t, err)
 }
 
-// TestWaitForHealthWithNil checks that an initial `nil` Health will not casue a panic,
+// TestWaitForHealthWithNil checks that an initial `nil` Health will not cause a panic,
 // and if the container eventually becomes healthy, the HealthStrategy will succeed.
 func TestWaitForHealthWithNil(t *testing.T) {
 	target := &healthStrategyTarget{


### PR DESCRIPTION
## What does this PR do?

Enables [misspell](https://golangci-lint.run/usage/linters/#misspell) and [gci](https://golangci-lint.run/usage/linters/#gci) linters

## Why is it important?

Fixes and prevent misspellings and organize in a fixed order the dependencies imports.