### PR TITLE
fix: use proper service name in Pulsar module

### DIFF
--- a/docs/modules/pulsar.md
+++ b/docs/modules/pulsar.md
@@ -30,7 +30,7 @@ where the `tt.opts` are the options to configure the container. See the [Contain
 
 ## Module Reference
 
-The Redis module exposes one entrypoint function to create the containerr, and this function receives two parameters:
+The Pulsar module exposes one entrypoint function to create the containerr, and this function receives two parameters:
 
 ```golang
 func RunContainer(ctx context.Context, opts ...testcontainers.ContainerCustomizer) (*Container, error)


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?

The pulsar module docs incorrectly mentioned the redis module. This PR updates the docs to correctly reference the pulsar module.

## Why is it important?

This is a pretty minor change that just updates some documentation.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- 

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
