### PR TITLE
fix(modules.kafka): Switch to MaxInt for 32-bit support

### DIFF
--- a/modules/kafka/kafka.go
+++ b/modules/kafka/kafka.go
@@ -52,7 +52,7 @@ func RunContainer(ctx context.Context, opts ...testcontainers.ContainerCustomize
 			"KAFKA_OFFSETS_TOPIC_NUM_PARTITIONS":             "1",
 			"KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR": "1",
 			"KAFKA_TRANSACTION_STATE_LOG_MIN_ISR":            "1",
-			"KAFKA_LOG_FLUSH_INTERVAL_MESSAGES":              fmt.Sprintf("%d", math.MaxInt64),
+			"KAFKA_LOG_FLUSH_INTERVAL_MESSAGES":              fmt.Sprintf("%d", math.MaxInt),
 			"KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS":         "0",
 			"KAFKA_NODE_ID":                                  "1",
 			"KAFKA_PROCESS_ROLES":                            "broker,controller",


### PR DESCRIPTION
## What does this PR do?

Avoid using MaxInt64, which only works on 64-bit systems.

## Why is it important?

Telegraf is a project that runs on a variety of architectures, and we do run our tests on a 32-bit system to ensure compatibility.

```s
❯ GOARCH=386 go vet ./modules/kafka/kafka.go 
# command-line-arguments
vet: modules/kafka/kafka.go:55:72: cannot use math.MaxInt64 (untyped int constant 9223372036854775807) as int value in argument to fmt.Sprintf (overflows)
```

## Related issues

fixes: #1921