### PR TITLE
Fix wrong module names in docs and comments

### DIFF
--- a/docs/modules/neo4j.md
+++ b/docs/modules/neo4j.md
@@ -48,7 +48,7 @@ When starting the Neo4j container, you can pass options in a variadic way to con
 #### Image
 
 If you need to set a different Neo4j Docker image, you can use `testcontainers.WithImage` with a valid Docker image
-for Couchbase. E.g. `testcontainers.WithImage("docker.io/neo4j:4.4")`.
+for Neo4j. E.g. `testcontainers.WithImage("docker.io/neo4j:4.4")`.
 
 By default, the container will use the following Docker image:
 

--- a/modules/elasticsearch/options.go
+++ b/modules/elasticsearch/options.go
@@ -24,7 +24,7 @@ func defaultOptions() *Options {
 // Compiler check to ensure that Option implements the testcontainers.ContainerCustomizer interface.
 var _ testcontainers.ContainerCustomizer = (*Option)(nil)
 
-// Option is an option for the Redpanda container.
+// Option is an option for the Elasticsearch container.
 type Option func(*Options)
 
 // Customize is a NOOP. It's defined to satisfy the testcontainers.ContainerCustomizer interface.

--- a/modules/gcloud/gcloud.go
+++ b/modules/gcloud/gcloud.go
@@ -53,7 +53,7 @@ func defaultOptions() options {
 // Compiler check to ensure that Option implements the testcontainers.ContainerCustomizer interface.
 var _ testcontainers.ContainerCustomizer = (*Option)(nil)
 
-// Option is an option for the Redpanda container.
+// Option is an option for the GCloud container.
 type Option func(*options)
 
 // Customize is a NOOP. It's defined to satisfy the testcontainers.ContainerCustomizer interface.

--- a/modules/nats/options.go
+++ b/modules/nats/options.go
@@ -19,7 +19,7 @@ func defaultOptions() options {
 // Compiler check to ensure that Option implements the testcontainers.ContainerCustomizer interface.
 var _ testcontainers.ContainerCustomizer = (*CmdOption)(nil)
 
-// CmdOption is an option for the Redpanda container.
+// CmdOption is an option for the NATS container.
 type CmdOption func(opts *options)
 
 // Customize is a NOOP. It's defined to satisfy the testcontainers.ContainerCustomizer interface.

--- a/modules/rabbitmq/options.go
+++ b/modules/rabbitmq/options.go
@@ -40,7 +40,7 @@ type SSLSettings struct {
 // Compiler check to ensure that Option implements the testcontainers.ContainerCustomizer interface.
 var _ testcontainers.ContainerCustomizer = (*Option)(nil)
 
-// Option is an option for the Redpanda container.
+// Option is an option for the RabbitMQ container.
 type Option func(*options)
 
 // Customize is a NOOP. It's defined to satisfy the testcontainers.ContainerCustomizer interface.


### PR DESCRIPTION
## What does this PR do?

I came across some wrong module names that were probably forgotten after copy-paste, then I checked all modules and fixed them.
