### PR TITLE
fix: remove extra equal in sonar.organization

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,5 +1,5 @@
 # Github organization linked to sonarcloud
-sonar.organization==testcontainers
+sonar.organization=testcontainers
 
 # Project key from sonarcloud dashboard for Github Action, otherwise pick a project key you like
 sonar.projectKey=testcontainers_testcontainers-go


### PR DESCRIPTION
## What does this PR do?
remove extra equal in sonar.organization

## Why is it important?

Otherwise the name is not recognized