### PR TITLE
WIP: PoC Container Stats

### DIFF
--- a/docker.go
+++ b/docker.go
@@ -1517,3 +1517,167 @@ func (p *DockerProvider) SaveImages(ctx context.Context, output string, images .
 func (p *DockerProvider) PullImage(ctx context.Context, image string) error {
 	return p.attemptToPullImage(ctx, image, types.ImagePullOptions{})
 }
+
+// ContainerStats defines a summary of the container's starts
+type ContainerStats struct {
+	Timestamp         time.Time
+	CPUUsageTotal     uint64
+	CPUUsageInKernel  uint64
+	CPUUsageUser      uint64
+	CPUPercentage     float64
+	MemoryUsage       uint64
+	MemoryMaxUsage    uint64
+	MemoryLimit       uint64
+	MemoryPercentage  float64
+	NetworkRxBytes    uint64
+	NetworkTxBytes    uint64
+	BlockIOReadBytes  uint64 // In Linux is an aggregate over all block devices
+	BlockIOWriteBytes uint64 // In Linux is an aggregate over all block devices
+}
+
+// Calculate the memory usage discounting the cache size.
+// Depending on whether docker is running with cgroups V1 or V2, cache size is reported differently
+func calculateMemoryUsage(memory types.MemoryStats) uint64 {
+	// check groups v1 format
+	if cache, isCgroup1 := memory.Stats["total_inactive_file"]; isCgroup1 && cache < memory.Usage {
+		return memory.Usage - cache
+	}
+
+	if cache := memory.Stats["inactive_file"]; cache < memory.Usage {
+		return memory.Usage - cache
+	}
+
+	return memory.Usage
+}
+
+// collects stats for a Linux system using a current sample and a base sample
+func collectLinuxStats(base, sample types.StatsJSON) ContainerStats {
+	stats := ContainerStats{}
+
+	stats.Timestamp = sample.Read
+
+	// CPU stats
+	stats.CPUUsageTotal = sample.CPUStats.CPUUsage.TotalUsage
+	stats.CPUUsageInKernel = sample.CPUStats.CPUUsage.UsageInKernelmode
+	stats.CPUUsageUser = sample.CPUStats.CPUUsage.UsageInUsermode
+
+	// usage stats are counters, so percentage is calculated over the delta of two samples
+	deltaUsage := float64(sample.CPUStats.CPUUsage.TotalUsage - base.CPUStats.CPUUsage.TotalUsage)
+	deltaSystemUsage := float64(sample.CPUStats.SystemUsage - base.CPUStats.SystemUsage)
+	if deltaSystemUsage > 0 && deltaUsage > 0 {
+		stats.CPUPercentage = deltaUsage / deltaSystemUsage * float64(sample.CPUStats.OnlineCPUs) * 100.0
+	}
+
+	// memory stats
+	stats.MemoryUsage = calculateMemoryUsage(sample.MemoryStats)
+	stats.MemoryMaxUsage = sample.MemoryStats.MaxUsage
+	stats.MemoryLimit = sample.MemoryStats.Limit
+	if sample.MemoryStats.Limit != 0 {
+		stats.MemoryPercentage = float64(stats.MemoryUsage) / float64(sample.MemoryStats.Limit) * 100.0
+	}
+
+	// aggregate block I/O states
+	for _, dev := range sample.BlkioStats.IoServiceBytesRecursive {
+		switch dev.Op {
+		case "read":
+			stats.BlockIOReadBytes += dev.Value
+		case "write":
+			stats.BlockIOWriteBytes += dev.Value
+		}
+	}
+
+	// aggregate network stats
+	for _, n := range sample.Networks {
+		stats.NetworkRxBytes += n.RxBytes
+		stats.NetworkTxBytes += n.TxBytes
+	}
+
+	return stats
+}
+
+// collects stats for a Windows system using a current sample and a base sample
+func collectWindowStats(base, sample types.StatsJSON) ContainerStats {
+	stats := ContainerStats{}
+
+	stats.Timestamp = sample.Read
+
+	// CPU stats (normalize to nanoseconds)
+	stats.CPUUsageTotal = sample.CPUStats.CPUUsage.TotalUsage * 100
+	stats.CPUUsageInKernel = sample.CPUStats.CPUUsage.UsageInKernelmode * 100
+	stats.CPUUsageUser = sample.CPUStats.CPUUsage.UsageInUsermode * 100
+
+	// measure the number of 100 nanosecond intervals between samples
+	intervals := uint64(sample.Read.Sub(base.PreRead).Nanoseconds()) / 100
+	if intervals > 0 {
+		// usage stats are counters, so percentage is calculated over the delta of two samples
+		intervalsUsed := sample.CPUStats.CPUUsage.TotalUsage - base.CPUStats.CPUUsage.TotalUsage
+		stats.CPUPercentage = float64(intervalsUsed) / float64(intervals) * 100.0
+	}
+
+	// memory stats
+	stats.MemoryMaxUsage = sample.MemoryStats.MaxUsage
+	stats.MemoryLimit = sample.MemoryStats.Limit
+	if sample.MemoryStats.Limit != 0 {
+		stats.MemoryPercentage = float64(sample.MemoryStats.Usage) / float64(sample.MemoryStats.Limit) * 100.0
+	}
+
+	stats.BlockIOReadBytes = sample.StorageStats.ReadSizeBytes
+	stats.BlockIOWriteBytes = sample.StorageStats.WriteSizeBytes
+
+	// aggregate network stats
+	for _, n := range sample.Networks {
+		stats.NetworkRxBytes += n.RxBytes
+		stats.NetworkTxBytes += n.TxBytes
+	}
+
+	return stats
+}
+
+// sampleStats get a one shot sample of stats. Returns the sample data and the OS type
+func (p *DockerProvider) sampleStats(ctx context.Context, containerID string) (types.StatsJSON, string, error) {
+	resp, err := p.client.ContainerStatsOneShot(ctx, containerID)
+	if err != nil {
+		return types.StatsJSON{}, "", fmt.Errorf("requesting stats %w", err)
+	}
+	defer resp.Body.Close()
+
+	buffer := bytes.Buffer{}
+	_, err = buffer.ReadFrom(resp.Body)
+	if err != nil {
+		return types.StatsJSON{}, "", fmt.Errorf("reading stats %w", err)
+	}
+
+	statsData := types.StatsJSON{}
+	err = json.Unmarshal(buffer.Bytes(), &statsData)
+	if err != nil {
+		return types.StatsJSON{}, "", fmt.Errorf("unmarshalling stats %w", err)
+	}
+
+	return statsData, resp.OSType, nil
+}
+
+// Stats works as Docker Stats command and retrieves a summary of container resource usage.
+// As CPU measurement are accumulated, in order to calculate CPU percentage, two samples are
+// taken a second apart and the incremental usage is used for estimating the percentage usage.
+func (p *DockerProvider) Stats(ctx context.Context, containerID string) (ContainerStats, error) {
+	base, _, err := p.sampleStats(ctx, containerID)
+	if err != nil {
+		return ContainerStats{}, err
+	}
+
+	time.Sleep(time.Second)
+
+	sample, os, err := p.sampleStats(ctx, containerID)
+	if err != nil {
+		return ContainerStats{}, err
+	}
+
+	switch os {
+	case "linux":
+		return collectLinuxStats(base, sample), nil
+	case "windows":
+		return collectWindowStats(base, sample), nil
+	default:
+		return ContainerStats{}, fmt.Errorf("unsupported OS: %s", os)
+	}
+}

--- a/docker_test.go
+++ b/docker_test.go
@@ -2136,3 +2136,29 @@ func TestImageBuiltFromDockerfile_KeepBuiltImage(t *testing.T) {
 		})
 	}
 }
+
+func TestContainerStats(t *testing.T) {
+	ctx := context.Background()
+
+	// delayed-nginx will wait 2s before opening port
+	stress, err := GenericContainer(ctx, GenericContainerRequest{
+		ProviderType: providerType,
+		ContainerRequest: ContainerRequest{
+			Image: "alexeiled/stress-ng",
+			Cmd:   []string{"--cpu", "1", "--cpu-load", "50"},
+		},
+		Started: true,
+	})
+
+	require.NoError(t, err)
+	terminateContainerOnEnd(t, ctx, stress)
+
+	provider, err := NewDockerProvider()
+	require.NoError(t, err, "get docker provider should not fail")
+
+	id := stress.GetContainerID()
+
+	stats, err := provider.Stats(ctx, id)
+	require.NoError(t, err)
+	t.Logf("stats %v", stats)
+}


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?

This PR is a proof of concept for gathering resource consumption stats for a container. 

> This is a WIP. The intention is to show the general approach and highlight some issues that need to be addressed.

Open Issues:
-  The new function was added to the Docker provider because adding it to the `Container` interface would break other implementations of the interface such as the `reaperContainer`
-  Calculating the CPU percentage requires two samples of the stats. Currently, this is implemented by issuing two requests separate by a hardcoded waiting time of `1s`. 
One alternative implementation could be passing the previous sample to the stats call. If it is nil, the instantaneous stats will be returned (with the CPU% as 0)
```golang
 base := provider.Stats(containerId, nil)     // returns CPU percentage = 0
 // execute test
 stats := provider.Stats(containerId, base)  // returns CPU percentage
```
-  Testing the new feature is challenging. A container's resource consumption varies depending on many factors. Therefore, the statistics retrieved from a container cannot just be compared with an expected value.

## Why is it important?

In some use cases, it would be convenient to have access to the container's stats to measure the resource (memory, CPU) consumption to detect regressions or establish a comparison between alternative implementations or configurations.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes #1826 


## How to test this PR

In its current form, the suggested way to test is by looking at the CPU stats and see if vales are "reasonable" . 
Automating tests is an ongoing effort. 

## Follow-ups