### PR TITLE
fix: avoid deadlocks when Docker is not available

### DIFF
--- a/docker_client.go
+++ b/docker_client.go
@@ -40,8 +40,6 @@ func (c *DockerClient) Info(ctx context.Context) (types.Info, error) {
 	dockerInfoOnce.Do(func() {
 		dockerInfo, err = c.Client.Info(ctx)
 		if err != nil {
-			// reset the state of the sync.Once so that the next call to Info will try again
-			dockerInfoOnce = sync.Once{}
 			return
 		}
 
@@ -65,6 +63,11 @@ func (c *DockerClient) Info(ctx context.Context) (types.Info, error) {
 			testcontainerssession.ProcessID(),
 		)
 	})
+
+	if err != nil {
+		// reset the state of the sync.Once so that the next call to Info will try again
+		dockerInfoOnce = sync.Once{}
+	}
 
 	return dockerInfo, err
 }


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
It restores the state of the `sync.Once` instance out of the Do block, which was incorrect, and buggy.

Before the changes, a panic was raised, but now we'll have a proper error message:

```
--- FAIL: TestContainerAttachedToNewNetwork (26.59s)
    docker_test.go:78: Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?: failed to create network
```

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
Removes a deadlock in the case the tests are run without Docker already running on the system.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Caused by #1490

## How to test this PR

1. Stop Docker (or its alternatives: Testcontainers Desktop, Podman...)
2. Run a test using testcontainers-go

**Expected result**: the test fail with a proper error message that Docker is not running
**Before this PR**: the test panicked with a deadlock.

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
