### PR TITLE
chore: fix workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,15 +4,17 @@ name: Main pipeline
 
 on:
   push:
+    branches:
+      - main
     paths-ignore:
-    - 'mkdocs.yml'
-    - 'docs/**'
-    - 'README.md'
+      - 'mkdocs.yml'
+      - 'docs/**'
+      - 'README.md'
   pull_request:
     paths-ignore:
-    - 'mkdocs.yml'
-    - 'docs/**'
-    - 'README.md'
+      - 'mkdocs.yml'
+      - 'docs/**'
+      - 'README.md'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.sha }}

--- a/modulegen/_template/ci.yml.tmpl
+++ b/modulegen/_template/ci.yml.tmpl
@@ -4,15 +4,17 @@ name: Main pipeline
 
 on:
   push:
+    branches:
+      - main
     paths-ignore:
-    - 'mkdocs.yml'
-    - 'docs/**'
-    - 'README.md'
+      - 'mkdocs.yml'
+      - 'docs/**'
+      - 'README.md'
   pull_request:
     paths-ignore:
-    - 'mkdocs.yml'
-    - 'docs/**'
-    - 'README.md'
+      - 'mkdocs.yml'
+      - 'docs/**'
+      - 'README.md'
 
 concurrency:
   group: {{ "${{ github.workflow }}-${{ github.head_ref || github.sha }}" }}

--- a/modulegen/main_test.go
+++ b/modulegen/main_test.go
@@ -479,11 +479,11 @@ func assertExampleGithubWorkflowContent(t *testing.T, example Example, exampleWo
 
 	modulesList, err := ctx.GetModules()
 	assert.Nil(t, err)
-	assert.Equal(t, "        module: ["+strings.Join(modulesList, ", ")+"]", data[90])
+	assert.Equal(t, "        module: ["+strings.Join(modulesList, ", ")+"]", data[92])
 
 	examplesList, err := ctx.GetExamples()
 	assert.Nil(t, err)
-	assert.Equal(t, "        module: ["+strings.Join(examplesList, ", ")+"]", data[106])
+	assert.Equal(t, "        module: ["+strings.Join(examplesList, ", ")+"]", data[108])
 }
 
 // assert content go.mod


### PR DESCRIPTION
When dependabot is creating a PR to update dependencies, it generates 226 jobs while on a PR from a fork on 116 are generated.

Triggering tests only on push on main branch will avoid this.
