### PR TITLE
chore: refine fail-fast strategy on CI

### DIFF
--- a/.github/workflows/ci-test-go.yml
+++ b/.github/workflows/ci-test-go.yml
@@ -12,6 +12,11 @@ on:
         required: true
         type: string
         description: "The platform to run the test on."
+      fail-fast:
+        required: false
+        type: boolean
+        default: true
+        description: "Fail the workflow if any of the jobs fail."
       project-directory:
         required: true
         type: string
@@ -42,6 +47,7 @@ jobs:
   test-go-project:
     name: "${{ inputs.project-directory }}/${{ inputs.platform }}/${{ inputs.go-version }}"
     runs-on: ${{ inputs.platform }}
+    continue-on-error: ${{ !inputs.fail-fast }}
     env:
       TESTCONTAINERS_RYUK_DISABLED: "${{ inputs.ryuk-disabled }}"
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,7 +113,7 @@ jobs:
         module: [bigtable, cockroachdb, consul, datastore, firestore, nats, nginx, pubsub, spanner, toxiproxy]
     uses: ./.github/workflows/ci-test-go.yml
     with:
-      go-version: "1.x"
+      go-version: "1.20.x"
       fail-fast: true
       platform: ${{ matrix.platform }}
       project-directory: examples/${{ matrix.module }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,5 +119,5 @@ jobs:
       platform: 'ubuntu-latest'
       project-directory: examples/${{ matrix.module }}
       rootless-docker: false
-      run-tests: yes
+      run-tests: true
       ryuk-disabled: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,12 +109,11 @@ jobs:
     needs: test-modules
     strategy:
       matrix:
-        go-version: [1.20.x, 1.x]
         platform: [ubuntu-latest, macos-latest]
         module: [bigtable, cockroachdb, consul, datastore, firestore, nats, nginx, pubsub, spanner, toxiproxy]
     uses: ./.github/workflows/ci-test-go.yml
     with:
-      go-version: ${{ matrix.go-version }}
+      go-version: "1.x"
       fail-fast: true
       platform: ${{ matrix.platform }}
       project-directory: examples/${{ matrix.module }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,7 @@ jobs:
     uses: ./.github/workflows/ci-test-go.yml
     with:
       go-version: ${{ matrix.go-version }}
+      fail-fast: true
       platform: ${{ matrix.platform }}
       project-directory: "."
       rootless-docker: false
@@ -46,6 +47,7 @@ jobs:
     uses: ./.github/workflows/ci-test-go.yml
     with:
       go-version: ${{ matrix.go-version }}
+      fail-fast: true
       platform: "ubuntu-latest"
       project-directory: "."
       rootless-docker: false
@@ -64,6 +66,7 @@ jobs:
     uses: ./.github/workflows/ci-test-go.yml
     with:
       go-version: ${{ matrix.go-version }}
+      fail-fast: true
       platform: "ubuntu-latest"
       project-directory: "."
       rootless-docker: true
@@ -78,6 +81,7 @@ jobs:
     uses: ./.github/workflows/ci-test-go.yml
     with:
       go-version: ${{ matrix.go-version }}
+      fail-fast: true
       platform: ${{ matrix.platform }}
       project-directory: "modulegen"
       rootless-docker: false
@@ -94,6 +98,7 @@ jobs:
     uses: ./.github/workflows/ci-test-go.yml
     with:
       go-version: ${{ matrix.go-version }}
+      fail-fast: false
       platform: ${{ matrix.platform }}
       project-directory: modules/${{ matrix.module }}
       rootless-docker: false
@@ -110,6 +115,7 @@ jobs:
     uses: ./.github/workflows/ci-test-go.yml
     with:
       go-version: ${{ matrix.go-version }}
+      fail-fast: true
       platform: ${{ matrix.platform }}
       project-directory: examples/${{ matrix.module }}
       rootless-docker: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,14 +111,13 @@ jobs:
     needs: test-modules
     strategy:
       matrix:
-        platform: [ubuntu-latest, macos-latest]
         module: [bigtable, cockroachdb, consul, datastore, firestore, nats, nginx, pubsub, spanner, toxiproxy]
     uses: ./.github/workflows/ci-test-go.yml
     with:
       go-version: "1.20.x"
       fail-fast: true
-      platform: ${{ matrix.platform }}
+      platform: 'ubuntu-latest'
       project-directory: examples/${{ matrix.module }}
       rootless-docker: false
-      run-tests: ${{ matrix.platform == 'ubuntu-latest' }}
+      run-tests: yes
       ryuk-disabled: false

--- a/modulegen/_template/ci.yml.tmpl
+++ b/modulegen/_template/ci.yml.tmpl
@@ -113,7 +113,7 @@ jobs:
         module: [{{ .Examples }}]
     uses: ./.github/workflows/ci-test-go.yml
     with:
-      go-version: "1.x"
+      go-version: "1.20.x"
       fail-fast: true
       platform: {{ "${{ matrix.platform }}" }}
       project-directory: {{ "examples/${{ matrix.module }}" }}

--- a/modulegen/_template/ci.yml.tmpl
+++ b/modulegen/_template/ci.yml.tmpl
@@ -111,14 +111,13 @@ jobs:
     needs: test-modules
     strategy:
       matrix:
-        platform: [ubuntu-latest, macos-latest]
         module: [{{ .Examples }}]
     uses: ./.github/workflows/ci-test-go.yml
     with:
       go-version: "1.20.x"
       fail-fast: true
-      platform: {{ "${{ matrix.platform }}" }}
+      platform: 'ubuntu-latest'
       project-directory: {{ "examples/${{ matrix.module }}" }}
       rootless-docker: false
-      run-tests: {{ "${{ matrix.platform == 'ubuntu-latest' }}" }}
+      run-tests: yes
       ryuk-disabled: false

--- a/modulegen/_template/ci.yml.tmpl
+++ b/modulegen/_template/ci.yml.tmpl
@@ -29,6 +29,7 @@ jobs:
     uses: ./.github/workflows/ci-test-go.yml
     with:
       go-version: {{ "${{ matrix.go-version }}" }}
+      fail-fast: true
       platform: {{ "${{ matrix.platform }}" }}
       project-directory: "."
       rootless-docker: false
@@ -46,6 +47,7 @@ jobs:
     uses: ./.github/workflows/ci-test-go.yml
     with:
       go-version: {{ "${{ matrix.go-version }}" }}
+      fail-fast: true
       platform: "ubuntu-latest"
       project-directory: "."
       rootless-docker: false
@@ -64,6 +66,7 @@ jobs:
     uses: ./.github/workflows/ci-test-go.yml
     with:
       go-version: {{ "${{ matrix.go-version }}" }}
+      fail-fast: true
       platform: "ubuntu-latest"
       project-directory: "."
       rootless-docker: true
@@ -78,6 +81,7 @@ jobs:
     uses: ./.github/workflows/ci-test-go.yml
     with:
       go-version: {{ "${{ matrix.go-version }}" }}
+      fail-fast: true
       platform: {{ "${{ matrix.platform }}" }}
       project-directory: "modulegen"
       rootless-docker: false
@@ -94,6 +98,7 @@ jobs:
     uses: ./.github/workflows/ci-test-go.yml
     with:
       go-version: {{ "${{ matrix.go-version }}" }}
+      fail-fast: false
       platform: {{ "${{ matrix.platform }}" }}
       project-directory: {{ "modules/${{ matrix.module }}" }}
       rootless-docker: false
@@ -104,12 +109,12 @@ jobs:
     needs: test-modules
     strategy:
       matrix:
-        go-version: [1.20.x, 1.x]
         platform: [ubuntu-latest, macos-latest]
         module: [{{ .Examples }}]
     uses: ./.github/workflows/ci-test-go.yml
     with:
-      go-version: {{ "${{ matrix.go-version }}" }}
+      go-version: "1.x"
+      fail-fast: true
       platform: {{ "${{ matrix.platform }}" }}
       project-directory: {{ "examples/${{ matrix.module }}" }}
       rootless-docker: false

--- a/modulegen/_template/ci.yml.tmpl
+++ b/modulegen/_template/ci.yml.tmpl
@@ -119,5 +119,5 @@ jobs:
       platform: 'ubuntu-latest'
       project-directory: {{ "examples/${{ matrix.module }}" }}
       rootless-docker: false
-      run-tests: yes
+      run-tests: true
       ryuk-disabled: false

--- a/modulegen/main_test.go
+++ b/modulegen/main_test.go
@@ -463,7 +463,7 @@ func assertExampleGithubWorkflowContent(t *testing.T, example Example, exampleWo
 
 	examplesList, err := ctx.GetExamples()
 	assert.Nil(t, err)
-	assert.Equal(t, "        module: ["+strings.Join(examplesList, ", ")+"]", data[114])
+	assert.Equal(t, "        module: ["+strings.Join(examplesList, ", ")+"]", data[113])
 }
 
 // assert content go.mod

--- a/modulegen/main_test.go
+++ b/modulegen/main_test.go
@@ -459,11 +459,11 @@ func assertExampleGithubWorkflowContent(t *testing.T, example Example, exampleWo
 
 	modulesList, err := ctx.GetModules()
 	assert.Nil(t, err)
-	assert.Equal(t, "        module: ["+strings.Join(modulesList, ", ")+"]", data[92])
+	assert.Equal(t, "        module: ["+strings.Join(modulesList, ", ")+"]", data[96])
 
 	examplesList, err := ctx.GetExamples()
 	assert.Nil(t, err)
-	assert.Equal(t, "        module: ["+strings.Join(examplesList, ", ")+"]", data[108])
+	assert.Equal(t, "        module: ["+strings.Join(examplesList, ", ")+"]", data[112])
 }
 
 // assert content go.mod


### PR DESCRIPTION
- chore: let all modules to finish their execution
- chore: save workers for examples

<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
This PR adds a new input parameter to the reusable workflow to run the Go tests, making it possible to call it with a fail-fast strategy.

At the same time, we are not running the Go examples (modules that do not expose any API, just code snippets) in one single version of Go: 1.20.x, and only in Ubuntu.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
The first change tries to avoid the cancellation of the entire matrix for modules, which could happen if a flaky build fails: the rest of those 60 builds will be cancelled.

The second change is to save GH workers, as examples as less critical in terms of build conditions. We will reduce by 4 the number of user workers for the examples: Given there are 10 examples, instead of 40 builds, we will have just 10.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->


<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
