### PR TITLE
Fix locations set to None in sitemap

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,4 +1,5 @@
 site_name: Testcontainers for Go
+site_url: https://golang.testcontainers.org
 plugins:
     - search
     - codeinclude


### PR DESCRIPTION
## What does this do
Fix a bug with the documentation generating a sitemap with `<loc>None</loc>` seamingly caused by not having `site_url` set in the mkdocs config.

e.g. 
```xml
<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
  <url>
    <loc>None</loc>
    <lastmod>2023-06-15</lastmod>
    <changefreq>daily</changefreq>
  </url>
  ...
</urlset>
```

## Why is this important
Search engines and other tools use the sitemap, presenting correct information is important for discoverability of the documentation.