### PR TITLE
chore: run Windows tests on a Linux container

### DIFF
--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -10,6 +10,8 @@ jobs:
     runs-on: [self-hosted, Windows, X64]
     strategy:
       fail-fast: false
+    container:
+      image: alpine:3.18
     steps:
       - name: Create pending status
         uses: actions/github-script@0.9.0

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -12,6 +12,8 @@ jobs:
       fail-fast: false
     container:
       image: alpine:3.18
+      volumes:
+        - //var/run/docker.sock:/var/run/docker.sock
     steps:
       - name: Create pending status
         uses: actions/github-script@0.9.0


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
It runs all the GH steps in the GH workflow for windows in an Alpine container. See https://docs.github.com/en/actions/using-jobs/running-jobs-in-a-container#example-running-a-job-within-a-container

> Use jobs.<job_id>.container to create a container to run any steps in a job that don't already specify a container. If you have steps that use both script and container actions, the container actions will run as sibling containers on the same network with the same volume mounts.
>
> If you do not set a container, all steps will run directly on the host specified by runs-on unless a step refers to an action configured to run in a container.

```yaml
name: CI
on:
  push:
    branches: [ main ]
jobs:
  container-test-job:
    runs-on: ubuntu-latest
    container:
      image: node:14.16
      env:
        NODE_ENV: development
      ports:
        - 80
      volumes:
        - my_docker_volume:/volume_mount
      options: --cpus 1
    steps:
      - name: Check for dockerenv file
        run: (ls /.dockerenv && echo Found dockerenv) || (echo No dockerenv)
```

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
Thanks to WSL, it's possible to install Docker Desktop in the baremetal host, and for that reason we can run linux containers in the Windows machine. With that, the docker socket path will be resolved to npipe, which at this moment is the main goal that we have (Windows containers are not supported yet)

At the same time, because everything runs inside a container, the workspace will be empty, so that we should not be affected by previous runs on the same self-hosted (baremetal) machine.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->


<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


## Follow-ups
Other tc-lang repos consuming the Windows workers should use the same strategy. cc/ @eddumelendez @cristianrgreco @HofmeisterAn 