### PR TITLE
feat: support creating a network for localstack

### DIFF
--- a/docs/modules/localstack.md
+++ b/docs/modules/localstack.md
@@ -54,11 +54,11 @@ It's possible to entirely override the default LocalStack container request:
 
 With simply passing the `testcontainers.CustomizeRequest` functional option to the `RunContainer` function, you'll be able to configure the LocalStack container with your own needs, as this new container request will be merged with the original one.
 
-In the following example you check how it's possible to set certain environment variables that are needed by the tests, the most important of them the AWS services you want to use. Besides, the container runs in a separate Docker network with an alias:
+In the above example you can check how it's possible to set certain environment variables that are needed by the tests, the most important ones are the AWS services you want to use. Besides, the container runs in a separate Docker network with an alias.
 
-<!--codeinclude-->
-[Overriding the default container request](../../modules/localstack/localstack_test.go) inside_block:withCustomContainerRequest
-<!--/codeinclude-->
+#### WithNetwork
+
+By default, the LocalStack container is started in the default Docker network. If you want to use a different Docker network, you can use the `WithNetwork(networkName string, alias string)` option, which receives the new network name and an alias as parameters, creating the new network, attaching the container to it, and setting the network alias for that network.
 
 ## Accessing hostname-sensitive services
 

--- a/modules/localstack/localstack.go
+++ b/modules/localstack/localstack.go
@@ -68,7 +68,11 @@ func WithNetwork(networkName string, alias string) testcontainers.CustomizeReque
 			},
 		})
 		if err != nil {
-			req.Logger.Printf("Failed to create network '%s'. Container won't be attached to this network: %v", networkName, err)
+			logger := req.Logger
+			if logger == nil {
+				logger = testcontainers.Logger
+			}
+			logger.Printf("Failed to create network '%s'. Container won't be attached to this network: %v", networkName, err)
 			return
 		}
 

--- a/modules/localstack/localstack.go
+++ b/modules/localstack/localstack.go
@@ -58,6 +58,29 @@ func isVersion2(image string) bool {
 	return true
 }
 
+// WithNetwork creates a network with the given name and attaches the container to it, setting the network alias
+// on that network to the given alias.
+func WithNetwork(networkName string, alias string) testcontainers.CustomizeRequestOption {
+	return func(req *testcontainers.GenericContainerRequest) {
+		_, err := testcontainers.GenericNetwork(context.Background(), testcontainers.GenericNetworkRequest{
+			NetworkRequest: testcontainers.NetworkRequest{
+				Name: networkName,
+			},
+		})
+		if err != nil {
+			req.Logger.Printf("Failed to create network '%s'. Container won't be attached to this network: %v", networkName, err)
+			return
+		}
+
+		req.Networks = append(req.Networks, networkName)
+
+		if req.NetworkAliases == nil {
+			req.NetworkAliases = make(map[string][]string)
+		}
+		req.NetworkAliases[networkName] = []string{alias}
+	}
+}
+
 // RunContainer creates an instance of the LocalStack container type, being possible to pass a custom request and options:
 // - overrideReq: a function that can be used to override the default container request, usually used to set the image version, environment variables for localstack, etc.
 func RunContainer(ctx context.Context, opts ...testcontainers.ContainerCustomizer) (*LocalStackContainer, error) {

--- a/modules/localstack/localstack_test.go
+++ b/modules/localstack/localstack_test.go
@@ -153,23 +153,16 @@ func TestStartWithoutOverride(t *testing.T) {
 func TestStartV2WithNetwork(t *testing.T) {
 	ctx := context.Background()
 
-	nw, err := testcontainers.GenericNetwork(ctx, testcontainers.GenericNetworkRequest{
-		NetworkRequest: testcontainers.NetworkRequest{
-			Name: "localstack-network-v2",
-		},
-	})
-	require.Nil(t, err)
-	assert.NotNil(t, nw)
-
 	// withCustomContainerRequest {
+	networkName := "localstack-network-v2"
+
 	localstack, err := RunContainer(
 		ctx,
+		WithNetwork(networkName, "localstack"),
 		testcontainers.CustomizeRequest(testcontainers.GenericContainerRequest{
 			ContainerRequest: testcontainers.ContainerRequest{
-				Image:          "localstack/localstack:2.0.0",
-				Env:            map[string]string{"SERVICES": "s3,sqs"},
-				Networks:       []string{"localstack-network-v2"},
-				NetworkAliases: map[string][]string{"localstack-network-v2": {"localstack"}},
+				Image: "localstack/localstack:2.0.0",
+				Env:   map[string]string{"SERVICES": "s3,sqs"},
 			},
 		}),
 	)
@@ -180,7 +173,7 @@ func TestStartV2WithNetwork(t *testing.T) {
 	cli, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
 		ContainerRequest: testcontainers.ContainerRequest{
 			Image:      "amazon/aws-cli:2.7.27",
-			Networks:   []string{"localstack-network-v2"},
+			Networks:   []string{networkName},
 			Entrypoint: []string{"tail"},
 			Cmd:        []string{"-f", "/dev/null"},
 			Env: map[string]string{


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
This PR adds a functional option to the localstack module, making it possible to create a Docker network for it and run localstack in that network with a given alias.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
Support for running the localstack module in a network, as demo'ed in the existing tests.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes #1602

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
