### PR TITLE
lint: enable nonamedreturns

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,6 +5,7 @@ linters:
     - gocritic
     - gofumpt
     - misspell
+    - nonamedreturns
 
 linters-settings:
   errorlint:

--- a/docker.go
+++ b/docker.go
@@ -1200,8 +1200,8 @@ func (p *DockerProvider) attemptToPullImage(ctx context.Context, tag string, pul
 
 // Health measure the healthiness of the provider. Right now we leverage the
 // docker-client Info endpoint to see if the daemon is reachable.
-func (p *DockerProvider) Health(ctx context.Context) (err error) {
-	_, err = p.client.Info(ctx)
+func (p *DockerProvider) Health(ctx context.Context) error {
+	_, err := p.client.Info(ctx)
 	defer p.Close()
 
 	return err

--- a/modules/kafka/consumer_test.go
+++ b/modules/kafka/consumer_test.go
@@ -15,7 +15,7 @@ type TestKafkaConsumer struct {
 	message *sarama.ConsumerMessage
 }
 
-func NewTestKafkaConsumer(t *testing.T) (consumer *TestKafkaConsumer, ready <-chan bool, done <-chan bool, cancel func()) {
+func NewTestKafkaConsumer(t *testing.T) (*TestKafkaConsumer, <-chan bool, <-chan bool, func()) {
 	kc := &TestKafkaConsumer{
 		t:      t,
 		ready:  make(chan bool, 1),

--- a/wait/exit.go
+++ b/wait/exit.go
@@ -60,7 +60,7 @@ func (ws *ExitStrategy) Timeout() *time.Duration {
 }
 
 // WaitUntilReady implements Strategy.WaitUntilReady
-func (ws *ExitStrategy) WaitUntilReady(ctx context.Context, target StrategyTarget) (err error) {
+func (ws *ExitStrategy) WaitUntilReady(ctx context.Context, target StrategyTarget) error {
 	if ws.timeout != nil {
 		var cancel context.CancelFunc
 		ctx, cancel = context.WithTimeout(ctx, *ws.timeout)

--- a/wait/health.go
+++ b/wait/health.go
@@ -61,7 +61,7 @@ func (ws *HealthStrategy) Timeout() *time.Duration {
 }
 
 // WaitUntilReady implements Strategy.WaitUntilReady
-func (ws *HealthStrategy) WaitUntilReady(ctx context.Context, target StrategyTarget) (err error) {
+func (ws *HealthStrategy) WaitUntilReady(ctx context.Context, target StrategyTarget) error {
 	timeout := defaultStartupTimeout()
 	if ws.timeout != nil {
 		timeout = *ws.timeout

--- a/wait/host_port.go
+++ b/wait/host_port.go
@@ -71,7 +71,7 @@ func (hp *HostPortStrategy) Timeout() *time.Duration {
 }
 
 // WaitUntilReady implements Strategy.WaitUntilReady
-func (hp *HostPortStrategy) WaitUntilReady(ctx context.Context, target StrategyTarget) (err error) {
+func (hp *HostPortStrategy) WaitUntilReady(ctx context.Context, target StrategyTarget) error {
 	timeout := defaultStartupTimeout()
 	if hp.timeout != nil {
 		timeout = *hp.timeout
@@ -82,7 +82,7 @@ func (hp *HostPortStrategy) WaitUntilReady(ctx context.Context, target StrategyT
 
 	ipAddress, err := target.Host(ctx)
 	if err != nil {
-		return
+		return err
 	}
 
 	waitInterval := hp.PollInterval
@@ -92,7 +92,7 @@ func (hp *HostPortStrategy) WaitUntilReady(ctx context.Context, target StrategyT
 		var ports nat.PortMap
 		ports, err = target.Ports(ctx)
 		if err != nil {
-			return
+			return err
 		}
 		if len(ports) > 0 {
 			for p := range ports {
@@ -103,8 +103,7 @@ func (hp *HostPortStrategy) WaitUntilReady(ctx context.Context, target StrategyT
 	}
 
 	if internalPort == "" {
-		err = fmt.Errorf("no port to wait for")
-		return
+		return fmt.Errorf("no port to wait for")
 	}
 
 	var port nat.Port

--- a/wait/http.go
+++ b/wait/http.go
@@ -130,7 +130,7 @@ func (ws *HTTPStrategy) Timeout() *time.Duration {
 }
 
 // WaitUntilReady implements Strategy.WaitUntilReady
-func (ws *HTTPStrategy) WaitUntilReady(ctx context.Context, target StrategyTarget) (err error) {
+func (ws *HTTPStrategy) WaitUntilReady(ctx context.Context, target StrategyTarget) error {
 	timeout := defaultStartupTimeout()
 	if ws.timeout != nil {
 		timeout = *ws.timeout
@@ -141,7 +141,7 @@ func (ws *HTTPStrategy) WaitUntilReady(ctx context.Context, target StrategyTarge
 
 	ipAddress, err := target.Host(ctx)
 	if err != nil {
-		return
+		return err
 	}
 
 	var mappedPort nat.Port
@@ -252,7 +252,7 @@ func (ws *HTTPStrategy) WaitUntilReady(ctx context.Context, target StrategyTarge
 	if ws.Body != nil {
 		body, err = io.ReadAll(ws.Body)
 		if err != nil {
-			return
+			return err
 		}
 	}
 

--- a/wait/log.go
+++ b/wait/log.go
@@ -83,7 +83,7 @@ func (ws *LogStrategy) Timeout() *time.Duration {
 }
 
 // WaitUntilReady implements Strategy.WaitUntilReady
-func (ws *LogStrategy) WaitUntilReady(ctx context.Context, target StrategyTarget) (err error) {
+func (ws *LogStrategy) WaitUntilReady(ctx context.Context, target StrategyTarget) error {
 	timeout := defaultStartupTimeout()
 	if ws.timeout != nil {
 		timeout = *ws.timeout

--- a/wait/sql.go
+++ b/wait/sql.go
@@ -64,7 +64,7 @@ func (w *waitForSql) Timeout() *time.Duration {
 // WaitUntilReady repeatedly tries to run "SELECT 1" or user defined query on the given port using sql and driver.
 //
 // If it doesn't succeed until the timeout value which defaults to 60 seconds, it will return an error.
-func (w *waitForSql) WaitUntilReady(ctx context.Context, target StrategyTarget) (err error) {
+func (w *waitForSql) WaitUntilReady(ctx context.Context, target StrategyTarget) error {
 	timeout := defaultStartupTimeout()
 	if w.timeout != nil {
 		timeout = *w.timeout
@@ -75,7 +75,7 @@ func (w *waitForSql) WaitUntilReady(ctx context.Context, target StrategyTarget) 
 
 	host, err := target.Host(ctx)
 	if err != nil {
-		return
+		return err
 	}
 
 	ticker := time.NewTicker(w.PollInterval)


### PR DESCRIPTION
## What does this PR do?

Enable nonamedreturns linter which ensures there is no named return value

## Why is it important?

It ensures the rule stay applied along time

## Related issues

Relates to https://github.com/testcontainers/testcontainers-go/pull/1902#discussion_r1382933308
