### PR TITLE
chore: define interfaces for file and project generation

### DIFF
--- a/modulegen/cmd/modules/example.go
+++ b/modulegen/cmd/modules/example.go
@@ -11,14 +11,14 @@ var newExampleCmd = &cobra.Command{
 	Short: "Create a new Example",
 	Long:  "Create a new Example",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return internal.Generate(*exampleVar, false)
+		return internal.Generate(*tcModuleVar, false)
 	},
 }
 
 func init() {
-	newExampleCmd.Flags().StringVarP(&exampleVar.Name, nameFlag, "n", "", "Name of the example. Only alphabetical characters are allowed.")
-	newExampleCmd.Flags().StringVarP(&exampleVar.NameTitle, titleFlag, "t", "", "(Optional) Title of the example name, used to override the name in the case of mixed casing (Mongodb -> MongoDB). Use camel-case when needed. Only alphabetical characters are allowed.")
-	newExampleCmd.Flags().StringVarP(&exampleVar.Image, imageFlag, "i", "", "Fully-qualified name of the Docker image to be used by the example")
+	newExampleCmd.Flags().StringVarP(&tcModuleVar.Name, nameFlag, "n", "", "Name of the example. Only alphabetical characters are allowed.")
+	newExampleCmd.Flags().StringVarP(&tcModuleVar.NameTitle, titleFlag, "t", "", "(Optional) Title of the example name, used to override the name in the case of mixed casing (Mongodb -> MongoDB). Use camel-case when needed. Only alphabetical characters are allowed.")
+	newExampleCmd.Flags().StringVarP(&tcModuleVar.Image, imageFlag, "i", "", "Fully-qualified name of the Docker image to be used by the example")
 
 	_ = newExampleCmd.MarkFlagRequired(imageFlag)
 	_ = newExampleCmd.MarkFlagRequired(nameFlag)

--- a/modulegen/cmd/modules/main.go
+++ b/modulegen/cmd/modules/main.go
@@ -6,7 +6,7 @@ import (
 	"github.com/testcontainers/testcontainers-go/modulegen/internal/context"
 )
 
-var exampleVar = &context.ExampleVar{}
+var tcModuleVar = &context.TestcontainersModuleVar{}
 
 var NewCmd = &cobra.Command{
 	Use:   "new",

--- a/modulegen/cmd/modules/module.go
+++ b/modulegen/cmd/modules/module.go
@@ -11,14 +11,14 @@ var newModuleCmd = &cobra.Command{
 	Short: "Create a new Module",
 	Long:  "Create a new Module",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return internal.Generate(*exampleVar, true)
+		return internal.Generate(*tcModuleVar, true)
 	},
 }
 
 func init() {
-	newModuleCmd.Flags().StringVarP(&exampleVar.Name, nameFlag, "n", "", "Name of the module. Only alphabetical characters are allowed.")
-	newModuleCmd.Flags().StringVarP(&exampleVar.NameTitle, titleFlag, "t", "", "(Optional) Title of the module name, used to override the name in the case of mixed casing (Mongodb -> MongoDB). Use camel-case when needed. Only alphabetical characters are allowed.")
-	newModuleCmd.Flags().StringVarP(&exampleVar.Image, imageFlag, "i", "", "Fully-qualified name of the Docker image to be used by the module")
+	newModuleCmd.Flags().StringVarP(&tcModuleVar.Name, nameFlag, "n", "", "Name of the module. Only alphabetical characters are allowed.")
+	newModuleCmd.Flags().StringVarP(&tcModuleVar.NameTitle, titleFlag, "t", "", "(Optional) Title of the module name, used to override the name in the case of mixed casing (Mongodb -> MongoDB). Use camel-case when needed. Only alphabetical characters are allowed.")
+	newModuleCmd.Flags().StringVarP(&tcModuleVar.Image, imageFlag, "i", "", "Fully-qualified name of the Docker image to be used by the module")
 
 	_ = newModuleCmd.MarkFlagRequired(imageFlag)
 	_ = newModuleCmd.MarkFlagRequired(nameFlag)

--- a/modulegen/internal/context/cmd.go
+++ b/modulegen/internal/context/cmd.go
@@ -1,6 +1,6 @@
 package context
 
-type ExampleVar struct {
+type TestcontainersModuleVar struct {
 	Name      string
 	NameTitle string
 	Image     string

--- a/modulegen/internal/context/types.go
+++ b/modulegen/internal/context/types.go
@@ -11,25 +11,25 @@ import (
 	"golang.org/x/text/language"
 )
 
-type Example struct {
+type TestcontainersModule struct {
 	Image     string // fully qualified name of the Docker image
-	IsModule  bool   // if true, the example will be generated as a Go module
+	IsModule  bool   // if true, the module will be generated as a Go module, otherwise an example
 	Name      string
-	TitleName string // title of the name: e.g. "mongodb" -> "MongoDB"
+	TitleName string // title of the name: m.g. "mongodb" -> "MongoDB"
 	TCVersion string // Testcontainers for Go version
 }
 
 // ContainerName returns the name of the container, which is the lower-cased title of the example
 // If the title is set, it will be used instead of the name
-func (e *Example) ContainerName() string {
-	name := e.Lower()
+func (m *TestcontainersModule) ContainerName() string {
+	name := m.Lower()
 
-	if e.IsModule {
-		name = e.Title()
+	if m.IsModule {
+		name = m.Title()
 	} else {
-		if e.TitleName != "" {
-			r, n := utf8.DecodeRuneInString(e.TitleName)
-			name = string(unicode.ToLower(r)) + e.TitleName[n:]
+		if m.TitleName != "" {
+			r, n := utf8.DecodeRuneInString(m.TitleName)
+			name = string(unicode.ToLower(r)) + m.TitleName[n:]
 		}
 	}
 
@@ -38,48 +38,48 @@ func (e *Example) ContainerName() string {
 
 // Entrypoint returns the name of the entrypoint function, which is the lower-cased title of the example
 // If the example is a module, the entrypoint will be "RunContainer"
-func (e *Example) Entrypoint() string {
-	if e.IsModule {
+func (m *TestcontainersModule) Entrypoint() string {
+	if m.IsModule {
 		return "RunContainer"
 	}
 
 	return "runContainer"
 }
 
-func (e *Example) Lower() string {
-	return strings.ToLower(e.Name)
+func (m *TestcontainersModule) Lower() string {
+	return strings.ToLower(m.Name)
 }
 
-func (e *Example) ParentDir() string {
-	if e.IsModule {
+func (m *TestcontainersModule) ParentDir() string {
+	if m.IsModule {
 		return "modules"
 	}
 
 	return "examples"
 }
 
-func (e *Example) Title() string {
-	if e.TitleName != "" {
-		return e.TitleName
+func (m *TestcontainersModule) Title() string {
+	if m.TitleName != "" {
+		return m.TitleName
 	}
 
-	return cases.Title(language.Und, cases.NoLower).String(e.Lower())
+	return cases.Title(language.Und, cases.NoLower).String(m.Lower())
 }
 
-func (e *Example) Type() string {
-	if e.IsModule {
+func (m *TestcontainersModule) Type() string {
+	if m.IsModule {
 		return "module"
 	}
 	return "example"
 }
 
-func (e *Example) Validate() error {
-	if !regexp.MustCompile(`^[A-Za-z][A-Za-z0-9]*$`).MatchString(e.Name) {
-		return fmt.Errorf("invalid name: %s. Only alphanumerical characters are allowed (leading character must be a letter)", e.Name)
+func (m *TestcontainersModule) Validate() error {
+	if !regexp.MustCompile(`^[A-Za-z][A-Za-z0-9]*$`).MatchString(m.Name) {
+		return fmt.Errorf("invalid name: %s. Only alphanumerical characters are allowed (leading character must be a letter)", m.Name)
 	}
 
-	if !regexp.MustCompile(`^[A-Za-z][A-Za-z0-9]*$`).MatchString(e.TitleName) {
-		return fmt.Errorf("invalid title: %s. Only alphanumerical characters are allowed (leading character must be a letter)", e.TitleName)
+	if !regexp.MustCompile(`^[A-Za-z][A-Za-z0-9]*$`).MatchString(m.TitleName) {
+		return fmt.Errorf("invalid title: %s. Only alphanumerical characters are allowed (leading character must be a letter)", m.TitleName)
 	}
 
 	return nil

--- a/modulegen/internal/dependabot/main.go
+++ b/modulegen/internal/dependabot/main.go
@@ -5,8 +5,8 @@ import (
 )
 
 // update examples in dependabot
-func GenerateDependabotUpdates(ctx *context.Context, example context.Example) error {
-	directory := "/" + example.ParentDir() + "/" + example.Lower()
+func GenerateDependabotUpdates(ctx *context.Context, m context.TestcontainersModule) error {
+	directory := "/" + m.ParentDir() + "/" + m.Lower()
 	return UpdateConfig(ctx.DependabotConfigFile(), directory, "gomod")
 }
 

--- a/modulegen/internal/dependabot/main.go
+++ b/modulegen/internal/dependabot/main.go
@@ -1,21 +1,35 @@
 package dependabot
 
-import (
-	"github.com/testcontainers/testcontainers-go/modulegen/internal/context"
-)
+import "github.com/testcontainers/testcontainers-go/modulegen/internal/context"
 
-// update examples in dependabot
-func GenerateDependabotUpdates(ctx *context.Context, m context.TestcontainersModule) error {
-	directory := "/" + m.ParentDir() + "/" + m.Lower()
-	return UpdateConfig(ctx.DependabotConfigFile(), directory, "gomod")
-}
+type Generator struct{}
 
-func UpdateConfig(configFile string, directory string, packageEcosystem string) error {
+// AddModule update dependabot with the new module
+func (g Generator) AddModule(ctx *context.Context, m context.TestcontainersModule) error {
+	configFile := ctx.DependabotConfigFile()
+
 	config, err := readConfig(configFile)
 	if err != nil {
 		return err
 	}
+
+	packageEcosystem := "gomod"
+	directory := "/" + m.ParentDir() + "/" + m.Lower()
+
 	config.addUpdate(newUpdate(directory, packageEcosystem))
+
+	return writeConfig(configFile, config)
+}
+
+// Generate generates dependabot config file from source
+func (g Generator) Generate(ctx *context.Context) error {
+	configFile := ctx.DependabotConfigFile()
+
+	config, err := readConfig(configFile)
+	if err != nil {
+		return err
+	}
+
 	return writeConfig(configFile, config)
 }
 

--- a/modulegen/internal/main.go
+++ b/modulegen/internal/main.go
@@ -75,9 +75,11 @@ func GenerateFiles(ctx *context.Context, m context.TestcontainersModule) error {
 	}
 
 	// they are based on the content of the modules in the project workspace,
-	// not in the new module to be added
+	// not in the new module to be added, that's why they happen after the actual
+	// module generation
 	projectGenerators := []ProjectGenerator{
 		workflow.Generator{}, // update github ci workflow
+		vscode.Generator{},   // update vscode workspace
 	}
 
 	for _, generator := range projectGenerators {
@@ -87,10 +89,5 @@ func GenerateFiles(ctx *context.Context, m context.TestcontainersModule) error {
 		}
 	}
 
-	// generate vscode workspace
-	err := vscode.GenerateVSCodeWorkspace(ctx)
-	if err != nil {
-		return err
-	}
 	return nil
 }

--- a/modulegen/internal/main.go
+++ b/modulegen/internal/main.go
@@ -14,25 +14,25 @@ import (
 	"github.com/testcontainers/testcontainers-go/modulegen/internal/workflow"
 )
 
-func Generate(exampleVar context.ExampleVar, isModule bool) error {
+func Generate(moduleVar context.TestcontainersModuleVar, isModule bool) error {
 	ctx, err := context.GetRootContext()
 	if err != nil {
 		return fmt.Errorf(">> could not get the root dir: %w", err)
 	}
 
-	example := context.Example{
-		Image:     exampleVar.Image,
+	m := context.TestcontainersModule{
+		Image:     moduleVar.Image,
 		IsModule:  isModule,
-		Name:      exampleVar.Name,
-		TitleName: exampleVar.NameTitle,
+		Name:      moduleVar.Name,
+		TitleName: moduleVar.NameTitle,
 	}
 
-	err = GenerateFiles(ctx, example)
+	err = GenerateFiles(ctx, m)
 	if err != nil {
-		return fmt.Errorf(">> error generating the example: %w", err)
+		return fmt.Errorf(">> error generating the module: %w", err)
 	}
 
-	cmdDir := filepath.Join(ctx.RootDir, example.ParentDir(), example.Lower())
+	cmdDir := filepath.Join(ctx.RootDir, m.ParentDir(), m.Lower())
 	err = tools.GoModTidy(cmdDir)
 	if err != nil {
 		return fmt.Errorf(">> error synchronizing the dependencies: %w", err)
@@ -48,17 +48,17 @@ func Generate(exampleVar context.ExampleVar, isModule bool) error {
 	return nil
 }
 
-func GenerateFiles(ctx *context.Context, example context.Example) error {
-	if err := example.Validate(); err != nil {
+func GenerateFiles(ctx *context.Context, m context.TestcontainersModule) error {
+	if err := m.Validate(); err != nil {
 		return err
 	}
-	// creates Makefile for example
-	err := make.GenerateMakefile(ctx, example)
+	// creates Makefile for module
+	err := make.GenerateMakefile(ctx, m)
 	if err != nil {
 		return err
 	}
 
-	err = module.GenerateGoModule(ctx, example)
+	err = module.GenerateGoModule(ctx, m)
 	if err != nil {
 		return err
 	}
@@ -69,12 +69,12 @@ func GenerateFiles(ctx *context.Context, example context.Example) error {
 		return err
 	}
 	// update examples in mkdocs
-	err = mkdocs.GenerateMkdocs(ctx, example)
+	err = mkdocs.GenerateMkdocs(ctx, m)
 	if err != nil {
 		return err
 	}
 	// update examples in dependabot
-	err = dependabot.GenerateDependabotUpdates(ctx, example)
+	err = dependabot.GenerateDependabotUpdates(ctx, m)
 	if err != nil {
 		return err
 	}

--- a/modulegen/internal/main.go
+++ b/modulegen/internal/main.go
@@ -60,25 +60,33 @@ func GenerateFiles(ctx *context.Context, m context.TestcontainersModule) error {
 		return err
 	}
 
-	// update github ci workflow
-	err := workflow.GenerateWorkflow(ctx)
-	if err != nil {
-		return err
-	}
 	// update examples in mkdocs
-	err = mkdocs.GenerateMkdocs(ctx, m)
+	err := mkdocs.GenerateMkdocs(ctx, m)
 	if err != nil {
 		return err
 	}
 
-	generators := []FileGenerator{
+	fileGenerators := []FileGenerator{
 		make.Generator{},       // creates Makefile for module
 		module.Generator{},     // creates go.mod for module
 		dependabot.Generator{}, // update examples in dependabot
 	}
 
-	for _, generator := range generators {
+	for _, generator := range fileGenerators {
 		err := generator.AddModule(ctx, m)
+		if err != nil {
+			return err
+		}
+	}
+
+	// they are based on the content of the modules in the project workspace,
+	// not in the new module to be added
+	projectGenerators := []ProjectGenerator{
+		workflow.Generator{}, // update github ci workflow
+	}
+
+	for _, generator := range projectGenerators {
+		err := generator.Generate(ctx)
 		if err != nil {
 			return err
 		}

--- a/modulegen/internal/main.go
+++ b/modulegen/internal/main.go
@@ -48,22 +48,19 @@ func Generate(moduleVar context.TestcontainersModuleVar, isModule bool) error {
 	return nil
 }
 
+type ProjectGenerator interface {
+	Generate(*context.Context) error
+}
 type FileGenerator interface {
 	AddModule(*context.Context, context.TestcontainersModule) error
-	Generate(*context.Context) error
 }
 
 func GenerateFiles(ctx *context.Context, m context.TestcontainersModule) error {
 	if err := m.Validate(); err != nil {
 		return err
 	}
-	// creates Makefile for module
-	err := make.GenerateMakefile(ctx, m)
-	if err != nil {
-		return err
-	}
 
-	err = module.GenerateGoModule(ctx, m)
+	err := module.GenerateGoModule(ctx, m)
 	if err != nil {
 		return err
 	}
@@ -80,6 +77,7 @@ func GenerateFiles(ctx *context.Context, m context.TestcontainersModule) error {
 	}
 
 	generators := []FileGenerator{
+		make.Generator{},       // creates Makefile for module
 		dependabot.Generator{}, // update examples in dependabot
 	}
 

--- a/modulegen/internal/main.go
+++ b/modulegen/internal/main.go
@@ -60,13 +60,8 @@ func GenerateFiles(ctx *context.Context, m context.TestcontainersModule) error {
 		return err
 	}
 
-	err := module.GenerateGoModule(ctx, m)
-	if err != nil {
-		return err
-	}
-
 	// update github ci workflow
-	err = workflow.GenerateWorkflow(ctx)
+	err := workflow.GenerateWorkflow(ctx)
 	if err != nil {
 		return err
 	}
@@ -78,6 +73,7 @@ func GenerateFiles(ctx *context.Context, m context.TestcontainersModule) error {
 
 	generators := []FileGenerator{
 		make.Generator{},       // creates Makefile for module
+		module.Generator{},     // creates go.mod for module
 		dependabot.Generator{}, // update examples in dependabot
 	}
 

--- a/modulegen/internal/main.go
+++ b/modulegen/internal/main.go
@@ -60,15 +60,10 @@ func GenerateFiles(ctx *context.Context, m context.TestcontainersModule) error {
 		return err
 	}
 
-	// update examples in mkdocs
-	err := mkdocs.GenerateMkdocs(ctx, m)
-	if err != nil {
-		return err
-	}
-
 	fileGenerators := []FileGenerator{
 		make.Generator{},       // creates Makefile for module
 		module.Generator{},     // creates go.mod for module
+		mkdocs.Generator{},     // update examples in mkdocs
 		dependabot.Generator{}, // update examples in dependabot
 	}
 
@@ -93,7 +88,7 @@ func GenerateFiles(ctx *context.Context, m context.TestcontainersModule) error {
 	}
 
 	// generate vscode workspace
-	err = vscode.GenerateVSCodeWorkspace(ctx)
+	err := vscode.GenerateVSCodeWorkspace(ctx)
 	if err != nil {
 		return err
 	}

--- a/modulegen/internal/make/main.go
+++ b/modulegen/internal/make/main.go
@@ -8,14 +8,29 @@ import (
 	internal_template "github.com/testcontainers/testcontainers-go/modulegen/internal/template"
 )
 
+type Generator struct{}
+
+// AddModule update dependabot with the new module
+func (g Generator) AddModule(ctx *context.Context, m context.TestcontainersModule) error {
+	moduleDir := filepath.Join(ctx.RootDir, m.ParentDir(), m.Lower())
+	moduleName := m.Lower()
+
+	name := "Makefile.tmpl"
+	t, err := template.New(name).ParseFiles(filepath.Join("_template", name))
+	if err != nil {
+		return err
+	}
+
+	moduleFilePath := filepath.Join(moduleDir, "Makefile")
+
+	return internal_template.GenerateFile(t, moduleFilePath, name, moduleName)
+}
+
 // creates Makefile for example
 func GenerateMakefile(ctx *context.Context, m context.TestcontainersModule) error {
 	moduleDir := filepath.Join(ctx.RootDir, m.ParentDir(), m.Lower())
 	moduleName := m.Lower()
-	return Generate(moduleDir, moduleName)
-}
 
-func Generate(moduleDir string, moduleName string) error {
 	name := "Makefile.tmpl"
 	t, err := template.New(name).ParseFiles(filepath.Join("_template", name))
 	if err != nil {

--- a/modulegen/internal/make/main.go
+++ b/modulegen/internal/make/main.go
@@ -9,20 +9,20 @@ import (
 )
 
 // creates Makefile for example
-func GenerateMakefile(ctx *context.Context, example context.Example) error {
-	exampleDir := filepath.Join(ctx.RootDir, example.ParentDir(), example.Lower())
-	exampleName := example.Lower()
-	return Generate(exampleDir, exampleName)
+func GenerateMakefile(ctx *context.Context, m context.TestcontainersModule) error {
+	moduleDir := filepath.Join(ctx.RootDir, m.ParentDir(), m.Lower())
+	moduleName := m.Lower()
+	return Generate(moduleDir, moduleName)
 }
 
-func Generate(exampleDir string, exampleName string) error {
+func Generate(moduleDir string, moduleName string) error {
 	name := "Makefile.tmpl"
 	t, err := template.New(name).ParseFiles(filepath.Join("_template", name))
 	if err != nil {
 		return err
 	}
 
-	exampleFilePath := filepath.Join(exampleDir, "Makefile")
+	moduleFilePath := filepath.Join(moduleDir, "Makefile")
 
-	return internal_template.GenerateFile(t, exampleFilePath, name, exampleName)
+	return internal_template.GenerateFile(t, moduleFilePath, name, moduleName)
 }

--- a/modulegen/internal/mkdocs/main.go
+++ b/modulegen/internal/mkdocs/main.go
@@ -7,8 +7,10 @@ import (
 	"github.com/testcontainers/testcontainers-go/modulegen/internal/context"
 )
 
-// update modules in mkdocs
-func GenerateMkdocs(ctx *context.Context, m context.TestcontainersModule) error {
+type Generator struct{}
+
+// AddModule update modules in mkdocs
+func (g Generator) AddModule(ctx *context.Context, m context.TestcontainersModule) error {
 	moduleMdFile := filepath.Join(ctx.DocsDir(), m.ParentDir(), m.Lower()+".md")
 	funcMap := template.FuncMap{
 		"Entrypoint":    func() string { return m.Entrypoint() },
@@ -23,10 +25,10 @@ func GenerateMkdocs(ctx *context.Context, m context.TestcontainersModule) error 
 	}
 	moduleMd := m.ParentDir() + "/" + m.Lower() + ".md"
 	indexMd := m.ParentDir() + "/index.md"
-	return UpdateConfig(ctx.MkdocsConfigFile(), m.IsModule, moduleMd, indexMd)
-}
 
-func UpdateConfig(configFile string, isModule bool, moduleMd string, indexMd string) error {
+	configFile := ctx.MkdocsConfigFile()
+	isModule := m.IsModule
+
 	config, err := ReadConfig(configFile)
 	if err != nil {
 		return err

--- a/modulegen/internal/mkdocs/main.go
+++ b/modulegen/internal/mkdocs/main.go
@@ -7,31 +7,31 @@ import (
 	"github.com/testcontainers/testcontainers-go/modulegen/internal/context"
 )
 
-// update examples in mkdocs
-func GenerateMkdocs(ctx *context.Context, example context.Example) error {
-	exampleMdFile := filepath.Join(ctx.DocsDir(), example.ParentDir(), example.Lower()+".md")
+// update modules in mkdocs
+func GenerateMkdocs(ctx *context.Context, m context.TestcontainersModule) error {
+	moduleMdFile := filepath.Join(ctx.DocsDir(), m.ParentDir(), m.Lower()+".md")
 	funcMap := template.FuncMap{
-		"Entrypoint":    func() string { return example.Entrypoint() },
-		"ContainerName": func() string { return example.ContainerName() },
-		"ParentDir":     func() string { return example.ParentDir() },
-		"ToLower":       func() string { return example.Lower() },
-		"Title":         func() string { return example.Title() },
+		"Entrypoint":    func() string { return m.Entrypoint() },
+		"ContainerName": func() string { return m.ContainerName() },
+		"ParentDir":     func() string { return m.ParentDir() },
+		"ToLower":       func() string { return m.Lower() },
+		"Title":         func() string { return m.Title() },
 	}
-	err := GenerateMdFile(exampleMdFile, funcMap, example)
+	err := GenerateMdFile(moduleMdFile, funcMap, m)
 	if err != nil {
 		return err
 	}
-	exampleMd := example.ParentDir() + "/" + example.Lower() + ".md"
-	indexMd := example.ParentDir() + "/index.md"
-	return UpdateConfig(ctx.MkdocsConfigFile(), example.IsModule, exampleMd, indexMd)
+	moduleMd := m.ParentDir() + "/" + m.Lower() + ".md"
+	indexMd := m.ParentDir() + "/index.md"
+	return UpdateConfig(ctx.MkdocsConfigFile(), m.IsModule, moduleMd, indexMd)
 }
 
-func UpdateConfig(configFile string, isModule bool, exampleMd string, indexMd string) error {
+func UpdateConfig(configFile string, isModule bool, moduleMd string, indexMd string) error {
 	config, err := ReadConfig(configFile)
 	if err != nil {
 		return err
 	}
-	config.addExample(isModule, exampleMd, indexMd)
+	config.addModule(isModule, moduleMd, indexMd)
 	return writeConfig(configFile, config)
 }
 

--- a/modulegen/internal/mkdocs/types.go
+++ b/modulegen/internal/mkdocs/types.go
@@ -44,36 +44,36 @@ type Config struct {
 	} `yaml:"extra"`
 }
 
-func (c *Config) addExample(isModule bool, exampleMd string, indexMd string) {
-	mkdocsExamplesNav := c.Nav[4].Examples
+func (c *Config) addModule(isModule bool, moduleMd string, indexMd string) {
+	mkdocsNavItems := c.Nav[4].Examples
 	if isModule {
-		mkdocsExamplesNav = c.Nav[3].Modules
+		mkdocsNavItems = c.Nav[3].Modules
 	}
 
-	if !slices.Contains(mkdocsExamplesNav, exampleMd) {
+	if !slices.Contains(mkdocsNavItems, moduleMd) {
 
 		// make sure the index.md is the first element in the list of examples in the nav
-		examplesNav := make([]string, len(mkdocsExamplesNav)-1)
+		navItems := make([]string, len(mkdocsNavItems)-1)
 		j := 0
 
-		for _, exampleNav := range mkdocsExamplesNav {
+		for _, navItem := range mkdocsNavItems {
 			// filter out the index.md file
-			if !strings.HasSuffix(exampleNav, "index.md") {
-				examplesNav[j] = exampleNav
+			if !strings.HasSuffix(navItem, "index.md") {
+				navItems[j] = navItem
 				j++
 			}
 		}
 
-		examplesNav = append(examplesNav, exampleMd)
-		sort.Strings(examplesNav)
+		navItems = append(navItems, moduleMd)
+		sort.Strings(navItems)
 
 		// prepend the index.md file
-		examplesNav = append([]string{indexMd}, examplesNav...)
+		navItems = append([]string{indexMd}, navItems...)
 
 		if isModule {
-			c.Nav[3].Modules = examplesNav
+			c.Nav[3].Modules = navItems
 		} else {
-			c.Nav[4].Examples = examplesNav
+			c.Nav[4].Examples = navItems
 		}
 	}
 }

--- a/modulegen/internal/module/main.go
+++ b/modulegen/internal/module/main.go
@@ -12,27 +12,27 @@ import (
 	internal_template "github.com/testcontainers/testcontainers-go/modulegen/internal/template"
 )
 
-func GenerateGoModule(ctx *context.Context, example context.Example) error {
-	exampleDir := filepath.Join(ctx.RootDir, example.ParentDir(), example.Lower())
-	err := generateGoFiles(exampleDir, example)
+func GenerateGoModule(ctx *context.Context, m context.TestcontainersModule) error {
+	moduleDir := filepath.Join(ctx.RootDir, m.ParentDir(), m.Lower())
+	err := generateGoFiles(moduleDir, m)
 	if err != nil {
 		return err
 	}
-	return generateGoModFile(exampleDir, example)
+	return generateGoModFile(moduleDir, m)
 }
 
-func generateGoFiles(exampleDir string, example context.Example) error {
+func generateGoFiles(moduleDir string, m context.TestcontainersModule) error {
 	funcMap := template.FuncMap{
-		"Entrypoint":    func() string { return example.Entrypoint() },
-		"ContainerName": func() string { return example.ContainerName() },
-		"ParentDir":     func() string { return example.ParentDir() },
-		"ToLower":       func() string { return example.Lower() },
-		"Title":         func() string { return example.Title() },
+		"Entrypoint":    func() string { return m.Entrypoint() },
+		"ContainerName": func() string { return m.ContainerName() },
+		"ParentDir":     func() string { return m.ParentDir() },
+		"ToLower":       func() string { return m.Lower() },
+		"Title":         func() string { return m.Title() },
 	}
-	return GenerateFiles(exampleDir, example.Lower(), funcMap, example)
+	return GenerateFiles(moduleDir, m.Lower(), funcMap, m)
 }
 
-func generateGoModFile(exampleDir string, example context.Example) error {
+func generateGoModFile(moduleDir string, m context.TestcontainersModule) error {
 	rootCtx, err := context.GetRootContext()
 	if err != nil {
 		return err
@@ -43,21 +43,21 @@ func generateGoModFile(exampleDir string, example context.Example) error {
 		return err
 	}
 	rootGoModFile := rootCtx.GoModFile()
-	directory := "/" + example.ParentDir() + "/" + example.Lower()
+	directory := "/" + m.ParentDir() + "/" + m.Lower()
 	tcVersion := mkdocsConfig.Extra.LatestVersion
-	return modfile.GenerateModFile(exampleDir, rootGoModFile, directory, tcVersion)
+	return modfile.GenerateModFile(moduleDir, rootGoModFile, directory, tcVersion)
 }
 
-func GenerateFiles(exampleDir string, exampleName string, funcMap template.FuncMap, example any) error {
+func GenerateFiles(moduleDir string, moduleName string, funcMap template.FuncMap, tcModule any) error {
 	for _, tmpl := range []string{"example_test.go", "example.go"} {
 		name := tmpl + ".tmpl"
 		t, err := template.New(name).Funcs(funcMap).ParseFiles(filepath.Join("_template", name))
 		if err != nil {
 			return err
 		}
-		exampleFilePath := filepath.Join(exampleDir, strings.ReplaceAll(tmpl, "example", exampleName))
+		moduleFilePath := filepath.Join(moduleDir, strings.ReplaceAll(tmpl, "example", moduleName))
 
-		err = internal_template.GenerateFile(t, exampleFilePath, name, example)
+		err = internal_template.GenerateFile(t, moduleFilePath, name, tcModule)
 		if err != nil {
 			return err
 		}

--- a/modulegen/internal/module/main.go
+++ b/modulegen/internal/module/main.go
@@ -12,7 +12,10 @@ import (
 	internal_template "github.com/testcontainers/testcontainers-go/modulegen/internal/template"
 )
 
-func GenerateGoModule(ctx *context.Context, m context.TestcontainersModule) error {
+type Generator struct{}
+
+// AddModule creates the go.mod file for the module
+func (g Generator) AddModule(ctx *context.Context, m context.TestcontainersModule) error {
 	moduleDir := filepath.Join(ctx.RootDir, m.ParentDir(), m.Lower())
 	err := generateGoFiles(moduleDir, m)
 	if err != nil {

--- a/modulegen/internal/vscode/main.go
+++ b/modulegen/internal/vscode/main.go
@@ -4,8 +4,10 @@ import (
 	"github.com/testcontainers/testcontainers-go/modulegen/internal/context"
 )
 
-// print out the workspace for vscode
-func GenerateVSCodeWorkspace(ctx *context.Context) error {
+type Generator struct{}
+
+// Generate updates the workspace for vscode
+func (g Generator) Generate(ctx *context.Context) error {
 	rootCtx, err := context.GetRootContext()
 	if err != nil {
 		return err
@@ -19,11 +21,5 @@ func GenerateVSCodeWorkspace(ctx *context.Context) error {
 		return err
 	}
 
-	return Generate(ctx.VSCodeWorkspaceFile(), examples, modules)
-}
-
-func Generate(exampleFilePath string, examples []string, modules []string) error {
-	config := newConfig(examples, modules)
-
-	return writeConfig(exampleFilePath, config)
+	return writeConfig(ctx.VSCodeWorkspaceFile(), newConfig(examples, modules))
 }

--- a/modulegen/internal/workflow/main.go
+++ b/modulegen/internal/workflow/main.go
@@ -8,8 +8,10 @@ import (
 	internal_template "github.com/testcontainers/testcontainers-go/modulegen/internal/template"
 )
 
-// update github ci workflow
-func GenerateWorkflow(ctx *context.Context) error {
+type Generator struct{}
+
+// Generate updates github ci workflow
+func (g Generator) Generate(ctx *context.Context) error {
 	rootCtx, err := context.GetRootContext()
 	if err != nil {
 		return err
@@ -22,10 +24,9 @@ func GenerateWorkflow(ctx *context.Context) error {
 	if err != nil {
 		return err
 	}
-	return Generate(ctx.GithubWorkflowsDir(), examples, modules)
-}
 
-func Generate(githubWorkflowsDir string, examples []string, modules []string) error {
+	githubWorkflowsDir := ctx.GithubWorkflowsDir()
+
 	projectDirectories := newProjectDirectories(examples, modules)
 	name := "ci.yml.tmpl"
 	t, err := template.New(name).ParseFiles(filepath.Join("_template", name))

--- a/modulegen/main_test.go
+++ b/modulegen/main_test.go
@@ -15,17 +15,17 @@ import (
 	"github.com/testcontainers/testcontainers-go/modulegen/internal/mkdocs"
 )
 
-func TestExample(t *testing.T) {
+func TestModule(t *testing.T) {
 	tests := []struct {
 		name                  string
-		example               context.Example
+		module                context.TestcontainersModule
 		expectedContainerName string
 		expectedEntrypoint    string
 		expectedTitle         string
 	}{
 		{
 			name: "Module with title",
-			example: context.Example{
+			module: context.TestcontainersModule{
 				Name:      "mongoDB",
 				IsModule:  true,
 				Image:     "mongodb:latest",
@@ -37,7 +37,7 @@ func TestExample(t *testing.T) {
 		},
 		{
 			name: "Module without title",
-			example: context.Example{
+			module: context.TestcontainersModule{
 				Name:     "mongoDB",
 				IsModule: true,
 				Image:    "mongodb:latest",
@@ -48,7 +48,7 @@ func TestExample(t *testing.T) {
 		},
 		{
 			name: "Example with title",
-			example: context.Example{
+			module: context.TestcontainersModule{
 				Name:      "mongoDB",
 				IsModule:  false,
 				Image:     "mongodb:latest",
@@ -60,7 +60,7 @@ func TestExample(t *testing.T) {
 		},
 		{
 			name: "Example without title",
-			example: context.Example{
+			module: context.TestcontainersModule{
 				Name:     "mongoDB",
 				IsModule: false,
 				Image:    "mongodb:latest",
@@ -73,48 +73,48 @@ func TestExample(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			example := test.example
+			module := test.module
 
-			assert.Equal(t, "mongodb", example.Lower())
-			assert.Equal(t, test.expectedTitle, example.Title())
-			assert.Equal(t, test.expectedContainerName, example.ContainerName())
-			assert.Equal(t, test.expectedEntrypoint, example.Entrypoint())
+			assert.Equal(t, "mongodb", module.Lower())
+			assert.Equal(t, test.expectedTitle, module.Title())
+			assert.Equal(t, test.expectedContainerName, module.ContainerName())
+			assert.Equal(t, test.expectedEntrypoint, module.Entrypoint())
 		})
 	}
 }
 
-func TestExample_Validate(outer *testing.T) {
+func TestModule_Validate(outer *testing.T) {
 	outer.Parallel()
 
 	tests := []struct {
 		name        string
-		example     context.Example
+		module      context.TestcontainersModule
 		expectedErr error
 	}{
 		{
 			name: "only alphabetical characters in name/title",
-			example: context.Example{
+			module: context.TestcontainersModule{
 				Name:      "AmazingDB",
 				TitleName: "AmazingDB",
 			},
 		},
 		{
 			name: "alphanumerical characters in name",
-			example: context.Example{
+			module: context.TestcontainersModule{
 				Name:      "AmazingDB4tw",
 				TitleName: "AmazingDB",
 			},
 		},
 		{
 			name: "alphanumerical characters in title",
-			example: context.Example{
+			module: context.TestcontainersModule{
 				Name:      "AmazingDB",
 				TitleName: "AmazingDB4tw",
 			},
 		},
 		{
 			name: "non-alphanumerical characters in name",
-			example: context.Example{
+			module: context.TestcontainersModule{
 				Name:      "Amazing DB 4 The Win",
 				TitleName: "AmazingDB",
 			},
@@ -122,7 +122,7 @@ func TestExample_Validate(outer *testing.T) {
 		},
 		{
 			name: "non-alphanumerical characters in title",
-			example: context.Example{
+			module: context.TestcontainersModule{
 				Name:      "AmazingDB",
 				TitleName: "Amazing DB 4 The Win",
 			},
@@ -130,7 +130,7 @@ func TestExample_Validate(outer *testing.T) {
 		},
 		{
 			name: "leading numerical character in name",
-			example: context.Example{
+			module: context.TestcontainersModule{
 				Name:      "1AmazingDB",
 				TitleName: "AmazingDB",
 			},
@@ -138,7 +138,7 @@ func TestExample_Validate(outer *testing.T) {
 		},
 		{
 			name: "leading numerical character in title",
-			example: context.Example{
+			module: context.TestcontainersModule{
 				Name:      "AmazingDB",
 				TitleName: "1AmazingDB",
 			},
@@ -148,12 +148,12 @@ func TestExample_Validate(outer *testing.T) {
 
 	for _, test := range tests {
 		outer.Run(test.name, func(t *testing.T) {
-			assert.Equal(t, test.expectedErr, test.example.Validate())
+			assert.Equal(t, test.expectedErr, test.module.Validate())
 		})
 	}
 }
 
-func TestGenerateWrongExampleName(t *testing.T) {
+func TestGenerateWrongModuleName(t *testing.T) {
 	tmpCtx := context.New(t.TempDir())
 	examplesTmp := filepath.Join(tmpCtx.RootDir, "examples")
 	examplesDocTmp := filepath.Join(tmpCtx.DocsDir(), "examples")
@@ -185,17 +185,17 @@ func TestGenerateWrongExampleName(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		example := context.Example{
+		module := context.TestcontainersModule{
 			Name:  test.name,
 			Image: "docker.io/example/" + test.name + ":latest",
 		}
 
-		err = internal.GenerateFiles(tmpCtx, example)
+		err = internal.GenerateFiles(tmpCtx, module)
 		assert.Error(t, err)
 	}
 }
 
-func TestGenerateWrongExampleTitle(t *testing.T) {
+func TestGenerateWrongModuleTitle(t *testing.T) {
 	tmpCtx := context.New(t.TempDir())
 	examplesTmp := filepath.Join(tmpCtx.RootDir, "examples")
 	examplesDocTmp := filepath.Join(tmpCtx.DocsDir(), "examples")
@@ -227,13 +227,13 @@ func TestGenerateWrongExampleTitle(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		example := context.Example{
+		module := context.TestcontainersModule{
 			Name:      "foo",
 			TitleName: test.title,
 			Image:     "docker.io/example/foo:latest",
 		}
 
-		err = internal.GenerateFiles(tmpCtx, example)
+		err = internal.GenerateFiles(tmpCtx, module)
 		assert.Error(t, err)
 	}
 }
@@ -263,41 +263,41 @@ func TestGenerate(t *testing.T) {
 	originalDependabotConfigUpdates, err := dependabot.GetUpdates(tmpCtx.DependabotConfigFile())
 	assert.Nil(t, err)
 
-	example := context.Example{
+	module := context.TestcontainersModule{
 		Name:      "foodb4tw",
 		TitleName: "FooDB4TheWin",
 		IsModule:  false,
 		Image:     "docker.io/example/foodb:latest",
 	}
-	exampleNameLower := example.Lower()
+	moduleNameLower := module.Lower()
 
-	err = internal.GenerateFiles(tmpCtx, example)
+	err = internal.GenerateFiles(tmpCtx, module)
 	assert.Nil(t, err)
 
-	exampleDirPath := filepath.Join(examplesTmp, exampleNameLower)
+	moduleDirPath := filepath.Join(examplesTmp, moduleNameLower)
 
-	exampleDirFileInfo, err := os.Stat(exampleDirPath)
+	moduleDirFileInfo, err := os.Stat(moduleDirPath)
 	assert.Nil(t, err) // error nil implies the file exist
-	assert.True(t, exampleDirFileInfo.IsDir())
+	assert.True(t, moduleDirFileInfo.IsDir())
 
-	exampleDocFile := filepath.Join(examplesDocTmp, exampleNameLower+".md")
-	_, err = os.Stat(exampleDocFile)
+	moduleDocFile := filepath.Join(examplesDocTmp, moduleNameLower+".md")
+	_, err = os.Stat(moduleDocFile)
 	assert.Nil(t, err) // error nil implies the file exist
 
 	mainWorkflowFile := filepath.Join(githubWorkflowsTmp, "ci.yml")
 	_, err = os.Stat(mainWorkflowFile)
 	assert.Nil(t, err) // error nil implies the file exist
 
-	assertExampleDocContent(t, example, exampleDocFile)
-	assertExampleGithubWorkflowContent(t, example, mainWorkflowFile)
+	assertModuleDocContent(t, module, moduleDocFile)
+	assertModuleGithubWorkflowContent(t, module, mainWorkflowFile)
 
-	generatedTemplatesDir := filepath.Join(examplesTmp, exampleNameLower)
-	assertExampleTestContent(t, example, filepath.Join(generatedTemplatesDir, exampleNameLower+"_test.go"))
-	assertExampleContent(t, example, filepath.Join(generatedTemplatesDir, exampleNameLower+".go"))
-	assertGoModContent(t, example, originalConfig.Extra.LatestVersion, filepath.Join(generatedTemplatesDir, "go.mod"))
-	assertMakefileContent(t, example, filepath.Join(generatedTemplatesDir, "Makefile"))
-	assertMkdocsExamplesNav(t, example, originalConfig, tmpCtx)
-	assertDependabotExamplesUpdates(t, example, originalDependabotConfigUpdates, tmpCtx)
+	generatedTemplatesDir := filepath.Join(examplesTmp, moduleNameLower)
+	assertModuleTestContent(t, module, filepath.Join(generatedTemplatesDir, moduleNameLower+"_test.go"))
+	assertModuleContent(t, module, filepath.Join(generatedTemplatesDir, moduleNameLower+".go"))
+	assertGoModContent(t, module, originalConfig.Extra.LatestVersion, filepath.Join(generatedTemplatesDir, "go.mod"))
+	assertMakefileContent(t, module, filepath.Join(generatedTemplatesDir, "Makefile"))
+	assertMkdocsNavItems(t, module, originalConfig, tmpCtx)
+	assertDependabotUpdates(t, module, originalDependabotConfigUpdates, tmpCtx)
 }
 
 func TestGenerateModule(t *testing.T) {
@@ -325,54 +325,54 @@ func TestGenerateModule(t *testing.T) {
 	originalDependabotConfigUpdates, err := dependabot.GetUpdates(tmpCtx.DependabotConfigFile())
 	assert.Nil(t, err)
 
-	example := context.Example{
+	module := context.TestcontainersModule{
 		Name:      "foodb",
 		TitleName: "FooDB",
 		IsModule:  true,
 		Image:     "docker.io/example/foodb:latest",
 	}
-	exampleNameLower := example.Lower()
+	moduleNameLower := module.Lower()
 
-	err = internal.GenerateFiles(tmpCtx, example)
+	err = internal.GenerateFiles(tmpCtx, module)
 	assert.Nil(t, err)
 
-	exampleDirPath := filepath.Join(modulesTmp, exampleNameLower)
+	moduleDirPath := filepath.Join(modulesTmp, moduleNameLower)
 
-	exampleDirFileInfo, err := os.Stat(exampleDirPath)
+	moduleDirFileInfo, err := os.Stat(moduleDirPath)
 	assert.Nil(t, err) // error nil implies the file exist
-	assert.True(t, exampleDirFileInfo.IsDir())
+	assert.True(t, moduleDirFileInfo.IsDir())
 
-	exampleDocFile := filepath.Join(modulesDocTmp, exampleNameLower+".md")
-	_, err = os.Stat(exampleDocFile)
+	moduleDocFile := filepath.Join(modulesDocTmp, moduleNameLower+".md")
+	_, err = os.Stat(moduleDocFile)
 	assert.Nil(t, err) // error nil implies the file exist
 
 	mainWorkflowFile := filepath.Join(githubWorkflowsTmp, "ci.yml")
 	_, err = os.Stat(mainWorkflowFile)
 	assert.Nil(t, err) // error nil implies the file exist
 
-	assertExampleDocContent(t, example, exampleDocFile)
-	assertExampleGithubWorkflowContent(t, example, mainWorkflowFile)
+	assertModuleDocContent(t, module, moduleDocFile)
+	assertModuleGithubWorkflowContent(t, module, mainWorkflowFile)
 
-	generatedTemplatesDir := filepath.Join(modulesTmp, exampleNameLower)
-	assertExampleTestContent(t, example, filepath.Join(generatedTemplatesDir, exampleNameLower+"_test.go"))
-	assertExampleContent(t, example, filepath.Join(generatedTemplatesDir, exampleNameLower+".go"))
-	assertGoModContent(t, example, originalConfig.Extra.LatestVersion, filepath.Join(generatedTemplatesDir, "go.mod"))
-	assertMakefileContent(t, example, filepath.Join(generatedTemplatesDir, "Makefile"))
-	assertMkdocsExamplesNav(t, example, originalConfig, tmpCtx)
-	assertDependabotExamplesUpdates(t, example, originalDependabotConfigUpdates, tmpCtx)
+	generatedTemplatesDir := filepath.Join(modulesTmp, moduleNameLower)
+	assertModuleTestContent(t, module, filepath.Join(generatedTemplatesDir, moduleNameLower+"_test.go"))
+	assertModuleContent(t, module, filepath.Join(generatedTemplatesDir, moduleNameLower+".go"))
+	assertGoModContent(t, module, originalConfig.Extra.LatestVersion, filepath.Join(generatedTemplatesDir, "go.mod"))
+	assertMakefileContent(t, module, filepath.Join(generatedTemplatesDir, "Makefile"))
+	assertMkdocsNavItems(t, module, originalConfig, tmpCtx)
+	assertDependabotUpdates(t, module, originalDependabotConfigUpdates, tmpCtx)
 }
 
-// assert content in the Examples nav from mkdocs.yml
-func assertDependabotExamplesUpdates(t *testing.T, example context.Example, originalConfigUpdates dependabot.Updates, tmpCtx *context.Context) {
-	examples, err := dependabot.GetUpdates(tmpCtx.DependabotConfigFile())
+// assert content in the Dependabot descriptor file
+func assertDependabotUpdates(t *testing.T, module context.TestcontainersModule, originalConfigUpdates dependabot.Updates, tmpCtx *context.Context) {
+	modules, err := dependabot.GetUpdates(tmpCtx.DependabotConfigFile())
 	assert.Nil(t, err)
 
-	assert.Equal(t, len(originalConfigUpdates)+1, len(examples))
+	assert.Equal(t, len(originalConfigUpdates)+1, len(modules))
 
-	// the example should be in the dependabot updates
+	// the module should be in the dependabot updates
 	found := false
-	for _, ex := range examples {
-		directory := "/" + example.ParentDir() + "/" + example.Lower()
+	for _, ex := range modules {
+		directory := "/" + module.ParentDir() + "/" + module.Lower()
 		if directory == ex.Directory {
 			found = true
 		}
@@ -381,25 +381,25 @@ func assertDependabotExamplesUpdates(t *testing.T, example context.Example, orig
 	assert.True(t, found)
 
 	// first item is the github-actions module
-	assert.Equal(t, "/", examples[0].Directory, examples)
-	assert.Equal(t, "github-actions", examples[0].PackageEcosystem, "PackageEcosystem should be github-actions")
+	assert.Equal(t, "/", modules[0].Directory, modules)
+	assert.Equal(t, "github-actions", modules[0].PackageEcosystem, "PackageEcosystem should be github-actions")
 
 	// second item is the core module
-	assert.Equal(t, "/", examples[1].Directory, examples)
-	assert.Equal(t, "gomod", examples[1].PackageEcosystem, "PackageEcosystem should be gomod")
+	assert.Equal(t, "/", modules[1].Directory, modules)
+	assert.Equal(t, "gomod", modules[1].PackageEcosystem, "PackageEcosystem should be gomod")
 
 	// third item is the pip module
-	assert.Equal(t, "/", examples[2].Directory, examples)
-	assert.Equal(t, "pip", examples[2].PackageEcosystem, "PackageEcosystem should be pip")
+	assert.Equal(t, "/", modules[2].Directory, modules)
+	assert.Equal(t, "pip", modules[2].PackageEcosystem, "PackageEcosystem should be pip")
 }
 
-// assert content example file in the docs
-func assertExampleDocContent(t *testing.T, example context.Example, exampleDocFile string) {
-	content, err := os.ReadFile(exampleDocFile)
+// assert content module file in the docs
+func assertModuleDocContent(t *testing.T, module context.TestcontainersModule, moduleDocFile string) {
+	content, err := os.ReadFile(moduleDocFile)
 	assert.Nil(t, err)
 
-	lower := example.Lower()
-	title := example.Title()
+	lower := module.Lower()
+	title := module.Title()
 
 	data := sanitiseContent(content)
 	assert.Equal(t, data[0], "# "+title)
@@ -408,38 +408,38 @@ func assertExampleDocContent(t *testing.T, example context.Example, exampleDocFi
 	assert.Equal(t, data[6], "The Testcontainers module for "+title+".")
 	assert.Equal(t, data[8], "## Adding this module to your project dependencies")
 	assert.Equal(t, data[10], "Please run the following command to add the "+title+" module to your Go dependencies:")
-	assert.Equal(t, data[13], "go get github.com/testcontainers/testcontainers-go/"+example.ParentDir()+"/"+lower)
+	assert.Equal(t, data[13], "go get github.com/testcontainers/testcontainers-go/"+module.ParentDir()+"/"+lower)
 	assert.Equal(t, data[18], "<!--codeinclude-->")
-	assert.Equal(t, data[19], "[Creating a "+title+" container](../../"+example.ParentDir()+"/"+lower+"/"+lower+".go)")
+	assert.Equal(t, data[19], "[Creating a "+title+" container](../../"+module.ParentDir()+"/"+lower+"/"+lower+".go)")
 	assert.Equal(t, data[20], "<!--/codeinclude-->")
 	assert.Equal(t, data[22], "<!--codeinclude-->")
-	assert.Equal(t, data[23], "[Test for a "+title+" container](../../"+example.ParentDir()+"/"+lower+"/"+lower+"_test.go)")
+	assert.Equal(t, data[23], "[Test for a "+title+" container](../../"+module.ParentDir()+"/"+lower+"/"+lower+"_test.go)")
 	assert.Equal(t, data[24], "<!--/codeinclude-->")
 	assert.Equal(t, data[28], "The "+title+" module exposes one entrypoint function to create the "+title+" container, and this function receives two parameters:")
 	assert.True(t, strings.HasSuffix(data[31], "(*"+title+"Container, error)"))
-	assert.Equal(t, "for "+title+". E.g. `testcontainers.WithImage(\""+example.Image+"\")`.", data[44])
+	assert.Equal(t, "for "+title+". E.g. `testcontainers.WithImage(\""+module.Image+"\")`.", data[44])
 }
 
-// assert content example test
-func assertExampleTestContent(t *testing.T, example context.Example, exampleTestFile string) {
+// assert content module test
+func assertModuleTestContent(t *testing.T, module context.TestcontainersModule, exampleTestFile string) {
 	content, err := os.ReadFile(exampleTestFile)
 	assert.Nil(t, err)
 
 	data := sanitiseContent(content)
-	assert.Equal(t, data[0], "package "+example.Lower())
-	assert.Equal(t, data[7], "func Test"+example.Title()+"(t *testing.T) {")
-	assert.Equal(t, data[10], "\tcontainer, err := "+example.Entrypoint()+"(ctx)")
+	assert.Equal(t, data[0], "package "+module.Lower())
+	assert.Equal(t, data[7], "func Test"+module.Title()+"(t *testing.T) {")
+	assert.Equal(t, data[10], "\tcontainer, err := "+module.Entrypoint()+"(ctx)")
 }
 
-// assert content example
-func assertExampleContent(t *testing.T, example context.Example, exampleFile string) {
+// assert content module
+func assertModuleContent(t *testing.T, module context.TestcontainersModule, exampleFile string) {
 	content, err := os.ReadFile(exampleFile)
 	assert.Nil(t, err)
 
-	lower := example.Lower()
-	containerName := example.ContainerName()
-	exampleName := example.Title()
-	entrypoint := example.Entrypoint()
+	lower := module.Lower()
+	containerName := module.ContainerName()
+	exampleName := module.Title()
+	entrypoint := module.Entrypoint()
 
 	data := sanitiseContent(content)
 	assert.Equal(t, data[0], "package "+lower)
@@ -447,13 +447,13 @@ func assertExampleContent(t *testing.T, example context.Example, exampleFile str
 	assert.Equal(t, data[9], "type "+containerName+" struct {")
 	assert.Equal(t, data[13], "// "+entrypoint+" creates an instance of the "+exampleName+" container type")
 	assert.Equal(t, data[14], "func "+entrypoint+"(ctx context.Context, opts ...testcontainers.ContainerCustomizer) (*"+containerName+", error) {")
-	assert.Equal(t, data[16], "\t\tImage: \""+example.Image+"\",")
+	assert.Equal(t, data[16], "\t\tImage: \""+module.Image+"\",")
 	assert.Equal(t, data[33], "\treturn &"+containerName+"{Container: container}, nil")
 }
 
-// assert content GitHub workflow for the example
-func assertExampleGithubWorkflowContent(t *testing.T, example context.Example, exampleWorkflowFile string) {
-	content, err := os.ReadFile(exampleWorkflowFile)
+// assert content GitHub workflow for the module
+func assertModuleGithubWorkflowContent(t *testing.T, module context.TestcontainersModule, moduleWorkflowFile string) {
+	content, err := os.ReadFile(moduleWorkflowFile)
 	assert.Nil(t, err)
 
 	data := sanitiseContent(content)
@@ -469,46 +469,46 @@ func assertExampleGithubWorkflowContent(t *testing.T, example context.Example, e
 }
 
 // assert content go.mod
-func assertGoModContent(t *testing.T, example context.Example, tcVersion string, goModFile string) {
+func assertGoModContent(t *testing.T, module context.TestcontainersModule, tcVersion string, goModFile string) {
 	content, err := os.ReadFile(goModFile)
 	assert.Nil(t, err)
 
 	data := sanitiseContent(content)
-	assert.Equal(t, "module github.com/testcontainers/testcontainers-go/"+example.ParentDir()+"/"+example.Lower(), data[0])
+	assert.Equal(t, "module github.com/testcontainers/testcontainers-go/"+module.ParentDir()+"/"+module.Lower(), data[0])
 	assert.Equal(t, "require github.com/testcontainers/testcontainers-go "+tcVersion, data[4])
 	assert.Equal(t, "replace github.com/testcontainers/testcontainers-go => ../..", data[6])
 }
 
 // assert content Makefile
-func assertMakefileContent(t *testing.T, example context.Example, makefile string) {
+func assertMakefileContent(t *testing.T, module context.TestcontainersModule, makefile string) {
 	content, err := os.ReadFile(makefile)
 	assert.Nil(t, err)
 
 	data := sanitiseContent(content)
-	assert.Equal(t, data[4], "\t$(MAKE) test-"+example.Lower())
+	assert.Equal(t, data[4], "\t$(MAKE) test-"+module.Lower())
 }
 
-// assert content in the Examples nav from mkdocs.yml
-func assertMkdocsExamplesNav(t *testing.T, example context.Example, originalConfig *mkdocs.Config, tmpCtx *context.Context) {
+// assert content in the nav items from mkdocs.yml
+func assertMkdocsNavItems(t *testing.T, module context.TestcontainersModule, originalConfig *mkdocs.Config, tmpCtx *context.Context) {
 	config, err := mkdocs.ReadConfig(tmpCtx.MkdocsConfigFile())
 	assert.Nil(t, err)
 
-	parentDir := example.ParentDir()
+	parentDir := module.ParentDir()
 
-	examples := config.Nav[4].Examples
+	navItems := config.Nav[4].Examples
 	expectedEntries := originalConfig.Nav[4].Examples
-	if example.IsModule {
-		examples = config.Nav[3].Modules
+	if module.IsModule {
+		navItems = config.Nav[3].Modules
 		expectedEntries = originalConfig.Nav[3].Modules
 	}
 
-	assert.Equal(t, len(expectedEntries)+1, len(examples))
+	assert.Equal(t, len(expectedEntries)+1, len(navItems))
 
-	// the example should be in the nav
+	// the module should be in the nav
 	found := false
-	for _, ex := range examples {
-		markdownExample := example.ParentDir() + "/" + example.Lower() + ".md"
-		if markdownExample == ex {
+	for _, ex := range navItems {
+		markdownModule := module.ParentDir() + "/" + module.Lower() + ".md"
+		if markdownModule == ex {
 			found = true
 		}
 	}
@@ -516,7 +516,7 @@ func assertMkdocsExamplesNav(t *testing.T, example context.Example, originalConf
 	assert.True(t, found)
 
 	// first item is the index
-	assert.Equal(t, parentDir+"/index.md", examples[0], examples)
+	assert.Equal(t, parentDir+"/index.md", navItems[0], navItems)
 }
 
 func sanitiseContent(bytes []byte) []string {

--- a/modulegen/mkdocs_test.go
+++ b/modulegen/mkdocs_test.go
@@ -56,7 +56,7 @@ func TestReadMkDocsConfig(t *testing.T) {
 	assert.Greater(t, len(nav[4].Examples), 0)
 }
 
-func TestExamples(t *testing.T) {
+func TestNavItems(t *testing.T) {
 	ctx := getTestRootContext(t)
 	examples, err := ctx.GetExamples()
 	require.NoError(t, err)


### PR DESCRIPTION
- chore: rename Example to TestcontainersModule
- chore: convert dependabot into a FileGenerator
- chore: convert makefile into a FileGenerator
- chore: convert go.mod into a FileGenerator
- chore: convert workflow into a ProjectGenerator
- chore: convert mkdocs into a FileGenerator
- chore: convert vscode into a ProjectGenerator

<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
This PRs renames the entities from Example to TestcontainersModule in order to be more intentional.

At the same time, creates two interfaces: FileGenerator and ProjectGenerator. The first one will generate files for a module when added, and the second one will inspect the state of the file system in order to generate the project files (CI workflow and VSCode workspace).

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
Better abstractions
<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Continues with #1536

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
