### PR TITLE
fix: check that no new logs have been output

### DIFF
--- a/container_test.go
+++ b/container_test.go
@@ -298,7 +298,7 @@ func Test_GetLogsFromFailedContainer(t *testing.T) {
 		Started:          true,
 	})
 
-	if err != nil && !errors.Is(err, context.DeadlineExceeded) {
+	if err != nil && err.Error() != "container exited with code 0: failed to start container" {
 		t.Fatal(err)
 	} else if err == nil {
 		terminateContainerOnEnd(t, ctx, c)

--- a/wait/log.go
+++ b/wait/log.go
@@ -81,6 +81,8 @@ func (ws *LogStrategy) WaitUntilReady(ctx context.Context, target StrategyTarget
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
+	length := 0
+
 LOOP:
 	for {
 		select {
@@ -102,11 +104,12 @@ LOOP:
 			}
 
 			logs := string(b)
-			if logs == "" && checkErr != nil {
+			if length == len(logs) && checkErr != nil {
 				return checkErr
 			} else if strings.Count(logs, ws.Log) >= ws.Occurrence {
 				break LOOP
 			} else {
+				length = len(logs)
 				time.Sleep(ws.PollInterval)
 				continue
 			}


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

This PR fixes the check that the container is not emitting new logs (please refer [this comment](https://github.com/testcontainers/testcontainers-go/pull/944#discussion_r1143430320)).

[`logs` variable](https://github.com/testcontainers/testcontainers-go/blob/c0e1c32cc709ea176d6ba0ebf7b53421df2f86e7/wait/log.go#L104) contains all logs after container start, so it can never be an empty string. Therefore, comparisons with empty strings are meaningless.
Instead, it is verified that the length of the logs has not changed since the last check in this PR.

This fix broke `Test_GetLogsFromFailedContainer`, so I fixed it too.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

When the container stop, LogStrategy should fail-fast, but it doesn't.
This PR will fix it.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes #1302

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
