### PR TITLE
feat: Allow the container working directory to be specified

### DIFF
--- a/container.go
+++ b/container.go
@@ -114,6 +114,7 @@ type ContainerRequest struct {
 	WaitingFor              wait.Strategy
 	Name                    string // for specifying container name
 	Hostname                string
+	WorkingDir              string                                     // specify the working directory of the container
 	ExtraHosts              []string                                   // Deprecated: Use HostConfigModifier instead
 	Privileged              bool                                       // For starting privileged container
 	Networks                []string                                   // for specifying network names
@@ -136,7 +137,6 @@ type ContainerRequest struct {
 	HostConfigModifier      func(*container.HostConfig)                // Modifier for the host config before container creation
 	EnpointSettingsModifier func(map[string]*network.EndpointSettings) // Modifier for the network settings before container creation
 	LifecycleHooks          []ContainerLifecycleHooks                  // define hooks to be executed during container lifecycle
-	WorkingDir              string                                     // specify the working directory of the container
 }
 
 // containerOptions functional options for a container

--- a/container.go
+++ b/container.go
@@ -136,6 +136,7 @@ type ContainerRequest struct {
 	HostConfigModifier      func(*container.HostConfig)                // Modifier for the host config before container creation
 	EnpointSettingsModifier func(map[string]*network.EndpointSettings) // Modifier for the network settings before container creation
 	LifecycleHooks          []ContainerLifecycleHooks                  // define hooks to be executed during container lifecycle
+	WorkingDir              string                                     // specify the working directory of the container
 }
 
 // containerOptions functional options for a container

--- a/docker.go
+++ b/docker.go
@@ -999,6 +999,7 @@ func (p *DockerProvider) CreateContainer(ctx context.Context, req ContainerReque
 		Cmd:        req.Cmd,
 		Hostname:   req.Hostname,
 		User:       req.User,
+		WorkingDir: req.WorkingDir,
 	}
 
 	hostConfig := &container.HostConfig{

--- a/docker_test.go
+++ b/docker_test.go
@@ -1059,6 +1059,34 @@ func TestEntrypoint(t *testing.T) {
 	terminateContainerOnEnd(t, ctx, c)
 }
 
+func TestWorkingDir(t *testing.T) {
+	/*
+		print the current working directory to ensure that
+		we can specify working directory in the
+		ContainerRequest and it will be used for the container
+	*/
+
+	ctx := context.Background()
+
+	req := ContainerRequest{
+		Image: "docker.io/alpine",
+		WaitingFor: wait.ForAll(
+			wait.ForLog("/var/tmp/test"),
+		),
+		Entrypoint: []string{"pwd"},
+		WorkingDir: "/var/tmp/test",
+	}
+
+	c, err := GenericContainer(ctx, GenericContainerRequest{
+		ProviderType:     providerType,
+		ContainerRequest: req,
+		Started:          true,
+	})
+
+	require.NoError(t, err)
+	terminateContainerOnEnd(t, ctx, c)
+}
+
 func ExampleDockerProvider_CreateContainer() {
 	ctx := context.Background()
 	req := ContainerRequest{


### PR DESCRIPTION
## What does this PR do?

This change allows the container working directory to be specified in the `ContainerRequest` struct.

## Why is it important?

Setting the working directory allows users to perform actions on files in an isolated directory, and to use relative paths, without using `cd` inside their containers.

## How to test this PR

A test (`TestWorkingDir`) has been added to cover this feature. This change can also be manually verified by setting the `WorkingDir` field in a `ContainerRequest`, using it to start a container, and validating the current working directory of the launched container using the `pwd` utility (if present in the image).

