### PR TITLE
docs: fix link to GH action in docs site

### DIFF
--- a/docs/system_requirements/index.md
+++ b/docs/system_requirements/index.md
@@ -4,4 +4,4 @@ From the [Go Release Policy](https://go.dev/doc/devel/release#policy):
 
 > Each major Go release is supported until there are two newer major releases. For example, Go 1.5 was supported until the Go 1.7 release, and Go 1.6 was supported until the Go 1.8 release. We fix critical problems, including critical security problems, in supported releases as needed by issuing minor revisions (for example, Go 1.6.1, Go 1.6.2, and so on).
 
-_Testcontainers for Go_ is tested against those two latest Go releases, therefore we recommend using any of them. You could check what versions are actually supported by looking at the [GitHub Action](../../.github/workflows/ci.yml) configuration, under the `test.strategy.matrix.go-version` key.
+_Testcontainers for Go_ is tested against those two latest Go releases, therefore we recommend using any of them. You could check what versions are actually supported by looking at the [GitHub Action](https://github.com/testcontainers/testcontainers-go/blob/main/.github/workflows/ci.yml) configuration, under the `test.strategy.matrix.go-version` key.


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
It updates the link to the GH action in the docs site, replacing a relative URL (relative to the website, not the sourcecode) with the full URL of the Github action in the Github repository.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
The link was broken in the docs site, causing a bad experience on users.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes #1369

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
