### PR TITLE
fix: fix log producer stopping block indefinitely

### DIFF
--- a/testdata/echoserver.go
+++ b/testdata/echoserver.go
@@ -29,6 +29,12 @@ func echoHandler(destination *os.File) http.HandlerFunc {
 	}
 }
 
+func crashHandler() http.HandlerFunc {
+	return func(w http.ResponseWriter, _ *http.Request) {
+		panic("manual panic via http")
+	}
+}
+
 // a simple server that will echo whatever is in the "echo" parameter to stdout
 // in the /stdout endpoint or to stderr in the /stderr endpoint
 func main() {
@@ -36,6 +42,7 @@ func main() {
 	mux.HandleFunc("/stdout", echoHandler(os.Stdout))
 	mux.HandleFunc("/stderr", echoHandler(os.Stderr))
 	mux.HandleFunc("/env", envHandler())
+	mux.HandleFunc("/crash", crashHandler())
 
 	ln, err := net.Listen("tcp", ":8080")
 	if err != nil {


### PR DESCRIPTION
Fixes an issue where stopping the log producer would block indefinitely if the log producer has exited before.

## What does this PR do?

Fixes stopping the log producer blocking by not requiring a read on the `stopProducer` channel but simply closing it.
There is no synchronization for the log producer to finish running anyways, so this should be fine.

## Why is it important?

If the log producer exits due to an exited container, `StopLogProducer` will hang indefinitely.

## Related issues

Closes #1407
Closes #1669

## How to test this PR

Test has been added.

## Follow-ups

`stopProducer` is currently not safe for concurrent use. Maybe add some synchronization in the future.