### PR TITLE
feat: support for executing commands in a container with user, workDir and env

### DIFF
--- a/docker_exec_test.go
+++ b/docker_exec_test.go
@@ -39,6 +39,73 @@ func TestExecWithMultiplexedResponse(t *testing.T) {
 	require.Equal(t, "html\n", str)
 }
 
+func TestExecWithOptions(t *testing.T) {
+	tests := []struct {
+		name string
+		cmds []string
+		opts []tcexec.ProcessOption
+		want string
+	}{
+		{
+			name: "with user",
+			cmds: []string{"whoami"},
+			opts: []tcexec.ProcessOption{
+				tcexec.WithUser("nginx"),
+			},
+			want: "nginx\n",
+		},
+		{
+			name: "with working dir",
+			cmds: []string{"pwd"},
+			opts: []tcexec.ProcessOption{
+				tcexec.WithWorkingDir("/var/log/nginx"),
+			},
+			want: "/var/log/nginx\n",
+		},
+		{
+			name: "with env",
+			cmds: []string{"env"},
+			opts: []tcexec.ProcessOption{
+				tcexec.WithEnv([]string{"TEST_ENV=test"}),
+			},
+			want: "TEST_ENV=test\n",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			req := ContainerRequest{
+				Image: nginxAlpineImage,
+			}
+
+			container, err := GenericContainer(ctx, GenericContainerRequest{
+				ProviderType:     providerType,
+				ContainerRequest: req,
+				Started:          true,
+			})
+
+			require.NoError(t, err)
+			terminateContainerOnEnd(t, ctx, container)
+
+			// always append the multiplexed option for having the output
+			// in a readable format
+			opts := append(tt.opts, tcexec.Multiplexed())
+
+			code, reader, err := container.Exec(ctx, tt.cmds, opts...)
+			require.NoError(t, err)
+			require.Zero(t, code)
+			require.NotNil(t, reader)
+
+			b, err := io.ReadAll(reader)
+			require.NoError(t, err)
+			require.NotNil(t, b)
+
+			str := string(b)
+			require.Contains(t, str, tt.want)
+		})
+	}
+}
+
 func TestExecWithNonMultiplexedResponse(t *testing.T) {
 	ctx := context.Background()
 	req := ContainerRequest{

--- a/docker_exec_test.go
+++ b/docker_exec_test.go
@@ -89,9 +89,9 @@ func TestExecWithOptions(t *testing.T) {
 
 			// always append the multiplexed option for having the output
 			// in a readable format
-			opts := append(tt.opts, tcexec.Multiplexed())
+			tt.opts = append(tt.opts, tcexec.Multiplexed())
 
-			code, reader, err := container.Exec(ctx, tt.cmds, opts...)
+			code, reader, err := container.Exec(ctx, tt.cmds, tt.opts...)
 			require.NoError(t, err)
 			require.Zero(t, code)
 			require.NotNil(t, reader)

--- a/docs/features/common_functional_options.md
+++ b/docs/features/common_functional_options.md
@@ -24,7 +24,10 @@ Testcontainers exposes the `WithStartupCommand(e ...Executable)` option to run a
 !!!info
     To better understand how this feature works, please read the [Create containers: Lifecycle Hooks](/features/creating_container/#lifecycle-hooks) documentation.
 
-It also exports an `Executable` interface, defining one single method: `AsCommand()`, which returns a slice of strings to represent the command and positional arguments to be executed in the container.
+It also exports an `Executable` interface, defining the following methods:
+
+- `AsCommand()`, which returns a slice of strings to represent the command and positional arguments to be executed in the container;
+- `Options()` to set the command options, such as the working directory, environment variables, user executing the command, etc. It returns a slice of functional options to configure the command.
 
 You could use this feature to run a custom script, or to run a command that is not supported by the module right after the container is started.
 

--- a/docs/features/common_functional_options.md
+++ b/docs/features/common_functional_options.md
@@ -27,7 +27,7 @@ Testcontainers exposes the `WithStartupCommand(e ...Executable)` option to run a
 It also exports an `Executable` interface, defining the following methods:
 
 - `AsCommand()`, which returns a slice of strings to represent the command and positional arguments to be executed in the container;
-- `Options()` to set the command options, such as the working directory, environment variables, user executing the command, etc. It returns a slice of functional options to configure the command.
+- `Options()`, which returns the slice of functional options with the Docker's ExecConfigs used to create the command in the container (the working directory, environment variables, user executing the command, etc) and the possible output format (Multiplexed).
 
 You could use this feature to run a custom script, or to run a command that is not supported by the module right after the container is started.
 

--- a/modules/cassandra/executable.go
+++ b/modules/cassandra/executable.go
@@ -2,9 +2,12 @@ package cassandra
 
 import (
 	"strings"
+
+	"github.com/testcontainers/testcontainers-go"
 )
 
 type initScript struct {
+	testcontainers.ExecOptions
 	File string
 }
 

--- a/modules/rabbitmq/examples_test.go
+++ b/modules/rabbitmq/examples_test.go
@@ -130,7 +130,10 @@ func ExampleRunContainer_withPlugins() {
 		testcontainers.WithImage("rabbitmq:3.7.25-management-alpine"),
 		// Multiple test implementations of the Executable interface, specific to RabbitMQ, exist in the types_test.go file.
 		// Please refer to them for more examples.
-		testcontainers.WithStartupCommand(testcontainers.RawCommand{"rabbitmq_shovel"}, testcontainers.RawCommand{"rabbitmq_random_exchange"}),
+		testcontainers.WithStartupCommand(
+			testcontainers.NewRawCommand([]string{"rabbitmq_shovel"}),
+			testcontainers.NewRawCommand([]string{"rabbitmq_random_exchange"}),
+		),
 	)
 	if err != nil {
 		panic(err)

--- a/modules/rabbitmq/rabbitmq_test.go
+++ b/modules/rabbitmq/rabbitmq_test.go
@@ -124,7 +124,7 @@ func TestRunContainer_withAllSettings(t *testing.T) {
 		}),
 		// }
 		// enablePlugins {
-		testcontainers.WithStartupCommand(Plugin("rabbitmq_shovel"), Plugin("rabbitmq_random_exchange")),
+		testcontainers.WithStartupCommand(Plugin{Name: "rabbitmq_shovel"}, Plugin{Name: "rabbitmq_random_exchange"}),
 		// }
 	)
 	if err != nil {

--- a/modules/rabbitmq/types_test.go
+++ b/modules/rabbitmq/types_test.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+
+	"github.com/testcontainers/testcontainers-go"
 )
 
 // The following structs are added as a demonstration for the RabbitMQ management API therefore,
@@ -15,6 +17,7 @@ import (
 // --------- Bindings ---------
 
 type Binding struct {
+	testcontainers.ConfigurableExec
 	VHost           string
 	Source          string
 	Destination     string
@@ -72,6 +75,7 @@ func (b Binding) AsCommand() []string {
 // --------- Exchange ---------
 
 type Exchange struct {
+	testcontainers.ConfigurableExec
 	Name       string
 	VHost      string
 	Type       string
@@ -117,6 +121,7 @@ func (e Exchange) AsCommand() []string {
 // --------- OperatorPolicy ---------
 
 type OperatorPolicy struct {
+	testcontainers.ConfigurableExec
 	Name       string
 	Pattern    string
 	Definition map[string]interface{}
@@ -151,6 +156,7 @@ func (op OperatorPolicy) AsCommand() []string {
 // --------- Parameter ---------
 
 type Parameter struct {
+	testcontainers.ConfigurableExec
 	Component string
 	Name      string
 	Value     string
@@ -176,6 +182,7 @@ func (p Parameter) AsCommand() []string {
 // --------- Permission ---------
 
 type Permission struct {
+	testcontainers.ConfigurableExec
 	VHost     string
 	User      string
 	Configure string
@@ -205,10 +212,13 @@ func (p Permission) AsCommand() []string {
 
 // --------- Plugin ---------
 
-type Plugin string
+type Plugin struct {
+	testcontainers.ConfigurableExec
+	Name string
+}
 
 func (p Plugin) AsCommand() []string {
-	return []string{"rabbitmq-plugins", "enable", string(p)}
+	return []string{"rabbitmq-plugins", "enable", p.Name}
 }
 
 // --------- Plugin ---------
@@ -216,6 +226,7 @@ func (p Plugin) AsCommand() []string {
 // --------- Policy ---------
 
 type Policy struct {
+	testcontainers.ConfigurableExec
 	VHost      string
 	Name       string
 	Pattern    string
@@ -257,6 +268,7 @@ func (p Policy) AsCommand() []string {
 // --------- Queue ---------
 
 type Queue struct {
+	testcontainers.ConfigurableExec
 	Name       string
 	VHost      string
 	AutoDelete bool
@@ -297,6 +309,7 @@ func (q Queue) AsCommand() []string {
 // --------- User ---------
 
 type User struct {
+	testcontainers.ConfigurableExec
 	Name     string
 	Password string
 	Tags     []string
@@ -325,6 +338,7 @@ func (u User) AsCommand() []string {
 // --------- Virtual Hosts --------
 
 type VirtualHost struct {
+	testcontainers.ConfigurableExec
 	Name    string
 	Tracing bool
 }
@@ -340,6 +354,7 @@ func (v VirtualHost) AsCommand() []string {
 }
 
 type VirtualHostLimit struct {
+	testcontainers.ConfigurableExec
 	VHost string
 	Name  string
 	Value int

--- a/modules/rabbitmq/types_test.go
+++ b/modules/rabbitmq/types_test.go
@@ -17,7 +17,7 @@ import (
 // --------- Bindings ---------
 
 type Binding struct {
-	testcontainers.ConfigurableExec
+	testcontainers.ExecOptions
 	VHost           string
 	Source          string
 	Destination     string
@@ -75,7 +75,7 @@ func (b Binding) AsCommand() []string {
 // --------- Exchange ---------
 
 type Exchange struct {
-	testcontainers.ConfigurableExec
+	testcontainers.ExecOptions
 	Name       string
 	VHost      string
 	Type       string
@@ -121,7 +121,7 @@ func (e Exchange) AsCommand() []string {
 // --------- OperatorPolicy ---------
 
 type OperatorPolicy struct {
-	testcontainers.ConfigurableExec
+	testcontainers.ExecOptions
 	Name       string
 	Pattern    string
 	Definition map[string]interface{}
@@ -156,7 +156,7 @@ func (op OperatorPolicy) AsCommand() []string {
 // --------- Parameter ---------
 
 type Parameter struct {
-	testcontainers.ConfigurableExec
+	testcontainers.ExecOptions
 	Component string
 	Name      string
 	Value     string
@@ -182,7 +182,7 @@ func (p Parameter) AsCommand() []string {
 // --------- Permission ---------
 
 type Permission struct {
-	testcontainers.ConfigurableExec
+	testcontainers.ExecOptions
 	VHost     string
 	User      string
 	Configure string
@@ -213,7 +213,7 @@ func (p Permission) AsCommand() []string {
 // --------- Plugin ---------
 
 type Plugin struct {
-	testcontainers.ConfigurableExec
+	testcontainers.ExecOptions
 	Name string
 }
 
@@ -226,7 +226,7 @@ func (p Plugin) AsCommand() []string {
 // --------- Policy ---------
 
 type Policy struct {
-	testcontainers.ConfigurableExec
+	testcontainers.ExecOptions
 	VHost      string
 	Name       string
 	Pattern    string
@@ -268,7 +268,7 @@ func (p Policy) AsCommand() []string {
 // --------- Queue ---------
 
 type Queue struct {
-	testcontainers.ConfigurableExec
+	testcontainers.ExecOptions
 	Name       string
 	VHost      string
 	AutoDelete bool
@@ -309,7 +309,7 @@ func (q Queue) AsCommand() []string {
 // --------- User ---------
 
 type User struct {
-	testcontainers.ConfigurableExec
+	testcontainers.ExecOptions
 	Name     string
 	Password string
 	Tags     []string
@@ -338,7 +338,7 @@ func (u User) AsCommand() []string {
 // --------- Virtual Hosts --------
 
 type VirtualHost struct {
-	testcontainers.ConfigurableExec
+	testcontainers.ExecOptions
 	Name    string
 	Tracing bool
 }
@@ -354,7 +354,7 @@ func (v VirtualHost) AsCommand() []string {
 }
 
 type VirtualHostLimit struct {
-	testcontainers.ConfigurableExec
+	testcontainers.ExecOptions
 	VHost string
 	Name  string
 	Value int

--- a/options.go
+++ b/options.go
@@ -10,6 +10,7 @@ import (
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/network"
 
+	tcexec "github.com/testcontainers/testcontainers-go/exec"
 	"github.com/testcontainers/testcontainers-go/wait"
 )
 
@@ -118,14 +119,37 @@ func WithNetwork(networkName string, alias string) CustomizeRequestOption {
 // as part of the PostStart lifecycle hook.
 type Executable interface {
 	AsCommand() []string
+	Options() []tcexec.ProcessOption
+}
+
+// ExecOptions is a struct that provides a default implementation for the Options method
+// of the Executable interface.
+type ExecOptions struct {
+	opts []tcexec.ProcessOption
+}
+
+func (ce ExecOptions) Options() []tcexec.ProcessOption {
+	return ce.opts
 }
 
 // RawCommand is a type that implements Executable and represents a command to be sent to a container
-type RawCommand []string
+type RawCommand struct {
+	ExecOptions
+	cmds []string
+}
+
+func NewRawCommand(cmds []string) RawCommand {
+	return RawCommand{
+		cmds: cmds,
+		ExecOptions: ExecOptions{
+			opts: []tcexec.ProcessOption{},
+		},
+	}
+}
 
 // AsCommand returns the command as a slice of strings
 func (r RawCommand) AsCommand() []string {
-	return r
+	return r.cmds
 }
 
 // WithStartupCommand will execute the command representation of each Executable into the container.
@@ -139,7 +163,7 @@ func WithStartupCommand(execs ...Executable) CustomizeRequestOption {
 
 		for _, exec := range execs {
 			execFn := func(ctx context.Context, c Container) error {
-				_, _, err := c.Exec(ctx, exec.AsCommand())
+				_, _, err := c.Exec(ctx, exec.AsCommand(), exec.Options()...)
 				return err
 			}
 

--- a/options.go
+++ b/options.go
@@ -115,10 +115,13 @@ func WithNetwork(networkName string, alias string) CustomizeRequestOption {
 	}
 }
 
-// Executable represents an executable command to be sent to a container
-// as part of the PostStart lifecycle hook.
+// Executable represents an executable command to be sent to a container, including options,
+// as part of the different lifecycle hooks.
 type Executable interface {
 	AsCommand() []string
+	// Options can container two different types of options:
+	// - Docker's ExecConfigs (WithUser, WithWorkingDir, WithEnv, etc.)
+	// - testcontainers' ProcessOptions (i.e. Multiplexed response)
 	Options() []tcexec.ProcessOption
 }
 

--- a/options_test.go
+++ b/options_test.go
@@ -120,14 +120,6 @@ func TestWithNetworkMultipleCallsWithSameNameReuseTheNetwork(t *testing.T) {
 	assert.Equal(t, "new-network", resources[0].Name)
 }
 
-type testExecutable struct {
-	cmds []string
-}
-
-func (t testExecutable) AsCommand() []string {
-	return t.cmds
-}
-
 func TestWithStartupCommand(t *testing.T) {
 	req := testcontainers.GenericContainerRequest{
 		ContainerRequest: testcontainers.ContainerRequest{
@@ -137,9 +129,7 @@ func TestWithStartupCommand(t *testing.T) {
 		Started: true,
 	}
 
-	testExec := testExecutable{
-		cmds: []string{"touch", "/tmp/.testcontainers"},
-	}
+	testExec := testcontainers.NewRawCommand([]string{"touch", "/tmp/.testcontainers"})
 
 	testcontainers.WithStartupCommand(testExec)(&req)
 


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
This PR adds some functional options to be applied to the ProcessOptions struct, in order to customise the container exec create response.

For that, and to avoid changing the signature of the Exec method, we are exntending the ProcessOptions struct to accept the User, WorkingDir and Env for a command. We are also adding the options to contribute them to the exec create response.

Because of the previous design, in which the ProcessOptions struct applies to the container exec attach response, we are making the current Multiplexed option to not be executed if its reader is nil. This is needed because we need two loops in the options:

1. for the exec create options
2. for the exec attach options

Without changing the API, this is the simplest manner to achieve it.

Finally, it includes a ⚠️**breaking change**⚠️  in the `Executable` interface: it now includes a `Options()` function that needs to be implemented. This method will allow configuring the exec options added in this PR for the `WithStartupCommand` functional option. If your code is implementing Executable, you can embed the `ExecOptions` struct in your own struct in order to satisfy the interface. Please take a look at the RabbitMQ test types to see examples on how to do it.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
Support running commands in the container passing the user, workingDir and the env, which is interesting for users.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Related issues
- Relates https://github.com/testcontainers/testcontainers-node/pull/668

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->


<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


## Follow-ups
We should probably update the Executable interface and the RawCommand struct, as it will need a way to receive the process options too.

