### PR TITLE
fix: run tests for module generator in all platforms

### DIFF
--- a/.github/workflows/ci-test-go.yml
+++ b/.github/workflows/ci-test-go.yml
@@ -22,6 +22,11 @@ on:
         type: boolean
         default: false
         description: "Run the test with rootless docker."
+      run-tests:
+        required: false
+        type: boolean
+        default: true
+        description: "Run the tests under conditions controlled by the caller workflow."
       ryuk-disabled:
         required: false
         type: boolean
@@ -69,7 +74,7 @@ jobs:
         # many (maybe, all?) images used can only be build on Linux, they don't have Windows in their manifest, and
         # we can't put Windows Server in "Linux Mode" in Github actions
         # another, host mode is only available on Linux, and we have tests around that, do we skip them?
-        if: ${{ inputs.platform == 'ubuntu-latest' }}
+        if: ${{ inputs.run-tests }}
         working-directory: ./${{ inputs.project-directory }}
         timeout-minutes: 30
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ jobs:
       platform: ${{ matrix.platform }}
       project-directory: "."
       rootless-docker: false
+      run-tests: ${{ matrix.platform == 'ubuntu-latest' }}
       ryuk-disabled: false
 
   # The job below is a copy of the job above, but with ryuk disabled.
@@ -44,6 +45,7 @@ jobs:
       platform: "ubuntu-latest"
       project-directory: "."
       rootless-docker: false
+      run-tests: true
       ryuk-disabled: true
 
   # The job below is a copy of the job above, but with Docker rootless.
@@ -61,6 +63,7 @@ jobs:
       platform: "ubuntu-latest"
       project-directory: "."
       rootless-docker: true
+      run-tests: true
       ryuk-disabled: false
 
   test-module-generator:
@@ -74,6 +77,7 @@ jobs:
       platform: ${{ matrix.platform }}
       project-directory: "modulegen"
       rootless-docker: false
+      run-tests: true
       ryuk-disabled: false
 
   test-modules:
@@ -92,6 +96,7 @@ jobs:
       platform: ${{ matrix.platform }}
       project-directory: modules/${{ matrix.module }}
       rootless-docker: false
+      run-tests: ${{ matrix.platform == 'ubuntu-latest' }}
       ryuk-disabled: false
 
   test-examples:
@@ -107,4 +112,5 @@ jobs:
       platform: ${{ matrix.platform }}
       project-directory: examples/${{ matrix.module }}
       rootless-docker: false
+      run-tests: ${{ matrix.platform == 'ubuntu-latest' }}
       ryuk-disabled: false

--- a/modulegen/main_test.go
+++ b/modulegen/main_test.go
@@ -418,7 +418,7 @@ func assertExampleDocContent(t *testing.T, example Example, exampleDocFile strin
 	lower := example.Lower()
 	title := example.Title()
 
-	data := strings.Split(string(content), "\n")
+	data := sanitiseContent(content)
 	assert.Equal(t, data[0], "# "+title)
 	assert.Equal(t, data[2], `Not available until the next release of testcontainers-go <a href="https://github.com/testcontainers/testcontainers-go"><span class="tc-version">:material-tag: main</span></a>`)
 	assert.Equal(t, data[4], "## Introduction")
@@ -442,7 +442,7 @@ func assertExampleTestContent(t *testing.T, example Example, exampleTestFile str
 	content, err := os.ReadFile(exampleTestFile)
 	assert.Nil(t, err)
 
-	data := strings.Split(string(content), "\n")
+	data := sanitiseContent(content)
 	assert.Equal(t, data[0], "package "+example.Lower())
 	assert.Equal(t, data[7], "func Test"+example.Title()+"(t *testing.T) {")
 	assert.Equal(t, data[10], "\tcontainer, err := RunContainer(ctx)")
@@ -458,7 +458,7 @@ func assertExampleContent(t *testing.T, example Example, exampleFile string) {
 	exampleName := example.Title()
 	entrypoint := example.Entrypoint()
 
-	data := strings.Split(string(content), "\n")
+	data := sanitiseContent(content)
 	assert.Equal(t, data[0], "package "+lower)
 	assert.Equal(t, data[8], "// "+containerName+" represents the "+exampleName+" container type used in the module")
 	assert.Equal(t, data[9], "type "+containerName+" struct {")
@@ -473,7 +473,7 @@ func assertExampleGithubWorkflowContent(t *testing.T, example Example, exampleWo
 	content, err := os.ReadFile(exampleWorkflowFile)
 	assert.Nil(t, err)
 
-	data := strings.Split(string(content), "\n")
+	data := sanitiseContent(content)
 
 	modulesList, err := getModulesOrExamplesAsString(true)
 	assert.Nil(t, err)
@@ -489,7 +489,7 @@ func assertGoModContent(t *testing.T, example Example, goModFile string) {
 	content, err := os.ReadFile(goModFile)
 	assert.Nil(t, err)
 
-	data := strings.Split(string(content), "\n")
+	data := sanitiseContent(content)
 	assert.Equal(t, "module github.com/testcontainers/testcontainers-go/"+example.ParentDir()+"/"+example.Lower(), data[0])
 	assert.Equal(t, "\tgithub.com/testcontainers/testcontainers-go "+example.TCVersion, data[5])
 }
@@ -499,7 +499,7 @@ func assertMakefileContent(t *testing.T, example Example, makefile string) {
 	content, err := os.ReadFile(makefile)
 	assert.Nil(t, err)
 
-	data := strings.Split(string(content), "\n")
+	data := sanitiseContent(content)
 	assert.Equal(t, data[4], "\t$(MAKE) test-"+example.Lower())
 }
 
@@ -532,4 +532,15 @@ func assertMkdocsExamplesNav(t *testing.T, example Example, originalConfig *MkDo
 
 	// first item is the index
 	assert.Equal(t, parentDir+"/index.md", examples[0], examples)
+}
+
+func sanitiseContent(bytes []byte) []string {
+	content := string(bytes)
+
+	// Windows uses \r\n for newlines, but we want to use \n
+	content = strings.ReplaceAll(content, "\r\n", "\n")
+
+	data := strings.Split(content, "\n")
+
+	return data
 }


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
This PR adds a new input parameter to the reusable workflow, in order to "run the tests" step. Is true, it will execute the step.

With this approach the caller decides whether the tests are run or not passing true/false in the new `run-tests` parameter. In general, they will pass a `true` value, but for the core library, where we want to run the tests only for Linux, we must check that the platform is `ubuntu-latest`, only.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
We noticed the value was hardcoded to run the tests only on Ubuntu, directly into the reusable workflow, but there are callers that need to run the tests on Mac and Windows too. For that reason we needed a way to tell the reusable workflow to skip the tests or to run them.
<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Completes #1478

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
