### PR TITLE
fix: skip host network tests in Docker Desktop

### DIFF
--- a/docker_test.go
+++ b/docker_test.go
@@ -132,12 +132,14 @@ func TestContainerWithHostNetworkOptions(t *testing.T) {
 		t.Skip("Skipping test that requires host network access when running in a container")
 	}
 
+	ctx := context.Background()
+	SkipIfDockerDesktop(t, ctx)
+
 	absPath, err := filepath.Abs(filepath.Join("testdata", "nginx-highport.conf"))
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	ctx := context.Background()
 	gcr := GenericContainerRequest{
 		ProviderType: providerType,
 		ContainerRequest: ContainerRequest{
@@ -209,7 +211,11 @@ func TestContainerWithNetworkModeAndNetworkTogether(t *testing.T) {
 		t.Skip("Skipping test that requires host network access when running in a container")
 	}
 
+	// skipIfDockerDesktop {
 	ctx := context.Background()
+	SkipIfDockerDesktop(t, ctx)
+	// }
+
 	gcr := GenericContainerRequest{
 		ProviderType: providerType,
 		ContainerRequest: ContainerRequest{
@@ -236,6 +242,7 @@ func TestContainerWithHostNetworkOptionsAndWaitStrategy(t *testing.T) {
 	}
 
 	ctx := context.Background()
+	SkipIfDockerDesktop(t, ctx)
 
 	absPath, err := filepath.Abs(filepath.Join("testdata", "nginx-highport.conf"))
 	if err != nil {
@@ -277,6 +284,7 @@ func TestContainerWithHostNetworkAndEndpoint(t *testing.T) {
 	}
 
 	ctx := context.Background()
+	SkipIfDockerDesktop(t, ctx)
 
 	absPath, err := filepath.Abs(filepath.Join("testdata", "nginx-highport.conf"))
 	if err != nil {

--- a/docker_test.go
+++ b/docker_test.go
@@ -236,7 +236,7 @@ func TestContainerWithNetworkModeAndNetworkTogether(t *testing.T) {
 	terminateContainerOnEnd(t, ctx, nginx)
 }
 
-func TestContainerWithHostNetworkOptionsAndWaitStrategy(t *testing.T) {
+func TestContainerWithHostNetwork(t *testing.T) {
 	if os.Getenv("XDG_RUNTIME_DIR") != "" {
 		t.Skip("Skipping test that requires host network access when running in a container")
 	}
@@ -266,6 +266,17 @@ func TestContainerWithHostNetworkOptionsAndWaitStrategy(t *testing.T) {
 
 	require.NoError(t, err)
 	terminateContainerOnEnd(t, ctx, nginxC)
+
+	portEndpoint, err := nginxC.PortEndpoint(ctx, nginxHighPort, "http")
+	if err != nil {
+		t.Errorf("Expected port endpoint %s. Got '%d'.", portEndpoint, err)
+	}
+	t.Log(portEndpoint)
+
+	_, err = http.Get(portEndpoint)
+	if err != nil {
+		t.Errorf("Expected OK response. Got '%v'.", err)
+	}
 
 	host, err := nginxC.Host(ctx)
 	if err != nil {
@@ -273,49 +284,6 @@ func TestContainerWithHostNetworkOptionsAndWaitStrategy(t *testing.T) {
 	}
 
 	_, err = http.Get("http://" + host + ":8080")
-	if err != nil {
-		t.Errorf("Expected OK response. Got '%v'.", err)
-	}
-}
-
-func TestContainerWithHostNetworkAndEndpoint(t *testing.T) {
-	if os.Getenv("XDG_RUNTIME_DIR") != "" {
-		t.Skip("Skipping test that requires host network access when running in a container")
-	}
-
-	ctx := context.Background()
-	SkipIfDockerDesktop(t, ctx)
-
-	absPath, err := filepath.Abs(filepath.Join("testdata", "nginx-highport.conf"))
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	gcr := GenericContainerRequest{
-		ProviderType: providerType,
-		ContainerRequest: ContainerRequest{
-			Image:      nginxAlpineImage,
-			WaitingFor: wait.ForListeningPort(nginxHighPort),
-			Mounts:     Mounts(BindMount(absPath, "/etc/nginx/conf.d/default.conf")),
-			HostConfigModifier: func(hc *container.HostConfig) {
-				hc.NetworkMode = "host"
-			},
-		},
-		Started: true,
-	}
-
-	nginxC, err := GenericContainer(ctx, gcr)
-
-	require.NoError(t, err)
-	terminateContainerOnEnd(t, ctx, nginxC)
-
-	hostN, err := nginxC.PortEndpoint(ctx, nginxHighPort, "http")
-	if err != nil {
-		t.Errorf("Expected host %s. Got '%d'.", hostN, err)
-	}
-	t.Log(hostN)
-
-	_, err = http.Get(hostN)
 	if err != nil {
 		t.Errorf("Expected OK response. Got '%v'.", err)
 	}

--- a/docker_test.go
+++ b/docker_test.go
@@ -132,7 +132,7 @@ func TestContainerWithHostNetworkOptions(t *testing.T) {
 		t.Skip("Skipping test that requires host network access when running in a container")
 	}
 
-	absPath, err := filepath.Abs("./testdata/nginx-highport.conf")
+	absPath, err := filepath.Abs(filepath.Join("testdata", "nginx-highport.conf"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -237,7 +237,7 @@ func TestContainerWithHostNetworkOptionsAndWaitStrategy(t *testing.T) {
 
 	ctx := context.Background()
 
-	absPath, err := filepath.Abs("./testdata/nginx-highport.conf")
+	absPath, err := filepath.Abs(filepath.Join("testdata", "nginx-highport.conf"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -278,7 +278,7 @@ func TestContainerWithHostNetworkAndEndpoint(t *testing.T) {
 
 	ctx := context.Background()
 
-	absPath, err := filepath.Abs("./testdata/nginx-highport.conf")
+	absPath, err := filepath.Abs(filepath.Join("testdata", "nginx-highport.conf"))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/docs/features/networking.md
+++ b/docs/features/networking.md
@@ -47,6 +47,24 @@ It is normally advisable to use `Host` and `MappedPort` together when constructi
 !!! info
     Setting the `TC_HOST` environment variable overrides the host of the docker daemon where the container port is exposed. For example, `TC_HOST=172.17.0.1`.
 
+## Docker's host networking mode
+
+From [Docker documentation](https://docs.docker.com/network/drivers/host/):
+
+> If you use the host network mode for a container, that container’s network stack is not isolated from the Docker host (the container shares the host’s networking namespace), and the container does not get its own IP-address allocated. For instance, if you run a container which binds to port 80 and you use host networking, the container’s application is available on port 80 on the host’s IP address.
+
+But according to those docs, it's supported only for Linux hosts:
+
+> The host networking driver only works on Linux hosts, and is not supported on Docker Desktop for Mac, Docker Desktop for Windows, or Docker EE for Windows Server.
+
+In the case you need to skip a test on non-Linux hosts, you can use the `SkipIfDockerDesktop` function:
+
+<!--codeinclude-->
+[Skipping tests on non-Linux hosts](../../docker_test.go) inside_block:skipIfDockerDesktop
+<!--/codeinclude-->
+
+It will try to get a Docker client and obtain its Info. In the case the Operation System is "Docker Desktop", it will skip the test.
+
 ## Advanced networking
 
 Docker provides the ability for you to create custom networks and place containers on one or more networks. Then, communication can occur between networked containers without the need of exposing ports through the host. With Testcontainers, you can do this as well. 

--- a/testing.go
+++ b/testing.go
@@ -23,7 +23,7 @@ func SkipIfProviderIsNotHealthy(t *testing.T) {
 	}
 }
 
-// SkipIfProviderIsNotHealthy is a utility function capable of skipping tests
+// SkipIfDockerDesktop is a utility function capable of skipping tests
 // if tests are run using Docker Desktop.
 func SkipIfDockerDesktop(t *testing.T, ctx context.Context) {
 	cli, err := testcontainersdocker.NewClient(ctx)

--- a/testing.go
+++ b/testing.go
@@ -3,6 +3,8 @@ package testcontainers
 import (
 	"context"
 	"testing"
+
+	"github.com/testcontainers/testcontainers-go/internal/testcontainersdocker"
 )
 
 // SkipIfProviderIsNotHealthy is a utility function capable of skipping tests
@@ -18,5 +20,23 @@ func SkipIfProviderIsNotHealthy(t *testing.T) {
 	err = provider.Health(ctx)
 	if err != nil {
 		t.Skipf("Docker is not running. TestContainers can't perform is work without it: %s", err)
+	}
+}
+
+// SkipIfProviderIsNotHealthy is a utility function capable of skipping tests
+// if tests are run using Docker Desktop.
+func SkipIfDockerDesktop(t *testing.T, ctx context.Context) {
+	cli, err := testcontainersdocker.NewClient(ctx)
+	if err != nil {
+		t.Fatalf("failed to create docker client: %s", err)
+	}
+
+	info, err := cli.Info(ctx)
+	if err != nil {
+		t.Fatalf("failed to get docker info: %s", err)
+	}
+
+	if info.OperatingSystem == "Docker Desktop" {
+		t.Skip("Skipping test that requires host network access when running in Docker Desktop")
 	}
 }


### PR DESCRIPTION
- chore: use filepath to build the absolute path in tests
- fix: skip host network tests in Docker Desktop

<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
This PR adds a public function to skip tests in the case Docker Desktop is used. We are also using this new function in 4 tests, that are setting Docker's host network via the `HostConfigModifier`. Therefore, they will be skipped when run on Docker Desktop.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
This PR fixes the execution of the test suite in those environments where it's not possible to run all the tests. As an example, using the host network is not possible when running Docker Desktop (for Mac or for Windows).

With this change, it's possible now to run the entire test suite across all OSs

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->


<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
