### PR TITLE
fix: return proper docker socket for remote Docker hosts

### DIFF
--- a/internal/testcontainersdocker/docker_host.go
+++ b/internal/testcontainersdocker/docker_host.go
@@ -135,6 +135,11 @@ func extractDockerSocket(ctx context.Context) string {
 func extractDockerSocketFromClient(ctx context.Context, cli client.APIClient) string {
 	tcHost, err := testcontainersHostFromProperties(ctx)
 	if err == nil {
+		// this use case will cover the case when the docker host is a tcp socket
+		if strings.HasPrefix(tcHost, "tcp://") {
+			return "/var/run/docker.sock"
+		}
+
 		return tcHost
 	}
 

--- a/internal/testcontainersdocker/docker_host_test.go
+++ b/internal/testcontainersdocker/docker_host_test.go
@@ -284,7 +284,7 @@ func TestExtractDockerSocketFromClient(t *testing.T) {
 		defer config.Reset()
 
 		socket := extractDockerSocketFromClient(context.Background(), mockCli{OS: "foo"})
-		assert.Equal(t, tmpSocket, socket)
+		assert.Equal(t, "/var/run/docker.sock", socket)
 	})
 
 	t.Run("Docker socket from Testcontainers host takes precedence over TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE", func(t *testing.T) {
@@ -299,10 +299,13 @@ func TestExtractDockerSocketFromClient(t *testing.T) {
 		t.Setenv("TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE", "/path/to/docker.sock")
 
 		socket := extractDockerSocketFromClient(context.Background(), mockCli{OS: "foo"})
-		assert.Equal(t, tmpSocket, socket)
+		assert.Equal(t, "/var/run/docker.sock", socket)
 	})
 
 	t.Run("Docker Socket as Testcontainers environment variable", func(t *testing.T) {
+		config.Reset()
+		setupTestcontainersProperties(t, "")
+		t.Cleanup(config.Reset)
 		t.Cleanup(resetSocketOverrideFn)
 
 		t.Setenv("TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE", "/path/to/docker.sock")
@@ -312,6 +315,9 @@ func TestExtractDockerSocketFromClient(t *testing.T) {
 	})
 
 	t.Run("Unix Docker Socket is passed as DOCKER_HOST variable (Docker Desktop)", func(t *testing.T) {
+		config.Reset()
+		setupTestcontainersProperties(t, "")
+		t.Cleanup(config.Reset)
 		t.Cleanup(resetSocketOverrideFn)
 
 		ctx := context.Background()
@@ -324,6 +330,9 @@ func TestExtractDockerSocketFromClient(t *testing.T) {
 	})
 
 	t.Run("Unix Docker Socket is passed as DOCKER_HOST variable (Not Docker Desktop)", func(t *testing.T) {
+		config.Reset()
+		setupTestcontainersProperties(t, "")
+		t.Cleanup(config.Reset)
 		t.Cleanup(resetSocketOverrideFn)
 
 		ctx := context.Background()


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
This PRs returns the default Docker host in the case the `tc.host` property is found

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
In #1161, we improved the resolution of the Docker socket depending on multiple scenarios (docker rootless, using a remote host, etc) but in the case the `tc.host` property is found, it simply returned it as the Docker socket path, which is incorrect. Instead, we must return the default docker socket path (`/var/run/docker.sock`)

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Caused by #1161

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
