### PR TITLE
feat: add image-keep option for built images

### DIFF
--- a/container.go
+++ b/container.go
@@ -86,6 +86,10 @@ type FromDockerfile struct {
 	BuildArgs      map[string]*string             // enable user to pass build args to docker daemon
 	PrintBuildLog  bool                           // enable user to print build log
 	AuthConfigs    map[string]registry.AuthConfig // Deprecated. Testcontainers will detect registry credentials automatically. Enable auth configs to be able to pull from an authenticated docker registry
+	// KeepImage describes whether DockerContainer.Terminate should not delete the
+	// container image. Useful for images that are built from a Dockerfile and take a
+	// long time to build. Keeping the image also Docker to reuse it.
+	KeepImage bool
 }
 
 type ContainerFile struct {
@@ -131,10 +135,6 @@ type ContainerRequest struct {
 	HostConfigModifier      func(*container.HostConfig)                // Modifier for the host config before container creation
 	EnpointSettingsModifier func(map[string]*network.EndpointSettings) // Modifier for the network settings before container creation
 	LifecycleHooks          []ContainerLifecycleHooks                  // define hooks to be executed during container lifecycle
-	// KeepImage describes whether DockerContainer.Terminate should not delete the
-	// container image. Useful for images that are built from a Dockerfile and take a
-	// long time to build. Keeping the image also Docker to reuse it.
-	KeepImage bool
 }
 
 // containerOptions functional options for a container
@@ -279,8 +279,8 @@ func (c *ContainerRequest) ShouldBuildImage() bool {
 	return c.FromDockerfile.Context != "" || c.FromDockerfile.ContextArchive != nil
 }
 
-func (c *ContainerRequest) ShouldKeepImage() bool {
-	return c.KeepImage
+func (c *ContainerRequest) ShouldKeepBuiltImage() bool {
+	return c.FromDockerfile.KeepImage
 }
 
 func (c *ContainerRequest) ShouldPrintBuildLog() bool {

--- a/container.go
+++ b/container.go
@@ -131,6 +131,10 @@ type ContainerRequest struct {
 	HostConfigModifier      func(*container.HostConfig)                // Modifier for the host config before container creation
 	EnpointSettingsModifier func(map[string]*network.EndpointSettings) // Modifier for the network settings before container creation
 	LifecycleHooks          []ContainerLifecycleHooks                  // define hooks to be executed during container lifecycle
+	// KeepImage describes whether DockerContainer.Terminate should not delete the
+	// container image. Useful for images that are built from a Dockerfile and take a
+	// long time to build. Keeping the image also Docker to reuse it.
+	KeepImage bool
 }
 
 // containerOptions functional options for a container
@@ -273,6 +277,10 @@ func (c *ContainerRequest) GetAuthConfigs() map[string]registry.AuthConfig {
 
 func (c *ContainerRequest) ShouldBuildImage() bool {
 	return c.FromDockerfile.Context != "" || c.FromDockerfile.ContextArchive != nil
+}
+
+func (c *ContainerRequest) ShouldKeepImage() bool {
+	return c.KeepImage
 }
 
 func (c *ContainerRequest) ShouldPrintBuildLog() bool {

--- a/docker.go
+++ b/docker.go
@@ -59,8 +59,10 @@ type DockerContainer struct {
 	WaitingFor wait.Strategy
 	Image      string
 
-	isRunning         bool
-	imageWasBuilt     bool
+	isRunning     bool
+	imageWasBuilt bool
+	// keepImage makes Terminate not remove the image if imageWasBuilt.
+	keepImage         bool
 	provider          *DockerProvider
 	sessionID         string
 	terminationSignal chan bool
@@ -273,7 +275,7 @@ func (c *DockerContainer) Terminate(ctx context.Context) error {
 		return err
 	}
 
-	if c.imageWasBuilt {
+	if c.imageWasBuilt && !c.keepImage {
 		_, err := c.provider.client.ImageRemove(ctx, c.Image, types.ImageRemoveOptions{
 			Force:         true,
 			PruneChildren: true,
@@ -1072,6 +1074,7 @@ func (p *DockerProvider) CreateContainer(ctx context.Context, req ContainerReque
 		WaitingFor:        req.WaitingFor,
 		Image:             tag,
 		imageWasBuilt:     req.ShouldBuildImage(),
+		keepImage:         req.ShouldKeepImage(),
 		sessionID:         testcontainerssession.SessionID(),
 		provider:          p,
 		terminationSignal: termSignal,

--- a/docker.go
+++ b/docker.go
@@ -61,8 +61,8 @@ type DockerContainer struct {
 
 	isRunning     bool
 	imageWasBuilt bool
-	// keepImage makes Terminate not remove the image if imageWasBuilt.
-	keepImage         bool
+	// keepBuiltImage makes Terminate not remove the image if imageWasBuilt.
+	keepBuiltImage    bool
 	provider          *DockerProvider
 	sessionID         string
 	terminationSignal chan bool
@@ -275,7 +275,7 @@ func (c *DockerContainer) Terminate(ctx context.Context) error {
 		return err
 	}
 
-	if c.imageWasBuilt && !c.keepImage {
+	if c.imageWasBuilt && !c.keepBuiltImage {
 		_, err := c.provider.client.ImageRemove(ctx, c.Image, types.ImageRemoveOptions{
 			Force:         true,
 			PruneChildren: true,
@@ -1074,7 +1074,7 @@ func (p *DockerProvider) CreateContainer(ctx context.Context, req ContainerReque
 		WaitingFor:        req.WaitingFor,
 		Image:             tag,
 		imageWasBuilt:     req.ShouldBuildImage(),
-		keepImage:         req.ShouldKeepImage(),
+		keepBuiltImage:    req.ShouldKeepBuiltImage(),
 		sessionID:         testcontainerssession.SessionID(),
 		provider:          p,
 		terminationSignal: termSignal,

--- a/docker_test.go
+++ b/docker_test.go
@@ -2092,7 +2092,7 @@ func TestImageBuiltFromDockerfile_KeepBuiltImage(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(fmt.Sprintf("keep_built_image_%t", tt.keepBuiltImage), func(t *testing.T) {
+		t.Run(fmt.Sprintf("Keep built image: %t", tt.keepBuiltImage), func(t *testing.T) {
 			ctx := context.Background()
 			// Set up CLI.
 			provider, err := NewDockerProvider()

--- a/docker_test.go
+++ b/docker_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/docker/docker/api/types"
 	"io"
 	"log"
 	"math/rand"
@@ -16,6 +15,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/strslice"
 	"github.com/docker/docker/api/types/volume"

--- a/docker_test.go
+++ b/docker_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/docker/docker/api/types"
 	"io"
 	"log"
 	"math/rand"
@@ -2080,4 +2081,58 @@ func TestDockerProviderFindContainerByName(t *testing.T) {
 	assert.NoError(t, err)
 	require.NotNil(t, c)
 	assert.Contains(t, c.Names, c1Name)
+}
+
+func TestImageBuiltFromDockerfile_NoKeep(t *testing.T) {
+	test := func(t *testing.T, keepImage bool) {
+		ctx := context.Background()
+		// Set up CLI.
+		provider, err := NewDockerProvider()
+		require.NoError(t, err, "get docker provider should not fail")
+		defer func() { _ = provider.Close() }()
+		cli := provider.Client()
+		// Create container.
+		c, err := GenericContainer(ctx, GenericContainerRequest{
+			ProviderType: providerType,
+			ContainerRequest: ContainerRequest{
+				FromDockerfile: FromDockerfile{
+					Context:    "testdata",
+					Dockerfile: "echo.Dockerfile",
+				},
+				KeepImage: keepImage,
+			},
+		})
+		require.NoError(t, err, "create container should not fail")
+		defer func() { _ = c.Terminate(context.Background()) }()
+		// Get the image ID.
+		containerName, err := c.Name(ctx)
+		require.NoError(t, err, "get container name should not fail")
+		containerDetails, err := cli.ContainerInspect(ctx, containerName)
+		require.NoError(t, err, "inspect container should not fail")
+		containerImage := containerDetails.Image
+		t.Cleanup(func() {
+			_, _ = cli.ImageRemove(ctx, containerImage, types.ImageRemoveOptions{
+				Force:         true,
+				PruneChildren: true,
+			})
+		})
+		// Now, we terminate the container and check whether the image still exists.
+		err = c.Terminate(ctx)
+		require.NoError(t, err, "terminate container should not fail")
+		if keepImage {
+			_, _, err = cli.ImageInspectWithRaw(ctx, containerImage)
+			assert.Nil(t, err, "image should still exist")
+		} else {
+			_, _, err = cli.ImageInspectWithRaw(ctx, containerImage)
+			assert.NotNil(t, err, "image should not exist anymore")
+		}
+	}
+
+	t.Run("do_not_keep_image", func(t *testing.T) {
+		test(t, false)
+	})
+
+	t.Run("keep_image", func(t *testing.T) {
+		test(t, true)
+	})
 }

--- a/docs/features/build_from_dockerfile.md
+++ b/docs/features/build_from_dockerfile.md
@@ -66,3 +66,20 @@ req := ContainerRequest{
 	},
 }
 ```
+
+## Keeping built images
+
+Per default, built images are deleted after being used.
+However, some images you build might have no or only minor changes during development.
+Building them for each test run might take a lot of time.
+You can avoid this by setting `KeepImage` in `FromDockerfile`.
+If the image is being kept, cached layers might be reused during building or even the whole image.
+
+```go
+req := ContainerRequest{
+    FromDockerfile: testcontainers.FromDockerfile{
+        // ...
+		KeepImage: true,
+	},
+}
+```


### PR DESCRIPTION
## What does this PR do?

Adds an option to keep images if they have been built.
This avoids the need to build these images every time from scratch.
Built images are being kept in `DockerContainer.Terminate` when `KeepImage` is set to `true` in `ContainerRequest`.

## Why is it important?

If images for testing are built with long build time, they are currently always deleted.
This means that for each test run, the whole image needs to be rebuilt.
If the image stays the same for every test, this may take up a lot of time.

## Related issues

_None_

## How to test this PR

Create a container with image-build manually and set `KeepImage` to true.
Tests for this functionality have been added as well.