### PR TITLE
Reduce flakiness in ClickHouse tests

### DIFF
--- a/modules/clickhouse/clickhouse_test.go
+++ b/modules/clickhouse/clickhouse_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
 	"github.com/cenkalti/backoff/v4"
 	"github.com/stretchr/testify/assert"
+
 	"github.com/testcontainers/testcontainers-go"
 )
 

--- a/modules/clickhouse/clickhouse_test.go
+++ b/modules/clickhouse/clickhouse_test.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"path/filepath"
 	"testing"
-	"time"
 
 	ch "github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+	"github.com/cenkalti/backoff/v4"
 	"github.com/stretchr/testify/assert"
 	"github.com/testcontainers/testcontainers-go"
 )
@@ -219,32 +219,28 @@ func TestClickHouseWithConfigFile(t *testing.T) {
 
 func performCRUD(conn driver.Conn) ([]Test, error) {
 	var (
-		maxRetry = 5
-		delay    = 100 * time.Millisecond
-		err      error
-		rows     []Test
+		err  error
+		rows []Test
 	)
 
-	for i := 0; i < maxRetry; i++ {
-		time.Sleep(time.Duration(i) * delay)
-
+	err = backoff.Retry(func() error {
 		err = conn.Exec(context.Background(), "create table if not exists test_table (id UInt64) engine = MergeTree PRIMARY KEY (id) ORDER BY (id) SETTINGS index_granularity = 8192;")
 		if err != nil {
-			continue
+			return err
 		}
 
 		err = conn.Exec(context.Background(), "INSERT INTO test_table (id) VALUES (1);")
 		if err != nil {
-			continue
+			return err
 		}
 
 		rows, err = getAllRows(conn)
 		if err != nil {
-			continue
+			return err
 		}
 
-		return rows, err
-	}
+		return nil
+	}, backoff.NewExponentialBackOff())
 
 	return rows, err
 }


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

Reduce flakiness in ClickHouse tests by replacing `performCRUD` with `performCRUDWithRetry`.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes https://github.com/testcontainers/testcontainers-go/issues/1898

<!-- Recommended

## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
