### PR TITLE
chore(ci): enable code coverage on Sonarcloud

### DIFF
--- a/.github/workflows/ci-test-go.yml
+++ b/.github/workflows/ci-test-go.yml
@@ -109,7 +109,7 @@ jobs:
             make test-unit
             
       - name: Analyze with SonarCloud
-        if: ${{ github.ref_name == 'main' && inputs.run-tests && inputs.project-directory == '.' }}
+        if: ${{ github.ref_name == 'main' && github.repository_owner == 'testcontainers' && inputs.run-tests && inputs.project-directory == '.' }}
         uses: sonarsource/sonarcloud-github-action@master
         with:
           projectBaseDir: ${{ inputs.project-directory }}

--- a/.github/workflows/ci-test-go.yml
+++ b/.github/workflows/ci-test-go.yml
@@ -109,7 +109,7 @@ jobs:
             make test-unit
             
       - name: Analyze with SonarCloud
-        if: ${{ always() && inputs.run-tests && inputs.project-directory == '.' }}
+        if: ${{ github.ref_name == 'main' && inputs.run-tests && inputs.project-directory == '.' }}
         uses: sonarsource/sonarcloud-github-action@master
         with:
           projectBaseDir: ${{ inputs.project-directory }}

--- a/.github/workflows/ci-test-go.yml
+++ b/.github/workflows/ci-test-go.yml
@@ -107,6 +107,15 @@ jobs:
         run: |
             go install gotest.tools/gotestsum@latest
             make test-unit
+            
+      - name: Analyze with SonarCloud
+        if: ${{ always() && inputs.run-tests && inputs.project-directory == '.' }}
+        uses: sonarsource/sonarcloud-github-action@master
+        with:
+          projectBaseDir: ${{ inputs.project-directory }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
       - name: Run checker
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
         go-version: [1.20.x, 1.x]
         platform: [ubuntu-latest, macos-latest]
     uses: ./.github/workflows/ci-test-go.yml
+    secrets: inherit
     with:
       go-version: ${{ matrix.go-version }}
       fail-fast: true
@@ -51,6 +52,7 @@ jobs:
       matrix:
         go-version: [1.20.x, 1.x]
     uses: ./.github/workflows/ci-test-go.yml
+    secrets: inherit
     with:
       go-version: ${{ matrix.go-version }}
       fail-fast: true
@@ -72,6 +74,7 @@ jobs:
         go-version: [1.20.x, 1.x]
         platform: [ubuntu-latest]
     uses: ./.github/workflows/ci-test-go.yml
+    secrets: inherit
     with:
       go-version: ${{ matrix.go-version }}
       fail-fast: true
@@ -89,6 +92,7 @@ jobs:
         go-version: [1.20.x, 1.x]
         platform: [ubuntu-latest, macos-latest, windows-latest]
     uses: ./.github/workflows/ci-test-go.yml
+    secrets: inherit
     with:
       go-version: ${{ matrix.go-version }}
       fail-fast: true
@@ -108,6 +112,7 @@ jobs:
         platform: [ubuntu-latest, macos-latest]
         module: [artemis, clickhouse, compose, couchbase, elasticsearch, k3s, localstack, mariadb, mongodb, mysql, nats, neo4j, postgres, pulsar, redis, redpanda, vault]
     uses: ./.github/workflows/ci-test-go.yml
+    secrets: inherit
     with:
       go-version: ${{ matrix.go-version }}
       fail-fast: false
@@ -125,6 +130,7 @@ jobs:
       matrix:
         module: [bigtable, cockroachdb, consul, datastore, firestore, nginx, pubsub, spanner, toxiproxy]
     uses: ./.github/workflows/ci-test-go.yml
+    secrets: inherit
     with:
       go-version: "1.20.x"
       fail-fast: true

--- a/commons-test.mk
+++ b/commons-test.mk
@@ -12,7 +12,7 @@ test-%:
 		--packages="./..." \
 		--junitfile TEST-$*.xml \
 		-- \
-                -coverprofile=coverage.out ./... \
+                -coverprofile=coverage.out \
 		-timeout=30m
 
 .PHONY: tools

--- a/commons-test.mk
+++ b/commons-test.mk
@@ -12,6 +12,7 @@ test-%:
 		--packages="./..." \
 		--junitfile TEST-$*.xml \
 		-- \
+                -coverprofile=coverage.out ./... \
 		-timeout=30m
 
 .PHONY: tools

--- a/modulegen/_template/ci.yml.tmpl
+++ b/modulegen/_template/ci.yml.tmpl
@@ -31,6 +31,7 @@ jobs:
         go-version: [1.20.x, 1.x]
         platform: [ubuntu-latest, macos-latest]
     uses: ./.github/workflows/ci-test-go.yml
+    secrets: inherit
     with:
       go-version: {{ "${{ matrix.go-version }}" }}
       fail-fast: true
@@ -51,6 +52,7 @@ jobs:
       matrix:
         go-version: [1.20.x, 1.x]
     uses: ./.github/workflows/ci-test-go.yml
+    secrets: inherit
     with:
       go-version: {{ "${{ matrix.go-version }}" }}
       fail-fast: true
@@ -72,6 +74,7 @@ jobs:
         go-version: [1.20.x, 1.x]
         platform: [ubuntu-latest]
     uses: ./.github/workflows/ci-test-go.yml
+    secrets: inherit
     with:
       go-version: {{ "${{ matrix.go-version }}" }}
       fail-fast: true
@@ -89,6 +92,7 @@ jobs:
         go-version: [1.20.x, 1.x]
         platform: [ubuntu-latest, macos-latest, windows-latest]
     uses: ./.github/workflows/ci-test-go.yml
+    secrets: inherit
     with:
       go-version: {{ "${{ matrix.go-version }}" }}
       fail-fast: true
@@ -108,6 +112,7 @@ jobs:
         platform: [ubuntu-latest, macos-latest]
         module: [{{ .Modules }}]
     uses: ./.github/workflows/ci-test-go.yml
+    secrets: inherit
     with:
       go-version: {{ "${{ matrix.go-version }}" }}
       fail-fast: false
@@ -125,6 +130,7 @@ jobs:
       matrix:
         module: [{{ .Examples }}]
     uses: ./.github/workflows/ci-test-go.yml
+    secrets: inherit
     with:
       go-version: "1.20.x"
       fail-fast: true

--- a/modulegen/main_test.go
+++ b/modulegen/main_test.go
@@ -480,11 +480,11 @@ func assertModuleGithubWorkflowContent(t *testing.T, module context.Testcontaine
 
 	modulesList, err := ctx.GetModules()
 	assert.Nil(t, err)
-	assert.Equal(t, "        module: ["+strings.Join(modulesList, ", ")+"]", data[108])
+	assert.Equal(t, "        module: ["+strings.Join(modulesList, ", ")+"]", data[112])
 
 	examplesList, err := ctx.GetExamples()
 	assert.Nil(t, err)
-	assert.Equal(t, "        module: ["+strings.Join(examplesList, ", ")+"]", data[125])
+	assert.Equal(t, "        module: ["+strings.Join(examplesList, ", ")+"]", data[130])
 }
 
 // assert content go.mod

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,17 @@
+# Github organization linked to sonarcloud
+sonar.organization==testcontainers
+
+# Project key from sonarcloud dashboard for Github Action, otherwise pick a project key you like
+sonar.projectKey=testcontainers_testcontainers-go
+
+sonar.projectName=testcontainers-go
+sonar.projectVersion=v0.23.0
+
+sonar.sources=.
+sonar.exclusions=**/*_test.go,**/vendor/**,**/testdata/*
+
+sonar.tests=.
+sonar.test.inclusions=**/*_test.go
+sonar.test.exclusions=**/vendor/**
+sonar.go.tests.reportPaths=TEST-*.xml
+sonar.go.coverage.reportPaths=coverage.out


### PR DESCRIPTION
Hi @mdelapenya, 
It seems like sonar requires a SONAR_TOKEN secret, I tried to compare with testcontainers-donet and testcontainers-node that reports code coverage on their sonarcloud reports but I couldn’t find anything comparable as they are not using the sonarcloud action to upload their test results.
I tried to provide my own SONAR_TOKEN but it seems it not possible to use it in a fork repository. 
Any idea ? Or you prefer to keep things as it is now ? 