### PR TITLE
fix: upgrade docker client

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/cenkalti/backoff/v4 v4.2.0
 	github.com/containerd/containerd v1.6.19
 	github.com/cpuguy83/dockercfg v0.3.1
-	github.com/docker/docker v23.0.5+incompatible
+	github.com/docker/docker v23.0.7-0.20230718082441-f860ed7c77fc+incompatible
 	github.com/docker/go-connections v0.4.0
 	github.com/docker/go-units v0.5.0
 	github.com/google/uuid v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -36,8 +36,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/docker/distribution v2.8.2+incompatible h1:T3de5rq0dB1j30rp0sA2rER+m322EBzniBPB6ZIzuh8=
 github.com/docker/distribution v2.8.2+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
-github.com/docker/docker v23.0.5+incompatible h1:DaxtlTJjFSnLOXVNUBU1+6kXGz2lpDoEAH6QoxaSg8k=
-github.com/docker/docker v23.0.5+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
+github.com/docker/docker v23.0.7-0.20230718082441-f860ed7c77fc+incompatible h1:xG9WqOTGc9b5ifAkzuCQbuJ/akwZixdWA7IQtow3Ksk=
+github.com/docker/docker v23.0.7-0.20230718082441-f860ed7c77fc+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/go-connections v0.4.0 h1:El9xVISelRB7BuFusrZozjnkIM5YnzCViNKohAFqRJQ=
 github.com/docker/go-connections v0.4.0/go.mod h1:Gbd7IOopHjR8Iph03tsViu4nIes5XhDvyHbTtUxmeec=
 github.com/docker/go-units v0.4.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=


### PR DESCRIPTION
## What does this PR do?

Upgrades the `github.com/docker/docker` package.

~~The `AuthConfig` type was moved: https://github.com/moby/moby/pull/43885.~~ 👈 not relevant since I'm not upgrading to v24 anymore, but rather use the backported fix on v23.

Possibly https://github.com/testcontainers/moby-ryuk must be upgraded as well. 

## Why is it important?

You cannot use `testcontainers-go` with Go 1.20.6 currently, this PR should fix that.

## Related issues

- Closes #1359
