### PR TITLE
feat: expose a WithNetwork functional option

### DIFF
--- a/docs/features/common_functional_options.md
+++ b/docs/features/common_functional_options.md
@@ -34,6 +34,8 @@ You could use this feature to run a custom script, or to run a command that is n
 
 By default, the container is started in the default Docker network. If you want to use a different Docker network, you can use the `WithNetwork(networkName string, alias string)` option, which receives the new network name and an alias as parameters, creating the new network, attaching the container to it, and setting the network alias for that network.
 
+If the network already exists, _Testcontainers for Go_ won't create a new one, but it will attach the container to it and set the network alias.
+
 #### Docker type modifiers
 
 If you need an advanced configuration for the container, you can leverage the following Docker type modifiers:

--- a/docs/features/common_functional_options.md
+++ b/docs/features/common_functional_options.md
@@ -28,6 +28,12 @@ It also exports an `Executable` interface, defining one single method: `AsComman
 
 You could use this feature to run a custom script, or to run a command that is not supported by the module right after the container is started.
 
+#### WithNetwork
+
+- Not available until the next release of testcontainers-go <a href="https://github.com/testcontainers/testcontainers-go"><span class="tc-version">:material-tag: main</span></a>
+
+By default, the container is started in the default Docker network. If you want to use a different Docker network, you can use the `WithNetwork(networkName string, alias string)` option, which receives the new network name and an alias as parameters, creating the new network, attaching the container to it, and setting the network alias for that network.
+
 #### Docker type modifiers
 
 If you need an advanced configuration for the container, you can leverage the following Docker type modifiers:

--- a/docs/modules/localstack.md
+++ b/docs/modules/localstack.md
@@ -58,10 +58,6 @@ With simply passing the `testcontainers.CustomizeRequest` functional option to t
 
 In the above example you can check how it's possible to set certain environment variables that are needed by the tests, the most important ones are the AWS services you want to use. Besides, the container runs in a separate Docker network with an alias.
 
-#### WithNetwork
-
-By default, the LocalStack container is started in the default Docker network. If you want to use a different Docker network, you can use the `WithNetwork(networkName string, alias string)` option, which receives the new network name and an alias as parameters, creating the new network, attaching the container to it, and setting the network alias for that network.
-
 ## Accessing hostname-sensitive services
 
 Some Localstack APIs, such as SQS, require the container to be aware of the hostname that it is accessible on - for example, for construction of queue URLs in responses.

--- a/modules/localstack/localstack.go
+++ b/modules/localstack/localstack.go
@@ -61,29 +61,9 @@ func isVersion2(image string) bool {
 
 // WithNetwork creates a network with the given name and attaches the container to it, setting the network alias
 // on that network to the given alias.
+// Deprecated: use testcontainers.WithNetwork instead
 func WithNetwork(networkName string, alias string) testcontainers.CustomizeRequestOption {
-	return func(req *testcontainers.GenericContainerRequest) {
-		_, err := testcontainers.GenericNetwork(context.Background(), testcontainers.GenericNetworkRequest{
-			NetworkRequest: testcontainers.NetworkRequest{
-				Name: networkName,
-			},
-		})
-		if err != nil {
-			logger := req.Logger
-			if logger == nil {
-				logger = testcontainers.Logger
-			}
-			logger.Printf("Failed to create network '%s'. Container won't be attached to this network: %v", networkName, err)
-			return
-		}
-
-		req.Networks = append(req.Networks, networkName)
-
-		if req.NetworkAliases == nil {
-			req.NetworkAliases = make(map[string][]string)
-		}
-		req.NetworkAliases[networkName] = []string{alias}
-	}
+	return testcontainers.WithNetwork(networkName, alias)
 }
 
 // RunContainer creates an instance of the LocalStack container type, being possible to pass a custom request and options:


### PR DESCRIPTION
- feat: move WithNetwork functional option to the core
- chore: reuse the network if it already existed

<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
This PR moves the existing `WithNetwork` functional option that was present in the localstack module to all the modules.

This option will be improved to detect if a network with that name already existed and, in that case, reuse it instead of creating a new one. The latter was the observed behaviour in case somebody imported the localstack module to use that option: a new network would be created even though they used the same name.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
Allow modules to run on a separate network, and make it possibly in a reusable manner, without creating multiple networks.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->


<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
