### PR TITLE
fix: reset config in tests

### DIFF
--- a/config_test.go
+++ b/config_test.go
@@ -17,6 +17,9 @@ func resetTestEnv(t *testing.T) {
 
 func TestReadConfig(t *testing.T) {
 	resetTestEnv(t)
+	t.Cleanup(func() {
+		config.Reset()
+	})
 
 	t.Run("Config is read just once", func(t *testing.T) {
 		t.Setenv("HOME", "")

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -26,6 +26,10 @@ func TestReadConfig(t *testing.T) {
 	resetTestEnv(t)
 
 	t.Run("Config is read just once", func(t *testing.T) {
+		t.Cleanup(func() {
+			Reset()
+		})
+
 		t.Setenv("HOME", "")
 		t.Setenv("USERPROFILE", "") // Windows support
 		t.Setenv("DOCKER_HOST", "")

--- a/logconsumer_test.go
+++ b/logconsumer_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/testcontainers/testcontainers-go/internal/config"
 	"github.com/testcontainers/testcontainers-go/wait"
 )
 
@@ -253,6 +254,10 @@ func Test_StartStop(t *testing.T) {
 }
 
 func TestContainerLogWithErrClosed(t *testing.T) {
+	t.Cleanup(func() {
+		config.Reset()
+	})
+
 	if providerType == ProviderPodman {
 		t.Skip("Docker-in-Docker does not work with rootless Podman")
 	}


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
It resets the config synchronisation (sync.Once) in order to not affect other tests.
<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
I found this issue as a side effect of debugging another thing, and it took me a couple of hours to understand that the testcontainers.properties file was empty because somebody in the test execution called the ReadConfig() method, initialising the `sync.Once` that protects from multiple reads of the config.

I noticed the HOME variable was empty when reading the Docker Host, os.UserHomeDir returned an error, and that led me to identify the config as the culprit. Following the rabbot hole I found there were two tests reading the config but not resetting the original state (only available for internal use of the library), and this PR fixes that.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->


<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
