### PR TITLE
reduce timeout in context cancellation propegation test for test stability

### DIFF
--- a/docker_test.go
+++ b/docker_test.go
@@ -1265,7 +1265,7 @@ func TestContainerNonExistentImage(t *testing.T) {
 	})
 
 	t.Run("the context cancellation is propagated to container creation", func(t *testing.T) {
-		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 		defer cancel()
 		c, err := GenericContainer(ctx, GenericContainerRequest{
 			ProviderType: providerType,


### PR DESCRIPTION
## What does this PR do?

TestContainerNonExistentImage/the_context_cancellation_is_propagated_to_container_creation was failing on my laptop. After a bit of debugging it looks like there was a race condition and the container was able to startup and error out before the context timeout period.  

Heres the error text:

> === RUN   TestContainerNonExistentImage/the_context_cancellation_is_propagated_to_container_creation
> 2023/09/27 17:24:00 🐳 Creating container for image [[docker.io/postgres:12](http://docker.io/postgres:12)](http://[docker.io/postgres:12](http://docker.io/postgres:12))
> 2023/09/27 17:24:00 ✅ Container created: 3ba961202c0e
> 2023/09/27 17:24:00 🐳 Starting container: 3ba961202c0e
> 2023/09/27 17:24:01 ✅ Container started: 3ba961202c0e
> 2023/09/27 17:24:01 🚧 Waiting for container id 3ba961202c0e image: [docker.io/postgres:12](http://docker.io/postgres:12). Waiting for: &{timeout:<nil> Log:log IsRegexp:false Occurrence:1 PollInterval:100ms}
> 2023/09/27 17:24:01 container logs (container exited with code 1):
> Error: Database is uninitialized and superuser password is not specified.
> You must specify POSTGRES_PASSWORD to a non-empty value for the
> superuser. For example, "-e POSTGRES_PASSWORD=password" on "docker run".
> 
>  ```
>    You may also use "POSTGRES_HOST_AUTH_METHOD=trust" to allow all
>    connections without a password. This is *not* recommended.
> 
>    See PostgreSQL documentation about "trust":
>    <https://www.postgresql.org/docs/current/auth-trust.html>
> 
> docker_test.go:1281: err should be a ctx cancelled error container exited with code 1: failed to start container
> 
> ```
> 
> - -- FAIL: TestContainerNonExistentImage (1.70s)
> --- PASS: TestContainerNonExistentImage/if_the_image_not_found_don't_propagate_the_error (1.25s)
> --- FAIL: TestContainerNonExistentImage/the_context_cancellation_is_propagated_to_container_creation (0.45s)
> FAIL
> exit status 1
> FAIL	[[github.com/testcontainers/testcontainers-go](http://github.com/testcontainers/testcontainers-go)](http://github.com/testcontainers/testcontainers-go)	1.892s
> 
> 


This PR just reduced the timeout time to 100 milliseconds instead of 1 second. This causes the test to pass as expected on my system on my system. 

Another approach might be to use a different container that just sleeps for a defined amount of time before erroring out so the "race" is more deterministic. However the above approach seems to get the job done and is simpler. 

## Why is it important?

The tests will fail less unnecessarily in the future. 
