### PR TITLE
Simplify dependabot updates sorting

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,14 +8,14 @@ updates:
         day: sunday
       open-pull-requests-limit: 3
       rebase-strategy: disabled
-    - package-ecosystem: pip
+    - package-ecosystem: gomod
       directory: /
       schedule:
         interval: monthly
         day: sunday
       open-pull-requests-limit: 3
       rebase-strategy: disabled
-    - package-ecosystem: gomod
+    - package-ecosystem: pip
       directory: /
       schedule:
         interval: monthly

--- a/modulegen/dependabot.go
+++ b/modulegen/dependabot.go
@@ -63,7 +63,10 @@ func (u Updates) Len() int {
 // is not a transitive ordering when not-a-number (NaN) values are involved.
 // See Float64Slice.Less for a correct implementation for floating-point values.
 func (u Updates) Less(i, j int) bool {
-	return u[i].Directory < u[j].Directory
+	if u[i].Directory != u[j].Directory {
+		return u[i].Directory < u[j].Directory
+	}
+	return u[i].PackageEcosystem < u[j].PackageEcosystem
 }
 
 // Swap swaps the elements with indexes i and j.

--- a/modulegen/main.go
+++ b/modulegen/main.go
@@ -279,30 +279,8 @@ func generateDependabotUpdates(rootDir string, example Example) error {
 	if err != nil {
 		return err
 	}
-
-	dependabotExampleUpdates := dependabotConfig.Updates
-
-	// make sure GH actions, Pip and the core module are the three first elements in the list of examples
-	exampleUpdates := make(Updates, len(dependabotExampleUpdates)-3)
-	j := 0
-
-	for _, exampleUpdate := range dependabotExampleUpdates {
-		// filter out the root module
-		if exampleUpdate.PackageEcosystem == "gomod" && exampleUpdate.Directory != "/" {
-			exampleUpdates[j] = exampleUpdate
-			j++
-		}
-	}
-
-	exampleUpdates = append(exampleUpdates, NewUpdate(example))
-	sort.Sort(exampleUpdates)
-
-	// prepend the github actions, pip and main modules
-	firstUpdates := dependabotExampleUpdates[0:3]
-	exampleUpdates = append(firstUpdates, exampleUpdates...)
-
-	dependabotConfig.Updates = exampleUpdates
-
+	dependabotConfig.Updates = append(dependabotConfig.Updates, NewUpdate(example))
+	sort.Sort(dependabotConfig.Updates)
 	return writeDependabotConfig(rootDir, dependabotConfig)
 }
 

--- a/modulegen/main_test.go
+++ b/modulegen/main_test.go
@@ -403,11 +403,11 @@ func assertDependabotExamplesUpdates(t *testing.T, example Example, originalConf
 
 	// second item is the core module
 	assert.Equal(t, "/", examples[1].Directory, examples)
-	assert.Equal(t, "pip", examples[1].PackageEcosystem, "PackageEcosystem should be pip")
+	assert.Equal(t, "gomod", examples[1].PackageEcosystem, "PackageEcosystem should be gomod")
 
-	// third item is the core module
+	// third item is the pip module
 	assert.Equal(t, "/", examples[2].Directory, examples)
-	assert.Equal(t, "gomod", examples[2].PackageEcosystem, "PackageEcosystem should be gomod")
+	assert.Equal(t, "pip", examples[2].PackageEcosystem, "PackageEcosystem should be pip")
 }
 
 // assert content example file in the docs


### PR DESCRIPTION
Use the sorter capabilities to handle the sorting.
It uses the package-ecosystem and the directory. 
I know that the result is a bit different from the actual.