### PR TITLE
chore: simplify ReadConfig signature, not passing context

### DIFF
--- a/config.go
+++ b/config.go
@@ -1,8 +1,6 @@
 package testcontainers
 
 import (
-	"context"
-
 	"github.com/testcontainers/testcontainers-go/internal/config"
 )
 
@@ -18,15 +16,8 @@ type TestcontainersConfig struct {
 
 // ReadConfig reads from testcontainers properties file, storing the result in a singleton instance
 // of the TestcontainersConfig struct
-// Deprecated use ReadConfigWithContext instead
 func ReadConfig() TestcontainersConfig {
-	return ReadConfigWithContext(context.Background())
-}
-
-// ReadConfigWithContext reads from testcontainers properties file, storing the result in a singleton instance
-// of the TestcontainersConfig struct
-func ReadConfigWithContext(ctx context.Context) TestcontainersConfig {
-	cfg := config.Read(ctx)
+	cfg := config.Read()
 	return TestcontainersConfig{
 		Host:           cfg.Host,
 		TLSVerify:      cfg.TLSVerify,

--- a/config_test.go
+++ b/config_test.go
@@ -1,7 +1,6 @@
 package testcontainers
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -22,7 +21,7 @@ func TestReadConfig(t *testing.T) {
 		t.Setenv("HOME", "")
 		t.Setenv("TESTCONTAINERS_RYUK_DISABLED", "true")
 
-		cfg := ReadConfigWithContext(context.Background())
+		cfg := ReadConfig()
 
 		expected := TestcontainersConfig{
 			RyukDisabled: true,

--- a/docker_test.go
+++ b/docker_test.go
@@ -310,7 +310,8 @@ func TestContainerReturnItsContainerID(t *testing.T) {
 }
 
 func TestContainerStartsWithoutTheReaper(t *testing.T) {
-	tcConfig := config.Read(context.Background()) // read the config using the internal method to avoid the sync.Once
+	config.Reset() // reset the config using the internal method to avoid the sync.Once
+	tcConfig := config.Read()
 	if !tcConfig.RyukDisabled {
 		t.Skip("Ryuk is enabled, skipping test")
 	}
@@ -349,7 +350,8 @@ func TestContainerStartsWithoutTheReaper(t *testing.T) {
 }
 
 func TestContainerStartsWithTheReaper(t *testing.T) {
-	tcConfig := config.Read(context.Background()) // read the config using the internal method to avoid the sync.Once
+	config.Reset() // reset the config using the internal method to avoid the sync.Once
+	tcConfig := config.Read()
 	if tcConfig.RyukDisabled {
 		t.Skip("Ryuk is disabled, skipping test")
 	}
@@ -481,7 +483,8 @@ func TestContainerStateAfterTermination(t *testing.T) {
 }
 
 func TestContainerStopWithReaper(t *testing.T) {
-	tcConfig := config.Read(context.Background()) // read the config using the internal method to avoid the sync.Once
+	config.Reset() // reset the config using the internal method to avoid the sync.Once
+	tcConfig := config.Read()
 	if tcConfig.RyukDisabled {
 		t.Skip("Ryuk is disabled, skipping test")
 	}
@@ -528,7 +531,8 @@ func TestContainerStopWithReaper(t *testing.T) {
 }
 
 func TestContainerTerminationWithReaper(t *testing.T) {
-	tcConfig := config.Read(context.Background()) // read the config using the internal method to avoid the sync.Once
+	config.Reset() // reset the config using the internal method to avoid the sync.Once
+	tcConfig := config.Read()
 	if tcConfig.RyukDisabled {
 		t.Skip("Ryuk is disabled, skipping test")
 	}
@@ -567,7 +571,8 @@ func TestContainerTerminationWithReaper(t *testing.T) {
 }
 
 func TestContainerTerminationWithoutReaper(t *testing.T) {
-	tcConfig := config.Read(context.Background()) // read the config using the internal method to avoid the sync.Once
+	config.Reset() // reset the config using the internal method to avoid the sync.Once
+	tcConfig := config.Read()
 	if !tcConfig.RyukDisabled {
 		t.Skip("Ryuk is enabled, skipping test")
 	}

--- a/docs/features/configuration.md
+++ b/docs/features/configuration.md
@@ -23,10 +23,10 @@ _Testcontainers for Go_ provides a struct type to represent the configuration:
 [Supported properties](../../internal/config/config.go) inside_block:testcontainersConfig
 <!--/codeinclude-->
 
-You can read it with the `ReadConfigWithContext(ctx)` function:
+You can read it with the `ReadConfig()` function:
 
 ```go
-cfg := testcontainers.ReadConfigWithContext(ctx)
+cfg := testcontainers.ReadConfig()
 ```
 
 For advanced users, the Docker host connection can be configured **via configuration** in `~/.testcontainers.properties`, but environment variables will take precedence.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -29,9 +28,9 @@ type Config struct {
 
 // Read reads from testcontainers properties file, if it exists
 // it is possible that certain values get overridden when set as environment variables
-func Read(ctx context.Context) Config {
+func Read() Config {
 	tcConfigOnce.Do(func() {
-		tcConfig = read(ctx)
+		tcConfig = read()
 
 		if tcConfig.RyukDisabled {
 			ryukDisabledMessage := `
@@ -54,7 +53,7 @@ func Reset() {
 	tcConfigOnce = new(sync.Once)
 }
 
-func read(ctx context.Context) Config {
+func read() Config {
 	config := Config{}
 
 	applyEnvironmentConfiguration := func(config Config) Config {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -31,7 +30,7 @@ func TestReadConfig(t *testing.T) {
 		t.Setenv("DOCKER_HOST", "")
 		t.Setenv("TESTCONTAINERS_RYUK_DISABLED", "true")
 
-		config := Read(context.Background())
+		config := Read()
 
 		expected := Config{
 			RyukDisabled: true,
@@ -42,7 +41,7 @@ func TestReadConfig(t *testing.T) {
 
 		t.Setenv("TESTCONTAINERS_RYUK_DISABLED", "false")
 
-		config = Read(context.Background())
+		config = Read()
 		assert.Equal(t, expected, config)
 	})
 }
@@ -53,7 +52,7 @@ func TestReadTCConfig(t *testing.T) {
 	t.Run("HOME is not set", func(t *testing.T) {
 		t.Setenv("HOME", "")
 
-		config := read(context.Background())
+		config := read()
 
 		expected := Config{}
 
@@ -65,7 +64,7 @@ func TestReadTCConfig(t *testing.T) {
 		t.Setenv("TESTCONTAINERS_RYUK_DISABLED", "true")
 		t.Setenv("TESTCONTAINERS_RYUK_CONTAINER_PRIVILEGED", "true")
 
-		config := read(context.Background())
+		config := read()
 
 		expected := Config{
 			RyukDisabled:   true,
@@ -80,7 +79,7 @@ func TestReadTCConfig(t *testing.T) {
 		tmpDir := t.TempDir()
 		t.Setenv("HOME", tmpDir)
 
-		config := read(context.Background())
+		config := read()
 
 		expected := Config{}
 
@@ -92,7 +91,7 @@ func TestReadTCConfig(t *testing.T) {
 		t.Setenv("HOME", tmpDir)
 		t.Setenv("DOCKER_HOST", tcpDockerHost33293)
 
-		config := read(context.Background())
+		config := read()
 		expected := Config{} // the config does not read DOCKER_HOST, that's why it's empty
 
 		assert.Equal(t, expected, config)
@@ -104,7 +103,7 @@ func TestReadTCConfig(t *testing.T) {
 		t.Setenv("TESTCONTAINERS_RYUK_DISABLED", "true")
 		t.Setenv("TESTCONTAINERS_RYUK_CONTAINER_PRIVILEGED", "true")
 
-		config := read(context.Background())
+		config := read()
 		expected := Config{
 			RyukDisabled:   true,
 			RyukPrivileged: true,
@@ -402,7 +401,7 @@ func TestReadTCConfig(t *testing.T) {
 				}
 
 				//
-				config := read(context.Background())
+				config := read()
 
 				assert.Equal(t, tt.expected, config, "Configuration doesn't not match")
 			})

--- a/internal/testcontainersdocker/client.go
+++ b/internal/testcontainersdocker/client.go
@@ -11,7 +11,7 @@ import (
 
 // NewClient returns a new docker client extracting the docker host from the different alternatives
 func NewClient(ctx context.Context, ops ...client.Opt) (*client.Client, error) {
-	tcConfig := config.Read(ctx)
+	tcConfig := config.Read()
 
 	dockerHost := ExtractDockerHost(ctx)
 

--- a/internal/testcontainersdocker/docker_host.go
+++ b/internal/testcontainersdocker/docker_host.go
@@ -199,7 +199,7 @@ func dockerHostFromContext(ctx context.Context) (string, error) {
 
 // dockerHostFromProperties returns the docker host from the ~/.testcontainers.properties file, if it's not empty
 func dockerHostFromProperties(ctx context.Context) (string, error) {
-	cfg := config.Read(ctx)
+	cfg := config.Read()
 	socketPath := cfg.Host
 	if socketPath != "" {
 		parsed, err := parseURL(socketPath)
@@ -235,7 +235,7 @@ func dockerSocketPath(ctx context.Context) (string, error) {
 
 // testcontainersHostFromProperties returns the testcontainers host from the ~/.testcontainers.properties file, if it's not empty
 func testcontainersHostFromProperties(ctx context.Context) (string, error) {
-	cfg := config.Read(ctx)
+	cfg := config.Read()
 	testcontainersHost := cfg.TestcontainersHost
 	if testcontainersHost != "" {
 		parsed, err := parseURL(testcontainersHost)

--- a/logconsumer_test.go
+++ b/logconsumer_test.go
@@ -306,7 +306,7 @@ func TestContainerLogWithErrClosed(t *testing.T) {
 
 	provider := &DockerProvider{
 		client: client,
-		config: ReadConfigWithContext(ctx),
+		config: ReadConfig(),
 		DockerProviderOptions: &DockerProviderOptions{
 			GenericProviderOptions: &GenericProviderOptions{
 				Logger: TestLogger(t),

--- a/provider.go
+++ b/provider.go
@@ -143,7 +143,7 @@ func NewDockerProvider(provOpts ...DockerProviderOption) (*DockerProvider, error
 		return nil, err
 	}
 
-	tcConfig := ReadConfigWithContext(context.Background())
+	tcConfig := ReadConfig()
 
 	dockerHost := testcontainersdocker.ExtractDockerHost(context.Background())
 


### PR DESCRIPTION

<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
It removes the Go context object from the ReadConfig call, as it's not used internally.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
It's not needed: we added it in an intermediate state of #1161

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes #1290

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
