### PR TITLE
internal/testcontainersdocker: close unused client

### DIFF
--- a/internal/testcontainersdocker/docker_host.go
+++ b/internal/testcontainersdocker/docker_host.go
@@ -127,6 +127,7 @@ func extractDockerSocket(ctx context.Context) string {
 	if err != nil {
 		panic(err) // a Docker client is required to get the Docker info
 	}
+	defer cli.Close()
 
 	return extractDockerSocketFromClient(ctx, cli)
 }


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->
Closes unused docker client.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->
Docker client uses idle connections and if it is not closed it triggers goroutine leak detector.
I've created #1358 previously but while it is in discussion I propose to fix this obvious case which would also be enough for our project, see https://github.com/zalando/skipper/pull/2436

## Related issues

- Relates #1358


<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
