### PR TITLE
fix: avoid checking for the reaper out of its mutex

### DIFF
--- a/reaper_test.go
+++ b/reaper_test.go
@@ -134,9 +134,6 @@ func TestContainerStartsWithoutTheReaper(t *testing.T) {
 	terminateContainerOnEnd(t, ctx, container)
 
 	sessionID := testcontainerssession.SessionID()
-	if reaperInstance != nil {
-		sessionID = reaperInstance.SessionID
-	}
 
 	reaperContainer, err := lookUpReaperContainer(ctx, sessionID)
 	if err != nil {
@@ -172,9 +169,6 @@ func TestContainerStartsWithTheReaper(t *testing.T) {
 	terminateContainerOnEnd(t, ctx, c)
 
 	sessionID := testcontainerssession.SessionID()
-	if reaperInstance != nil {
-		sessionID = reaperInstance.SessionID
-	}
 
 	reaperContainer, err := lookUpReaperContainer(ctx, sessionID)
 	if err != nil {


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
This PR removes redudant checks for getting the test session ID, simply delegating it to the sessionID global value, not reading it from the reaper (which already uses the very same value).

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
Having a nil-check for the `reaperInstance` to get the test sessionID introduced a race condition, as it's only set to not nil under a code block that is protected by a Mutex. Therefore, the check caused problems instead of benefits. I added that check intentionally, thinking that always reading from the reaper could be a good idea. But it was not.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Caused by #1513

## How to test this PR

This should demonstrate the bug (before this fix) and the fix:

```go
go test -timeout 600s -run ^Test_BuildImageWithContexts$ . -race -count=1 -v
```

Also running all reaper tests:

```go
go test -timeout 600s -run "^(TestContainerStartsWithoutTheReaper|TestContainerStartsWithTheReaper|TestContainerStopWithReaper|TestContainerTerminationWithReaper|TestContainerTerminationWithoutReaper|Test_NewReaper|Test_ReaperForNetwork|Test_ReaperReusedIfHealthy|TestReaper_reuseItFromOtherTestProgramUsingDocker)$" github.com/testcontainers/testcontainers-go -count=1 -race -v
```

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
