### PR TITLE
chore: support linting all modules locally

### DIFF
--- a/commons-test.mk
+++ b/commons-test.mk
@@ -1,7 +1,13 @@
+ROOT_DIR:=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
+
 .PHONY: dependencies-scan
 dependencies-scan:
 	@echo ">> Scanning dependencies in $(CURDIR)..."
 	go list -json -m all | docker run --rm -i sonatypecommunity/nancy:latest sleuth --skip-update-check
+
+.PHONY: lint
+lint:
+	golangci-lint run --out-format=github-actions --path-prefix=. --verbose -c $(ROOT_DIR)/.golangci.yml --fix
 
 .PHONY: test-%
 test-%:

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -4,6 +4,10 @@ include ../commons-test.mk
 dependencies-scan-examples:
 	@find . -type f -name Makefile -execdir make dependencies-scan \;
 
+.PHONY: lint-examples
+lint-examples:
+	@find . -type f -name Makefile -execdir make lint \;
+
 .PHONY: tidy-examples
 tidy-examples:
 	@find . -type f -name Makefile -execdir make tools-tidy \;

--- a/modules/Makefile
+++ b/modules/Makefile
@@ -4,6 +4,10 @@ include ../commons-test.mk
 dependencies-scan-modules:
 	@find . -type f -name Makefile -execdir make dependencies-scan \;
 
+.PHONY: lint-modules
+lint-modules:
+	@find . -type f -name Makefile -execdir make lint \;
+
 .PHONY: tidy-modules
 tidy-modules:
 	@find . -type f -name Makefile -execdir make tools-tidy \;

--- a/modules/compose/compose_local.go
+++ b/modules/compose/compose_local.go
@@ -138,7 +138,7 @@ func (dc *LocalDockerCompose) applyStrategyToRunningContainer() error {
 		containerListOptions := types.ContainerListOptions{Filters: f, All: true}
 		containers, err := cli.ContainerList(context.Background(), containerListOptions)
 		if err != nil {
-			return fmt.Errorf("error %w occured while filtering the service %s: %d by name and published port", err, k.service, k.publishedPort)
+			return fmt.Errorf("error %w occurred while filtering the service %s: %d by name and published port", err, k.service, k.publishedPort)
 		}
 
 		if len(containers) == 0 {


### PR DESCRIPTION
- chore: support running golangci-lint for all modules
- fix: typo in error message

<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
It adds a Make goal to run the golangci-lint tool for all modules, with a single command.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
Support for running and fixing the lint stage locally before submitting a PR.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->


<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->

## How to test this PR

Run `make -C modules lint-modules` or `make -C examples lint-examples` or `cd modulegen; make lint`

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
