### PR TITLE
fix: remove wrong example from workspace

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,11 +7,13 @@ on:
     branches:
       - main
     paths-ignore:
+      - '.vscode/**'
       - 'mkdocs.yml'
       - 'docs/**'
       - 'README.md'
   pull_request:
     paths-ignore:
+      - '.vscode/**'
       - 'mkdocs.yml'
       - 'docs/**'
       - 'README.md'

--- a/.vscode/.testcontainers-go.code-workspace
+++ b/.vscode/.testcontainers-go.code-workspace
@@ -38,10 +38,6 @@
             "path": "../examples/pubsub"
         },
         {
-            "name": "example / questdb",
-            "path": "../examples/questdb"
-        },
-        {
             "name": "example / spanner",
             "path": "../examples/spanner"
         },

--- a/modulegen/_template/ci.yml.tmpl
+++ b/modulegen/_template/ci.yml.tmpl
@@ -7,11 +7,13 @@ on:
     branches:
       - main
     paths-ignore:
+      - '.vscode/**'
       - 'mkdocs.yml'
       - 'docs/**'
       - 'README.md'
   pull_request:
     paths-ignore:
+      - '.vscode/**'
       - 'mkdocs.yml'
       - 'docs/**'
       - 'README.md'

--- a/modulegen/main_test.go
+++ b/modulegen/main_test.go
@@ -459,11 +459,11 @@ func assertExampleGithubWorkflowContent(t *testing.T, example Example, exampleWo
 
 	modulesList, err := ctx.GetModules()
 	assert.Nil(t, err)
-	assert.Equal(t, "        module: ["+strings.Join(modulesList, ", ")+"]", data[92])
+	assert.Equal(t, "        module: ["+strings.Join(modulesList, ", ")+"]", data[94])
 
 	examplesList, err := ctx.GetExamples()
 	assert.Nil(t, err)
-	assert.Equal(t, "        module: ["+strings.Join(examplesList, ", ")+"]", data[108])
+	assert.Equal(t, "        module: ["+strings.Join(examplesList, ", ")+"]", data[110])
 }
 
 // assert content go.mod


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
Removes an entry in the VSCode workspace file.
<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
Added by mistake from a dirty Git workspace
<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Added by me by mistake in #1551

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
