### PR TITLE
feat: enable access to kafka using container hostname

### DIFF
--- a/modules/kafka/kafka.go
+++ b/modules/kafka/kafka.go
@@ -77,7 +77,13 @@ func RunContainer(ctx context.Context, opts ...testcontainers.ContainerCustomize
 							return err
 						}
 
-						scriptContent := fmt.Sprintf(starterScriptContent, host, port.Int(), host)
+						name, err := c.Name(ctx)
+						if err != nil {
+							return err
+						}
+						containerHost := strings.TrimPrefix(name, "/")
+
+						scriptContent := fmt.Sprintf(starterScriptContent, host, port.Int(), containerHost)
 
 						return c.CopyToContainer(ctx, []byte(scriptContent), starterScript, 0o755)
 					},


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?

This PR applies a fix to the entrypoint script template variables used in the kafka module container in order to make kafka accessible to other containers in the same network.

## Why is it important?

Kafka container created by the kafka module needs to be exposed to the other containers in the same network.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- No

## How to test this PR
After starting a Kafka container using the Kafka module, the `KAFKA_ADVERTISED_LISTENERS` should contain the endpoint of the container host.

E.g.
For Kafka container name set to `broker`, the `/usr/sbin/testcontainers_start.sh` script should contain the following value:
```
export KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://localhost:51702,BROKER://broker:9092
```
