### PR TITLE
chore: support for bumping ryuk in an automated manner

### DIFF
--- a/reaper.go
+++ b/reaper.go
@@ -24,7 +24,7 @@ const (
 	// Deprecated: it has been replaced by the internal testcontainersdocker.LabelReaper
 	TestcontainerLabelIsReaper = TestcontainerLabel + ".reaper"
 
-	ReaperDefaultImage = "docker.io/testcontainers/ryuk:0.4.0"
+	ReaperDefaultImage = "docker.io/testcontainers/ryuk:0.5.1"
 )
 
 var (

--- a/scripts/bump-reaper.sh
+++ b/scripts/bump-reaper.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+
+# This script is used to bump the version of Ryuk in Testcontainers for Go,
+# modifying the "reaper.go" file. By default, it will be run in
+# dry-run mode, which will print the commands that would be executed, without actually
+# executing them.
+#
+# Usage: ./scripts/bump-reaper.sh "docker.io/testcontainers/ryuk:1.2.3"
+#
+# It's possible to run the script without dry-run mode actually executing the commands.
+#
+# Usage: DRY_RUN="false" ./scripts/bump-reaper.sh "docker.io/testcontainers/ryuk:1.2.3"
+
+readonly CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+readonly DRY_RUN="${DRY_RUN:-true}"
+readonly ROOT_DIR="$(dirname "$CURRENT_DIR")"
+readonly REAPER_FILE="${ROOT_DIR}/reaper.go"
+
+function main() {
+  echo "Updating Ryuk version:"
+
+  local currentVersion="$(extractCurrentVersion)"
+  echo " - Current: ${currentVersion}"
+
+  local ryukVersion="${1}"
+  local escapedRyukVersion="${ryukVersion//\//\\/}"
+  echo " - New: ${ryukVersion}"
+
+  # Bump the version in the version.go file
+  if [[ "${DRY_RUN}" == "true" ]]; then
+    echo "sed \"s/ReaperDefaultImage = \".*\"/ReaperDefaultImage = \"${escapedRyukVersion}\"/g\" ${REAPER_FILE} > ${REAPER_FILE}.tmp"
+    echo "mv ${REAPER_FILE}.tmp ${REAPER_FILE}"
+  else
+    # replace using sed the version in the reaper.go file
+    sed "s/ReaperDefaultImage = \".*\"/ReaperDefaultImage = \"${escapedRyukVersion}\"/g" ${REAPER_FILE} > ${REAPER_FILE}.tmp
+    mv ${REAPER_FILE}.tmp ${REAPER_FILE}
+  fi
+}
+
+# This function reads the reaper.go file and extracts the current version.
+function extractCurrentVersion() {
+  cat "${REAPER_FILE}" | grep 'ReaperDefaultImage = "' | cut -d '"' -f 2
+}
+
+main "$@"


### PR DESCRIPTION
- chore: bump Ryuk to v0.5.1
- chore: add a script to bump ryuk in an automated manner

<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
This PRs bumps Ryuk to the latest version (v0.5.1), and adds a shell script to bump the Ryuk version in an automated manner. The script consumes just the first argument of a call, which should be the full qualified name of the Docker image representing Ryuk: e.g. "docker.io/testcontainers/ryuk:0.5.1"

This script is used to bump the version of Ryuk in Testcontainers for Go, modifying the "reaper.go" file. By default, it will be run in dry-run mode, which will print the commands that would be executed, without actually executing them.

>Usage: ./scripts/bump-reaper.sh "docker.io/testcontainers/ryuk:1.2.3"

It's possible to run the script without dry-run mode actually executing the commands.

> Usage: DRY_RUN="false" ./scripts/bump-reaper.sh "docker.io/testcontainers/ryuk:1.2.3"

The passed argument will replace the content of the `ReaperDefaultImage` variable in the `reaper.go` file.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
We would like to eventually bump the ryuk version in an automated manner, e.g. when ryuk is bumped in their repo, automatically clone all dependent repos (e.g. go, .net, node, java) and run the very same entrypoint in all of them, finally sending a PR. This shell script would represent the entrypoint for that, and should be eventually copied across the testcontainers projects, with the specific parsing code to extract the Ryuk version from them.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->


<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->


<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


## Follow-ups
We must include a way to pass the new features from Ryuk (verbose mode). I did not add them because it will cause conflicts with #1161, as it affects how the testcontainers config struct is populated
