### PR TITLE
avoid race conditions by waiting one polling interval 

### DIFF
--- a/wait/http.go
+++ b/wait/http.go
@@ -146,8 +146,10 @@ func (ws *HTTPStrategy) WaitUntilReady(ctx context.Context, target StrategyTarge
 
 	var mappedPort nat.Port
 	if ws.Port == "" {
-		ports, err := target.Ports(ctx)
-		for err != nil {
+		var err error
+		var ports nat.PortMap
+		// we wait one polling interval before we grab the ports otherwise they might not be bound yet on startup
+		for err != nil || ports == nil {
 			select {
 			case <-ctx.Done():
 				return fmt.Errorf("%w: %w", ctx.Err(), err)

--- a/wait/http_test.go
+++ b/wait/http_test.go
@@ -562,7 +562,8 @@ func TestHttpStrategyFailsWhileGettingPortDueToNoExposedPorts(t *testing.T) {
 		},
 		StateImpl: func(_ context.Context) (*types.ContainerState, error) {
 			return &types.ContainerState{
-				Status: "running",
+				Status:  "running",
+				Running: true,
 			}, nil
 		},
 		PortsImpl: func(ctx context.Context) (nat.PortMap, error) {
@@ -602,7 +603,8 @@ func TestHttpStrategyFailsWhileGettingPortDueToOnlyUDPPorts(t *testing.T) {
 		},
 		StateImpl: func(_ context.Context) (*types.ContainerState, error) {
 			return &types.ContainerState{
-				Status: "running",
+				Running: true,
+				Status:  "running",
 			}, nil
 		},
 		PortsImpl: func(ctx context.Context) (nat.PortMap, error) {
@@ -649,7 +651,8 @@ func TestHttpStrategyFailsWhileGettingPortDueToExposedPortNoBindings(t *testing.
 		},
 		StateImpl: func(_ context.Context) (*types.ContainerState, error) {
 			return &types.ContainerState{
-				Status: "running",
+				Running: true,
+				Status:  "running",
 			}, nil
 		},
 		PortsImpl: func(ctx context.Context) (nat.PortMap, error) {


### PR DESCRIPTION
## What does this PR do?

I've observed intermittent failures with TestShouldStartContainersInParallel. After digging into it I realized that there's a race in http WaitUntilReady. There's a brief period of time where no error is returned, but the external port hasn't been bound yet. To fix this I simply updated the logic so that one interval passes before we check the ports for the first time. This seems to do the trick and the test doesn't fail intermittently for me now.  

The interval time still seems like an arbitrary sleep though.  I also tried a different solution which retried until the port gets bound (or context timed out), but then you would need to  either: 

1) Change multiple other tests to accommodate timeouts and get rid entire concept of "No exposed tcp ports or mapped ports - cannot wait for status" errors, as these would cease to exist. 
2) Introduce some sort of separate port binding timeout concept, which would change the API. 

I think 1) probably makes the most sense to me. Waiting for http on a container with no exposed ports seems like it should timeout.  But this would be a much bigger change. 

## Why is it important?

Intermittently failed tests make it hard to develop :)

## Related issues

N/A
