### PR TITLE
ci(lint): enable errorlint linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,10 +1,21 @@
 linters:
   enable:
+    - errorlint
     - gci
     - gofumpt
     - misspell
 
 linters-settings:
+  errorlint:
+    # Check whether fmt.Errorf uses the %w verb for formatting errors.
+    # See the https://github.com/polyfloyd/go-errorlint for caveats.
+    errorf: true
+    # Permit more than 1 %w verb, valid per Go 1.20 (Requires errorf:true)
+    errorf-multi: true
+    # Check for plain type assertions and type switches.
+    asserts: true
+    # Check for plain error comparisons.
+    comparison: true
   gci:
     sections:
       - standard

--- a/docker.go
+++ b/docker.go
@@ -795,7 +795,7 @@ func (p *DockerProvider) BuildImage(ctx context.Context, img ImageBuildInfo) (st
 		resp, err = p.client.ImageBuild(ctx, buildContext, buildOptions)
 		if err != nil {
 			var enf errdefs.ErrNotFound
-			if ok := errors.As(err, &enf); ok {
+			if errors.As(err, &enf) {
 				return backoff.Permanent(err)
 			}
 			Logger.Printf("Failed to build image: %s, will retry", err)
@@ -1163,7 +1163,7 @@ func (p *DockerProvider) attemptToPullImage(ctx context.Context, tag string, pul
 		pull, err = p.client.ImagePull(ctx, tag, pullOpt)
 		if err != nil {
 			var enf errdefs.ErrNotFound
-			if ok := errors.As(err, &enf); ok {
+			if errors.As(err, &enf) {
 				return backoff.Permanent(err)
 			}
 			Logger.Printf("Failed to pull image: %s, will retry", err)

--- a/docker.go
+++ b/docker.go
@@ -794,7 +794,8 @@ func (p *DockerProvider) BuildImage(ctx context.Context, img ImageBuildInfo) (st
 	err = backoff.Retry(func() error {
 		resp, err = p.client.ImageBuild(ctx, buildContext, buildOptions)
 		if err != nil {
-			if _, ok := err.(errdefs.ErrNotFound); ok {
+			var enf errdefs.ErrNotFound
+			if ok := errors.As(err, &enf); ok {
 				return backoff.Permanent(err)
 			}
 			Logger.Printf("Failed to build image: %s, will retry", err)
@@ -1161,7 +1162,8 @@ func (p *DockerProvider) attemptToPullImage(ctx context.Context, tag string, pul
 	err = backoff.Retry(func() error {
 		pull, err = p.client.ImagePull(ctx, tag, pullOpt)
 		if err != nil {
-			if _, ok := err.(errdefs.ErrNotFound); ok {
+			var enf errdefs.ErrNotFound
+			if ok := errors.As(err, &enf); ok {
 				return backoff.Permanent(err)
 			}
 			Logger.Printf("Failed to pull image: %s, will retry", err)

--- a/internal/testcontainersdocker/docker_host.go
+++ b/internal/testcontainersdocker/docker_host.go
@@ -112,7 +112,7 @@ func extractDockerHost(ctx context.Context) string {
 	for _, dockerHostFn := range dockerHostFns {
 		dockerHost, err := dockerHostFn(ctx)
 		if err != nil {
-			outerErr = fmt.Errorf("%w: %v", outerErr, err)
+			outerErr = fmt.Errorf("%w: %w", outerErr, err)
 			continue
 		}
 

--- a/internal/testcontainersdocker/docker_rootless.go
+++ b/internal/testcontainersdocker/docker_rootless.go
@@ -57,7 +57,7 @@ func rootlessDockerSocketPath(_ context.Context) (string, error) {
 	for _, socketPathFn := range socketPathFns {
 		s, err := socketPathFn()
 		if err != nil {
-			outerErr = fmt.Errorf("%w: %v", outerErr, err)
+			outerErr = fmt.Errorf("%w: %w", outerErr, err)
 			continue
 		}
 

--- a/parallel_test.go
+++ b/parallel_test.go
@@ -2,6 +2,7 @@ package testcontainers
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -100,10 +101,10 @@ func TestParallelContainers(t *testing.T) {
 			res, err := ParallelContainers(context.Background(), tc.reqs, ParallelContainersOptions{})
 			if err != nil {
 				require.NotZero(t, tc.expErrors)
-				e, _ := err.(ParallelContainersError)
-
+				var e ParallelContainersError
+				errors.As(err, &e)
 				if len(e.Errors) != tc.expErrors {
-					t.Fatalf("expected erorrs: %d, got: %d\n", tc.expErrors, len(e.Errors))
+					t.Fatalf("expected errors: %d, got: %d\n", tc.expErrors, len(e.Errors))
 				}
 			}
 
@@ -157,7 +158,8 @@ func TestParallelContainersWithReuse(t *testing.T) {
 
 	res, err := ParallelContainers(ctx, parallelRequest, ParallelContainersOptions{})
 	if err != nil {
-		e, _ := err.(ParallelContainersError)
+		var e ParallelContainersError
+		errors.As(err, &e)
 		t.Fatalf("expected errors: %d, got: %d\n", 0, len(e.Errors))
 	}
 	// Container is reused, only terminate first container

--- a/wait/errors.go
+++ b/wait/errors.go
@@ -3,8 +3,11 @@
 
 package wait
 
-import "syscall"
+import (
+	"errors"
+	"syscall"
+)
 
 func isConnRefusedErr(err error) bool {
-	return err == syscall.ECONNREFUSED
+	return errors.Is(err, syscall.ECONNREFUSED)
 }

--- a/wait/exec_test.go
+++ b/wait/exec_test.go
@@ -129,7 +129,7 @@ func TestExecStrategyWaitUntilReady_DeadlineExceeded(t *testing.T) {
 	}
 	wg := wait.NewExecStrategy([]string{"true"})
 	err := wg.WaitUntilReady(ctx, target)
-	if err != context.DeadlineExceeded {
+	if !errors.Is(err, context.DeadlineExceeded) {
 		t.Fatal(err)
 	}
 }

--- a/wait/host_port.go
+++ b/wait/host_port.go
@@ -156,9 +156,9 @@ func externalCheck(ctx context.Context, ipAddress string, port nat.Port, target 
 		conn, err := dialer.DialContext(ctx, proto, address)
 		if err != nil {
 			var v *net.OpError
-			if ok := errors.As(err, &v); ok {
+			if errors.As(err, &v) {
 				var v2 *os.SyscallError
-				if ok := errors.As(v.Err, &v2); ok {
+				if errors.As(v.Err, &v2) {
 					if isConnRefusedErr(v2.Err) {
 						time.Sleep(waitInterval)
 						continue

--- a/wait/host_port.go
+++ b/wait/host_port.go
@@ -116,7 +116,7 @@ func (hp *HostPortStrategy) WaitUntilReady(ctx context.Context, target StrategyT
 
 		select {
 		case <-ctx.Done():
-			return fmt.Errorf("%s:%w", ctx.Err(), err)
+			return fmt.Errorf("%w: %w", ctx.Err(), err)
 		case <-time.After(waitInterval):
 			if err := checkTarget(ctx, target); err != nil {
 				return err
@@ -155,8 +155,10 @@ func externalCheck(ctx context.Context, ipAddress string, port nat.Port, target 
 		}
 		conn, err := dialer.DialContext(ctx, proto, address)
 		if err != nil {
-			if v, ok := err.(*net.OpError); ok {
-				if v2, ok := (v.Err).(*os.SyscallError); ok {
+			var v *net.OpError
+			if ok := errors.As(err, &v); ok {
+				var v2 *os.SyscallError
+				if ok := errors.As(v.Err, &v2); ok {
 					if isConnRefusedErr(v2.Err) {
 						time.Sleep(waitInterval)
 						continue

--- a/wait/http.go
+++ b/wait/http.go
@@ -150,7 +150,7 @@ func (ws *HTTPStrategy) WaitUntilReady(ctx context.Context, target StrategyTarge
 		for err != nil {
 			select {
 			case <-ctx.Done():
-				return fmt.Errorf("%s:%w", ctx.Err(), err)
+				return fmt.Errorf("%w: %w", ctx.Err(), err)
 			case <-time.After(ws.PollInterval):
 				if err := checkTarget(ctx, target); err != nil {
 					return err
@@ -177,7 +177,7 @@ func (ws *HTTPStrategy) WaitUntilReady(ctx context.Context, target StrategyTarge
 		for mappedPort == "" {
 			select {
 			case <-ctx.Done():
-				return fmt.Errorf("%s:%w", ctx.Err(), err)
+				return fmt.Errorf("%w: %w", ctx.Err(), err)
 			case <-time.After(ws.PollInterval):
 				if err := checkTarget(ctx, target); err != nil {
 					return err

--- a/wait/sql.go
+++ b/wait/sql.go
@@ -87,7 +87,7 @@ func (w *waitForSql) WaitUntilReady(ctx context.Context, target StrategyTarget) 
 	for port == "" {
 		select {
 		case <-ctx.Done():
-			return fmt.Errorf("%s:%w", ctx.Err(), err)
+			return fmt.Errorf("%w: %w", ctx.Err(), err)
 		case <-ticker.C:
 			if err := checkTarget(ctx, target); err != nil {
 				return err
@@ -98,7 +98,7 @@ func (w *waitForSql) WaitUntilReady(ctx context.Context, target StrategyTarget) 
 
 	db, err := sql.Open(w.Driver, w.URL(host, port))
 	if err != nil {
-		return fmt.Errorf("sql.Open: %v", err)
+		return fmt.Errorf("sql.Open: %w", err)
 	}
 	defer db.Close()
 	for {


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?

Enables [errolint](https://golangci-lint.run/usage/linters/#errorlint) linter

## Why is it important?

Errorlint is a linter for that can be used to find code that will cause problems with the error wrapping scheme introduced in Go 1.13.