### PR TITLE
Allowing building a target in multi-stage build

### DIFF
--- a/container.go
+++ b/container.go
@@ -65,6 +65,7 @@ type ImageBuildInfo interface {
 	ShouldBuildImage() bool                      // return true if the image needs to be built
 	GetBuildArgs() map[string]*string            // return the environment args used to build the from Dockerfile
 	GetAuthConfigs() map[string]types.AuthConfig // return the auth configs to be able to pull from an authenticated docker registry
+	GetTarget() string
 }
 
 // FromDockerfile represents the parameters needed to build an image from a Dockerfile
@@ -121,6 +122,7 @@ type ContainerRequest struct {
 	HostConfigModifier      func(*container.HostConfig)                // Modifier for the host config before container creation
 	EnpointSettingsModifier func(map[string]*network.EndpointSettings) // Modifier for the network settings before container creation
 	LifecycleHooks          []ContainerLifecycleHooks                  // define hooks to be executed during container lifecycle
+	Target                  string                                     // the build target to stop at for multi-stage builds
 }
 
 // containerOptions functional options for a container
@@ -165,6 +167,10 @@ func (c *ContainerRequest) Validate() error {
 	}
 
 	return nil
+}
+
+func (c *ContainerRequest) GetTarget() string {
+	return c.Target
 }
 
 // GetContext retrieve the build context for the request

--- a/docker.go
+++ b/docker.go
@@ -798,6 +798,7 @@ func (p *DockerProvider) BuildImage(ctx context.Context, img ImageBuildInfo) (st
 		BuildArgs:   img.GetBuildArgs(),
 		Dockerfile:  img.GetDockerfile(),
 		AuthConfigs: img.GetAuthConfigs(),
+		Target:      img.GetTarget(),
 		Context:     buildContext,
 		Tags:        []string{repoTag},
 		Remove:      true,

--- a/testdata/multi-stage.Dockerfile
+++ b/testdata/multi-stage.Dockerfile
@@ -1,0 +1,7 @@
+FROM docker.io/alpine AS first_stage
+
+CMD 'echo first stage'
+
+FROM first_stage AS second_stage
+
+CMD 'echo second stage'


### PR DESCRIPTION
if a Dockerfile specifies build stages, allow the user to set the target build stage in ContainerRequest

<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

This PR allows a user to specify [a target to stop at during multi-stage builds](https://docs.docker.com/build/building/multi-stage/#stop-at-a-specific-build-stage)

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

There are cases where people will want to run tests a container built and stopped at a specific stage. (ex. perhaps later stages remove test dependencies)

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->

I apologize, I didn't base this on an issue, I thought it would be quickest just to take care of it.  I didn't think it would be controversial.  I am happy to change if needed.

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
