### PR TITLE
feat: provide container logs on container startup failures

### DIFF
--- a/docker.go
+++ b/docker.go
@@ -193,22 +193,10 @@ func (c *DockerContainer) Start(ctx context.Context) error {
 		return err
 	}
 
-	shortID := c.ID[:12]
-
 	if err := c.provider.client.ContainerStart(ctx, c.ID, types.ContainerStartOptions{}); err != nil {
 		return err
 	}
 	defer c.provider.Close()
-
-	// if a Wait Strategy has been specified, wait before returning
-	if c.WaitingFor != nil {
-		c.logger.Printf("🚧 Waiting for container id %s image: %s", shortID, c.Image)
-		if err := c.WaitingFor.WaitUntilReady(ctx, c); err != nil {
-			return err
-		}
-	}
-
-	c.isRunning = true
 
 	err = c.startedHook(ctx)
 	if err != nil {
@@ -1026,6 +1014,24 @@ func (p *DockerProvider) CreateContainer(ctx context.Context, req ContainerReque
 							return fmt.Errorf("can't copy %s to container: %w", f.HostFilePath, err)
 						}
 					}
+
+					return nil
+				},
+			},
+			PostStarts: []ContainerHook{
+				// first post-start hook is to wait for the container to be ready
+				func(ctx context.Context, c Container) error {
+					dockerContainer := c.(*DockerContainer)
+
+					// if a Wait Strategy has been specified, wait before returning
+					if dockerContainer.WaitingFor != nil {
+						dockerContainer.logger.Printf("🚧 Waiting for container id %s image: %s", dockerContainer.ID[:12], dockerContainer.Image)
+						if err := dockerContainer.WaitingFor.WaitUntilReady(ctx, c); err != nil {
+							return err
+						}
+					}
+
+					dockerContainer.isRunning = true
 
 					return nil
 				},

--- a/docker.go
+++ b/docker.go
@@ -1025,7 +1025,10 @@ func (p *DockerProvider) CreateContainer(ctx context.Context, req ContainerReque
 
 					// if a Wait Strategy has been specified, wait before returning
 					if dockerContainer.WaitingFor != nil {
-						dockerContainer.logger.Printf("🚧 Waiting for container id %s image: %s", dockerContainer.ID[:12], dockerContainer.Image)
+						dockerContainer.logger.Printf(
+							"🚧 Waiting for container id %s image: %s. Waiting for: %+v",
+							dockerContainer.ID[:12], dockerContainer.Image, dockerContainer.WaitingFor,
+						)
 						if err := dockerContainer.WaitingFor.WaitUntilReady(ctx, c); err != nil {
 							return err
 						}


### PR DESCRIPTION
- chore: move waitFor to the default container hooks
- chore: print wait for values in the log
- feat: add container logs when the starting/started hooks of the container fails

<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
This PR adds 3 things:

1. it extract the logic to start the wait strategies from the Start container method to the default life cycle hooks, as the first PostStart function.

2. it adds the string representation of the wait strategy struct to the log, using the `%+v` formatter, which will add fields and values. I'm doing it in this manner for simplicity: to avoid adding a String method to all the wait strategies, with custom output message. But I'm OK if we want to do that in this PR or in a follow up one.

> 2023/06/20 08:43:28 🚧 Waiting for container id bc42707acea8 image: fcd1ad29-af53-4055-9143-1b36c4fdea43:a13d99be-4bf6-4df3-adb9-08d78baacba7. Waiting for: &{timeout:<nil> Log:Ready to accept connections!!!! Occurrence:1 PollInterval:100ms}

3. it adds a private method to the DockerContainer struct to print out its container's logs. It will use the defined logger for the container, as set in the GenericContainerRequest struct. This is important as we are adding a test to demonstrate this behaviour, and in it we are adding a test-logger that stores the logs in an array of strings, therefore we are able to test that the logger is receiving the container logs. 

The `c.printLogs` method will be called on any failure occurring at both the Starting and Started hooks: we have access to the container here, so we can get its logs.

```
2023/06/20 08:43:28 container logs:
        1:C 20 Jun 2023 06:43:28.010 # oO0OoO0OoO0Oo Redis is starting oO0OoO0OoO0Oo
        1:C 20 Jun 2023 06:43:28.010 # Redis version=5.0.14, bits=64, commit=00000000, modified=0, pid=1, just started
        1:C 20 Jun 2023 06:43:28.010 # Warning: no config file specified, using the default config. In order to specify a config file use redis-server /path/to/redis.conf
        1:M 20 Jun 2023 06:43:28.011 * Running mode=standalone, port=6379.
        1:M 20 Jun 2023 06:43:28.011 # Server initialized
        1:M 20 Jun 2023 06:43:28.011 # WARNING you have Transparent Huge Pages (THP) support enabled in your kernel. This will create latency and memory usage issues with Redis. To fix this issue run the command 'echo never > /sys/kernel/mm/transparent_hugepage/enabled' as root, and add it to your /etc/rc.local in order to retain the setting after a reboot. Redis must be restarted after THP is disabled.
        1:M 20 Jun 2023 06:43:28.012 * Ready to accept connections
```

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
Many times the container fails the wait strategy and the user does not have feedback on why. Printing the logs will help them troubleshoot any error at that time.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes #1280 

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


## Follow-ups
We could implement the Stringer interface in all the existing wait strategies, adding custom and explicit info for each. Nowadays, with the current proposal, the pointer types will be printed as their memory representation (e.g. timeout, which TBH I do not know why it's a pointer)

Another follow-up would be adding the print container logs on the rest of hooks where we have access to a running container: stopping/stopped/terminating/terminated 🤔 . I can do it in this PR if needed