### PR TITLE
chore: make rabbitmq examples more readable

### DIFF
--- a/modules/rabbitmq/examples_test.go
+++ b/modules/rabbitmq/examples_test.go
@@ -128,8 +128,9 @@ func ExampleRunContainer_withPlugins() {
 
 	rabbitmqContainer, err := rabbitmq.RunContainer(ctx,
 		testcontainers.WithImage("rabbitmq:3.7.25-management-alpine"),
-		// Plugin is a test implementation of an Executable, please check types_test.go file for more details
-		testcontainers.WithStartupCommand(Plugin("rabbitmq_shovel"), Plugin("rabbitmq_random_exchange")),
+		// Multiple test implementations of the Executable interface, specific to RabbitMQ, exist in the types_test.go file.
+		// Please refer to them for more examples.
+		testcontainers.WithStartupCommand(testcontainers.RawCommand{"rabbitmq_shovel"}, testcontainers.RawCommand{"rabbitmq_random_exchange"}),
 	)
 	if err != nil {
 		panic(err)

--- a/modules/rabbitmq/types_test.go
+++ b/modules/rabbitmq/types_test.go
@@ -10,6 +10,7 @@ import (
 // they are not used in the RabbitMQ module.
 // All of them implement the testcontainers.Executable interface, which is used to generate
 // the command that will be executed, with the "AsCommand" method.
+// Please be aware that they could be outdated, as they are not actively maintained, just here for reference.
 
 // --------- Bindings ---------
 

--- a/options.go
+++ b/options.go
@@ -120,6 +120,14 @@ type Executable interface {
 	AsCommand() []string
 }
 
+// RawCommand is a type that implements Executable and represents a command to be sent to a container
+type RawCommand []string
+
+// AsCommand returns the command as a slice of strings
+func (r RawCommand) AsCommand() []string {
+	return r
+}
+
 // WithStartupCommand will execute the command representation of each Executable into the container.
 // It will leverage the container lifecycle hooks to call the command right after the container
 // is started.


### PR DESCRIPTION
- chore: add raw command implementation of Executable
- chore: make rabbitmq examples more readable

<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
This PR adds a new struct implementing the Executable interface. This new type is basically a slice of string representing a `RawCommand` that can be used in the `WithStartupCommand` functional option.

As a consequence, we can simplify the examples for RabbitMQ without exposing in the docs the sample types we created for reference only (not public API). We are simply using the new type, which makes the examples copiable.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
Simplicity

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes #1702 

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
