### PR TITLE
fix(redpanda): add wait for listening port condition on startup

### DIFF
--- a/modules/redpanda/redpanda.go
+++ b/modules/redpanda/redpanda.go
@@ -176,9 +176,11 @@ func RunContainer(ctx context.Context, opts ...testcontainers.ContainerCustomize
 	}
 
 	// 6. Wait until Redpanda is ready to serve requests
-	err = wait.ForLog("Successfully started Redpanda!").
-		WithPollInterval(100*time.Millisecond).
+	err = wait.ForAll(
+		wait.ForListeningPort(defaultKafkaAPIPort),
+		wait.ForLog("Successfully started Redpanda!").WithPollInterval(100*time.Millisecond)).
 		WaitUntilReady(ctx, container)
+
 	if err != nil {
 		return nil, fmt.Errorf("failed to wait for Redpanda readiness: %w", err)
 	}


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

When starting the Redpanda container, adds the readiness condition to wait for the listening port to be available.
## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->
The container may not be ready to accept connections yet, although the process started gets to log the targetted log: "Successfully started Redpanda!"
## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes #1827

## How to test this PR

Just run the tests in the redpanda module:
```
cd modules/redpanda
make test
```

<!-- Recommended


Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
