### PR TITLE
fix: prefer cross-platform default DOCKER_HOST

### DIFF
--- a/internal/testcontainersdocker/docker_socket.go
+++ b/internal/testcontainersdocker/docker_socket.go
@@ -1,5 +1,12 @@
 package testcontainersdocker
 
+import (
+	"net/url"
+	"strings"
+
+	"github.com/docker/docker/client"
+)
+
 // DockerSocketSchema is the unix schema.
 var DockerSocketSchema = "unix://"
 
@@ -11,3 +18,29 @@ var DockerSocketPathWithSchema = DockerSocketSchema + DockerSocketPath
 
 // TCPSchema is the tcp schema.
 var TCPSchema = "tcp://"
+
+func init() {
+	const DefaultDockerHost = client.DefaultDockerHost
+
+	u, err := url.Parse(DefaultDockerHost)
+	if err != nil {
+		// unsupported default host specified by the docker client package,
+		// so revert to the default unix docker socket path
+		return
+	}
+
+	switch u.Scheme {
+	case "unix", "npipe":
+		DockerSocketSchema = u.Scheme + "://"
+		DockerSocketPath = u.Path
+		if !strings.HasPrefix(DockerSocketPath, "/") {
+			// seeing as the code in this module depends on DockerSocketPath having
+			// a slash (`/`) prefix, we add it here if it is missing.
+			// for the known environments, we do not foresee how the socket-path
+			// should miss the slash, however this extra if-condition is worth to
+			// save future pain from innocent users.
+			DockerSocketPath = "/" + DockerSocketPath
+		}
+		DockerSocketPathWithSchema = DockerSocketSchema + DockerSocketPath
+	}
+}


### PR DESCRIPTION
Instead of blindly assuming a Linux operating system we can rely on the docker client package to tell us the appropriate default docker host.

## What does this PR do?

I've changed the default `DOCKER_HOST` socket from its Linux value by relying on Docker's client library to supply their cross-platform values.

I chose to parse their value as a URL (I say `parseURL` doing the same) to separate between the schema and the path.

I was defensive because I am unfamiliar with the codebase - that's the reason for the suffix/prefix validations. Also, upon errors (url parsing, or unknown schema) I fallback to the predefined default rendering the changes of this PR a no-op.

## Why is it important?

Windows users really want to use test-containers too! 🪟🐳 

Before release `v0.20.1` the host was not explicitly set to a default, hence it fell-back to the docker library's default anyways.

## Related issues

- Closes #1249 

## How to test this PR

I haven't been able to run all the tests because I currently use a Windows machine. However, I ran some container-based tests (that broke with release `v0.20.1`) on my machine and they have passed 🤗 
