### PR TITLE
fix: data race in docker client `Info()`

### DIFF
--- a/commons-test.mk
+++ b/commons-test.mk
@@ -18,7 +18,7 @@ test-%:
 		--packages="./..." \
 		--junitfile TEST-unit.xml \
 		-- \
-                -coverprofile=coverage.out \
+		-coverprofile=coverage.out \
 		-timeout=30m
 
 .PHONY: tools

--- a/docker_client_test.go
+++ b/docker_client_test.go
@@ -1,0 +1,41 @@
+package testcontainers
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetDockerInfo(t *testing.T) {
+	t.Run("works", func(t *testing.T) {
+		ctx := context.Background()
+		c, err := NewDockerClientWithOpts(ctx)
+		require.NoError(t, err)
+
+		info, err := c.Info(ctx)
+		require.NoError(t, err)
+		require.NotNil(t, info)
+	})
+
+	t.Run("is goroutine safe", func(t *testing.T) {
+		ctx := context.Background()
+		c, err := NewDockerClientWithOpts(ctx)
+		require.NoError(t, err)
+
+		count := 1024
+		wg := sync.WaitGroup{}
+		wg.Add(count)
+
+		for i := 0; i < count; i++ {
+			go func() {
+				defer wg.Done()
+				info, err := c.Info(ctx)
+				require.NoError(t, err)
+				require.NotNil(t, info)
+			}()
+		}
+		wg.Wait()
+	})
+}


### PR DESCRIPTION
## What does this PR do?

This fixes a data race in docker client `Info()` which occurs when e.g. docker socket is unreachable:

```
==================
WARNING: DATA RACE
Write at 0x0001098d6700 by goroutine 29:
  github.com/testcontainers/testcontainers-go.(*DockerClient).Info()
      /Users/USER/code_/testcontainers-go/docker_client.go:69 +0xa4
  github.com/testcontainers/testcontainers-go.NewDockerClientWithOpts()
      /Users/USER/code_/testcontainers-go/docker_client.go:110 +0xd4
  github.com/testcontainers/testcontainers-go.NewDockerProvider()
      /Users/USER/code_/testcontainers-go/provider.go:142 +0x1e4
  github.com/testcontainers/testcontainers-go.ProviderType.GetProvider()
      /Users/USER/code_/testcontainers-go/provider.go:113 +0x654
  github.com/testcontainers/testcontainers-go.GenericContainer()
      /Users/USER/code_/testcontainers-go/generic.go:154 +0x110
  github.com/kong/kubernetes-ingress-controller/v2/test/kongintegration/containers.NewKong()
      /Users/USER/code_/kubernetes-ingress-controller/test/kongintegration/containers/kong.go:60 +0x690
  github.com/kong/kubernetes-ingress-controller/v2/test/kongintegration.TestUpdateStrategyInMemory_PropagatesResourcesErrors()
      /Users/USER/code_/kubernetes-ingress-controller/test/kongintegration/inmemory_update_strategy_test.go:34 +0x54
  testing.tRunner()
      /Users/USER/.gvm/gos/go1.21.3/src/testing/testing.go:1595 +0x194
  testing.(*T).Run.func1()
      /Users/USER/.gvm/gos/go1.21.3/src/testing/testing.go:1648 +0x40

Previous read at 0x0001098d6700 by goroutine 28:
  ??()
      -:0 +0x106d43e30
  sync/atomic.LoadUint32()
      <autogenerated>:1 +0x10
  github.com/testcontainers/testcontainers-go.(*DockerClient).Info()
      /Users/USER/code_/testcontainers-go/docker_client.go:40 +0x8c
  github.com/testcontainers/testcontainers-go.NewDockerClientWithOpts()
      /Users/USER/code_/testcontainers-go/docker_client.go:110 +0xd4
  github.com/testcontainers/testcontainers-go.NewDockerProvider()
      /Users/USER/code_/testcontainers-go/provider.go:142 +0x1e4
  github.com/testcontainers/testcontainers-go.ProviderType.GetProvider()
      /Users/USER/code_/testcontainers-go/provider.go:113 +0x654
  github.com/testcontainers/testcontainers-go.GenericContainer()
      /Users/USER/code_/testcontainers-go/generic.go:154 +0x110
  github.com/kong/kubernetes-ingress-controller/v2/test/kongintegration/containers.NewKong()
      /Users/USER/code_/kubernetes-ingress-controller/test/kongintegration/containers/kong.go:60 +0x690
  github.com/kong/kubernetes-ingress-controller/v2/test/kongintegration.TestExpressionsRouterMatchers_GenerateValidExpressions()
      /Users/USER/code_/kubernetes-ingress-controller/test/kongintegration/expression_router_test.go:34 +0x54
  testing.tRunner()
      /Users/USER/.gvm/gos/go1.21.3/src/testing/testing.go:1595 +0x194
  testing.(*T).Run.func1()
      /Users/USER/.gvm/gos/go1.21.3/src/testing/testing.go:1648 +0x40

Goroutine 29 (running) created at:
  testing.(*T).Run()
      /Users/USER/.gvm/gos/go1.21.3/src/testing/testing.go:1648 +0x5d8
  testing.runTests.func1()
      /Users/USER/.gvm/gos/go1.21.3/src/testing/testing.go:2054 +0x80
  testing.tRunner()
      /Users/USER/.gvm/gos/go1.21.3/src/testing/testing.go:1595 +0x194
  testing.runTests()
      /Users/USER/.gvm/gos/go1.21.3/src/testing/testing.go:2052 +0x6d8
  testing.(*M).Run()
      /Users/USER/.gvm/gos/go1.21.3/src/testing/testing.go:1925 +0x908
  main.main()
      _testmain.go:85 +0x2b4

Goroutine 28 (running) created at:
  testing.(*T).Run()
      /Users/USER/.gvm/gos/go1.21.3/src/testing/testing.go:1648 +0x5d8
  testing.runTests.func1()
      /Users/USER/.gvm/gos/go1.21.3/src/testing/testing.go:2054 +0x80
  testing.tRunner()
      /Users/USER/.gvm/gos/go1.21.3/src/testing/testing.go:1595 +0x194
  testing.runTests()
      /Users/USER/.gvm/gos/go1.21.3/src/testing/testing.go:2052 +0x6d8
  testing.(*M).Run()
      /Users/USER/.gvm/gos/go1.21.3/src/testing/testing.go:1925 +0x908
  main.main()
      _testmain.go:85 +0x2b4
==================
```

## Why is it important?

It's nice to not have data races in code.

## Related issues


## How to test this PR

```
go test -race -run TestGetDockerInfo ./...
```
