### PR TITLE
fix: stronger validation for the schema of the Docker socket path

### DIFF
--- a/docs/features/configuration.md
+++ b/docs/features/configuration.md
@@ -95,3 +95,5 @@ Path to Docker's socket. Used by Ryuk, Docker Compose, and a few other container
 5. If the socket contains the unix schema, the schema is removed (e.g. `unix:///var/run/docker.sock` -> `/var/run/docker.sock`)
 
 6. Else, the default location of the docker socket is used: `/var/run/docker.sock`
+
+In any case, if the docker socket schema is `tcp://`, the default docker socket path will be returned.

--- a/internal/testcontainersdocker/docker_host.go
+++ b/internal/testcontainersdocker/docker_host.go
@@ -81,6 +81,8 @@ func ExtractDockerHost(ctx context.Context) string {
 //  4. Else, Get the current Docker Host from the existing strategies: see ExtractDockerHost.
 //  5. If the socket contains the unix schema, the schema is removed (e.g. unix:///var/run/docker.sock -> /var/run/docker.sock)
 //  6. Else, the default location of the docker socket is used (/var/run/docker.sock)
+//
+// In any case, if the docker socket schema is "tcp://", the default docker socket path will be returned.
 func ExtractDockerSocket(ctx context.Context) string {
 	dockerSocketPathOnce.Do(func() {
 		dockerSocketPathCache = extractDockerSocket(ctx)
@@ -133,19 +135,28 @@ func extractDockerSocket(ctx context.Context) string {
 // and receiving an instance of the Docker API client interface.
 // This internal method is handy for testing purposes, passing a mock type simulating the desired behaviour.
 func extractDockerSocketFromClient(ctx context.Context, cli client.APIClient) string {
-	tcHost, err := testcontainersHostFromProperties(ctx)
-	if err == nil {
+	// check that the socket is not a tcp or unix socket
+	checkDockerSocketFn := func(socket string) string {
 		// this use case will cover the case when the docker host is a tcp socket
-		if strings.HasPrefix(tcHost, "tcp://") {
+		if strings.HasPrefix(socket, TCPSchema) {
 			return "/var/run/docker.sock"
 		}
 
-		return tcHost
+		if strings.HasPrefix(socket, DockerSocketSchema) {
+			return strings.Replace(socket, DockerSocketSchema, "", 1)
+		}
+
+		return socket
+	}
+
+	tcHost, err := testcontainersHostFromProperties(ctx)
+	if err == nil {
+		return checkDockerSocketFn(tcHost)
 	}
 
 	testcontainersDockerSocket, err := dockerSocketOverridePath(ctx)
 	if err == nil {
-		return testcontainersDockerSocket
+		return checkDockerSocketFn(testcontainersDockerSocket)
 	}
 
 	info, err := cli.Info(ctx)
@@ -160,11 +171,7 @@ func extractDockerSocketFromClient(ctx context.Context, cli client.APIClient) st
 
 	dockerHost := extractDockerHost(ctx)
 
-	if strings.HasPrefix(dockerHost, DockerSocketSchema) {
-		return strings.Replace(dockerHost, DockerSocketSchema, "", 1)
-	}
-
-	return dockerHost
+	return checkDockerSocketFn(dockerHost)
 }
 
 // dockerHostFromEnv returns the docker host from the DOCKER_HOST environment variable, if it's not empty

--- a/internal/testcontainersdocker/docker_host.go
+++ b/internal/testcontainersdocker/docker_host.go
@@ -139,7 +139,7 @@ func extractDockerSocketFromClient(ctx context.Context, cli client.APIClient) st
 	checkDockerSocketFn := func(socket string) string {
 		// this use case will cover the case when the docker host is a tcp socket
 		if strings.HasPrefix(socket, TCPSchema) {
-			return "/var/run/docker.sock"
+			return DockerSocketPath
 		}
 
 		if strings.HasPrefix(socket, DockerSocketSchema) {
@@ -166,7 +166,7 @@ func extractDockerSocketFromClient(ctx context.Context, cli client.APIClient) st
 
 	// Because Docker Desktop runs in a VM, we need to use the default docker path for rootless docker
 	if info.OperatingSystem == "Docker Desktop" {
-		return "/var/run/docker.sock"
+		return DockerSocketPath
 	}
 
 	dockerHost := extractDockerHost(ctx)

--- a/internal/testcontainersdocker/docker_host_test.go
+++ b/internal/testcontainersdocker/docker_host_test.go
@@ -275,7 +275,7 @@ func TestExtractDockerSocketFromClient(t *testing.T) {
 		setupTestcontainersProperties(t, content)
 
 		socket := extractDockerSocketFromClient(context.Background(), mockCli{OS: "foo"})
-		assert.Equal(t, "/var/run/docker.sock", socket)
+		assert.Equal(t, DockerSocketPath, socket)
 	})
 
 	t.Run("Docker socket from Testcontainers host takes precedence over TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE", func(t *testing.T) {
@@ -288,7 +288,7 @@ func TestExtractDockerSocketFromClient(t *testing.T) {
 		t.Setenv("TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE", "/path/to/docker.sock")
 
 		socket := extractDockerSocketFromClient(context.Background(), mockCli{OS: "foo"})
-		assert.Equal(t, "/var/run/docker.sock", socket)
+		assert.Equal(t, DockerSocketPath, socket)
 	})
 
 	t.Run("Docker Socket as Testcontainers environment variable", func(t *testing.T) {
@@ -313,7 +313,7 @@ func TestExtractDockerSocketFromClient(t *testing.T) {
 
 		t.Setenv("TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE", TCPSchema+"127.0.0.1:12345")
 		host = extractDockerSocketFromClient(context.Background(), mockCli{OS: "foo"})
-		assert.Equal(t, "/var/run/docker.sock", host)
+		assert.Equal(t, DockerSocketPath, host)
 	})
 
 	t.Run("Unix Docker Socket is passed as DOCKER_HOST variable (Docker Desktop)", func(t *testing.T) {
@@ -327,7 +327,7 @@ func TestExtractDockerSocketFromClient(t *testing.T) {
 
 		socket := extractDockerSocketFromClient(ctx, mockCli{OS: "Docker Desktop"})
 
-		assert.Equal(t, "/var/run/docker.sock", socket)
+		assert.Equal(t, DockerSocketPath, socket)
 	})
 
 	t.Run("Unix Docker Socket is passed as DOCKER_HOST variable (Not Docker Desktop)", func(t *testing.T) {
@@ -358,7 +358,7 @@ func TestExtractDockerSocketFromClient(t *testing.T) {
 
 		t.Setenv("DOCKER_HOST", TCPSchema+"127.0.0.1:12345")
 		socket = extractDockerSocketFromClient(ctx, mockCli{OS: "Ubuntu"})
-		assert.Equal(t, "/var/run/docker.sock", socket)
+		assert.Equal(t, DockerSocketPath, socket)
 	})
 }
 

--- a/internal/testcontainersdocker/docker_socket.go
+++ b/internal/testcontainersdocker/docker_socket.go
@@ -8,3 +8,6 @@ var DockerSocketPath = "/var/run/docker.sock"
 
 // DockerSocketPathWithSchema is the path to the docker socket under unix systems with the unix schema.
 var DockerSocketPathWithSchema = DockerSocketSchema + DockerSocketPath
+
+// TCPSchema is the tcp schema.
+var TCPSchema = "tcp://"


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
This PR is adding an anonymous function to sanitise the docker socket path after calculating it from the different alternatives (properties, variables, resolved Docker host...).

The sanitisation process will remove the `unix://` prefix from the socket path, and if the path relates to a remote host using the `tcp://` protocol, then the default Docker socket (`/var/run/docker.sock`) will be returned.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
Consistency retrieving the Docker socket path.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Continues #1281

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
