### PR TITLE
chore: Use generic db url for postgresql container

### DIFF
--- a/modules/postgres/postgres.go
+++ b/modules/postgres/postgres.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net"
 	"path/filepath"
+	"strings"
 
 	"github.com/testcontainers/testcontainers-go"
 )
@@ -36,14 +37,7 @@ func (c *PostgresContainer) ConnectionString(ctx context.Context, args ...string
 		return "", err
 	}
 
-	extraArgs := ""
-	if len(args) >= 1 {
-		extraArgs = args[0]
-	}
-	for _, arg := range args[1:] {
-		extraArgs += "&" + arg
-	}
-
+	extraArgs := strings.Join(args, "&")
 	connStr := fmt.Sprintf("postgres://%s:%s@%s/%s?%s", c.user, c.password, net.JoinHostPort(host, containerPort.Port()), c.dbName, extraArgs)
 	return connStr, nil
 }

--- a/modules/postgres/postgres_test.go
+++ b/modules/postgres/postgres_test.go
@@ -78,6 +78,11 @@ func TestPostgres(t *testing.T) {
 			assert.NoError(t, err)
 			// }
 
+			// Ensure connection string is using generic format
+			id, err := container.MappedPort(ctx, "5432/tcp")
+			assert.NoError(t, err)
+			assert.Equal(t, fmt.Sprintf("postgres://%s:%s@%s:%s/%s?sslmode=disable&application_name=test", user, password, "localhost", id.Port(), dbname), connStr)
+
 			// perform assertions
 			db, err := sql.Open("postgres", connStr)
 			assert.NoError(t, err)


### PR DESCRIPTION
## What does this PR do?

Use generic db url format with PG containers instead of PG specific one.


## Why is it important?

Before we where using the PG specific url format but most tools would expect the url on the generic one (i.e https://github.com/golang-migrate/migrate).

People could indeed write their own connString mapper but that would be unnecessary. (Ideally tools would not try to parse the url and instead just use the string but sometimes they might need to, thus using the generic format would work most of the times)