### PR TITLE
fix: fallback matching of registry authentication config

### DIFF
--- a/docker_auth.go
+++ b/docker_auth.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"net/url"
 	"os"
 
 	"github.com/cpuguy83/dockercfg"
@@ -24,11 +25,31 @@ func DockerImageAuth(ctx context.Context, image string) (string, registry.AuthCo
 		return reg, registry.AuthConfig{}, err
 	}
 
-	if cfg, ok := cfgs[reg]; ok {
+	if cfg, ok := getRegistryAuth(reg, cfgs); ok {
 		return reg, cfg, nil
 	}
 
 	return reg, registry.AuthConfig{}, dockercfg.ErrCredentialsNotFound
+}
+
+func getRegistryAuth(reg string, cfgs map[string]registry.AuthConfig) (registry.AuthConfig, bool) {
+	if cfg, ok := cfgs[reg]; ok {
+		return cfg, true
+	}
+
+	// fallback match using authentication key host
+	for k, cfg := range cfgs {
+		keyURL, err := url.Parse(k)
+		if err != nil {
+			continue
+		}
+
+		if keyURL.Host == reg {
+			return cfg, true
+		}
+	}
+
+	return registry.AuthConfig{}, false
 }
 
 // defaultRegistry returns the default registry to use when pulling images


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?

This PR will fix an issue when config.json contains `auths` with keys set to the a registry URL such as `https://artifactory.com`. This way the authentication configuration for the registry will be matched with the configuration file and used.

## Why is it important?

In case where a registry is configured with an `https://` prefix, the authentication to pull images from that registry fails.

## How to test this PR
Manually add a registry and its authentication config in the `~/.docker/config.json` and run a test that requires authentication to pull images and start containers.


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
