### PR TITLE
chore: always generate the examples including a explicit image

### DIFF
--- a/modulegen/_template/examples_test.go.tmpl
+++ b/modulegen/_template/examples_test.go.tmpl
@@ -1,9 +1,10 @@
-{{ $entrypoint := Entrypoint }}{{ $lower := ToLower }}{{ $title := Title }}package {{ $lower }}_test
+{{ $entrypoint := Entrypoint }}{{ $image := Image }}{{ $lower := ToLower }}{{ $title := Title }}package {{ $lower }}_test
 
 import (
 	"context"
 	"fmt"
 
+	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/modules/{{ $lower }}"
 )
 
@@ -11,7 +12,7 @@ func Example{{ $entrypoint }}() {
 	// run{{ $title }}Container {
 	ctx := context.Background()
 
-	{{ $lower }}Container, err := {{ $lower }}.{{ $entrypoint }}(ctx)
+	{{ $lower }}Container, err := {{ $lower }}.{{ $entrypoint }}(ctx, testcontainers.WithImage("{{ $image }}"))
 	if err != nil {
 		panic(err)
 	}

--- a/modulegen/_template/module_test.go.tmpl
+++ b/modulegen/_template/module_test.go.tmpl
@@ -1,14 +1,16 @@
-{{ $entrypoint := Entrypoint }}{{ $lower := ToLower }}{{ $title := Title }}package {{ $lower }}
+{{ $entrypoint := Entrypoint }}{{ $image := Image }}{{ $lower := ToLower }}{{ $title := Title }}package {{ $lower }}
 
 import (
 	"context"
 	"testing"
+
+	"github.com/testcontainers/testcontainers-go"
 )
 
 func Test{{ $title }}(t *testing.T) {
 	ctx := context.Background()
 
-	container, err := {{ $entrypoint }}(ctx)
+	container, err := {{ $entrypoint }}(ctx, testcontainers.WithImage("{{ $image }}"))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/modulegen/internal/module/main.go
+++ b/modulegen/internal/module/main.go
@@ -28,6 +28,7 @@ func generateGoFiles(moduleDir string, tcModule context.TestcontainersModule) er
 	funcMap := template.FuncMap{
 		"Entrypoint":    tcModule.Entrypoint,
 		"ContainerName": tcModule.ContainerName,
+		"Image":         func() string { return tcModule.Image },
 		"ParentDir":     tcModule.ParentDir,
 		"ToLower":       tcModule.Lower,
 		"Title":         tcModule.Title,

--- a/modulegen/main_test.go
+++ b/modulegen/main_test.go
@@ -430,13 +430,14 @@ func assertExamplesTestContent(t *testing.T, module context.TestcontainersModule
 
 	data := sanitiseContent(content)
 	assert.Equal(t, data[0], "package "+lower+"_test")
-	assert.Equal(t, data[6], "\t\"github.com/testcontainers/testcontainers-go/modules/"+lower+"\"")
-	assert.Equal(t, data[9], "func Example"+entrypoint+"() {")
-	assert.Equal(t, data[10], "\t// run"+title+"Container {")
-	assert.Equal(t, data[13], "\t"+lower+"Container, err := "+lower+"."+entrypoint+"(ctx)")
-	assert.Equal(t, data[31], "\tfmt.Println(state.Running)")
-	assert.Equal(t, data[33], "\t// Output:")
-	assert.Equal(t, data[34], "\t// true")
+	assert.Equal(t, data[6], "\t\"github.com/testcontainers/testcontainers-go\"")
+	assert.Equal(t, data[7], "\t\"github.com/testcontainers/testcontainers-go/modules/"+lower+"\"")
+	assert.Equal(t, data[10], "func Example"+entrypoint+"() {")
+	assert.Equal(t, data[11], "\t// run"+title+"Container {")
+	assert.Equal(t, data[14], "\t"+lower+"Container, err := "+lower+"."+entrypoint+"(ctx, testcontainers.WithImage(\""+module.Image+"\"))")
+	assert.Equal(t, data[32], "\tfmt.Println(state.Running)")
+	assert.Equal(t, data[34], "\t// Output:")
+	assert.Equal(t, data[35], "\t// true")
 }
 
 // assert content module test
@@ -446,8 +447,8 @@ func assertModuleTestContent(t *testing.T, module context.TestcontainersModule, 
 
 	data := sanitiseContent(content)
 	assert.Equal(t, data[0], "package "+module.Lower())
-	assert.Equal(t, data[7], "func Test"+module.Title()+"(t *testing.T) {")
-	assert.Equal(t, data[10], "\tcontainer, err := "+module.Entrypoint()+"(ctx)")
+	assert.Equal(t, data[9], "func Test"+module.Title()+"(t *testing.T) {")
+	assert.Equal(t, data[12], "\tcontainer, err := "+module.Entrypoint()+"(ctx, testcontainers.WithImage(\""+module.Image+"\"))")
 }
 
 // assert content module


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
This PR updates the module templates to always include the default image for the new module. It applies to:

- examples_test.go
- module_test.go

Therefore, the all `RunContainer` calls in the examples will include the `testcontainers.WithImage("foo:bar")` functional option.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
Users copy&pasting our code examples will receive a code snippet including the image, which is important for awareness of what version of the technology they are using.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->


<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
