### PR TITLE
fix TestContainerRunningCheckingStatusCode to pass on arm platforms

### DIFF
--- a/docker_test.go
+++ b/docker_test.go
@@ -1836,8 +1836,9 @@ func TestContainerCapAdd(t *testing.T) {
 func TestContainerRunningCheckingStatusCode(t *testing.T) {
 	ctx := context.Background()
 	req := ContainerRequest{
-		Image:        "influxdb:1.8.10", // influxdb doesn't provide an alpine+arm build (https://github.com/influxdata/influxdata-docker/issues/335)
-		ExposedPorts: []string{"8086/tcp"},
+		Image:         "influxdb:1.8.10-alpine",
+		ExposedPorts:  []string{"8086/tcp"},
+		ImagePlatform: "linux/amd64", // influxdb doesn't provide an alpine+arm build (https://github.com/influxdata/influxdata-docker/issues/335)
 		WaitingFor: wait.ForAll(
 			wait.ForHTTP("/ping").WithPort("8086/tcp").WithStatusCodeMatcher(
 				func(status int) bool {

--- a/docker_test.go
+++ b/docker_test.go
@@ -1836,7 +1836,7 @@ func TestContainerCapAdd(t *testing.T) {
 func TestContainerRunningCheckingStatusCode(t *testing.T) {
 	ctx := context.Background()
 	req := ContainerRequest{
-		Image:        "influxdb:1.8.10-alpine",
+		Image:        "influxdb:1.8.10", // influxdb doesn't provide an alpine+arm build (https://github.com/influxdata/influxdata-docker/issues/335)
 		ExposedPorts: []string{"8086/tcp"},
 		WaitingFor: wait.ForAll(
 			wait.ForHTTP("/ping").WithPort("8086/tcp").WithStatusCodeMatcher(


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?

This PR uses the non-alpine influxdb image for the TestContainerRunningCheckingStatusCode test. There's no ARM alpine image for influx db. See https://github.com/influxdata/influxdata-docker/issues/335.

## Why is it important?

The test won't pass with Docker running under ARM. Example: Mac OS with Apply Silicon and Docker Desktop.  Seems like a simple fix to get the test passing more broadly.

## Related issues

N/A

<!-- Recommended
## How to test this PR

This should work under both x86 and ARM since it's just using the default non-alpine image (tested on ARM).

