### PR TITLE
docs: Fix typo and mention the relevant function name in doc

### DIFF
--- a/docs/modules/mariadb.md
+++ b/docs/modules/mariadb.md
@@ -66,7 +66,7 @@ options.
 #### Init Scripts
 
 If you would like to perform DDL or DML operations in the MariaDB container, add one or more `*.sql`, `*.sql.gz`, or `*.sh`
-scripts to the container request. Those files will be copied under `/docker-entrypoint-initdb.d`.
+scripts to the container request, using the `WithScripts(scriptPaths ...string)`. Those files will be copied under `/docker-entrypoint-initdb.d`.
 
 <!--codeinclude-->
 [Example of Init script](../../modules/mariadb/testdata/schema.sql)

--- a/docs/modules/postgres.md
+++ b/docs/modules/postgres.md
@@ -51,7 +51,7 @@ If you need to set a different database, and its credentials, you can use the `W
 
 #### Init Scripts
 
-If you would like to do additional initialization in the Postgres container, add one or more `*.sql`, `*.sql.gz`, or `*.sh` scripts to the container request with the `WithInitScript` function.
+If you would like to do additional initialization in the Postgres container, add one or more `*.sql`, `*.sql.gz`, or `*.sh` scripts to the container request with the `WithInitScripts` function.
 Those files will be copied after the container is created but before it's started under `/docker-entrypoint-initdb.d`. According to Postgres Docker image,
 it will run any `*.sql` files, run any executable `*.sh` scripts, and source any non-executable `*.sh` scripts found in that directory to do further
 initialization before starting the service.


### PR DESCRIPTION
## What does this PR do?

Some document fixes what i come across:

- Fix typo in postgresql doc `WithInitScript` -> `WithInitScripts` 
- Mention the `WithScripts` name in mariadb document just like mentioned in mysql document
