### PR TITLE
fix: define a two-phase release process

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -18,7 +18,7 @@ git remote -v
 Once the remote is properly set, please follow these steps:
 
 - Run the [release.sh](./scripts/pre-release.sh) shell script to run it in dry-run mode.
-- You can use the `DRY_RUN`variable to enable or disable the dry-run mode. By default, it's enabled.
+- You can use the `DRY_RUN` variable to enable or disable the dry-run mode. By default, it's enabled.
 - To prepare for a release, updating the _Testcontainers for Go_ dependency for all the modules and examples, without performing any Git operation:
 
         DRY_RUN="false" ./scripts/pre-release.sh
@@ -123,7 +123,7 @@ mv vault.md.tmp vault.md
 Once you are satisfied with the modified files in the git state:
 
 - Run the [release.sh](./scripts/release.sh) shell script to create the release in dry-run mode.
-- You can use the `DRY_RUN`variable to enable or disable the dry-run mode. By default, it's enabled.
+- You can use the `DRY_RUN` variable to enable or disable the dry-run mode. By default, it's enabled.
 
         DRY_RUN="false" ./scripts/release.sh
 
@@ -135,7 +135,7 @@ Once you are satisfied with the modified files in the git state:
              "${directory}/${module_name}/${version}", e.g. "examples/mysql/v0.18.0", "modules/compose/v0.18.0"
 
 - The script will create a commit in the **main** branch if the `DRY_RUN` variable is set to `false`.
-- The script will push the git the main branch including the tags to the upstream repository, https://github.com/testcontainers/testcontainers-go, if the `DRY_RUN` variable is set to `false`.
+- The script will push the main branch including the tags to the upstream repository, https://github.com/testcontainers/testcontainers-go, if the `DRY_RUN` variable is set to `false`.
 - Finally, the script will trigger the Golang proxy to update the modules in https://proxy.golang.org/, if the `DRY_RUN` variable is set to `false`.
 
 An example execution, with dry-run mode enabled:

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -2,6 +2,8 @@
 
 In order to create a release, we have added a shell script that performs all the tasks for you, allowing a dry-run mode for checking it before creating the release. We are going to explain how to use it in this document.
 
+## Prerequisites
+
 First, it's really important that you first check that the [version.go](./internal/version.go) file is up-to-date, containing the right version you want to create. That file will be used by the automation to perform the release.
 Once the version file is correct in the repository:
 
@@ -11,136 +13,191 @@ Second, check that the git remote for the `origin` is pointing to `github.com/te
 git remote -v
 ```
 
+## Prepare the release
+
 Once the remote is properly set, please follow these steps:
 
-- Run the [release.sh](./scripts/release.sh) shell script to run it in dry-run mode.
+- Run the [release.sh](./scripts/pre-release.sh) shell script to run it in dry-run mode.
 - You can use the `DRY_RUN`variable to enable or disable the dry-run mode. By default, it's enabled.
-- You can use the `COMMIT` variable to enable or disable the commit creation. By default, it's disabled.
-- To update the _Testcontainers for Go_ dependency for all the modules and examples, without performing any Git operation, nor creating a release:
+- To prepare for a release, updating the _Testcontainers for Go_ dependency for all the modules and examples, without performing any Git operation:
 
-        DRY_RUN="false" COMMIT="false" ./scripts/release.sh
+        DRY_RUN="false" ./scripts/pre-release.sh
 
-- To perform a release:
+- The script will update the [mkdocs.yml](./mkdocks.yml) file, updating the `latest_version` field to the current version.
+- The script will update the [version.go](./internal/version.go) file, setting the next development version to the next **minor** version by default. For example, if the current version is `v0.18.0`, the script will update the [version.go](./internal/version.go) file with the next development version `v0.19.0`.
+- You can define the bump type, using the `BUMP_TYPE` environment variable. The default value is `minor`, but you can also use `major` or `patch` (the script will fail if the value is not one of these three):
 
-        DRY_RUN="false" COMMIT="true" ./scripts/release.sh
+        BUMP_TYPE="major" ./scripts/pre-release.sh
 
+- The script will update the `go.mod` files for each Go modules and example modules under the examples and modules directories, updating the version of the testcontainers-go dependency to the recently created tag.
+- The script will modify the docs for the each Go module **that was not released yet**, updating the version of _Testcontainers for Go_ where it was added to the recently created tag.
+
+An example execution, with dry-run mode enabled:
+
+```shell
+sed "s/latest_version: .*/latest_version: v0.20.1/g" /Users/mdelapenya/sourcecode/src/github.com/testcontainers/testcontainers-go/mkdocs.yml > /Users/mdelapenya/sourcecode/src/github.com/testcontainers/testcontainers-go/mkdocs.yml.tmp
+mv /Users/mdelapenya/sourcecode/src/github.com/testcontainers/testcontainers-go/mkdocs.yml.tmp /Users/mdelapenya/sourcecode/src/github.com/testcontainers/testcontainers-go/mkdocs.yml
+sed "s/testcontainers-go v.*/testcontainers-go v0.20.1/g" bigtable/go.mod > bigtable/go.mod.tmp
+mv bigtable/go.mod.tmp bigtable/go.mod
+sed "s/testcontainers-go v.*/testcontainers-go v0.20.1/g" cockroachdb/go.mod > cockroachdb/go.mod.tmp
+mv cockroachdb/go.mod.tmp cockroachdb/go.mod
+sed "s/testcontainers-go v.*/testcontainers-go v0.20.1/g" consul/go.mod > consul/go.mod.tmp
+mv consul/go.mod.tmp consul/go.mod
+sed "s/testcontainers-go v.*/testcontainers-go v0.20.1/g" datastore/go.mod > datastore/go.mod.tmp
+mv datastore/go.mod.tmp datastore/go.mod
+sed "s/testcontainers-go v.*/testcontainers-go v0.20.1/g" firestore/go.mod > firestore/go.mod.tmp
+mv firestore/go.mod.tmp firestore/go.mod
+sed "s/testcontainers-go v.*/testcontainers-go v0.20.1/g" mongodb/go.mod > mongodb/go.mod.tmp
+mv mongodb/go.mod.tmp mongodb/go.mod
+sed "s/testcontainers-go v.*/testcontainers-go v0.20.1/g" nginx/go.mod > nginx/go.mod.tmp
+mv nginx/go.mod.tmp nginx/go.mod
+sed "s/testcontainers-go v.*/testcontainers-go v0.20.1/g" pubsub/go.mod > pubsub/go.mod.tmp
+mv pubsub/go.mod.tmp pubsub/go.mod
+sed "s/testcontainers-go v.*/testcontainers-go v0.20.1/g" spanner/go.mod > spanner/go.mod.tmp
+mv spanner/go.mod.tmp spanner/go.mod
+sed "s/testcontainers-go v.*/testcontainers-go v0.20.1/g" toxiproxy/go.mod > toxiproxy/go.mod.tmp
+mv toxiproxy/go.mod.tmp toxiproxy/go.mod
+go mod tidy
+go mod tidy
+go mod tidy
+go mod tidy
+go mod tidy
+go mod tidy
+go mod tidy
+go mod tidy
+go mod tidy
+go mod tidy
+go mod tidy
+sed "s/testcontainers-go v.*/testcontainers-go v0.20.1/g" compose/go.mod > compose/go.mod.tmp
+mv compose/go.mod.tmp compose/go.mod
+sed "s/testcontainers-go v.*/testcontainers-go v0.20.1/g" couchbase/go.mod > couchbase/go.mod.tmp
+mv couchbase/go.mod.tmp couchbase/go.mod
+sed "s/testcontainers-go v.*/testcontainers-go v0.20.1/g" localstack/go.mod > localstack/go.mod.tmp
+mv localstack/go.mod.tmp localstack/go.mod
+sed "s/testcontainers-go v.*/testcontainers-go v0.20.1/g" mysql/go.mod > mysql/go.mod.tmp
+mv mysql/go.mod.tmp mysql/go.mod
+sed "s/testcontainers-go v.*/testcontainers-go v0.20.1/g" neo4j/go.mod > neo4j/go.mod.tmp
+mv neo4j/go.mod.tmp neo4j/go.mod
+sed "s/testcontainers-go v.*/testcontainers-go v0.20.1/g" postgres/go.mod > postgres/go.mod.tmp
+mv postgres/go.mod.tmp postgres/go.mod
+sed "s/testcontainers-go v.*/testcontainers-go v0.20.1/g" pulsar/go.mod > pulsar/go.mod.tmp
+mv pulsar/go.mod.tmp pulsar/go.mod
+sed "s/testcontainers-go v.*/testcontainers-go v0.20.1/g" redis/go.mod > redis/go.mod.tmp
+mv redis/go.mod.tmp redis/go.mod
+sed "s/testcontainers-go v.*/testcontainers-go v0.20.1/g" redpanda/go.mod > redpanda/go.mod.tmp
+mv redpanda/go.mod.tmp redpanda/go.mod
+sed "s/testcontainers-go v.*/testcontainers-go v0.20.1/g" vault/go.mod > vault/go.mod.tmp
+mv vault/go.mod.tmp vault/go.mod
+go mod tidy
+go mod tidy
+go mod tidy
+go mod tidy
+go mod tidy
+go mod tidy
+go mod tidy
+go mod tidy
+go mod tidy
+go mod tidy
+sed "s/Not available until the next release of testcontainers-go <a href=\"https:\/\/github.com\/testcontainers\/testcontainers-go\"><span class=\"tc-version\">:material-tag: main<\/span><\/a>/Since testcontainers-go <a href=\"https:\/\/github.com\/testcontainers\/testcontainers-go\/releases\/tag\/v0.20.1\"><span class=\"tc-version\">:material-tag: v0.20.1<\/span><\/a>/g" couchbase.md > couchbase.md.tmp
+mv couchbase.md.tmp couchbase.md
+sed "s/Not available until the next release of testcontainers-go <a href=\"https:\/\/github.com\/testcontainers\/testcontainers-go\"><span class=\"tc-version\">:material-tag: main<\/span><\/a>/Since testcontainers-go <a href=\"https:\/\/github.com\/testcontainers\/testcontainers-go\/releases\/tag\/v0.20.1\"><span class=\"tc-version\">:material-tag: v0.20.1<\/span><\/a>/g" localstack.md > localstack.md.tmp
+mv localstack.md.tmp localstack.md
+sed "s/Not available until the next release of testcontainers-go <a href=\"https:\/\/github.com\/testcontainers\/testcontainers-go\"><span class=\"tc-version\">:material-tag: main<\/span><\/a>/Since testcontainers-go <a href=\"https:\/\/github.com\/testcontainers\/testcontainers-go\/releases\/tag\/v0.20.1\"><span class=\"tc-version\">:material-tag: v0.20.1<\/span><\/a>/g" mysql.md > mysql.md.tmp
+mv mysql.md.tmp mysql.md
+sed "s/Not available until the next release of testcontainers-go <a href=\"https:\/\/github.com\/testcontainers\/testcontainers-go\"><span class=\"tc-version\">:material-tag: main<\/span><\/a>/Since testcontainers-go <a href=\"https:\/\/github.com\/testcontainers\/testcontainers-go\/releases\/tag\/v0.20.1\"><span class=\"tc-version\">:material-tag: v0.20.1<\/span><\/a>/g" neo4j.md > neo4j.md.tmp
+mv neo4j.md.tmp neo4j.md
+sed "s/Not available until the next release of testcontainers-go <a href=\"https:\/\/github.com\/testcontainers\/testcontainers-go\"><span class=\"tc-version\">:material-tag: main<\/span><\/a>/Since testcontainers-go <a href=\"https:\/\/github.com\/testcontainers\/testcontainers-go\/releases\/tag\/v0.20.1\"><span class=\"tc-version\">:material-tag: v0.20.1<\/span><\/a>/g" postgres.md > postgres.md.tmp
+mv postgres.md.tmp postgres.md
+sed "s/Not available until the next release of testcontainers-go <a href=\"https:\/\/github.com\/testcontainers\/testcontainers-go\"><span class=\"tc-version\">:material-tag: main<\/span><\/a>/Since testcontainers-go <a href=\"https:\/\/github.com\/testcontainers\/testcontainers-go\/releases\/tag\/v0.20.1\"><span class=\"tc-version\">:material-tag: v0.20.1<\/span><\/a>/g" pulsar.md > pulsar.md.tmp
+mv pulsar.md.tmp pulsar.md
+sed "s/Not available until the next release of testcontainers-go <a href=\"https:\/\/github.com\/testcontainers\/testcontainers-go\"><span class=\"tc-version\">:material-tag: main<\/span><\/a>/Since testcontainers-go <a href=\"https:\/\/github.com\/testcontainers\/testcontainers-go\/releases\/tag\/v0.20.1\"><span class=\"tc-version\">:material-tag: v0.20.1<\/span><\/a>/g" redis.md > redis.md.tmp
+mv redis.md.tmp redis.md
+sed "s/Not available until the next release of testcontainers-go <a href=\"https:\/\/github.com\/testcontainers\/testcontainers-go\"><span class=\"tc-version\">:material-tag: main<\/span><\/a>/Since testcontainers-go <a href=\"https:\/\/github.com\/testcontainers\/testcontainers-go\/releases\/tag\/v0.20.1\"><span class=\"tc-version\">:material-tag: v0.20.1<\/span><\/a>/g" redpanda.md > redpanda.md.tmp
+mv redpanda.md.tmp redpanda.md
+sed "s/Not available until the next release of testcontainers-go <a href=\"https:\/\/github.com\/testcontainers\/testcontainers-go\"><span class=\"tc-version\">:material-tag: main<\/span><\/a>/Since testcontainers-go <a href=\"https:\/\/github.com\/testcontainers\/testcontainers-go\/releases\/tag\/v0.20.1\"><span class=\"tc-version\">:material-tag: v0.20.1<\/span><\/a>/g" vault.md > vault.md.tmp
+mv vault.md.tmp vault.md
+```
+
+## Performing a release
+
+Once you are satisfied with the modified files in the git state:
+
+- Run the [release.sh](./scripts/release.sh) shell script to create the release in dry-run mode.
+- You can use the `DRY_RUN`variable to enable or disable the dry-run mode. By default, it's enabled.
+
+        DRY_RUN="false" ./scripts/release.sh
+
+- The script will commit the current state of the git repository, if the `DRY_RUN` variable is set to `false`. The modified files are the ones modified by the `pre-release.sh` script.
 - The script will create a git tag with the current value of the [version.go](./internal/version.go) file, starting with `v`: e.g. `v0.18.0`, for the following Go modules:
     - the root module, representing the Testcontainers for Go library.
     - all the Go modules living in both the `examples` and `modules` directory. The git tag value for these Go modules will be created using this name convention:
 
              "${directory}/${module_name}/${version}", e.g. "examples/mysql/v0.18.0", "modules/compose/v0.18.0"
 
-- The script will update the [mkdocs.yml](./mkdocks.yml) file, updating the `latest_version` field to the current version.
-- The script will update the [version.go](./internal/version.go) file, setting the next development version to the next **minor** version by default. For example, if the current version is `v0.18.0`, the script will update the [version.go](./internal/version.go) file with the next development version `v0.19.0`.
-- You can define the bump type, using the `BUMP_TYPE` environment variable. The default value is `minor`, but you can also use `major` or `patch` (the script will fail if the value is not one of these three):
-
-        BUMP_TYPE="major" ./scripts/release.sh
-
-- The script will update the `go.mod` files for each Go modules and example modules under the examples and modules directories, updating the version of the testcontainers-go dependency to the recently created tag.
-- The script will modify the docs for the each Go module **that was not released yet**, updating the version of _Testcontainers for Go_ where it was added to the recently created tag.
-- The script will create a commit in the **main** branch if the `COMMIT` variable is set to `true`.
-- The script will push the git the main branch including the tags to the upstream repository, https://github.com/testcontainers/testcontainers-go, if the `COMMIT` variable is set to `true`.
+- The script will create a commit in the **main** branch if the `DRY_RUN` variable is set to `false`.
+- The script will push the git the main branch including the tags to the upstream repository, https://github.com/testcontainers/testcontainers-go, if the `DRY_RUN` variable is set to `false`.
+- Finally, the script will trigger the Golang proxy to update the modules in https://proxy.golang.org/, if the `DRY_RUN` variable is set to `false`.
 
 An example execution, with dry-run mode enabled:
 
 ```
 $ ./scripts/release.sh
-git tag v0.19.0
-git tag examples/bigtable/v0.19.0
-git tag examples/cockroachdb/v0.19.0
-git tag examples/consul/v0.19.0
-git tag examples/datastore/v0.19.0
-git tag examples/firestore/v0.19.0
-git tag examples/mongodb/v0.19.0
-git tag examples/mysql/v0.19.0
-git tag examples/nginx/v0.19.0
-git tag examples/postgres/v0.19.0
-git tag examples/pubsub/v0.19.0
-git tag examples/pulsar/v0.19.0
-git tag examples/redis/v0.19.0
-git tag examples/spanner/v0.19.0
-git tag examples/toxiproxy/v0.19.0
-git tag modules/compose/v0.19.0
-git tag modules/localstack/v0.19.0
-git stash
-git checkout main
-sed "s/const Version = ".*"/const Version = "0.20.0"/g" /Users/mdelapenya/sourcecode/src/github.com/testcontainers/testcontainers-go/internal/version.go > /Users/mdelapenya/sourcecode/src/github.com/testcontainers/testcontainers-go/internal/version.go.tmp
-mv /Users/mdelapenya/sourcecode/src/github.com/testcontainers/testcontainers-go/internal/version.go.tmp /Users/mdelapenya/sourcecode/src/github.com/testcontainers/testcontainers-go/internal/version.go
-sed "s/latest_version: .*/latest_version: v0.19.0/g" /Users/mdelapenya/sourcecode/src/github.com/testcontainers/testcontainers-go/mkdocs.yml > /Users/mdelapenya/sourcecode/src/github.com/testcontainers/testcontainers-go/mkdocs.yml.tmp
-mv /Users/mdelapenya/sourcecode/src/github.com/testcontainers/testcontainers-go/mkdocs.yml.tmp /Users/mdelapenya/sourcecode/src/github.com/testcontainers/testcontainers-go/mkdocs.yml
-sed "s/testcontainers-go .*/testcontainers-go v0.19.0/g" examples/bigtable/go.mod > examples/bigtable/go.mod.tmp
-mv examples/bigtable/go.mod.tmp examples/bigtable/go.mod
-sed "s/testcontainers-go .*/testcontainers-go v0.19.0/g" examples/cockroachdb/go.mod > examples/cockroachdb/go.mod.tmp
-mv examples/cockroachdb/go.mod.tmp examples/cockroachdb/go.mod
-sed "s/testcontainers-go .*/testcontainers-go v0.19.0/g" examples/consul/go.mod > examples/consul/go.mod.tmp
-mv examples/consul/go.mod.tmp examples/consul/go.mod
-sed "s/testcontainers-go .*/testcontainers-go v0.19.0/g" examples/datastore/go.mod > examples/datastore/go.mod.tmp
-mv examples/datastore/go.mod.tmp examples/datastore/go.mod
-sed "s/testcontainers-go .*/testcontainers-go v0.19.0/g" examples/firestore/go.mod > examples/firestore/go.mod.tmp
-mv examples/firestore/go.mod.tmp examples/firestore/go.mod
-sed "s/testcontainers-go .*/testcontainers-go v0.19.0/g" examples/mongodb/go.mod > examples/mongodb/go.mod.tmp
-mv examples/mongodb/go.mod.tmp examples/mongodb/go.mod
-sed "s/testcontainers-go .*/testcontainers-go v0.19.0/g" examples/mysql/go.mod > examples/mysql/go.mod.tmp
-mv examples/mysql/go.mod.tmp examples/mysql/go.mod
-sed "s/testcontainers-go .*/testcontainers-go v0.19.0/g" examples/nginx/go.mod > examples/nginx/go.mod.tmp
-mv examples/nginx/go.mod.tmp examples/nginx/go.mod
-sed "s/testcontainers-go .*/testcontainers-go v0.19.0/g" examples/postgres/go.mod > examples/postgres/go.mod.tmp
-mv examples/postgres/go.mod.tmp examples/postgres/go.mod
-sed "s/testcontainers-go .*/testcontainers-go v0.19.0/g" examples/pubsub/go.mod > examples/pubsub/go.mod.tmp
-mv examples/pubsub/go.mod.tmp examples/pubsub/go.mod
-sed "s/testcontainers-go .*/testcontainers-go v0.19.0/g" examples/pulsar/go.mod > examples/pulsar/go.mod.tmp
-mv examples/pulsar/go.mod.tmp examples/pulsar/go.mod
-sed "s/testcontainers-go .*/testcontainers-go v0.19.0/g" examples/redis/go.mod > examples/redis/go.mod.tmp
-mv examples/redis/go.mod.tmp examples/redis/go.mod
-sed "s/testcontainers-go .*/testcontainers-go v0.19.0/g" examples/spanner/go.mod > examples/spanner/go.mod.tmp
-mv examples/spanner/go.mod.tmp examples/spanner/go.mod
-sed "s/testcontainers-go .*/testcontainers-go v0.19.0/g" examples/toxiproxy/go.mod > examples/toxiproxy/go.mod.tmp
-mv examples/toxiproxy/go.mod.tmp examples/toxiproxy/go.mod
-go mod tidy
-go mod tidy
-go mod tidy
-go mod tidy
-go mod tidy
-go mod tidy
-go mod tidy
-go mod tidy
-go mod tidy
-go mod tidy
-go mod tidy
-go mod tidy
-go mod tidy
-go mod tidy
-go mod tidy
-sed "s/testcontainers-go .*/testcontainers-go v0.19.0/g" modules/compose/go.mod > modules/compose/go.mod.tmp
-mv modules/compose/go.mod.tmp modules/compose/go.mod
-sed "s/testcontainers-go .*/testcontainers-go v0.19.0/g" modules/localstack/go.mod > modules/localstack/go.mod.tmp
-mv modules/localstack/go.mod.tmp modules/localstack/go.mod
-go mod tidy
-go mod tidy
+Current version: v0.20.1
 git add /Users/mdelapenya/sourcecode/src/github.com/testcontainers/testcontainers-go/internal/version.go
 git add /Users/mdelapenya/sourcecode/src/github.com/testcontainers/testcontainers-go/mkdocs.yml
-git add examples/**/go.mod
-git add modules/**/go.mod
-git commit -m chore: prepare for next minor development cycle (0.20.0)
+git add examples/**/go.*
+git add modules/**/go.*
+git commit -m chore: use new version (v0.20.1) in modules and examples
+git tag v0.20.1
+git tag examples/bigtable/v0.20.1
+git tag examples/cockroachdb/v0.20.1
+git tag examples/consul/v0.20.1
+git tag examples/datastore/v0.20.1
+git tag examples/firestore/v0.20.1
+git tag examples/mongodb/v0.20.1
+git tag examples/nginx/v0.20.1
+git tag examples/pubsub/v0.20.1
+git tag examples/spanner/v0.20.1
+git tag examples/toxiproxy/v0.20.1
+git tag modules/compose/v0.20.1
+git tag modules/couchbase/v0.20.1
+git tag modules/localstack/v0.20.1
+git tag modules/mysql/v0.20.1
+git tag modules/neo4j/v0.20.1
+git tag modules/postgres/v0.20.1
+git tag modules/pulsar/v0.20.1
+git tag modules/redis/v0.20.1
+git tag modules/redpanda/v0.20.1
+git tag modules/vault/v0.20.1
+WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested
+Producing a minor bump of the version, from 0.20.1 to 0.21.0
+sed "s/const Version = ".*"/const Version = "0.21.0"/g" /Users/mdelapenya/sourcecode/src/github.com/testcontainers/testcontainers-go/internal/version.go > /Users/mdelapenya/sourcecode/src/github.com/testcontainers/testcontainers-go/internal/version.go.tmp
+mv /Users/mdelapenya/sourcecode/src/github.com/testcontainers/testcontainers-go/internal/version.go.tmp /Users/mdelapenya/sourcecode/src/github.com/testcontainers/testcontainers-go/internal/version.go
+git add /Users/mdelapenya/sourcecode/src/github.com/testcontainers/testcontainers-go/internal/version.go
+git commit -m chore: prepare for next minor development cycle (0.21.0)
 git push origin main --tags
+curl https://proxy.golang.org/github.com/testcontainers/testcontainers-go/@v/v0.20.1.info
+curl https://proxy.golang.org/github.com/testcontainers/testcontainers-go/examples/bigtable/@v/v0.20.1.info
+curl https://proxy.golang.org/github.com/testcontainers/testcontainers-go/examples/cockroachdb/@v/v0.20.1.info
+curl https://proxy.golang.org/github.com/testcontainers/testcontainers-go/examples/consul/@v/v0.20.1.info
+curl https://proxy.golang.org/github.com/testcontainers/testcontainers-go/examples/datastore/@v/v0.20.1.info
+curl https://proxy.golang.org/github.com/testcontainers/testcontainers-go/examples/firestore/@v/v0.20.1.info
+curl https://proxy.golang.org/github.com/testcontainers/testcontainers-go/examples/mongodb/@v/v0.20.1.info
+curl https://proxy.golang.org/github.com/testcontainers/testcontainers-go/examples/nginx/@v/v0.20.1.info
+curl https://proxy.golang.org/github.com/testcontainers/testcontainers-go/examples/pubsub/@v/v0.20.1.info
+curl https://proxy.golang.org/github.com/testcontainers/testcontainers-go/examples/spanner/@v/v0.20.1.info
+curl https://proxy.golang.org/github.com/testcontainers/testcontainers-go/examples/toxiproxy/@v/v0.20.1.info
+curl https://proxy.golang.org/github.com/testcontainers/testcontainers-go/modules/compose/@v/v0.20.1.info
+curl https://proxy.golang.org/github.com/testcontainers/testcontainers-go/modules/couchbase/@v/v0.20.1.info
+curl https://proxy.golang.org/github.com/testcontainers/testcontainers-go/modules/localstack/@v/v0.20.1.info
+curl https://proxy.golang.org/github.com/testcontainers/testcontainers-go/modules/mysql/@v/v0.20.1.info
+curl https://proxy.golang.org/github.com/testcontainers/testcontainers-go/modules/neo4j/@v/v0.20.1.info
+curl https://proxy.golang.org/github.com/testcontainers/testcontainers-go/modules/postgres/@v/v0.20.1.info
+curl https://proxy.golang.org/github.com/testcontainers/testcontainers-go/modules/pulsar/@v/v0.20.1.info
+curl https://proxy.golang.org/github.com/testcontainers/testcontainers-go/modules/redis/@v/v0.20.1.info
+curl https://proxy.golang.org/github.com/testcontainers/testcontainers-go/modules/redpanda/@v/v0.20.1.info
+curl https://proxy.golang.org/github.com/testcontainers/testcontainers-go/modules/vault/@v/v0.20.1.info
 git stash pop
-curl https://proxy.golang.org/github.com/testcontainers/testcontainers-go/@v/v0.19.0
-curl https://proxy.golang.org/github.com/testcontainers/testcontainers-go/examples/bigtable/@v/v0.19.0
-curl https://proxy.golang.org/github.com/testcontainers/testcontainers-go/examples/cockroachdb/@v/v0.19.0
-curl https://proxy.golang.org/github.com/testcontainers/testcontainers-go/examples/consul/@v/v0.19.0
-curl https://proxy.golang.org/github.com/testcontainers/testcontainers-go/examples/datastore/@v/v0.19.0
-curl https://proxy.golang.org/github.com/testcontainers/testcontainers-go/examples/firestore/@v/v0.19.0
-curl https://proxy.golang.org/github.com/testcontainers/testcontainers-go/examples/mongodb/@v/v0.19.0
-curl https://proxy.golang.org/github.com/testcontainers/testcontainers-go/examples/mysql/@v/v0.19.0
-curl https://proxy.golang.org/github.com/testcontainers/testcontainers-go/examples/nginx/@v/v0.19.0
-curl https://proxy.golang.org/github.com/testcontainers/testcontainers-go/examples/postgres/@v/v0.19.0
-curl https://proxy.golang.org/github.com/testcontainers/testcontainers-go/examples/pubsub/@v/v0.19.0
-curl https://proxy.golang.org/github.com/testcontainers/testcontainers-go/examples/pulsar/@v/v0.19.0
-curl https://proxy.golang.org/github.com/testcontainers/testcontainers-go/examples/redis/@v/v0.19.0
-curl https://proxy.golang.org/github.com/testcontainers/testcontainers-go/examples/spanner/@v/v0.19.0
-curl https://proxy.golang.org/github.com/testcontainers/testcontainers-go/examples/toxiproxy/@v/v0.19.0
-curl https://proxy.golang.org/github.com/testcontainers/testcontainers-go/modules/compose/@v/v0.19.0
-curl https://proxy.golang.org/github.com/testcontainers/testcontainers-go/modules/localstack/@v/v0.19.0
 ```
 
 Right after that, you have to:

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -5,6 +5,14 @@ In order to create a release, we have added a shell script that performs all the
 First, it's really important that you first check that the [version.go](./internal/version.go) file is up-to-date, containing the right version you want to create. That file will be used by the automation to perform the release.
 Once the version file is correct in the repository:
 
+Second, check that the git remote for the `origin` is pointing to `github.com/testcontainers/testcontainers-go`. You can check it by running:
+
+```shell
+git remote -v
+```
+
+Once the remote is properly set, please follow these steps:
+
 - Run the [release.sh](./scripts/release.sh) shell script to run it in dry-run mode.
 - You can use the `DRY_RUN`variable to enable or disable the dry-run mode. By default, it's enabled.
 - You can use the `COMMIT` variable to enable or disable the commit creation. By default, it's disabled.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -197,7 +197,6 @@ curl https://proxy.golang.org/github.com/testcontainers/testcontainers-go/module
 curl https://proxy.golang.org/github.com/testcontainers/testcontainers-go/modules/redis/@v/v0.20.1.info
 curl https://proxy.golang.org/github.com/testcontainers/testcontainers-go/modules/redpanda/@v/v0.20.1.info
 curl https://proxy.golang.org/github.com/testcontainers/testcontainers-go/modules/vault/@v/v0.20.1.info
-git stash pop
 ```
 
 Right after that, you have to:

--- a/internal/version.go
+++ b/internal/version.go
@@ -1,3 +1,4 @@
 package internal
 
+// Version is the next development version of the application
 const Version = "0.21.0"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -88,4 +88,4 @@ nav:
     - Getting help: getting_help.md
 edit_uri: edit/main/docs/
 extra:
-    latest_version: v0.20.0
+    latest_version: v0.21.0

--- a/scripts/pre-release.sh
+++ b/scripts/pre-release.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+
+# This script is used to release a new version of the Testcontainers for Go library.
+# It creates a tag for the root module and for each module in the modules directory,
+# and then triggers the Go proxy to fetch the module. BY default, it will be run in
+# dry-run mode, which will print the commands that would be executed, without actually
+# executing them.
+#
+# Usage: ./scripts/release.sh
+#
+# It's possible to run the script without dry-run mode actually executing the commands.
+#
+# Usage: DRY_RUN="false" ./scripts/release.sh
+
+readonly DRY_RUN="${DRY_RUN:-true}"
+readonly CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+readonly ROOT_DIR="$(dirname "$CURRENT_DIR")"
+readonly MKDOCS_FILE="${ROOT_DIR}/mkdocs.yml"
+readonly VERSION_FILE="${ROOT_DIR}/internal/version.go"
+
+readonly REPOSITORY="github.com/testcontainers/testcontainers-go"
+readonly DIRECTORIES=(examples modules)
+
+function main() {
+  readonly version="$(extractCurrentVersion)"
+  readonly vVersion="v${version}"
+
+  #gitState
+  bumpVersion "${version}"
+}
+
+# This function is used to bump the version in the version.go file and in the mkdocs.yml file.
+function bumpVersion() {
+  local versionToBumpWithoutV="${1}"
+  local versionToBump="v${versionToBumpWithoutV}"
+
+  if [[ "${DRY_RUN}" == "true" ]]; then
+    echo "sed \"s/latest_version: .*/latest_version: ${versionToBump}/g\" ${MKDOCS_FILE} > ${MKDOCS_FILE}.tmp"
+    echo "mv ${MKDOCS_FILE}.tmp ${MKDOCS_FILE}"
+  else
+    sed "s/latest_version: .*/latest_version: ${versionToBump}/g" ${MKDOCS_FILE} > ${MKDOCS_FILE}.tmp
+    mv ${MKDOCS_FILE}.tmp ${MKDOCS_FILE}
+  fi
+
+  for directory in "${DIRECTORIES[@]}"
+  do
+    cd "${ROOT_DIR}/${directory}"
+
+    ls -d */ | grep -v "_template" | while read -r module; do
+      module="${module%?}" # remove trailing slash
+      module_mod_file="${module}/go.mod" # e.g. modules/mongodb/go.mod
+      if [[ "${DRY_RUN}" == "true" ]]; then
+        echo "sed \"s/testcontainers-go v.*/testcontainers-go v${versionToBumpWithoutV}/g\" ${module_mod_file} > ${module_mod_file}.tmp"
+        echo "mv ${module_mod_file}.tmp ${module_mod_file}"
+      else
+        sed "s/testcontainers-go v.*/testcontainers-go v${versionToBumpWithoutV}/g" ${module_mod_file} > ${module_mod_file}.tmp
+        mv ${module_mod_file}.tmp ${module_mod_file}
+      fi
+    done
+
+    make "tidy-${directory}"
+  done
+
+  cd "${ROOT_DIR}/docs/modules"
+
+  versionEscapingDots="${versionToBumpWithoutV/./\.}"
+  NON_RELEASED_STRING='Not available until the next release of testcontainers-go <a href=\"https:\/\/github.com\/testcontainers\/testcontainers-go\"><span class=\"tc-version\">:material-tag: main<\/span><\/a>'
+  RELEASED_STRING="Since testcontainers-go <a href=\\\"https:\/\/github.com\/testcontainers\/testcontainers-go\/releases\/tag\/v${versionEscapingDots}\\\"><span class=\\\"tc-version\\\">:material-tag: v${versionEscapingDots}<\/span><\/a>"
+
+  ls | grep -v "index.md" | while read -r module_file; do
+    if [[ "${DRY_RUN}" == "true" ]]; then
+      echo "sed \"s/${NON_RELEASED_STRING}/${RELEASED_STRING}/g\" ${module_file} > ${module_file}.tmp"
+      echo "mv ${module_file}.tmp ${module_file}"
+    else
+      sed "s/${NON_RELEASED_STRING}/${RELEASED_STRING}/g" ${module_file} > ${module_file}.tmp
+      mv ${module_file}.tmp ${module_file}
+    fi
+  done
+}
+
+# This function reads the version.go file and extracts the current version.
+function extractCurrentVersion() {
+  cat "${VERSION_FILE}" | grep 'const Version = ' | cut -d '"' -f 2
+}
+
+# This function is used to run git commands
+function gitFn() {
+  args=("$@")
+  if [[ "${DRY_RUN}" == "true" ]]; then
+    echo "git ${args[@]}"
+    return
+  fi
+
+  git "${args[@]}"
+}
+
+# This function is setting the git state to the next development cycle:
+# - Stashing the changes
+# - Moving to the main branch
+function gitState() {
+  gitFn stash
+  gitFn checkout main
+}
+
+main "$@"

--- a/scripts/pre-release.sh
+++ b/scripts/pre-release.sh
@@ -1,16 +1,14 @@
 #!/usr/bin/env bash
 
-# This script is used to release a new version of the Testcontainers for Go library.
-# It creates a tag for the root module and for each module in the modules directory,
-# and then triggers the Go proxy to fetch the module. BY default, it will be run in
-# dry-run mode, which will print the commands that would be executed, without actually
+# This script is used to prepare a release for a new version of the Testcontainers for Go library.
+# By default, it will be run in dry-run mode, which will print the commands that would be executed, without actually
 # executing them.
 #
-# Usage: ./scripts/release.sh
+# Usage: ./scripts/pre-release.sh
 #
 # It's possible to run the script without dry-run mode actually executing the commands.
 #
-# Usage: DRY_RUN="false" ./scripts/release.sh
+# Usage: DRY_RUN="false" ./scripts/pre-release.sh
 
 readonly DRY_RUN="${DRY_RUN:-true}"
 readonly CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"

--- a/scripts/pre-release.sh
+++ b/scripts/pre-release.sh
@@ -25,7 +25,7 @@ function main() {
   readonly version="$(extractCurrentVersion)"
   readonly vVersion="v${version}"
 
-  #gitState
+  gitFn checkout main
   bumpVersion "${version}"
 }
 
@@ -92,14 +92,6 @@ function gitFn() {
   fi
 
   git "${args[@]}"
-}
-
-# This function is setting the git state to the next development cycle:
-# - Stashing the changes
-# - Moving to the main branch
-function gitState() {
-  gitFn stash
-  gitFn checkout main
 }
 
 main "$@"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -77,8 +77,6 @@ function main() {
       curlGolangProxy "${module_path}" "${vVersion}" # e.g. github.com/testcontainers/testcontainers-go/modules/mongodb/@v/v0.0.1.info
     done
   done
-
-  gitUnstash
 }
 
 # This function is used to trigger the Go proxy to fetch the module.
@@ -140,10 +138,6 @@ function gitNextDevelopment() {
 # This function is used to push the tags to the remote repository.
 function gitPushTags() {
   gitFn push origin main --tags
-}
-
-function gitUnstash() {
-  gitFn stash pop
 }
 
 # This function is used to create a tag for the module.

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -129,7 +129,7 @@ function curlGolangProxy() {
   local module_version="${2}"
 
   if [[ "${DRY_RUN}" == "true" || "${COMMIT}" == "false" ]]; then
-    echo "curl https://proxy.golang.org/${module_path}/@v/${module_version}"
+    echo "curl https://proxy.golang.org/${module_path}/@v/${module_version}.info"
     return
   fi
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -12,21 +12,24 @@
 #
 # Usage: DRY_RUN="false" ./scripts/release.sh
 
+readonly BUMP_TYPE="${BUMP_TYPE:-minor}"
 readonly DOCKER_IMAGE_SEMVER="docker.io/mdelapenya/semver-tool:3.4.0"
-readonly COMMIT="${COMMIT:-false}"
 readonly DRY_RUN="${DRY_RUN:-true}"
 readonly CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 readonly ROOT_DIR="$(dirname "$CURRENT_DIR")"
 readonly MKDOCS_FILE="${ROOT_DIR}/mkdocs.yml"
 readonly VERSION_FILE="${ROOT_DIR}/internal/version.go"
-readonly BUMP_TYPE="${BUMP_TYPE:-minor}"
 
 readonly REPOSITORY="github.com/testcontainers/testcontainers-go"
 readonly DIRECTORIES=(examples modules)
 
 function main() {
-  readonly version="$(extractCurrentVersion)"
-  readonly vVersion="v${version}"
+  local version="$(extractCurrentVersion)"
+  local vVersion="v${version}"
+  echo "Current version: ${vVersion}"
+
+  # Commit the project in the current state
+  gitCommitVersion "${vVersion}"
 
   tagModule "${vVersion}"
 
@@ -41,33 +44,11 @@ function main() {
     done
   done
 
-  gitState
-  bumpVersion "${version}"
-  gitPushTags
-  gitUnstash
+  # Get the version to bump to from the semver-tool and the bump type
+  local newVersion=$(docker run --rm "${DOCKER_IMAGE_SEMVER}" bump "${BUMP_TYPE}" "${vVersion}")
+  echo "Producing a ${BUMP_TYPE} bump of the version, from ${version} to ${newVersion}"
 
-  curlGolangProxy "${REPOSITORY}" "${vVersion}" # e.g. github.com/testcontainers/testcontainers-go/@v/v0.0.1
-
-  for directory in "${DIRECTORIES[@]}"
-  do
-    cd "${ROOT_DIR}/${directory}"
-
-    ls -d */ | grep -v "_template" | while read -r module; do
-      module="${module%?}" # remove trailing slash
-      module_path="${REPOSITORY}/${directory}/${module}"
-      curlGolangProxy "${module_path}" "${vVersion}" # e.g. github.com/testcontainers/testcontainers-go/modules/mongodb/@v/v0.0.1
-    done
-  done
-}
-
-# This function is used to bump the version in the version.go file and in the mkdocs.yml file.
-function bumpVersion() {
-  local versionToBumpWithoutV="${1}"
-  local versionToBump="v${versionToBumpWithoutV}"
-
-  local newVersion=$(docker run --rm "${DOCKER_IMAGE_SEMVER}" bump "${BUMP_TYPE}" "${versionToBump}")
-  echo "Producing a ${BUMP_TYPE} bump of the version, from ${versionToBump} to ${newVersion}"
-
+  # Bump the version in the version.go file
   if [[ "${DRY_RUN}" == "true" ]]; then
     echo "sed \"s/const Version = \".*\"/const Version = \"${newVersion}\"/g\" ${VERSION_FILE} > ${VERSION_FILE}.tmp"
     echo "mv ${VERSION_FILE}.tmp ${VERSION_FILE}"
@@ -76,50 +57,28 @@ function bumpVersion() {
     mv ${VERSION_FILE}.tmp ${VERSION_FILE}
   fi
 
-  if [[ "${DRY_RUN}" == "true" ]]; then
-    echo "sed \"s/latest_version: .*/latest_version: ${versionToBump}/g\" ${MKDOCS_FILE} > ${MKDOCS_FILE}.tmp"
-    echo "mv ${MKDOCS_FILE}.tmp ${MKDOCS_FILE}"
-  else
-    sed "s/latest_version: .*/latest_version: ${versionToBump}/g" ${MKDOCS_FILE} > ${MKDOCS_FILE}.tmp
-    mv ${MKDOCS_FILE}.tmp ${MKDOCS_FILE}
-  fi
+  # Commit the version.go file in the next development version
+  gitNextDevelopment "${newVersion}"
 
+  # Update the remote repository with the new tags
+  gitPushTags
+
+  # Trigger the Go proxy to fetch the core module
+  curlGolangProxy "${REPOSITORY}" "${vVersion}" # e.g. github.com/testcontainers/testcontainers-go/@v/v0.0.1.info
+
+  # Trigger the Go proxy to fetch the modules
   for directory in "${DIRECTORIES[@]}"
   do
     cd "${ROOT_DIR}/${directory}"
 
     ls -d */ | grep -v "_template" | while read -r module; do
       module="${module%?}" # remove trailing slash
-      module_mod_file="${module}/go.mod" # e.g. modules/mongodb/go.mod
-      if [[ "${DRY_RUN}" == "true" ]]; then
-        echo "sed \"s/testcontainers-go v.*/testcontainers-go v${versionToBumpWithoutV}/g\" ${module_mod_file} > ${module_mod_file}.tmp"
-        echo "mv ${module_mod_file}.tmp ${module_mod_file}"
-      else
-        sed "s/testcontainers-go v.*/testcontainers-go v${versionToBumpWithoutV}/g" ${module_mod_file} > ${module_mod_file}.tmp
-        mv ${module_mod_file}.tmp ${module_mod_file}
-      fi
+      module_path="${REPOSITORY}/${directory}/${module}"
+      curlGolangProxy "${module_path}" "${vVersion}" # e.g. github.com/testcontainers/testcontainers-go/modules/mongodb/@v/v0.0.1.info
     done
-
-    make "tidy-${directory}"
   done
 
-  cd "${ROOT_DIR}/docs/modules"
-
-  versionEscapingDots="${versionToBumpWithoutV/./\.}"
-  NON_RELEASED_STRING='Not available until the next release of testcontainers-go <a href=\"https:\/\/github.com\/testcontainers\/testcontainers-go\"><span class=\"tc-version\">:material-tag: main<\/span><\/a>'
-  RELEASED_STRING="Since testcontainers-go <a href=\\\"https:\/\/github.com\/testcontainers\/testcontainers-go\/releases\/tag\/v${versionEscapingDots}\\\"><span class=\\\"tc-version\\\">:material-tag: v${versionEscapingDots}<\/span><\/a>"
-
-  ls | grep -v "index.md" | while read -r module_file; do
-    if [[ "${DRY_RUN}" == "true" ]]; then
-      echo "sed \"s/${NON_RELEASED_STRING}/${RELEASED_STRING}/g\" ${module_file} > ${module_file}.tmp"
-      echo "mv ${module_file}.tmp ${module_file}"
-    else
-      sed "s/${NON_RELEASED_STRING}/${RELEASED_STRING}/g" ${module_file} > ${module_file}.tmp
-      mv ${module_file}.tmp ${module_file}
-    fi
-  done
-
-  gitCommitVersion "${newVersion}"
+  gitUnstash
 }
 
 # This function is used to trigger the Go proxy to fetch the module.
@@ -128,7 +87,7 @@ function curlGolangProxy() {
   local module_path="${1}"
   local module_version="${2}"
 
-  if [[ "${DRY_RUN}" == "true" || "${COMMIT}" == "false" ]]; then
+  if [[ "${DRY_RUN}" == "true" ]]; then
     echo "curl https://proxy.golang.org/${module_path}/@v/${module_version}.info"
     return
   fi
@@ -147,7 +106,7 @@ function extractCurrentVersion() {
 # This function is used to run git commands
 function gitFn() {
   args=("$@")
-  if [[ "${DRY_RUN}" == "true" || "${COMMIT}" == "false" ]]; then
+  if [[ "${DRY_RUN}" == "true" ]]; then
     echo "git ${args[@]}"
     return
   fi
@@ -155,9 +114,9 @@ function gitFn() {
   git "${args[@]}"
 }
 
-# This function is used to commit the version.go file.
+# This function is used to commit the version.go file, mkdocs, examples and modules.
 function gitCommitVersion() {
-  local newVersion="${1}" 
+  local version="${1}" 
 
   cd "${ROOT_DIR}"
 
@@ -165,20 +124,22 @@ function gitCommitVersion() {
   gitFn add "${MKDOCS_FILE}"
   gitFn add "examples/**/go.*"
   gitFn add "modules/**/go.*"
+  gitFn commit -m "chore: use new version (${version}) in modules and examples"
+}
+
+# This function is used to commit the version.go file.
+function gitNextDevelopment() {
+  local newVersion="${1}" 
+
+  cd "${ROOT_DIR}"
+
+  gitFn add "${VERSION_FILE}"
   gitFn commit -m "chore: prepare for next ${BUMP_TYPE} development cycle (${newVersion})"
 }
 
 # This function is used to push the tags to the remote repository.
 function gitPushTags() {
   gitFn push origin main --tags
-}
-
-# This function is setting the git state to the next development cycle:
-# - Stashing the changes
-# - Moving to the main branch
-function gitState() {
-  gitFn stash
-  gitFn checkout main
 }
 
 function gitUnstash() {


### PR DESCRIPTION
- chore: improve dry_run log when hitting the Golang proxy
- chore: bump tc-go version in mkdocs
- docs: verify that the origin remote is set
- fix: define a two-phase release process

<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
This PR resolves the inconsistencies in the current release script, defining two separate phases for the release: pre-release and release.

The pre-release phase includes the modification of the files, based on the state of the version value in the `version.go` file. This version contains the next development version, and it's the value used to perform a release.
Therefore, that value drives the release process to set it as the version for all downstream modules and examples.

This pre-release phase will modify the files without creating a commit, so that an eventual release engineer is able to check that the git state is correct.

Once the modified files are correct, we can safely trigger the second phase with the `release.sh` script. This script does:

- commits the modified files.
- creates the git tags for the new release, in the core module and examples and modules.
- calculates the next development version (default a minor bump).
- modifies the `version.go` file with the next version, creating a commit for that.
- pushes the main branch and all tags to the remote **origin** repository.
- triggers the Golang proxy to fetch all modules in the project, based on the git tags.

As a consequence of these changes in the release scripts, the `RELEASE.md` has been updated.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
We do not want to mess the state of a release. A wrong git tag in the repo and an eventual fetch of the Golang proxy will cache the tag forever, causing disastrous consequences to our users, as that cached version will be there forever. This happened with the `v0.20.0` release, were the script failed in the middle but created an inconsistent state of the git tags, so I manually performed a release deleting the upstream tags.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->


<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->

## How to test this PR
<!-- Recommended

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->
To perform a release in DRY_RUN mode:

1. change the `version.go` to a version of your interest: e.g. 1.0.0
2. run `DRY_RUN=false ./scripts/pre-release.sh`
  - the files will be modified, so all modules should contain the `v1.0.0` version in their go.mod files.
3. run `DRY_RUN=true ./scripts/release.sh`
  - a log output will show up with all the operations that are described in the release document, withouht changing the state of both the local and remote git repository.

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
