### PR TITLE
feat(redpanda): Add option to enable topic auto-creation

### DIFF
--- a/modules/redpanda/mounts/bootstrap.yaml.tpl
+++ b/modules/redpanda/mounts/bootstrap.yaml.tpl
@@ -14,3 +14,7 @@ superusers:
 {{- if .KafkaAPIEnableAuthorization }}
 kafka_enable_authorization: true
 {{- end }}
+
+{{- if .AutoCreateTopics }}
+auto_create_topics_enabled: true
+{{- end }}

--- a/modules/redpanda/mounts/redpanda.yaml.tpl
+++ b/modules/redpanda/mounts/redpanda.yaml.tpl
@@ -38,3 +38,5 @@ schema_registry_client:
   brokers:
     - address: localhost
       port: 9093
+
+auto_create_topics_enabled: {{ .AutoCreateTopics }}

--- a/modules/redpanda/options.go
+++ b/modules/redpanda/options.go
@@ -23,6 +23,9 @@ type options struct {
 	// You must use SCRAM-SHA-256 as algorithm when authenticating on the
 	// Kafka API.
 	ServiceAccounts map[string]string
+
+	// AutoCreateTopics is a flag to allow topic auto creation.
+	AutoCreateTopics bool
 }
 
 func defaultOptions() options {
@@ -32,6 +35,7 @@ func defaultOptions() options {
 		KafkaAuthenticationMethod:          "none",
 		SchemaRegistryAuthenticationMethod: "none",
 		ServiceAccounts:                    make(map[string]string, 0),
+		AutoCreateTopics:                   false,
 	}
 }
 
@@ -80,5 +84,12 @@ func WithEnableKafkaAuthorization() Option {
 func WithEnableSchemaRegistryHTTPBasicAuth() Option {
 	return func(o *options) {
 		o.SchemaRegistryAuthenticationMethod = "http_basic"
+	}
+}
+
+// WithAutoCreateTopics enables topic auto creation.
+func WithAutoCreateTopics() Option {
+	return func(o *options) {
+		o.AutoCreateTopics = true
 	}
 }

--- a/modules/redpanda/redpanda.go
+++ b/modules/redpanda/redpanda.go
@@ -229,6 +229,7 @@ func createBootstrapConfigFile(settings options) (*os.File, error) {
 	bootstrapTplParams := redpandaBootstrapConfigTplParams{
 		Superusers:                  settings.Superusers,
 		KafkaAPIEnableAuthorization: settings.KafkaEnableAuthorization,
+		AutoCreateTopics:            settings.AutoCreateTopics,
 	}
 
 	tpl, err := template.New("bootstrap.yaml").Parse(bootstrapConfigTpl)
@@ -257,6 +258,7 @@ func createBootstrapConfigFile(settings options) (*os.File, error) {
 // byte array.
 func renderNodeConfig(settings options, hostIP string, advertisedKafkaPort int) ([]byte, error) {
 	tplParams := redpandaConfigTplParams{
+		AutoCreateTopics: settings.AutoCreateTopics,
 		KafkaAPI: redpandaConfigTplParamsKafkaAPI{
 			AdvertisedHost:       hostIP,
 			AdvertisedPort:       advertisedKafkaPort,
@@ -284,11 +286,13 @@ func renderNodeConfig(settings options, hostIP string, advertisedKafkaPort int) 
 type redpandaBootstrapConfigTplParams struct {
 	Superusers                  []string
 	KafkaAPIEnableAuthorization bool
+	AutoCreateTopics            bool
 }
 
 type redpandaConfigTplParams struct {
-	KafkaAPI       redpandaConfigTplParamsKafkaAPI
-	SchemaRegistry redpandaConfigTplParamsSchemaRegistry
+	KafkaAPI         redpandaConfigTplParamsKafkaAPI
+	SchemaRegistry   redpandaConfigTplParamsSchemaRegistry
+	AutoCreateTopics bool
 }
 
 type redpandaConfigTplParamsKafkaAPI struct {

--- a/modules/redpanda/redpanda_test.go
+++ b/modules/redpanda/redpanda_test.go
@@ -36,6 +36,7 @@ func TestRedpanda(t *testing.T) {
 		kgo.SeedBrokers(seedBroker),
 	)
 	require.NoError(t, err)
+	defer kafkaCl.Close()
 
 	kafkaAdmCl := kadm.NewClient(kafkaCl)
 	metadata, err := kafkaAdmCl.Metadata(ctx)

--- a/modules/redpanda/redpanda_test.go
+++ b/modules/redpanda/redpanda_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/twmb/franz-go/pkg/kadm"
+	"github.com/twmb/franz-go/pkg/kerr"
 	"github.com/twmb/franz-go/pkg/kgo"
 	"github.com/twmb/franz-go/pkg/sasl/scram"
 )
@@ -63,6 +64,10 @@ func TestRedpanda(t *testing.T) {
 	require.NoError(t, err)
 	defer resp.Body.Close()
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	// Test produce to unknown topic
+	results := kafkaCl.ProduceSync(ctx, &kgo.Record{Topic: "test", Value: []byte("test message")})
+	require.Error(t, results.FirstErr(), kerr.UnknownTopicOrPartition)
 }
 
 func TestRedpandaWithAuthentication(t *testing.T) {
@@ -172,4 +177,30 @@ func TestRedpandaWithAuthentication(t *testing.T) {
 		assert.Equal(t, http.StatusOK, resp.StatusCode)
 		resp.Body.Close()
 	}
+}
+
+func TestRedpandaProduceWithAutoCreateTopics(t *testing.T) {
+	ctx := context.Background()
+
+	container, err := RunContainer(ctx, WithAutoCreateTopics())
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		if err := container.Terminate(ctx); err != nil {
+			t.Fatalf("failed to terminate container: %s", err)
+		}
+	})
+
+	brokers, err := container.KafkaSeedBroker(ctx)
+	require.NoError(t, err)
+
+	kafkaCl, err := kgo.NewClient(
+		kgo.SeedBrokers(brokers),
+		kgo.AllowAutoTopicCreation(),
+	)
+	require.NoError(t, err)
+	defer kafkaCl.Close()
+
+	results := kafkaCl.ProduceSync(ctx, &kgo.Record{Topic: "test", Value: []byte("test message")})
+	require.NoError(t, results.FirstErr())
 }


### PR DESCRIPTION
## What does this PR do?

Adds an option to enable topic auto-creation

## Why is it important?

The option to enable automatic topic creation is particularly useful for testing environments, allowing users to produce data into topics without the need to create them beforehand.