### PR TITLE
docs: have common options in a common markdown file

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -8,6 +8,7 @@ verify_ssl = true
 [packages]
 mkdocs = "==1.5.2"
 mkdocs-codeinclude-plugin = "==0.2.1"
+mkdocs-include-markdown-plugin = "==6.0.1"
 mkdocs-material = "==9.2.8"
 mkdocs-markdownextradata-plugin = "==0.2.5"
 

--- a/docs/features/common_functional_options.md
+++ b/docs/features/common_functional_options.md
@@ -1,0 +1,31 @@
+#### Wait Strategies
+
+If you need to set a different wait strategy for the container, you can use `testcontainers.WithWaitStrategy` with a valid wait strategy.
+
+!!!info
+    The default deadline for the wait strategy is 60 seconds.
+
+At the same time, it's possible to set a wait strategy and a custom deadline with `testcontainers.WithWaitStrategyAndDeadline`.
+
+#### Startup Commands
+
+- Not available until the next release of testcontainers-go <a href="https://github.com/testcontainers/testcontainers-go"><span class="tc-version">:material-tag: main</span></a>
+
+Testcontainers exposes the `WithStartupCommand(e ...Executable)` option to run arbitrary commands in the container right after it's started.
+
+!!!info
+    To better understand how this feature works, please read the [Create containers: Lifecycle Hooks](/features/creating_container/#lifecycle-hooks) documentation.
+
+It also exports an `Executable` interface, defining one single method: `AsCommand()`, which returns a slice of strings to represent the command and positional arguments to be executed in the container.
+
+You could use this feature to run a custom script, or to run a command that is not supported by the module right after the container is started.
+
+#### Docker type modifiers
+
+If you need an advanced configuration for the container, you can leverage the following Docker type modifiers:
+
+- `testcontainers.WithConfigModifier`
+- `testcontainers.WithHostConfigModifier`
+- `testcontainers.WithEndpointSettingsModifier`
+
+Please read the [Create containers: Advanced Settings](/features/creating_container.md#advanced-settings) documentation for more information.

--- a/docs/modules/artemis.md
+++ b/docs/modules/artemis.md
@@ -44,15 +44,7 @@ When starting the Artemis container, you can pass options in a variadic way to c
 If you need to set a different Artemis Docker image, you can use `testcontainers.WithImage` with a valid Docker image
 for Artemis. E.g. `testcontainers.WithImage("docker.io/apache/activemq-artemis:2.30.0")`.
 
-#### Wait Strategies
-
-If you need to set a different wait strategy for Artemis, you can use `testcontainers.WithWaitStrategy` with a valid wait strategy
-for Artemis.
-
-!!!info
-    The default deadline for the wait strategy is 60 seconds.
-
-At the same time, it's possible to set a wait strategy and a custom deadline with `testcontainers.WithWaitStrategyAndDeadline`.
+{% include "../features/common_functional_options.md" %}
 
 #### Credentials
 
@@ -82,30 +74,6 @@ Setting this value will override the default.
 <!--codeinclude-->
 [With Extra Arguments](../../modules/artemis/artemis_test.go) inside_block:withExtraArgs
 <!--/codeinclude-->
-
-#### Docker type modifiers
-
-If you need an advanced configuration for Artemis, you can leverage the following Docker type modifiers:
-
-- `testcontainers.WithConfigModifier`
-- `testcontainers.WithHostConfigModifier`
-- `testcontainers.WithEndpointSettingsModifier`
-
-Please read the [Create containers: Advanced Settings](../features/creating_container.md#advanced-settings) documentation for more information.
-
-#### Startup Commands
-
-!!!info
-    Not available until the next release of testcontainers-go <a href="https://github.com/testcontainers/testcontainers-go"><span class="tc-version">:material-tag: main</span></a>
-
-Testcontainers exposes the `WithStartupCommand(e ...Executable)` option to run arbitrary commands in the container right after it's started.
-
-!!!info
-    To better understand how this feature works, please read the [Create containers: Lifecycle Hooks](../../features/creating_container/#lifecycle-hooks) documentation.
-
-It also exports an `Executable` interface, defining one single method: `AsCommand()`, which returns a slice of strings to represent the command and positional arguments to be executed in the container.
-
-You could use this feature to run a custom script, or to run a command that is not supported by the module right after the Artemis container is started.
 
 ### Container Methods
 

--- a/docs/modules/clickhouse.md
+++ b/docs/modules/clickhouse.md
@@ -48,39 +48,7 @@ When starting the ClickHouse container, you can pass options in a variadic way t
 If you need to set a different ClickHouse Docker image, you can use `testcontainers.WithImage` with a valid Docker image
 for ClickHouse. E.g. `testcontainers.WithImage("clickhouse/clickhouse-server:23.3.8.21-alpine")`.
 
-#### Wait Strategies
-
-If you need to set a different wait strategy for ClickHouse, you can use `testcontainers.WithWaitStrategy` with a valid wait strategy
-for ClickHouse.
-
-!!!info
-    The default deadline for the wait strategy is 60 seconds.
-
-At the same time, it's possible to set a wait strategy and a custom deadline with `testcontainers.WithWaitStrategyAndDeadline`.
-
-#### Docker type modifiers
-
-If you need an advanced configuration for ClickHouse, you can leverage the following Docker type modifiers:
-
-- `testcontainers.WithConfigModifier`
-- `testcontainers.WithHostConfigModifier`
-- `testcontainers.WithEndpointSettingsModifier`
-
-Please read the [Create containers: Advanced Settings](../features/creating_container.md#advanced-settings) documentation for more information.
-
-#### Startup Commands
-
-!!!info
-    Not available until the next release of testcontainers-go <a href="https://github.com/testcontainers/testcontainers-go"><span class="tc-version">:material-tag: main</span></a>
-
-Testcontainers exposes the `WithStartupCommand(e ...Executable)` option to run arbitrary commands in the container right after it's started.
-
-!!!info
-    To better understand how this feature works, please read the [Create containers: Lifecycle Hooks](../../features/creating_container/#lifecycle-hooks) documentation.
-
-It also exports an `Executable` interface, defining one single method: `AsCommand()`, which returns a slice of strings to represent the command and positional arguments to be executed in the container.
-
-You could use this feature to run a custom script, or to run a command that is not supported by the module right after the ClickHouse container is started.
+{% include "../features/common_functional_options.md" %}
 
 #### Set username, password and database name
 

--- a/docs/modules/couchbase.md
+++ b/docs/modules/couchbase.md
@@ -79,39 +79,7 @@ You can find the Docker images that are currently tested in this module, for the
 [Docker images](../../modules/couchbase/couchbase_test.go) inside_block:dockerImages
 <!--/codeinclude-->
 
-#### Wait Strategies
-
-If you need to set a different wait strategy for Couchbase, you can use `testcontainers.WithWaitStrategy` with a valid wait strategy
-for Couchbase.
-
-!!!info
-    The default deadline for the wait strategy is 60 seconds.
-
-At the same time, it's possible to set a wait strategy and a custom deadline with `testcontainers.WithWaitStrategyAndDeadline`.
-
-#### Docker type modifiers
-
-If you need an advanced configuration for Couchbase, you can leverage the following Docker type modifiers:
-
-- `testcontainers.WithConfigModifier`
-- `testcontainers.WithHostConfigModifier`
-- `testcontainers.WithEndpointSettingsModifier`
-
-Please read the [Create containers: Advanced Settings](../features/creating_container.md#advanced-settings) documentation for more information.
-
-#### Startup Commands
-
-!!!info
-    Not available until the next release of testcontainers-go <a href="https://github.com/testcontainers/testcontainers-go"><span class="tc-version">:material-tag: main</span></a>
-
-Testcontainers exposes the `WithStartupCommand(e ...Executable)` option to run arbitrary commands in the container right after it's started.
-
-!!!info
-    To better understand how this feature works, please read the [Create containers: Lifecycle Hooks](../../features/creating_container/#lifecycle-hooks) documentation.
-
-It also exports an `Executable` interface, defining one single method: `AsCommand()`, which returns a slice of strings to represent the command and positional arguments to be executed in the container.
-
-You could use this feature to run a custom script, or to run a command that is not supported by the module right after the Couchbase container is started.
+{% include "../features/common_functional_options.md" %}
 
 #### Credentials
 

--- a/docs/modules/elasticsearch.md
+++ b/docs/modules/elasticsearch.md
@@ -40,39 +40,7 @@ When starting the Elasticsearch container, you can pass options in a variadic wa
 If you need to set a different Elasticsearch Docker image, you can use `testcontainers.WithImage` with a valid Docker image
 for Elasticsearch. E.g. `testcontainers.WithImage("docker.elastic.co/elasticsearch/elasticsearch:8.0.0")`.
 
-#### Wait Strategies
-
-If you need to set a different wait strategy for Elasticsearch, you can use `testcontainers.WithWaitStrategy` with a valid wait strategy
-for Elasticsearch.
-
-!!!info
-    The default deadline for the wait strategy is 60 seconds.
-
-At the same time, it's possible to set a wait strategy and a custom deadline with `testcontainers.WithWaitStrategyAndDeadline`.
-
-#### Docker type modifiers
-
-If you need an advanced configuration for Elasticsearch, you can leverage the following Docker type modifiers:
-
-- `testcontainers.WithConfigModifier`
-- `testcontainers.WithHostConfigModifier`
-- `testcontainers.WithEndpointSettingsModifier`
-
-Please read the [Create containers: Advanced Settings](../features/creating_container.md#advanced-settings) documentation for more information.
-
-#### Startup Commands
-
-!!!info
-    Not available until the next release of testcontainers-go <a href="https://github.com/testcontainers/testcontainers-go"><span class="tc-version">:material-tag: main</span></a>
-
-Testcontainers exposes the `WithStartupCommand(e ...Executable)` option to run arbitrary commands in the container right after it's started.
-
-!!!info
-    To better understand how this feature works, please read the [Create containers: Lifecycle Hooks](../../features/creating_container/#lifecycle-hooks) documentation.
-
-It also exports an `Executable` interface, defining one single method: `AsCommand()`, which returns a slice of strings to represent the command and positional arguments to be executed in the container.
-
-You could use this feature to run a custom script, or to run a command that is not supported by the module right after the Elasticsearch container is started.
+{% include "../features/common_functional_options.md" %}
 
 #### Elasticsearch password
 

--- a/docs/modules/k3s.md
+++ b/docs/modules/k3s.md
@@ -47,39 +47,7 @@ When starting the K3s container, you can pass options in a variadic way to confi
 If you need to set a different K3s Docker image, you can use `testcontainers.WithImage` with a valid Docker image
 for K3s. E.g. `testcontainers.WithImage("docker.io/rancher/k3s:v1.27.1-k3s1")`.
 
-#### Wait Strategies
-
-If you need to set a different wait strategy for K3s, you can use `testcontainers.WithWaitStrategy` with a valid wait strategy
-for K3s.
-
-!!!info
-    The default deadline for the wait strategy is 60 seconds.
-
-At the same time, it's possible to set a wait strategy and a custom deadline with `testcontainers.WithWaitStrategyAndDeadline`.
-
-#### Docker type modifiers
-
-If you need an advanced configuration for K3s, you can leverage the following Docker type modifiers:
-
-- `testcontainers.WithConfigModifier`
-- `testcontainers.WithHostConfigModifier`
-- `testcontainers.WithEndpointSettingsModifier`
-
-Please read the [Create containers: Advanced Settings](../features/creating_container.md#advanced-settings) documentation for more information.
-
-#### Startup Commands
-
-!!!info
-    Not available until the next release of testcontainers-go <a href="https://github.com/testcontainers/testcontainers-go"><span class="tc-version">:material-tag: main</span></a>
-
-Testcontainers exposes the `WithStartupCommand(e ...Executable)` option to run arbitrary commands in the container right after it's started.
-
-!!!info
-    To better understand how this feature works, please read the [Create containers: Lifecycle Hooks](../../features/creating_container/#lifecycle-hooks) documentation.
-
-It also exports an `Executable` interface, defining one single method: `AsCommand()`, which returns a slice of strings to represent the command and positional arguments to be executed in the container.
-
-You could use this feature to run a custom script, or to run a command that is not supported by the module right after the K3s container is started.
+{% include "../features/common_functional_options.md" %}
 
 ### Container Methods
 

--- a/docs/modules/kafka.md
+++ b/docs/modules/kafka.md
@@ -61,39 +61,7 @@ The environment variables that are already set by default are:
 [Environment variables](../../modules/kafka/kafka.go) inside_block:envVars
 <!--/codeinclude-->
 
-#### Wait Strategies
-
-If you need to set a different wait strategy for Kafka, you can use `testcontainers.WithWaitStrategy` with a valid wait strategy
-for Kafka.
-
-!!!info
-    The default deadline for the wait strategy is 60 seconds.
-
-At the same time, it's possible to set a wait strategy and a custom deadline with `testcontainers.WithWaitStrategyAndDeadline`.
-
-#### Docker type modifiers
-
-If you need an advanced configuration for Kafka, you can leverage the following Docker type modifiers:
-
-- `testcontainers.WithConfigModifier`
-- `testcontainers.WithHostConfigModifier`
-- `testcontainers.WithEndpointSettingsModifier`
-
-Please read the [Create containers: Advanced Settings](../features/creating_container.md#advanced-settings) documentation for more information.
-
-#### Startup Commands
-
-!!!info
-    Not available until the next release of testcontainers-go <a href="https://github.com/testcontainers/testcontainers-go"><span class="tc-version">:material-tag: main</span></a>
-
-Testcontainers exposes the `WithStartupCommand(e ...Executable)` option to run arbitrary commands in the container right after it's started.
-
-!!!info
-    To better understand how this feature works, please read the [Create containers: Lifecycle Hooks](../../features/creating_container/#lifecycle-hooks) documentation.
-
-It also exports an `Executable` interface, defining one single method: `AsCommand()`, which returns a slice of strings to represent the command and positional arguments to be executed in the container.
-
-You could use this feature to run a custom script, or to run a command that is not supported by the module right after the Kafka container is started.
+{% include "../features/common_functional_options.md" %}
 
 ### Container Methods
 

--- a/docs/modules/localstack.md
+++ b/docs/modules/localstack.md
@@ -44,6 +44,8 @@ When starting the Localstack container, you can pass options in a variadic way t
 
 By default, the image used is `localstack:1.4.0`.  If you need to use a different image, you can use `testcontainers.WithImage` option.
 
+{% include "../features/common_functional_options.md" %}
+
 #### Customize the container request
 
 It's possible to entirely override the default LocalStack container request:
@@ -55,20 +57,6 @@ It's possible to entirely override the default LocalStack container request:
 With simply passing the `testcontainers.CustomizeRequest` functional option to the `RunContainer` function, you'll be able to configure the LocalStack container with your own needs, as this new container request will be merged with the original one.
 
 In the above example you can check how it's possible to set certain environment variables that are needed by the tests, the most important ones are the AWS services you want to use. Besides, the container runs in a separate Docker network with an alias.
-
-#### Startup Commands
-
-!!!info
-    Not available until the next release of testcontainers-go <a href="https://github.com/testcontainers/testcontainers-go"><span class="tc-version">:material-tag: main</span></a>
-
-Testcontainers exposes the `WithStartupCommand(e ...Executable)` option to run arbitrary commands in the container right after it's started.
-
-!!!info
-    To better understand how this feature works, please read the [Create containers: Lifecycle Hooks](../../features/creating_container/#lifecycle-hooks) documentation.
-
-It also exports an `Executable` interface, defining one single method: `AsCommand()`, which returns a slice of strings to represent the command and positional arguments to be executed in the container.
-
-You could use this feature to run a custom script, or to run a command that is not supported by the module right after the LocalStack container is started.
 
 #### WithNetwork
 

--- a/docs/modules/mariadb.md
+++ b/docs/modules/mariadb.md
@@ -53,39 +53,7 @@ for MariaDB. E.g. `testcontainers.WithImage("mariadb:11.0.3")`.
 
 The MariaDB module will take all the environment variables that start with `MARIADB_` and duplicate them with the `MYSQL_` prefix.
 
-#### Wait Strategies
-
-If you need to set a different wait strategy for MariaDB, you can use `testcontainers.WithWaitStrategy` with a valid wait strategy
-for MariaDB.
-
-!!!info
-    The default deadline for the wait strategy is 60 seconds.
-
-At the same time, it's possible to set a wait strategy and a custom deadline with `testcontainers.WithWaitStrategyAndDeadline`.
-
-#### Docker type modifiers
-
-If you need an advanced configuration for MariaDB, you can leverage the following Docker type modifiers:
-
-- `testcontainers.WithConfigModifier`
-- `testcontainers.WithHostConfigModifier`
-- `testcontainers.WithEndpointSettingsModifier`
-
-Please read the [Create containers: Advanced Settings](../features/creating_container.md#advanced-settings) documentation for more information.
-
-#### Startup Commands
-
-!!!info
-    Not available until the next release of testcontainers-go <a href="https://github.com/testcontainers/testcontainers-go"><span class="tc-version">:material-tag: main</span></a>
-
-Testcontainers exposes the `WithStartupCommand(e ...Executable)` option to run arbitrary commands in the container right after it's started.
-
-!!!info
-    To better understand how this feature works, please read the [Create containers: Lifecycle Hooks](../../features/creating_container/#lifecycle-hooks) documentation.
-
-It also exports an `Executable` interface, defining one single method: `AsCommand()`, which returns a slice of strings to represent the command and positional arguments to be executed in the container.
-
-You could use this feature to run a custom script, or to run a command that is not supported by the module right after the MariaDB container is started.
+{% include "../features/common_functional_options.md" %}
 
 #### Set username, password and database name
 

--- a/docs/modules/mongodb.md
+++ b/docs/modules/mongodb.md
@@ -40,39 +40,7 @@ When starting the MongoDB container, you can pass options in a variadic way to c
 If you need to set a different MongoDB Docker image, you can use `testcontainers.WithImage` with a valid Docker image
 for MongoDB. E.g. `testcontainers.WithImage("mongo:6")`.
 
-#### Wait Strategies
-
-If you need to set a different wait strategy for MongoDB, you can use `testcontainers.WithWaitStrategy` with a valid wait strategy
-for MongoDB.
-
-!!!info
-    The default deadline for the wait strategy is 60 seconds.
-
-At the same time, it's possible to set a wait strategy and a custom deadline with `testcontainers.WithWaitStrategyAndDeadline`.
-
-#### Docker type modifiers
-
-If you need an advanced configuration for MongoDB, you can leverage the following Docker type modifiers:
-
-- `testcontainers.WithConfigModifier`
-- `testcontainers.WithHostConfigModifier`
-- `testcontainers.WithEndpointSettingsModifier`
-
-Please read the [Create containers: Advanced Settings](../features/creating_container.md#advanced-settings) documentation for more information.
-
-#### Startup Commands
-
-!!!info
-    Not available until the next release of testcontainers-go <a href="https://github.com/testcontainers/testcontainers-go"><span class="tc-version">:material-tag: main</span></a>
-
-Testcontainers exposes the `WithStartupCommand(e ...Executable)` option to run arbitrary commands in the container right after it's started.
-
-!!!info
-    To better understand how this feature works, please read the [Create containers: Lifecycle Hooks](../../features/creating_container/#lifecycle-hooks) documentation.
-
-It also exports an `Executable` interface, defining one single method: `AsCommand()`, which returns a slice of strings to represent the command and positional arguments to be executed in the container.
-
-You could use this feature to run a custom script, or to run a command that is not supported by the module right after the MongoDB container is started.
+{% include "../features/common_functional_options.md" %}
 
 ### Container Methods
 

--- a/docs/modules/mysql.md
+++ b/docs/modules/mysql.md
@@ -50,39 +50,7 @@ By default, the container will use the following Docker image:
 [Default Docker image](../../modules/mysql/mysql.go) inside_block:defaultImage
 <!--/codeinclude-->
 
-#### Wait Strategies
-
-If you need to set a different wait strategy for MySQL, you can use `testcontainers.WithWaitStrategy` with a valid wait strategy
-for MySQL.
-
-!!!info
-    The default deadline for the wait strategy is 60 seconds.
-
-At the same time, it's possible to set a wait strategy and a custom deadline with `testcontainers.WithWaitStrategyAndDeadline`.
-
-#### Docker type modifiers
-
-If you need an advanced configuration for MySQL, you can leverage the following Docker type modifiers:
-
-- `testcontainers.WithConfigModifier`
-- `testcontainers.WithHostConfigModifier`
-- `testcontainers.WithEndpointSettingsModifier`
-
-Please read the [Create containers: Advanced Settings](../features/creating_container.md#advanced-settings) documentation for more information.
-
-#### Startup Commands
-
-!!!info
-    Not available until the next release of testcontainers-go <a href="https://github.com/testcontainers/testcontainers-go"><span class="tc-version">:material-tag: main</span></a>
-
-Testcontainers exposes the `WithStartupCommand(e ...Executable)` option to run arbitrary commands in the container right after it's started.
-
-!!!info
-    To better understand how this feature works, please read the [Create containers: Lifecycle Hooks](../../features/creating_container/#lifecycle-hooks) documentation.
-
-It also exports an `Executable` interface, defining one single method: `AsCommand()`, which returns a slice of strings to represent the command and positional arguments to be executed in the container.
-
-You could use this feature to run a custom script, or to run a command that is not supported by the module right after the MySQL container is started.
+{% include "../features/common_functional_options.md" %}
 
 #### Set username, password and database name
 

--- a/docs/modules/nats.md
+++ b/docs/modules/nats.md
@@ -40,39 +40,7 @@ When starting the NATS container, you can pass options in a variadic way to conf
 If you need to set a different NATS Docker image, you can use `testcontainers.WithImage` with a valid Docker image
 for NATS. E.g. `testcontainers.WithImage("nats:2.9")`.
 
-#### Wait Strategies
-
-If you need to set a different wait strategy for NATS, you can use `testcontainers.WithWaitStrategy` with a valid wait strategy
-for NATS.
-
-!!!info
-    The default deadline for the wait strategy is 60 seconds.
-
-At the same time, it's possible to set a wait strategy and a custom deadline with `testcontainers.WithWaitStrategyAndDeadline`.
-
-#### Docker type modifiers
-
-If you need an advanced configuration for NATS, you can leverage the following Docker type modifiers:
-
-- `testcontainers.WithConfigModifier`
-- `testcontainers.WithHostConfigModifier`
-- `testcontainers.WithEndpointSettingsModifier`
-
-Please read the [Create containers: Advanced Settings](../features/creating_container.md#advanced-settings) documentation for more information.
-
-#### Startup Commands
-
-!!!info
-    Not available until the next release of testcontainers-go <a href="https://github.com/testcontainers/testcontainers-go"><span class="tc-version">:material-tag: main</span></a>
-
-Testcontainers exposes the `WithStartupCommand(e ...Executable)` option to run arbitrary commands in the container right after it's started.
-
-!!!info
-    To better understand how this feature works, please read the [Create containers: Lifecycle Hooks](../../features/creating_container/#lifecycle-hooks) documentation.
-
-It also exports an `Executable` interface, defining one single method: `AsCommand()`, which returns a slice of strings to represent the command and positional arguments to be executed in the container.
-
-You could use this feature to run a custom script, or to run a command that is not supported by the module right after the NATS container is started.
+{% include "../features/common_functional_options.md" %}
 
 #### Set username and password
 

--- a/docs/modules/neo4j.md
+++ b/docs/modules/neo4j.md
@@ -56,39 +56,7 @@ By default, the container will use the following Docker image:
 [Default Docker image](../../modules/neo4j/neo4j.go) inside_block:defaultImage
 <!--/codeinclude-->
 
-#### Wait Strategies
-
-If you need to set a different wait strategy for Neo4j, you can use `testcontainers.WithWaitStrategy` with a valid wait strategy
-for Neo4j.
-
-!!!info
-    The default deadline for the wait strategy is 60 seconds.
-
-At the same time, it's possible to set a wait strategy and a custom deadline with `testcontainers.WithWaitStrategyAndDeadline`.
-
-#### Docker type modifiers
-
-If you need an advanced configuration for Neo4j, you can leverage the following Docker type modifiers:
-
-- `testcontainers.WithConfigModifier`
-- `testcontainers.WithHostConfigModifier`
-- `testcontainers.WithEndpointSettingsModifier`
-
-Please read the [Create containers: Advanced Settings](../features/creating_container.md#advanced-settings) documentation for more information.
-
-#### Startup Commands
-
-!!!info
-    Not available until the next release of testcontainers-go <a href="https://github.com/testcontainers/testcontainers-go"><span class="tc-version">:material-tag: main</span></a>
-
-Testcontainers exposes the `WithStartupCommand(e ...Executable)` option to run arbitrary commands in the container right after it's started.
-
-!!!info
-    To better understand how this feature works, please read the [Create containers: Lifecycle Hooks](../../features/creating_container/#lifecycle-hooks) documentation.
-
-It also exports an `Executable` interface, defining one single method: `AsCommand()`, which returns a slice of strings to represent the command and positional arguments to be executed in the container.
-
-You could use this feature to run a custom script, or to run a command that is not supported by the module right after the Neo4j container is started.
+{% include "../features/common_functional_options.md" %}
 
 #### Logger
 

--- a/docs/modules/postgres.md
+++ b/docs/modules/postgres.md
@@ -43,43 +43,7 @@ When starting the Postgres container, you can pass options in a variadic way to 
 If you need to set a different Postgres Docker image, you can use `testcontainers.WithImage` with a valid Docker image
 for Postgres. E.g. `testcontainers.WithImage("docker.io/postgres:9.6")`.
 
-#### Wait Strategies
-
-If you need to set a different wait strategy for Postgres, you can use `testcontainers.WithWaitStrategy` with a valid wait strategy
-for Postgres.
-
-!!!info
-    The default deadline for the wait strategy is 60 seconds.
-
-At the same time, it's possible to set a wait strategy and a custom deadline with `testcontainers.WithWaitStrategyAndDeadline`.
-
-<!--codeinclude-->
-[Set Wait Strategy](../../modules/postgres/postgres_test.go) inside_block:withWaitStrategy
-<!--/codeinclude-->
-
-#### Docker type modifiers
-
-If you need an advanced configuration for Postgres, you can leverage the following Docker type modifiers:
-
-- `testcontainers.WithConfigModifier`
-- `testcontainers.WithHostConfigModifier`
-- `testcontainers.WithEndpointSettingsModifier`
-
-Please read the [Create containers: Advanced Settings](../features/creating_container.md#advanced-settings) documentation for more information.
-
-#### Startup Commands
-
-!!!info
-    Not available until the next release of testcontainers-go <a href="https://github.com/testcontainers/testcontainers-go"><span class="tc-version">:material-tag: main</span></a>
-
-Testcontainers exposes the `WithStartupCommand(e ...Executable)` option to run arbitrary commands in the container right after it's started.
-
-!!!info
-    To better understand how this feature works, please read the [Create containers: Lifecycle Hooks](../../features/creating_container/#lifecycle-hooks) documentation.
-
-It also exports an `Executable` interface, defining one single method: `AsCommand()`, which returns a slice of strings to represent the command and positional arguments to be executed in the container.
-
-You could use this feature to run a custom script, or to run a command that is not supported by the module right after the Postgres container is started.
+{% include "../features/common_functional_options.md" %}
 
 #### Initial Database
 

--- a/docs/modules/pulsar.md
+++ b/docs/modules/pulsar.md
@@ -46,45 +46,13 @@ When starting the Pulsar container, you can pass options in a variadic way to co
 If you need to set a different Pulsar Docker image, you can use `testcontainers.WithImage` with a valid Docker image
 for Pulsar. E.g. `testcontainers.WithImage("docker.io/apachepulsar/pulsar:2.10.2")`.
 
-#### Wait Strategies
-
-If you need to set a different wait strategy for Pulsar, you can use `testcontainers.WithWaitStrategy` with a valid wait strategy
-for Pulsar.
-
-!!!info
-    The default deadline for the wait strategy is 60 seconds.
-
-At the same time, it's possible to set a wait strategy and a custom deadline with `testcontainers.WithWaitStrategyAndDeadline`.
-
-#### Docker type modifiers
-
-If you need an advanced configuration for Pulsar, you can leverage the following Docker type modifiers:
-
-- `testcontainers.WithConfigModifier`
-- `testcontainers.WithHostConfigModifier`
-- `testcontainers.WithEndpointSettingsModifier`
-
-Please read the [Create containers: Advanced Settings](../features/creating_container.md#advanced-settings) documentation for more information.
+{% include "../features/common_functional_options.md" %}
 
 <!--codeinclude-->
 [Advanced Docker settings](../../modules/pulsar/pulsar_test.go) inside_block:advancedDockerSettings
 <!--/codeinclude-->
 
 Here, the `nwName` relates to the name of a previously created Docker network. Please see the [How to create a network](../features/creating_networks.md) documentation for more information.
-
-#### Startup Commands
-
-!!!info
-    Not available until the next release of testcontainers-go <a href="https://github.com/testcontainers/testcontainers-go"><span class="tc-version">:material-tag: main</span></a>
-
-Testcontainers exposes the `WithStartupCommand(e ...Executable)` option to run arbitrary commands in the container right after it's started.
-
-!!!info
-    To better understand how this feature works, please read the [Create containers: Lifecycle Hooks](../../features/creating_container/#lifecycle-hooks) documentation.
-
-It also exports an `Executable` interface, defining one single method: `AsCommand()`, which returns a slice of strings to represent the command and positional arguments to be executed in the container.
-
-You could use this feature to run a custom script, or to run a command that is not supported by the module right after the Pulsar container is started.
 
 #### Pulsar Configuration
 If you need to set Pulsar configuration variables you can use the `WithPulsarEnv` to set Pulsar environment variables: the `PULSAR_PREFIX_` prefix will be automatically added for you.

--- a/docs/modules/redis.md
+++ b/docs/modules/redis.md
@@ -43,39 +43,7 @@ When starting the Redis container, you can pass options in a variadic way to con
 If you need to set a different Redis Docker image, you can use `testcontainers.WithImage` with a valid Docker image
 for Redis. E.g. `testcontainers.WithImage("docker.io/redis:7")`.
 
-#### Wait Strategies
-
-If you need to set a different wait strategy for Redis, you can use `testcontainers.WithWaitStrategy` with a valid wait strategy
-for Redis.
-
-!!!info
-    The default deadline for the wait strategy is 60 seconds.
-
-At the same time, it's possible to set a wait strategy and a custom deadline with `testcontainers.WithWaitStrategyAndDeadline`.
-
-#### Docker type modifiers
-
-If you need an advanced configuration for Redis, you can leverage the following Docker type modifiers:
-
-- `testcontainers.WithConfigModifier`
-- `testcontainers.WithHostConfigModifier`
-- `testcontainers.WithEndpointSettingsModifier`
-
-Please read the [Create containers: Advanced Settings](../features/creating_container.md#advanced-settings) documentation for more information.
-
-#### Startup Commands
-
-!!!info
-    Not available until the next release of testcontainers-go <a href="https://github.com/testcontainers/testcontainers-go"><span class="tc-version">:material-tag: main</span></a>
-
-Testcontainers exposes the `WithStartupCommand(e ...Executable)` option to run arbitrary commands in the container right after it's started.
-
-!!!info
-    To better understand how this feature works, please read the [Create containers: Lifecycle Hooks](../../features/creating_container/#lifecycle-hooks) documentation.
-
-It also exports an `Executable` interface, defining one single method: `AsCommand()`, which returns a slice of strings to represent the command and positional arguments to be executed in the container.
-
-You could use this feature to run a custom script, or to run a command that is not supported by the module right after the Redis container is started.
+{% include "../features/common_functional_options.md" %}
 
 #### Snapshotting
 

--- a/docs/modules/redpanda.md
+++ b/docs/modules/redpanda.md
@@ -45,43 +45,11 @@ When starting the Redpanda container, you can pass options in a variadic way to 
 If you need to set a different Redpanda Docker image, you can use `testcontainers.WithImage` with a valid Docker image
 for Redpanda. E.g. `testcontainers.WithImage("docker.redpanda.com/redpandadata/redpanda:v23.1.7")`.
 
-#### Wait Strategies
-
-If you need to set a different wait strategy for Redpanda, you can use `testcontainers.WithWaitStrategy` with a valid wait strategy
-for Redpanda.
-
-!!!info
-    The default deadline for the wait strategy is 60 seconds.
-
-At the same time, it's possible to set a wait strategy and a custom deadline with `testcontainers.WithWaitStrategyAndDeadline`.
+{% include "../features/common_functional_options.md" %}
 
 #### TLS Encryption
 
 If you need to enable TLS use `WithTLS` with a valid PEM encoded certificate and key.
-
-#### Docker type modifiers
-
-If you need an advanced configuration for Redpanda, you can leverage the following Docker type modifiers:
-
-- `testcontainers.WithConfigModifier`
-- `testcontainers.WithHostConfigModifier`
-- `testcontainers.WithEndpointSettingsModifier`
-
-Please read the [Create containers: Advanced Settings](../features/creating_container.md#advanced-settings) documentation for more information.
-
-#### Startup Commands
-
-!!!info
-    Not available until the next release of testcontainers-go <a href="https://github.com/testcontainers/testcontainers-go"><span class="tc-version">:material-tag: main</span></a>
-
-Testcontainers exposes the `WithStartupCommand(e ...Executable)` option to run arbitrary commands in the container right after it's started.
-
-!!!info
-    To better understand how this feature works, please read the [Create containers: Lifecycle Hooks](../../features/creating_container/#lifecycle-hooks) documentation.
-
-It also exports an `Executable` interface, defining one single method: `AsCommand()`, which returns a slice of strings to represent the command and positional arguments to be executed in the container.
-
-You could use this feature to run a custom script, or to run a command that is not supported by the module right after the Redis container is started.
 
 ### Container Methods
 

--- a/docs/modules/vault.md
+++ b/docs/modules/vault.md
@@ -73,39 +73,7 @@ for Vault. E.g. `testcontainers.WithImage("hashicorp/vault:1.13.0")`.
 [Set image name](../../modules/vault/vault_test.go) inside_block:WithImageName
 <!--/codeinclude-->
 
-#### Wait Strategies
-
-If you need to set a different wait strategy for Vault, you can use `testcontainers.WithWaitStrategy` with a valid wait strategy
-for Vault.
-
-!!!info
-    The default deadline for the wait strategy is 60 seconds.
-
-At the same time, it's possible to set a wait strategy and a custom deadline with `testcontainers.WithWaitStrategyAndDeadline`.
-
-#### Docker type modifiers
-
-If you need an advanced configuration for Vault, you can leverage the following Docker type modifiers:
-
-- `testcontainers.WithConfigModifier`
-- `testcontainers.WithHostConfigModifier`
-- `testcontainers.WithEndpointSettingsModifier`
-
-Please read the [Create containers: Advanced Settings](../features/creating_container.md#advanced-settings) documentation for more information.
-
-#### Startup Commands
-
-!!!info
-    Not available until the next release of testcontainers-go <a href="https://github.com/testcontainers/testcontainers-go"><span class="tc-version">:material-tag: main</span></a>
-
-Testcontainers exposes the `WithStartupCommand(e ...Executable)` option to run arbitrary commands in the container right after it's started.
-
-!!!info
-    To better understand how this feature works, please read the [Create containers: Lifecycle Hooks](../../features/creating_container/#lifecycle-hooks) documentation.
-
-It also exports an `Executable` interface, defining one single method: `AsCommand()`, which returns a slice of strings to represent the command and positional arguments to be executed in the container.
-
-You could use this feature to run a custom script, or to run a command that is not supported by the module right after the Vault container is started.
+{% include "../features/common_functional_options.md" %}
 
 #### Token
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,6 +4,7 @@ site_url: https://golang.testcontainers.org
 plugins:
     - search
     - codeinclude
+    - include-markdown
     - markdownextradata
 theme:
     name: material

--- a/modulegen/_template/module.md.tmpl
+++ b/modulegen/_template/module.md.tmpl
@@ -40,25 +40,7 @@ When starting the {{ $title }} container, you can pass options in a variadic way
 If you need to set a different {{ $title }} Docker image, you can use `testcontainers.WithImage` with a valid Docker image
 for {{ $title }}. E.g. `testcontainers.WithImage("{{ .Image }}")`.
 
-#### Wait Strategies
-
-If you need to set a different wait strategy for {{ $title }}, you can use `testcontainers.WithWaitStrategy` with a valid wait strategy
-for {{ $title }}.
-
-!!!info
-    The default deadline for the wait strategy is 60 seconds.
-
-At the same time, it's possible to set a wait strategy and a custom deadline with `testcontainers.WithWaitStrategyAndDeadline`.
-
-#### Docker type modifiers
-
-If you need an advanced configuration for {{ $title }}, you can leverage the following Docker type modifiers:
-
-- `testcontainers.WithConfigModifier`
-- `testcontainers.WithHostConfigModifier`
-- `testcontainers.WithEndpointSettingsModifier`
-
-Please read the [Create containers: Advanced Settings](../features/creating_container.md#advanced-settings) documentation for more information.
+{% include "../features/common_functional_options.md" %}
 
 #### Startup Commands
 

--- a/modules/postgres/postgres_test.go
+++ b/modules/postgres/postgres_test.go
@@ -120,7 +120,6 @@ func TestContainerWithWaitForSQL(t *testing.T) {
 		require.NotNil(t, container)
 	})
 	t.Run("custom query", func(t *testing.T) {
-		// withWaitStrategy {
 		container, err := RunContainer(
 			ctx,
 			WithDatabase(dbname),
@@ -128,7 +127,6 @@ func TestContainerWithWaitForSQL(t *testing.T) {
 			WithPassword(password),
 			testcontainers.WithWaitStrategy(wait.ForSQL(nat.Port(port), "postgres", dbURL).WithStartupTimeout(time.Second*5).WithQuery("SELECT 10")),
 		)
-		// }
 		require.NoError(t, err)
 		require.NotNil(t, container)
 	})

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 mkdocs==1.5.2
 mkdocs-codeinclude-plugin==0.2.1
+mkdocs-include-markdown-plugin==6.0.1
 mkdocs-material==8.2.7
 mkdocs-markdownextradata-plugin==0.2.5


### PR DESCRIPTION

<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
This PR adds support for including markdown files into others, leveraging the `mkdocs-include-markdown-plugin` plugin.

We will define a shared markdown file for all the available and common functional options, and will include that file into all existing modules and template.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
When a new functional option appears, then just adding it to the file will work without having to add it to all the existing modules.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->


<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
