### PR TITLE
modulegen: generate md file inside internal/mkdocs

### DIFF
--- a/modulegen/_template/example.md.tmpl
+++ b/modulegen/_template/example.md.tmpl
@@ -16,13 +16,13 @@ go get github.com/testcontainers/testcontainers-go/{{ ParentDir }}/{{ $lower }}
 
 ## Usage example
 
-{{ codeinclude "<!--codeinclude-->" }}
+<!--codeinclude-->
 [Creating a {{ $title }} container](../../{{ ParentDir }}/{{ $lower }}/{{ $lower }}.go)
-{{ codeinclude "<!--/codeinclude-->" }}
+<!--/codeinclude-->
 
-{{ codeinclude "<!--codeinclude-->" }}
+<!--codeinclude-->
 [Test for a {{ $title }} container](../../{{ ParentDir }}/{{ $lower }}/{{ $lower }}_test.go)
-{{ codeinclude "<!--/codeinclude-->" }}
+<!--/codeinclude-->
 
 ## Module reference
 

--- a/modulegen/internal/mkdocs/template.go
+++ b/modulegen/internal/mkdocs/template.go
@@ -1,0 +1,17 @@
+package mkdocs
+
+import (
+	"path/filepath"
+	"text/template"
+
+	internal_template "github.com/testcontainers/testcontainers-go/modulegen/internal/template"
+)
+
+func GenerateMdFile(filePath string, funcMap template.FuncMap, example any) error {
+	name := "example.md.tmpl"
+	t, err := template.New(name).Funcs(funcMap).ParseFiles(filepath.Join("_template", name))
+	if err != nil {
+		return err
+	}
+	return internal_template.Generate(t, filePath, name, example)
+}

--- a/modulegen/mkdocs.go
+++ b/modulegen/mkdocs.go
@@ -1,11 +1,26 @@
 package main
 
 import (
+	"path/filepath"
+	"text/template"
+
 	"github.com/testcontainers/testcontainers-go/modulegen/internal/mkdocs"
 )
 
 // update examples in mkdocs
 func generateMkdocs(ctx *Context, example Example) error {
+	exampleMdFile := filepath.Join(ctx.DocsDir(), example.ParentDir(), example.Lower()+".md")
+	funcMap := template.FuncMap{
+		"Entrypoint":    func() string { return example.Entrypoint() },
+		"ContainerName": func() string { return example.ContainerName() },
+		"ParentDir":     func() string { return example.ParentDir() },
+		"ToLower":       func() string { return example.Lower() },
+		"Title":         func() string { return example.Title() },
+	}
+	err := mkdocs.GenerateMdFile(exampleMdFile, funcMap, example)
+	if err != nil {
+		return err
+	}
 	exampleMd := example.ParentDir() + "/" + example.Lower() + ".md"
 	indexMd := example.ParentDir() + "/index.md"
 	return mkdocs.UpdateConfig(ctx.MkdocsConfigFile(), example.IsModule, exampleMd, indexMd)


### PR DESCRIPTION
## What does this PR do?
This removes codeinclude function and use text/template instead of html/template.

It also moves the logic of markdown example file creation to the internal/mkdocs package.

## Why is it important?
This is separating code in there domain to improve the readability and maintanability.

## Related issues
- Relates #1536

## Follow-ups
Remove Example functions and replace them with fields so they are calculated once.