### PR TITLE
ci(sonarcloud): run only when docker is not rootless

### DIFF
--- a/.github/workflows/ci-test-go.yml
+++ b/.github/workflows/ci-test-go.yml
@@ -79,7 +79,7 @@ jobs:
           # Optional: working directory, useful for monorepos
           working-directory: ${{ inputs.project-directory }}
           # Optional: golangci-lint command line arguments.
-          args: --verbose
+          args: --verbose --out-format=checkstyle:golangci-lint.report.xml
           # Optional: if set to true then the all caching functionality will be complete disabled,
           #           takes precedence over all other caching options.
           skip-cache: true
@@ -109,7 +109,7 @@ jobs:
             make test-unit
             
       - name: Analyze with SonarCloud
-        if: ${{ github.ref_name == 'main' && github.repository_owner == 'testcontainers' && inputs.run-tests && inputs.project-directory == '.' }}
+        if: ${{ github.ref_name == 'main' && github.repository_owner == 'testcontainers' && inputs.run-tests && !inputs.rootless-docker && inputs.project-directory == '.' }}
         uses: sonarsource/sonarcloud-github-action@master
         with:
           projectBaseDir: ${{ inputs.project-directory }}

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -22,6 +22,5 @@ linters-settings:
       - standard
       - default
       - prefix(github.com/testcontainers)
-
 run:
   timeout: 5m

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -5,13 +5,17 @@ sonar.organization=testcontainers
 sonar.projectKey=testcontainers_testcontainers-go
 
 sonar.projectName=testcontainers-go
+
 sonar.projectVersion=v0.23.0
 
 sonar.sources=.
+
 sonar.exclusions=**/*_test.go,**/vendor/**,**/testdata/*
 
 sonar.tests=.
 sonar.test.inclusions=**/*_test.go
 sonar.test.exclusions=**/vendor/**
-sonar.go.tests.reportPaths=TEST-*.xml
+
 sonar.go.coverage.reportPaths=coverage.out
+sonar.go.golangci-lint.reportPaths=golangci-lint.report.xml
+sonar.go.tests.reportPaths=TEST-unit.xml


### PR DESCRIPTION
## What does this PR do?

* run sonarcloud only when docker is not rootless
* generate a checkstyle report from golangci-lint for sonarcloud,  see [documentation](https://docs.sonarcloud.io/enriching/external-analyzer-reports/) 
* correct path of test report as it was not correctly discovered