### PR TITLE
chore: use fixed version in k3s module

### DIFF
--- a/docs/modules/k3s.md
+++ b/docs/modules/k3s.md
@@ -45,7 +45,7 @@ When starting the K3s container, you can pass options in a variadic way to confi
 #### Image
 
 If you need to set a different K3s Docker image, you can use `testcontainers.WithImage` with a valid Docker image
-for K3s. E.g. `testcontainers.WithImage("docker.io/rancher/k3s:latest")`.
+for K3s. E.g. `testcontainers.WithImage("docker.io/rancher/k3s:v1.27.1-k3s1")`.
 
 #### Wait Strategies
 

--- a/modules/k3s/k3s.go
+++ b/modules/k3s/k3s.go
@@ -29,7 +29,7 @@ type K3sContainer struct {
 // RunContainer creates an instance of the K3s container type
 func RunContainer(ctx context.Context, opts ...testcontainers.ContainerCustomizer) (*K3sContainer, error) {
 	req := testcontainers.ContainerRequest{
-		Image: "docker.io/rancher/k3s:latest",
+		Image: "docker.io/rancher/k3s:v1.27.1-k3s1",
 		ExposedPorts: []string{
 			defaultKubeSecurePort,
 			defaultRancherWebhookPort,


### PR DESCRIPTION
## What does this PR do?

Fixes version of k3s to pull its docker image. 

cc @mdelapenya 

