### PR TITLE
chore(deps): bump cloud.google.com/go/datastore from 1.13.0 to 1.14.0 and google.golang.org/grpc from 1.58.1 to 1.58.2 and cloud.google.com/go/spanner from 1.47.0 to 1.49.0 in /modules/gcloud

### DIFF
--- a/modules/gcloud/go.mod
+++ b/modules/gcloud/go.mod
@@ -8,7 +8,8 @@ require (
 	cloud.google.com/go/datastore v1.13.0
 	cloud.google.com/go/firestore v1.11.0
 	cloud.google.com/go/pubsub v1.33.0
-	cloud.google.com/go/spanner v1.47.0
+	cloud.google.com/go/spanner v1.49.0
+	github.com/docker/go-connections v0.4.0
 	github.com/testcontainers/testcontainers-go v0.24.1
 	google.golang.org/api v0.142.0
 	google.golang.org/grpc v1.58.1
@@ -36,7 +37,6 @@ require (
 	github.com/cpuguy83/dockercfg v0.3.1 // indirect
 	github.com/docker/distribution v2.8.2+incompatible // indirect
 	github.com/docker/docker v24.0.6+incompatible // indirect
-	github.com/docker/go-connections v0.4.0 // indirect
 	github.com/docker/go-units v0.5.0 // indirect
 	github.com/envoyproxy/go-control-plane v0.11.1 // indirect
 	github.com/envoyproxy/protoc-gen-validate v1.0.2 // indirect

--- a/modules/gcloud/go.sum
+++ b/modules/gcloud/go.sum
@@ -21,8 +21,8 @@ cloud.google.com/go/longrunning v0.5.1 h1:Fr7TXftcqTudoyRJa113hyaqlGdiBQkp0Gq7tE
 cloud.google.com/go/longrunning v0.5.1/go.mod h1:spvimkwdz6SPWKEt/XBij79E9fiTkHSQl/fRUUQJYJc=
 cloud.google.com/go/pubsub v1.33.0 h1:6SPCPvWav64tj0sVX/+npCBKhUi/UjJehy9op/V3p2g=
 cloud.google.com/go/pubsub v1.33.0/go.mod h1:f+w71I33OMyxf9VpMVcZbnG5KSUkCOUHYpFd5U1GdRc=
-cloud.google.com/go/spanner v1.47.0 h1:aqiMP8dhsEXgn9K5EZBWxPG7dxIiyM2VaikqeU4iteg=
-cloud.google.com/go/spanner v1.47.0/go.mod h1:IXsJwVW2j4UKs0eYDqodab6HgGuA1bViSqW4uH9lfUI=
+cloud.google.com/go/spanner v1.49.0 h1:+HY8C4uztU7XyLz3xMi/LCXdetLEOExhvRFJu2NiVXM=
+cloud.google.com/go/spanner v1.49.0/go.mod h1:eGj9mQGK8+hkgSVbHNQ06pQ4oS+cyc4tXXd6Dif1KoM=
 cloud.google.com/go/storage v1.30.1 h1:uOdMxAs8HExqBlnLtnQyP0YkvbiDpdGShGKtx6U/oNM=
 dario.cat/mergo v1.0.0 h1:AGCNq9Evsj31mOgNPcLyXc+4PNABt905YmuqPYYpBWk=
 dario.cat/mergo v1.0.0/go.mod h1:uNxQE+84aUszobStD9th8a29P2fMDhsBdgRYvZOxGmk=


### PR DESCRIPTION
:warning: This PR has been created with the [combine-prs](https://github.com/mdelapenya/gh-combine-prs) `gh` extension.
Command:/Users/mdelapenya/.local/share/gh/extensions/gh-combine-prs/gh-combine-prs --query author:app/dependabot gcloud --interactive --verbose --skip-pr-check.

It combines the following PRs:

- chore(deps): bump cloud.google.com/go/spanner from 1.47.0 to 1.49.0 in /modules/gcloud (#1678) @app/dependabot
- chore(deps): bump google.golang.org/grpc from 1.58.1 to 1.58.2 in /modules/gcloud (#1677) @app/dependabot
- chore(deps): bump cloud.google.com/go/datastore from 1.13.0 to 1.14.0 in /modules/gcloud (#1676) @app/dependabot

## Related Issues:

- Closes #1678
- Closes #1677
- Closes #1676
