### PR TITLE
Fix module generator for examples

### DIFF
--- a/modulegen/_template/example_test.go.tmpl
+++ b/modulegen/_template/example_test.go.tmpl
@@ -1,4 +1,4 @@
-{{ $lower := ToLower }}{{ $title := Title }}package {{ $lower }}
+{{ $entrypoint := Entrypoint }}{{ $lower := ToLower }}{{ $title := Title }}package {{ $lower }}
 
 import (
 	"context"
@@ -8,7 +8,7 @@ import (
 func Test{{ $title }}(t *testing.T) {
 	ctx := context.Background()
 
-	container, err := RunContainer(ctx)
+	container, err := {{ $entrypoint }}(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/modulegen/main_test.go
+++ b/modulegen/main_test.go
@@ -446,7 +446,7 @@ func assertExampleTestContent(t *testing.T, example Example, exampleTestFile str
 	data := sanitiseContent(content)
 	assert.Equal(t, data[0], "package "+example.Lower())
 	assert.Equal(t, data[7], "func Test"+example.Title()+"(t *testing.T) {")
-	assert.Equal(t, data[10], "\tcontainer, err := RunContainer(ctx)")
+	assert.Equal(t, data[10], "\tcontainer, err := "+example.Entrypoint()+"(ctx)")
 }
 
 // assert content example


### PR DESCRIPTION
Closes #1544

I tested it with : 

```
go run . --name questdb --image "questdb/questdb:latest" --title QuestDB
```

