### PR TITLE
modulegen: create internal/make

### DIFF
--- a/modulegen/_template/Makefile.tmpl
+++ b/modulegen/_template/Makefile.tmpl
@@ -1,5 +1,5 @@
-{{ $lower := ToLower }}include ../../commons-test.mk
+include ../../commons-test.mk
 
 .PHONY: test
 test:
-	$(MAKE) test-{{ $lower }}
+	$(MAKE) test-{{ . }}

--- a/modulegen/dependabot.go
+++ b/modulegen/dependabot.go
@@ -1,0 +1,11 @@
+package main
+
+import (
+	"github.com/testcontainers/testcontainers-go/modulegen/internal/dependabot"
+)
+
+// update examples in dependabot
+func generateDependabotUpdates(ctx *Context, example Example) error {
+	directory := "/" + example.ParentDir() + "/" + example.Lower()
+	return dependabot.UpdateConfig(ctx.DependabotConfigFile(), directory, "gomod")
+}

--- a/modulegen/internal/make/main.go
+++ b/modulegen/internal/make/main.go
@@ -1,0 +1,17 @@
+package make
+
+import (
+	"path/filepath"
+	"text/template"
+
+	internal_template "github.com/testcontainers/testcontainers-go/modulegen/internal/template"
+)
+
+func Generate(exampleDir string, exampleName string) error {
+	name := "Makefile.tmpl"
+	t, err := template.New(name).ParseFiles(filepath.Join("_template", name))
+	if err != nil {
+		return err
+	}
+	return internal_template.Generate(t, filepath.Join(exampleDir, "Makefile"), name, exampleName)
+}

--- a/modulegen/main.go
+++ b/modulegen/main.go
@@ -6,18 +6,10 @@ import (
 	"html/template"
 	"os"
 	"path/filepath"
-	"regexp"
 	"strings"
-	"unicode"
-	"unicode/utf8"
 
-	"golang.org/x/text/cases"
-	"golang.org/x/text/language"
-
-	"github.com/testcontainers/testcontainers-go/modulegen/internal/dependabot"
 	"github.com/testcontainers/testcontainers-go/modulegen/internal/mkdocs"
 	"github.com/testcontainers/testcontainers-go/modulegen/internal/tools"
-	"github.com/testcontainers/testcontainers-go/modulegen/internal/workflow"
 )
 
 var (
@@ -27,89 +19,13 @@ var (
 	imageVar     string
 )
 
-var templates = []string{
-	"docs_example.md", "example_test.go", "example.go", "go.mod", "Makefile",
-}
+var templates = []string{"docs_example.md", "example_test.go", "example.go", "go.mod"}
 
 func init() {
 	flag.StringVar(&nameVar, "name", "", "Name of the example. Only alphabetical characters are allowed.")
 	flag.StringVar(&nameTitleVar, "title", "", "(Optional) Title of the example name, used to override the name in the case of mixed casing (Mongodb -> MongoDB). Use camel-case when needed. Only alphabetical characters are allowed.")
 	flag.StringVar(&imageVar, "image", "", "Fully-qualified name of the Docker image to be used by the example")
 	flag.BoolVar(&asModuleVar, "as-module", false, "If set, the example will be generated as a Go module, under the modules directory. Otherwise, it will be generated as a subdirectory of the examples directory.")
-}
-
-type Example struct {
-	Image     string // fully qualified name of the Docker image
-	IsModule  bool   // if true, the example will be generated as a Go module
-	Name      string
-	TitleName string // title of the name: e.g. "mongodb" -> "MongoDB"
-	TCVersion string // Testcontainers for Go version
-}
-
-// ContainerName returns the name of the container, which is the lower-cased title of the example
-// If the title is set, it will be used instead of the name
-func (e *Example) ContainerName() string {
-	name := e.Lower()
-
-	if e.IsModule {
-		name = e.Title()
-	} else {
-		if e.TitleName != "" {
-			r, n := utf8.DecodeRuneInString(e.TitleName)
-			name = string(unicode.ToLower(r)) + e.TitleName[n:]
-		}
-	}
-
-	return name + "Container"
-}
-
-// Entrypoint returns the name of the entrypoint function, which is the lower-cased title of the example
-// If the example is a module, the entrypoint will be "RunContainer"
-func (e *Example) Entrypoint() string {
-	if e.IsModule {
-		return "RunContainer"
-	}
-
-	return "runContainer"
-}
-
-func (e *Example) Lower() string {
-	return strings.ToLower(e.Name)
-}
-
-func (e *Example) ParentDir() string {
-	if e.IsModule {
-		return "modules"
-	}
-
-	return "examples"
-}
-
-func (e *Example) Title() string {
-	if e.TitleName != "" {
-		return e.TitleName
-	}
-
-	return cases.Title(language.Und, cases.NoLower).String(e.Lower())
-}
-
-func (e *Example) Type() string {
-	if e.IsModule {
-		return "module"
-	}
-	return "example"
-}
-
-func (e *Example) Validate() error {
-	if !regexp.MustCompile(`^[A-Za-z][A-Za-z0-9]*$`).MatchString(e.Name) {
-		return fmt.Errorf("invalid name: %s. Only alphanumerical characters are allowed (leading character must be a letter)", e.Name)
-	}
-
-	if !regexp.MustCompile(`^[A-Za-z][A-Za-z0-9]*$`).MatchString(e.TitleName) {
-		return fmt.Errorf("invalid title: %s. Only alphanumerical characters are allowed (leading character must be a letter)", e.TitleName)
-	}
-
-	return nil
 }
 
 func main() {
@@ -237,6 +153,12 @@ func generate(example Example, ctx *Context) error {
 			return err
 		}
 	}
+	// creates Makefile for example
+	err = generateMakefile(ctx, example)
+	if err != nil {
+		return err
+	}
+
 	// update github ci workflow
 	err = generateWorkFlow(ctx)
 	if err != nil {
@@ -253,35 +175,6 @@ func generate(example Example, ctx *Context) error {
 		return err
 	}
 	return nil
-}
-
-func generateDependabotUpdates(ctx *Context, example Example) error {
-	// update examples in dependabot
-	directory := "/" + example.ParentDir() + "/" + example.Lower()
-	return dependabot.UpdateConfig(ctx.DependabotConfigFile(), directory, "gomod")
-}
-
-func generateMkdocs(ctx *Context, example Example) error {
-	// update examples in mkdocs
-	exampleMd := example.ParentDir() + "/" + example.Lower() + ".md"
-	indexMd := example.ParentDir() + "/index.md"
-	return mkdocs.UpdateConfig(ctx.MkdocsConfigFile(), example.IsModule, exampleMd, indexMd)
-}
-
-func generateWorkFlow(ctx *Context) error {
-	rootCtx, err := getRootContext()
-	if err != nil {
-		return err
-	}
-	examples, err := rootCtx.GetExamples()
-	if err != nil {
-		return err
-	}
-	modules, err := rootCtx.GetModules()
-	if err != nil {
-		return err
-	}
-	return workflow.Generate(ctx.GithubWorkflowsDir(), examples, modules)
 }
 
 func getRootContext() (*Context, error) {

--- a/modulegen/make.go
+++ b/modulegen/make.go
@@ -1,0 +1,14 @@
+package main
+
+import (
+	"path/filepath"
+
+	"github.com/testcontainers/testcontainers-go/modulegen/internal/make"
+)
+
+// creates Makefile for example
+func generateMakefile(ctx *Context, example Example) error {
+	exampleDir := filepath.Join(ctx.RootDir, example.ParentDir(), example.Lower())
+	exampleName := example.Lower()
+	return make.Generate(exampleDir, exampleName)
+}

--- a/modulegen/mkdocs.go
+++ b/modulegen/mkdocs.go
@@ -1,0 +1,12 @@
+package main
+
+import (
+	"github.com/testcontainers/testcontainers-go/modulegen/internal/mkdocs"
+)
+
+// update examples in mkdocs
+func generateMkdocs(ctx *Context, example Example) error {
+	exampleMd := example.ParentDir() + "/" + example.Lower() + ".md"
+	indexMd := example.ParentDir() + "/index.md"
+	return mkdocs.UpdateConfig(ctx.MkdocsConfigFile(), example.IsModule, exampleMd, indexMd)
+}

--- a/modulegen/types.go
+++ b/modulegen/types.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
+)
+
+type Example struct {
+	Image     string // fully qualified name of the Docker image
+	IsModule  bool   // if true, the example will be generated as a Go module
+	Name      string
+	TitleName string // title of the name: e.g. "mongodb" -> "MongoDB"
+	TCVersion string // Testcontainers for Go version
+}
+
+// ContainerName returns the name of the container, which is the lower-cased title of the example
+// If the title is set, it will be used instead of the name
+func (e *Example) ContainerName() string {
+	name := e.Lower()
+
+	if e.IsModule {
+		name = e.Title()
+	} else {
+		if e.TitleName != "" {
+			r, n := utf8.DecodeRuneInString(e.TitleName)
+			name = string(unicode.ToLower(r)) + e.TitleName[n:]
+		}
+	}
+
+	return name + "Container"
+}
+
+// Entrypoint returns the name of the entrypoint function, which is the lower-cased title of the example
+// If the example is a module, the entrypoint will be "RunContainer"
+func (e *Example) Entrypoint() string {
+	if e.IsModule {
+		return "RunContainer"
+	}
+
+	return "runContainer"
+}
+
+func (e *Example) Lower() string {
+	return strings.ToLower(e.Name)
+}
+
+func (e *Example) ParentDir() string {
+	if e.IsModule {
+		return "modules"
+	}
+
+	return "examples"
+}
+
+func (e *Example) Title() string {
+	if e.TitleName != "" {
+		return e.TitleName
+	}
+
+	return cases.Title(language.Und, cases.NoLower).String(e.Lower())
+}
+
+func (e *Example) Type() string {
+	if e.IsModule {
+		return "module"
+	}
+	return "example"
+}
+
+func (e *Example) Validate() error {
+	if !regexp.MustCompile(`^[A-Za-z][A-Za-z0-9]*$`).MatchString(e.Name) {
+		return fmt.Errorf("invalid name: %s. Only alphanumerical characters are allowed (leading character must be a letter)", e.Name)
+	}
+
+	if !regexp.MustCompile(`^[A-Za-z][A-Za-z0-9]*$`).MatchString(e.TitleName) {
+		return fmt.Errorf("invalid title: %s. Only alphanumerical characters are allowed (leading character must be a letter)", e.TitleName)
+	}
+
+	return nil
+}

--- a/modulegen/workflow.go
+++ b/modulegen/workflow.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"github.com/testcontainers/testcontainers-go/modulegen/internal/workflow"
+)
+
+// update github ci workflow
+func generateWorkFlow(ctx *Context) error {
+	rootCtx, err := getRootContext()
+	if err != nil {
+		return err
+	}
+	examples, err := rootCtx.GetExamples()
+	if err != nil {
+		return err
+	}
+	modules, err := rootCtx.GetModules()
+	if err != nil {
+		return err
+	}
+	return workflow.Generate(ctx.GithubWorkflowsDir(), examples, modules)
+}


### PR DESCRIPTION
- extract Makefile file generation in /internal/make
- Extract the generation in a dedicated file for each internal domain.
- Isolate Example in a dedicated file `types.go`.
