### PR TITLE
Update java docs domain

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@
 
 <p align="center"><strong>Not using Go? Here are other supported languages!</strong></p>
 <div class="card-grid">
-    <a href="https://testcontainers.org" class="card-grid-item"><img src="language-logos/java.svg"/>Java</a>
+    <a href="https://java.testcontainers.org" class="card-grid-item"><img src="language-logos/java.svg"/>Java</a>
     <a class="card-grid-item"><img src="language-logos/go.svg"/>Go</a>
     <a href="https://dotnet.testcontainers.org/" class="card-grid-item"><img src="language-logos/dotnet.svg"/>.NET</a>
     <a href="https://node.testcontainers.org/" class="card-grid-item"><img src="language-logos/nodejs.svg"/>Node.js</a></a>


### PR DESCRIPTION
## What does this PR do?
This updates the Java docs domain in any links in the docs. 

## Why is it important?
The Java docs are migrating subdomain from `www` to `java`. 