### PR TITLE
Add database driver note to SQL Wait strategy docs

### DIFF
--- a/docs/features/wait/sql.md
+++ b/docs/features/wait/sql.md
@@ -20,3 +20,5 @@ req := ContainerRequest{
         WithQuery("SELECT 10"),
 }
 ```
+
+Note: You'll also need to import the appropriate [database driver](https://github.com/golang/go/wiki/SQLDrivers) in your test code such that Testcontainers can pick it up when connecting to the database.


### PR DESCRIPTION
## What does this PR do?

Documentation change for the [SQL Wait strategy](https://golang.testcontainers.org/features/wait/sql/) page.

## Why is it important?

Users might get confused when running the tests they just wrote if they forget to import the appropriate driver.

## Related issues

N/A

## How to test this PR

The docs will have to be rebuilt & redeployed.

PS: Thank you for maintaining this cool project!