### PR TITLE
docs: add default options to k6 module

### DIFF
--- a/docs/modules/k6.md
+++ b/docs/modules/k6.md
@@ -80,3 +80,7 @@ Use the `WithTestScript` option to specify the test script to run. The path to t
 ```golang
 k6.RunContainer(ctx, k6.WithTestScript("/tests/test.js"))
 ```
+
+### Container Methods
+
+The K6 container does not expose any method.

--- a/docs/modules/k6.md
+++ b/docs/modules/k6.md
@@ -45,7 +45,7 @@ When starting the K6 container, you can pass options in a variadic way to config
 #### Image
 
 !!! warning
-    The K6 module uses a custom Docker image to build the `k6` binary with all the required extensions. This image is based on the official `k6` image and it is available on [Docker Hub](https://hub.docker.com/r/szkiba/k6x). Therefore, only the `szkiba/k6x` image should be used with this module.
+    The K6 module uses a `k6x` image to build a `k6` binary with all the required extensions. Therefore, only the [szkiba/k6x](https://hub.docker.com/r/szkiba/k6x) image should be used with this module.
 
 If you need to set a different K6 Docker image, you can use `testcontainers.WithImage` with a valid Docker image
 for k6x. E.g. `testcontainers.WithImage("szkiba/k6x:v0.3.1")`.

--- a/docs/modules/k6.md
+++ b/docs/modules/k6.md
@@ -44,6 +44,9 @@ When starting the K6 container, you can pass options in a variadic way to config
 
 #### Image
 
+!!! warning
+    The K6 module uses a custom Docker image to build the `k6` binary with all the required extensions. This image is based on the official `k6` image and it is available on [Docker Hub](https://hub.docker.com/r/szkiba/k6x). Therefore, only the `szkiba/k6x` image should be used with this module.
+
 If you need to set a different K6 Docker image, you can use `testcontainers.WithImage` with a valid Docker image
 for k6x. E.g. `testcontainers.WithImage("szkiba/k6x:v0.3.1")`.
 

--- a/docs/modules/k6.md
+++ b/docs/modules/k6.md
@@ -6,7 +6,6 @@ Not available until the next release of testcontainers-go <a href="https://githu
 
 The Testcontainers module for K6.
 
-
 ### Using k6 extensions
 
 This module takes advantage of [k6x](https://github.com/szkiba/k6x) to dynamically build a `k6` binary with all the [k6 extensions](https://k6.io/docs/extensions/get-started/explore/) required by the test script.
@@ -39,6 +38,13 @@ func RunContainer(ctx context.Context, opts ...testcontainers.ContainerCustomize
 ### Container Options
 
 When starting the K6 container, you can pass options in a variadic way to configure it.
+
+#### Image
+
+If you need to set a different K6 Docker image, you can use `testcontainers.WithImage` with a valid Docker image
+for Cassandra. E.g. `testcontainers.WithImage("szkiba/k6x:v0.3.1")`.
+
+{% include "../features/common_functional_options.md" %}
 
 #### SetEnvVar
 

--- a/docs/modules/k6.md
+++ b/docs/modules/k6.md
@@ -21,6 +21,9 @@ go get github.com/testcontainers/testcontainers-go/modules/k6
 ## Usage example
 
 <!--codeinclude-->
+[Creating a httpbin application](../../modules/k6/examples_test.go) inside_block:runHTTPBin
+[Obtain IP for the httpbin application](../../modules/k6/examples_test.go) inside_block:getHTTPBinIP
+[httpbin script](../../modules/k6/scripts/httpbin.js)
 [Creating a K6 container](../../modules/k6/examples_test.go) inside_block:runK6Container
 <!--/codeinclude-->
 

--- a/docs/modules/k6.md
+++ b/docs/modules/k6.md
@@ -23,7 +23,7 @@ go get github.com/testcontainers/testcontainers-go/modules/k6
 <!--codeinclude-->
 [Creating a httpbin application](../../modules/k6/examples_test.go) inside_block:runHTTPBin
 [Obtain IP for the httpbin application](../../modules/k6/examples_test.go) inside_block:getHTTPBinIP
-[httpbin script](../../modules/k6/scripts/httpbin.js)
+[k6 script for testing httpbin](../../modules/k6/scripts/httpbin.js)
 [Creating a K6 container](../../modules/k6/examples_test.go) inside_block:runK6Container
 <!--/codeinclude-->
 
@@ -45,7 +45,7 @@ When starting the K6 container, you can pass options in a variadic way to config
 #### Image
 
 If you need to set a different K6 Docker image, you can use `testcontainers.WithImage` with a valid Docker image
-for Cassandra. E.g. `testcontainers.WithImage("szkiba/k6x:v0.3.1")`.
+for k6x. E.g. `testcontainers.WithImage("szkiba/k6x:v0.3.1")`.
 
 {% include "../features/common_functional_options.md" %}
 

--- a/modules/k6/examples_test.go
+++ b/modules/k6/examples_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func ExampleRunContainer() {
-	// runK6Container {
+	// runHTTPBin {
 	ctx := context.Background()
 
 	// create a container with the httpbin application that will be the target
@@ -37,17 +37,21 @@ func ExampleRunContainer() {
 			panic(fmt.Errorf("failed to terminate container: %w", err))
 		}
 	}()
+	// }
 
+	// getHTTPBinIP {
 	httpbinIP, err := httpbin.ContainerIP(ctx)
 	if err != nil {
 		panic(fmt.Errorf("failed to get httpbin IP: %w", err))
 	}
+	// }
 
 	absPath, err := filepath.Abs(filepath.Join("scripts", "httpbin.js"))
 	if err != nil {
 		panic(fmt.Errorf("failed to get path to test script: %w", err))
 	}
 
+	// runK6Container {
 	// run the httpbin.js test scripts passing the IP address the httpbin container
 	k6, err := k6.RunContainer(
 		ctx,


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
This PR adds the core options to the k6 module, updating the markdown file for it.

At the same time, it's splitting the usage example in different parts: create the httpbin app using a generic container, getting its IP, the JS script to be used, and the k6 container.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
We forgot adding them in previous PRs.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Completes #1721

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
