### PR TITLE
chore(deps): bump Github actions

### DIFF
--- a/.github/workflows/ci-test-go.yml
+++ b/.github/workflows/ci-test-go.yml
@@ -80,7 +80,7 @@ jobs:
             ./scripts/check_environment.sh
 
       - name: Test Summary
-        uses: test-summary/action@4ee9ece4bca777a38f05c8fc578ac2007fe266f7
+        uses: test-summary/action@62bc5c68de2a6a0d02039763b8c754569df99e3f
         with:
             paths: "**/${{ inputs.project-directory }}/TEST-unit*.xml"
         if: always()

--- a/.github/workflows/ci-test-go.yml
+++ b/.github/workflows/ci-test-go.yml
@@ -44,7 +44,7 @@ jobs:
         run: sudo rm -rf /var/run/docker.sock
 
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
             go-version: ${{ inputs.go-version }}
         id: go

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
     steps:
       - name: Create pending status
-        uses: actions/github-script@0.9.0
+        uses: actions/github-script@v6.4.1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -58,7 +58,7 @@ jobs:
           gotestsum --format short-verbose --rerun-fails=5 --packages="./..."  --junitfile TEST-unit.xml
 
       - name: Create success status
-        uses: actions/github-script@0.9.0
+        uses: actions/github-script@v6.4.1
         if: success()
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
@@ -73,7 +73,7 @@ jobs:
             })
 
       - name: Create failure status
-        uses: actions/github-script@0.9.0
+        uses: actions/github-script@v6.4.1
         if: failure()
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -38,7 +38,7 @@ jobs:
           ref: ${{ github.event.client_payload.pull_request.head.ref }}
 
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           go-version: 1.x
         id: go

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -20,7 +20,7 @@ jobs:
   static-analysis:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v4
         with:
           go-version: 1.19
       - uses: actions/checkout@v3


### PR DESCRIPTION
This PR combines the following PRs:

- chore(deps): bump test-summary/action from 2.0 to 2.1 (#1423) @app/dependabot
- chore(deps): bump actions/github-script from 0.9.0 to 6.4.1 (#1422) @app/dependabot
- chore(deps): bump actions/setup-go from 3 to 4 (#1421) @app/dependabot

## Related Issues:

- Closes #1423
- Closes #1422
- Closes #1421
