### PR TITLE
feat: get container image

### DIFF
--- a/container.go
+++ b/container.go
@@ -42,6 +42,7 @@ type Container interface {
 	MappedPort(context.Context, nat.Port) (nat.Port, error)         // get externally mapped port for a container port
 	Ports(context.Context) (nat.PortMap, error)                     // get all exposed ports
 	SessionID() string                                              // get session id
+	ContainerImage(context.Context) (string, error)                 // get the container image
 	IsRunning() bool
 	Start(context.Context) error                 // start the container
 	Stop(context.Context, *time.Duration) error  // stop the container

--- a/docker.go
+++ b/docker.go
@@ -378,6 +378,15 @@ func (c *DockerContainer) Name(ctx context.Context) (string, error) {
 	return inspect.Name, nil
 }
 
+// ContainerImage gets the image of the container.
+func (c *DockerContainer) ContainerImage(ctx context.Context) (string, error) {
+	inspect, err := c.inspectContainer(ctx)
+	if err != nil {
+		return "", err
+	}
+	return inspect.Image, nil
+}
+
 // State returns container's running state
 func (c *DockerContainer) State(ctx context.Context) (*types.ContainerState, error) {
 	inspect, err := c.inspectRawContainer(ctx)


### PR DESCRIPTION
## What does this PR do?

As per the `testcontainers.Container.Name` method, allow retrieving the image from a `testcontainers.Container` interface.

The function has been named `ContainerImage` since `Image` clashes with the Container struct field.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?

I'm using it on a project to retrieve images from containers running in a docker host and I use testcontainers-go to create containers for a testing environment.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Related issues

No related issues.

## How to test this PR
This PR works exactly like `Container.Name()` method, which hasn't been tested, probably because it mainly uses external dependencies. 