### PR TITLE
fix: use correct path for gotestsum output

### DIFF
--- a/.github/workflows/module-postgres.yml
+++ b/.github/workflows/module-postgres.yml
@@ -52,5 +52,5 @@ jobs:
       - name: Test Summary
         uses: test-summary/action@4ee9ece4bca777a38f05c8fc578ac2007fe266f7
         with:
-          paths: "**/TEST-postgres*.xml"
+          paths: "**/TEST-unit*.xml"
         if: always()


### PR DESCRIPTION
## What does this PR do?

Use the correct path for the gotestsum output in the module-postgres pipeline

## Why is it important?

It's broken.

## Related issues

<!-- Recommended

- Relates #11246


<!-- Recommended
## How to test this PR

Check module-postgres pipeline

<!-- Optional
## Follow-ups

If this fix works we can check other pipelines as well if they need a fix too.
