### PR TITLE
fix: support running the semver Docker image interactively during the release process

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -46,7 +46,7 @@ function main() {
   done
 
   # Get the version to bump to from the semver-tool and the bump type
-  local newVersion=$(docker run --rm "${DOCKER_IMAGE_SEMVER}" bump "${BUMP_TYPE}" "${vVersion}")
+  local newVersion=$(docker run --rm --platform=linux/amd64 -i "${DOCKER_IMAGE_SEMVER}" bump "${BUMP_TYPE}" "${vVersion}")
   echo "Producing a ${BUMP_TYPE} bump of the version, from ${version} to ${newVersion}"
 
   # Bump the version in the version.go file


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
It forces the `linux/amd64` platform and the interactive flag when running the semver Docker image using during the release.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
When running against a remote Docker engine, there was no response, causing a commit with an empty value for the next release. See:
- fee2ce2b309c5acc1ae9a55d8a6e3a1a98f99ca7
- fe847d2372d70a0ff14d423644657653e7be8cbe

They were caused because of I was running against a remote Docker daemon.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->


<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
