### PR TITLE
test: fix TestGetDockerConfig

### DIFF
--- a/docker_auth_test.go
+++ b/docker_auth_test.go
@@ -22,33 +22,23 @@ var testDockerConfigDirPath = filepath.Join("testdata", ".docker")
 
 var indexDockerIO = testcontainersdocker.IndexDockerIO
 
-var originalDockerAuthConfig string
-
-func init() {
-	originalDockerAuthConfig = os.Getenv("DOCKER_AUTH_CONFIG")
-}
-
 func TestGetDockerConfig(t *testing.T) {
 	const expectedErrorMessage = "Expected to find %s in auth configs"
 
 	// Verify that the default docker config file exists before any test in this suite runs.
 	// Then, we can safely run the tests that rely on it.
-	cfg, err := dockercfg.LoadDefaultConfig()
+	defaultCfg, err := dockercfg.LoadDefaultConfig()
 	require.Nil(t, err)
-	require.NotNil(t, cfg)
+	require.NotNil(t, defaultCfg)
 
 	t.Run("without DOCKER_CONFIG env var retrieves default", func(t *testing.T) {
+		t.Setenv("DOCKER_CONFIG", "")
+
 		cfg, err := getDockerConfig()
 		require.Nil(t, err)
 		require.NotNil(t, cfg)
 
-		assert.Greater(t, len(cfg.AuthConfigs), 0)
-
-		authCfgs := cfg.AuthConfigs
-
-		if _, ok := authCfgs[indexDockerIO]; !ok {
-			t.Errorf(expectedErrorMessage, indexDockerIO)
-		}
+		assert.Equal(t, defaultCfg, cfg)
 	})
 
 	t.Run("with DOCKER_CONFIG env var pointing to a non-existing file raises error", func(t *testing.T) {
@@ -82,10 +72,6 @@ func TestGetDockerConfig(t *testing.T) {
 	})
 
 	t.Run("DOCKER_AUTH_CONFIG env var takes precedence", func(t *testing.T) {
-		t.Cleanup(func() {
-			os.Setenv("DOCKER_AUTH_CONFIG", originalDockerAuthConfig)
-		})
-
 		t.Setenv("DOCKER_AUTH_CONFIG", `{
 			"auths": {
 					"`+exampleAuth+`": {}
@@ -111,10 +97,6 @@ func TestGetDockerConfig(t *testing.T) {
 	})
 
 	t.Run("retrieve auth with DOCKER_AUTH_CONFIG env var", func(t *testing.T) {
-		t.Cleanup(func() {
-			os.Setenv("DOCKER_AUTH_CONFIG", originalDockerAuthConfig)
-		})
-
 		base64 := "Z29waGVyOnNlY3JldA==" // gopher:secret
 
 		t.Setenv("DOCKER_AUTH_CONFIG", `{
@@ -170,10 +152,6 @@ func removeImageFromLocalCache(t *testing.T, image string) {
 }
 
 func TestBuildContainerFromDockerfileWithDockerAuthConfig(t *testing.T) {
-	t.Cleanup(func() {
-		os.Setenv("DOCKER_AUTH_CONFIG", originalDockerAuthConfig)
-	})
-
 	// using the same credentials as in the Docker Registry
 	base64 := "dGVzdHVzZXI6dGVzdHBhc3N3b3Jk" // testuser:testpassword
 	t.Setenv("DOCKER_AUTH_CONFIG", `{
@@ -203,10 +181,6 @@ func TestBuildContainerFromDockerfileWithDockerAuthConfig(t *testing.T) {
 }
 
 func TestBuildContainerFromDockerfileShouldFailWithWrongDockerAuthConfig(t *testing.T) {
-	t.Cleanup(func() {
-		os.Setenv("DOCKER_AUTH_CONFIG", originalDockerAuthConfig)
-	})
-
 	// using different credentials than in the Docker Registry
 	base64 := "Zm9vOmJhcg==" // foo:bar
 	t.Setenv("DOCKER_AUTH_CONFIG", `{
@@ -236,11 +210,6 @@ func TestBuildContainerFromDockerfileShouldFailWithWrongDockerAuthConfig(t *test
 }
 
 func TestCreateContainerFromPrivateRegistry(t *testing.T) {
-	t.Cleanup(func() {
-		os.Setenv("DOCKER_AUTH_CONFIG", originalDockerAuthConfig)
-	})
-	os.Unsetenv("DOCKER_AUTH_CONFIG")
-
 	// using the same credentials as in the Docker Registry
 	base64 := "dGVzdHVzZXI6dGVzdHBhc3N3b3Jk" // testuser:testpassword
 	t.Setenv("DOCKER_AUTH_CONFIG", `{


### PR DESCRIPTION
## What does this PR do?

Do not assume non-empty auths section in local config file but test that getDockerConfig returns default config when DOCKER_CONFIG env variable is not set.

Also remove t.Cleanup calls that restore env variables because t.Setenv restores them itself.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->
Fixes failing test that depends on local environment.

## Related issues

- Relates #1394

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
