### PR TITLE
fix: do not remove the file schema in docker.host property

### DIFF
--- a/internal/testcontainersdocker/docker_host.go
+++ b/internal/testcontainersdocker/docker_host.go
@@ -212,12 +212,7 @@ func dockerHostFromProperties(ctx context.Context) (string, error) {
 	cfg := config.Read()
 	socketPath := cfg.Host
 	if socketPath != "" {
-		parsed, err := parseURL(socketPath)
-		if err != nil {
-			return "", err
-		}
-
-		return parsed, nil
+		return socketPath, nil
 	}
 
 	return "", ErrDockerSocketNotSetInProperties

--- a/internal/testcontainersdocker/docker_host_test.go
+++ b/internal/testcontainersdocker/docker_host_test.go
@@ -400,7 +400,6 @@ func TestExtractDockerSocketFromClient(t *testing.T) {
 		content := "docker.host=" + DockerSocketSchema + "/this/is/a/sample.sock"
 		setupTestcontainersProperties(t, content)
 		setupDockerSocketNotFound(t)
-		setupRootlessNotFound(t)
 
 		t.Cleanup(resetSocketOverrideFn)
 

--- a/internal/testcontainersdocker/docker_host_test.go
+++ b/internal/testcontainersdocker/docker_host_test.go
@@ -107,6 +107,16 @@ func TestExtractDockerHost(t *testing.T) {
 		assert.Equal(t, "/this/is/a/sample.sock", host)
 	})
 
+	t.Run("Unix Docker Host is passed as docker.host", func(t *testing.T) {
+		content := "docker.host=" + DockerSocketSchema + "/this/is/a/sample.sock"
+
+		setupTestcontainersProperties(t, content)
+
+		host := extractDockerHost(context.Background())
+
+		assert.Equal(t, DockerSocketSchema+"/this/is/a/sample.sock", host)
+	})
+
 	t.Run("Default Docker socket", func(t *testing.T) {
 		setupRootlessNotFound(t)
 		tmpSocket := setupDockerSocket(t)
@@ -225,8 +235,8 @@ func TestExtractDockerHost(t *testing.T) {
 		})
 
 		t.Run("Docker host is defined in properties", func(t *testing.T) {
-			tmpSocket := "/this/is/a/sample.sock"
-			content := "docker.host=unix://" + tmpSocket
+			tmpSocket := "unix:///this/is/a/sample.sock"
+			content := "docker.host=" + tmpSocket
 
 			setupTestcontainersProperties(t, content)
 
@@ -382,6 +392,21 @@ func TestExtractDockerSocketFromClient(t *testing.T) {
 		t.Setenv("DOCKER_HOST", testRemoteHost)
 		socket = extractDockerSocketFromClient(ctx, mockCli{OS: "Ubuntu"})
 		assert.Equal(t, DockerSocketPath, socket)
+	})
+
+	t.Run("Unix Docker Socket is passed as docker.host property", func(t *testing.T) {
+		content := "docker.host=" + DockerSocketSchema + "/this/is/a/sample.sock"
+		setupTestcontainersProperties(t, content)
+
+		t.Cleanup(resetSocketOverrideFn)
+
+		ctx := context.Background()
+		os.Unsetenv("TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE")
+		os.Unsetenv("DOCKER_HOST")
+
+		socket := extractDockerSocketFromClient(ctx, mockCli{OS: "Ubuntu"})
+
+		assert.Equal(t, "/this/is/a/sample.sock", socket)
 	})
 }
 

--- a/internal/testcontainersdocker/docker_host_test.go
+++ b/internal/testcontainersdocker/docker_host_test.go
@@ -108,6 +108,8 @@ func TestExtractDockerHost(t *testing.T) {
 	})
 
 	t.Run("Unix Docker Host is passed as docker.host", func(t *testing.T) {
+		setupDockerSocketNotFound(t)
+		setupRootlessNotFound(t)
 		content := "docker.host=" + DockerSocketSchema + "/this/is/a/sample.sock"
 
 		setupTestcontainersProperties(t, content)
@@ -397,6 +399,8 @@ func TestExtractDockerSocketFromClient(t *testing.T) {
 	t.Run("Unix Docker Socket is passed as docker.host property", func(t *testing.T) {
 		content := "docker.host=" + DockerSocketSchema + "/this/is/a/sample.sock"
 		setupTestcontainersProperties(t, content)
+		setupDockerSocketNotFound(t)
+		setupRootlessNotFound(t)
 
 		t.Cleanup(resetSocketOverrideFn)
 


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
This PR removes the code to parse the docker host when it comes from the `docker.host` property in the testcontainers.properties file.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
It must behave as the DOCKER_HOST variable.
<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Resolves #1338

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
