### PR TITLE
make ryuk timeouts configurable via properties file

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"sync"
+	"time"
 
 	"github.com/magiconair/properties"
 )
@@ -18,12 +19,14 @@ var (
 // Config represents the configuration for Testcontainers
 // testcontainersConfig {
 type Config struct {
-	Host               string `properties:"docker.host,default="`
-	TLSVerify          int    `properties:"docker.tls.verify,default=0"`
-	CertPath           string `properties:"docker.cert.path,default="`
-	RyukDisabled       bool   `properties:"ryuk.disabled,default=false"`
-	RyukPrivileged     bool   `properties:"ryuk.container.privileged,default=false"`
-	TestcontainersHost string `properties:"tc.host,default="`
+	Host                    string        `properties:"docker.host,default="`
+	TLSVerify               int           `properties:"docker.tls.verify,default=0"`
+	CertPath                string        `properties:"docker.cert.path,default="`
+	RyukDisabled            bool          `properties:"ryuk.disabled,default=false"`
+	RyukPrivileged          bool          `properties:"ryuk.container.privileged,default=false"`
+	RyukReconnectionTimeout time.Duration `properties:"ryuk.reconnection.timeout,default=10s"`
+	RyukConnectionTimeout   time.Duration `properties:"ryuk.connection.timeout,default=1m"`
+	TestcontainersHost      string        `properties:"tc.host,default="`
 }
 
 // }
@@ -93,8 +96,6 @@ func read() Config {
 }
 
 func parseBool(input string) bool {
-	if _, err := strconv.ParseBool(input); err == nil {
-		return true
-	}
-	return false
+	_, err := strconv.ParseBool(input)
+	return err == nil
 }

--- a/reaper.go
+++ b/reaper.go
@@ -214,6 +214,13 @@ func newReaper(ctx context.Context, sessionID string, provider ReaperProvider, o
 			hc.AutoRemove = true
 			hc.NetworkMode = Bridge
 		},
+		Env: map[string]string{},
+	}
+	if to := tcConfig.RyukConnectionTimeout; to > time.Duration(0) {
+		req.Env["RYUK_CONNECTION_TIMEOUT"] = to.String()
+	}
+	if to := tcConfig.RyukReconnectionTimeout; to > time.Duration(0) {
+		req.Env["RYUK_RECONNECTION_TIMEOUT"] = to.String()
 	}
 
 	// keep backwards compatibility


### PR DESCRIPTION
## What does this PR do?

This adds two new properties, like

    ryuk.connection.timeout=2m
    ryuk.reconnection.timeout=3m

to control the timeouts used with the reaper container.

Their defaults are 1 minute (connection) and 10 seconds (reconnection), matching the defaults of the ryuk container's env vars.

## Why is it important?

In an E2E run, TC had problems re-creating the reaper container after it had stopped because the reconnection timeout was exceeded. With this, we can workaround that problem by increasing the timeout.

## Related issues

[🗨️ Discussed in Slack](https://testcontainers.slack.com/archives/CBWBNR76G/p1695319794716519)

## How to test this PR

Unit tests have been updated and added.

## Follow-ups

1. Some properties can also be controlled via env vars. We could do the same for these two new ones.
2. It might make sense to also add support for `ryuk.verbose=true`.
3. The actual underlying problem, being unable to start a second reaper instance after the first one went away, would also be good to fix, I think.