### PR TITLE
chore(ci): set LongPathsEnabled on WIndows workers

### DIFF
--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -25,6 +25,11 @@ jobs:
               context: 'Windows tests',
             })
 
+      - name: Set LongPathsEnabled using Powershell
+        shell: pwsh
+        run: |
+          Set-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Control\FileSystem' -Name 'LongPathsEnabled' -Value 1
+
       - name: Checkout
         uses: actions/checkout@v3
         with:


### PR DESCRIPTION

<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
It executes a Powershell command on the Windows worker to enable long paths.

This is a temporary fix until the target machine have it as a built-in

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
The git checkout fails and we think this is the most plausible solution

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Continues #1375

## How to test this PR

In a PR, i.e. this one, add the `/windows-test` GH comment so that the Windows workflow gets triggered.

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
