### PR TITLE
chore: increase timeout for go test and GH action steps

### DIFF
--- a/.github/workflows/ci-test-go.yml
+++ b/.github/workflows/ci-test-go.yml
@@ -71,6 +71,7 @@ jobs:
         # another, host mode is only available on Linux, and we have tests around that, do we skip them?
         if: ${{ inputs.platform == 'ubuntu-latest' }}
         working-directory: ./${{ inputs.project-directory }}
+        timeout-minutes: 30
         run: |
             go install gotest.tools/gotestsum@latest
             make test-unit

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -49,9 +49,10 @@ jobs:
         run: go build
 
       - name: go test
+        timeout-minutes: 30
         run: |
           go install gotest.tools/gotestsum@latest
-          gotestsum --format short-verbose --rerun-fails=5 --packages="./..."  --junitfile TEST-unit.xml
+          gotestsum --format short-verbose --rerun-fails=5 --packages="./..."  --junitfile TEST-unit.xml -- -timeout=30m
 
       - name: Create success status
         uses: actions/github-script@0.9.0

--- a/commons-test.mk
+++ b/commons-test.mk
@@ -10,7 +10,9 @@ test-%:
 		--format short-verbose \
 		--rerun-fails=5 \
 		--packages="./..." \
-		--junitfile TEST-$*.xml
+		--junitfile TEST-$*.xml \
+		-- \
+		-timeout=30m
 
 .PHONY: tools
 tools:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
It increases the max timeout for `go test` and for the GH action step that actually executes the tests.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
Avoid undesired max timeout reached, specially on Windows

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Continues #1474

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
