### PR TITLE
docs: fix passing env vars example

### DIFF
--- a/docs/features/build_from_dockerfile.md
+++ b/docs/features/build_from_dockerfile.md
@@ -27,12 +27,13 @@ ARG FOO
 You can specify them like:
 
 ```go
+val := "BAR" 
 req := ContainerRequest{
 		FromDockerfile: testcontainers.FromDockerfile{
 			Context: "/path/to/build/context",
 			Dockerfile: "CustomDockerfile",
 			BuildArgs: map[string]*string {
-				"FOO": "BAR",
+				"FOO": &val,
 			},
 		},
 	}


### PR DESCRIPTION
Doc fix, the current given example does not compile, suggested a fix.