### PR TITLE
Fix - respect ContainerCustomizer in neo4j module

### DIFF
--- a/modules/neo4j/examples_test.go
+++ b/modules/neo4j/examples_test.go
@@ -15,7 +15,7 @@ func ExampleRunContainer() {
 	testPassword := "letmein!"
 
 	neo4jContainer, err := neo4j.RunContainer(ctx,
-		testcontainers.WithImage("docker.io/neo4j:15.2-alpine"),
+		testcontainers.WithImage("docker.io/neo4j:4.4"),
 		neo4j.WithAdminPassword(testPassword),
 		neo4j.WithLabsPlugin(neo4j.Apoc),
 		neo4j.WithNeo4jSetting("dbms.tx_log.rotation.size", "42M"),

--- a/modules/neo4j/neo4j.go
+++ b/modules/neo4j/neo4j.go
@@ -91,10 +91,7 @@ func RunContainer(ctx context.Context, options ...testcontainers.ContainerCustom
 		return nil, err
 	}
 
-	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
-		ContainerRequest: request,
-		Started:          true,
-	})
+	container, err := testcontainers.GenericContainer(ctx, genericContainerReq)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## What does this PR do?

Respect all `ContainerCustomizer` options passed to the neo4j `RunContainer` function.

Additionally, this fixes a nonexistent image tag in the `ExampleRunContainer` test.

## Why is it important?

Currently the neo4j module only respects `ContainerCustomizer`s that affect the `ContainerRequest` field, not other fields. This means that options like the logging implementation cannot be changed.

## Related issues

- Closes #1901 
