### PR TITLE
feat: support for custom registry prefixes at the configuration level

### DIFF
--- a/container.go
+++ b/container.go
@@ -125,7 +125,7 @@ type ContainerRequest struct {
 	User                    string                                     // for specifying uid:gid
 	SkipReaper              bool                                       // Deprecated: The reaper is globally controlled by the .testcontainers.properties file or the TESTCONTAINERS_RYUK_DISABLED environment variable
 	ReaperImage             string                                     // Deprecated: use WithImageName ContainerOption instead. Alternative reaper image
-	ReaperOptions           []ContainerOption                          // options for the reaper
+	ReaperOptions           []ContainerOption                          // Deprecated: the reaper is configured at the properties level, for an entire test session
 	AutoRemove              bool                                       // Deprecated: Use HostConfigModifier instead. If set to true, the container will be removed from the host when stopped
 	AlwaysPullImage         bool                                       // Always pull image
 	ImagePlatform           string                                     // ImagePlatform describes the platform which the image runs on.
@@ -145,9 +145,11 @@ type containerOptions struct {
 	RegistryCredentials string // Deprecated: Testcontainers will detect registry credentials automatically
 }
 
+// Deprecated: it will be removed in the next major release
 // functional option for setting the reaper image
 type ContainerOption func(*containerOptions)
 
+// Deprecated: it will be removed in the next major release
 // WithImageName sets the reaper image name
 func WithImageName(imageName string) ContainerOption {
 	return func(o *containerOptions) {
@@ -155,7 +157,7 @@ func WithImageName(imageName string) ContainerOption {
 	}
 }
 
-// Deprecated: Testcontainers will detect registry credentials automatically
+// Deprecated: Testcontainers will detect registry credentials automatically, and it will be removed in the next major release
 // WithRegistryCredentials sets the reaper registry credentials
 func WithRegistryCredentials(registryCredentials string) ContainerOption {
 	return func(o *containerOptions) {

--- a/docker.go
+++ b/docker.go
@@ -882,20 +882,13 @@ func (p *DockerProvider) CreateContainer(ctx context.Context, req ContainerReque
 		req.Labels = make(map[string]string)
 	}
 
-	reaperOpts := containerOptions{
-		ImageName: req.ReaperImage,
-	}
-	for _, opt := range req.ReaperOptions {
-		opt(&reaperOpts)
-	}
-
 	tcConfig := p.Config().Config
 
 	var termSignal chan bool
 	// the reaper does not need to start a reaper for itself
-	isReaperContainer := strings.EqualFold(imageName, reaperImage(reaperOpts.ImageName))
+	isReaperContainer := strings.EqualFold(imageName, tcConfig.RyukImage)
 	if !tcConfig.RyukDisabled && !isReaperContainer {
-		r, err := reuseOrCreateReaper(context.WithValue(ctx, testcontainersdocker.DockerHostContextKey, p.host), testcontainerssession.SessionID(), p, req.ReaperOptions...)
+		r, err := reuseOrCreateReaper(context.WithValue(ctx, testcontainersdocker.DockerHostContextKey, p.host), testcontainerssession.SessionID(), p)
 		if err != nil {
 			return nil, fmt.Errorf("%w: creating reaper failed", err)
 		}
@@ -1146,7 +1139,7 @@ func (p *DockerProvider) ReuseOrCreateContainer(ctx context.Context, req Contain
 
 	var termSignal chan bool
 	if !tcConfig.RyukDisabled {
-		r, err := reuseOrCreateReaper(context.WithValue(ctx, testcontainersdocker.DockerHostContextKey, p.host), sessionID, p, req.ReaperOptions...)
+		r, err := reuseOrCreateReaper(context.WithValue(ctx, testcontainersdocker.DockerHostContextKey, p.host), sessionID, p)
 		if err != nil {
 			return nil, fmt.Errorf("%w: creating reaper failed", err)
 		}
@@ -1314,7 +1307,7 @@ func (p *DockerProvider) CreateNetwork(ctx context.Context, req NetworkRequest) 
 
 	var termSignal chan bool
 	if !tcConfig.RyukDisabled {
-		r, err := reuseOrCreateReaper(context.WithValue(ctx, testcontainersdocker.DockerHostContextKey, p.host), sessionID, p, req.ReaperOptions...)
+		r, err := reuseOrCreateReaper(context.WithValue(ctx, testcontainersdocker.DockerHostContextKey, p.host), sessionID, p)
 		if err != nil {
 			return nil, fmt.Errorf("%w: creating network reaper failed", err)
 		}

--- a/docker.go
+++ b/docker.go
@@ -31,6 +31,7 @@ import (
 	specs "github.com/opencontainers/image-spec/specs-go/v1"
 
 	tcexec "github.com/testcontainers/testcontainers-go/exec"
+	"github.com/testcontainers/testcontainers-go/internal/config"
 	"github.com/testcontainers/testcontainers-go/internal/testcontainersdocker"
 	"github.com/testcontainers/testcontainers-go/internal/testcontainerssession"
 	"github.com/testcontainers/testcontainers-go/wait"
@@ -886,7 +887,7 @@ func (p *DockerProvider) CreateContainer(ctx context.Context, req ContainerReque
 
 	var termSignal chan bool
 	// the reaper does not need to start a reaper for itself
-	isReaperContainer := strings.EqualFold(imageName, tcConfig.RyukImage)
+	isReaperContainer := strings.HasSuffix(imageName, config.ReaperDefaultImage)
 	if !tcConfig.RyukDisabled && !isReaperContainer {
 		r, err := reuseOrCreateReaper(context.WithValue(ctx, testcontainersdocker.DockerHostContextKey, p.host), testcontainerssession.SessionID(), p)
 		if err != nil {

--- a/docker.go
+++ b/docker.go
@@ -910,14 +910,19 @@ func (p *DockerProvider) CreateContainer(ctx context.Context, req ContainerReque
 		return nil, err
 	}
 
+	// always append the hub substitutor after the user-defined ones
+	req.ImageSubstitutors = append(req.ImageSubstitutors, newPrependHubRegistry())
+
 	for _, is := range req.ImageSubstitutors {
 		modifiedTag, err := is.Substitute(imageName)
 		if err != nil {
 			return nil, fmt.Errorf("failed to substitute image %s with %s: %w", imageName, is.Description(), err)
 		}
 
-		p.Logger.Printf("✍🏼 Replacing image with %s. From: %s to %s\n", is.Description(), imageName, modifiedTag)
-		imageName = modifiedTag
+		if modifiedTag != imageName {
+			p.Logger.Printf("✍🏼 Replacing image with %s. From: %s to %s\n", is.Description(), imageName, modifiedTag)
+			imageName = modifiedTag
+		}
 	}
 
 	var platform *specs.Platform

--- a/docs/features/common_functional_options.md
+++ b/docs/features/common_functional_options.md
@@ -2,7 +2,16 @@
 
 - Since testcontainers-go <a href="https://github.com/testcontainers/testcontainers-go/releases/tag/v0.26.0"><span class="tc-version">:material-tag: v0.26.0</span></a>
 
-{% include "./image_name_substitution.md" %}
+In more locked down / secured environments, it can be problematic to pull images from Docker Hub and run them without additional precautions.
+
+An image name substitutor converts a Docker image name, as may be specified in code, to an alternative name. This is intended to provide a way to override image names, for example to enforce pulling of images from a private registry.
+
+_Testcontainers for Go_ exposes an interface to perform this operations: `ImageSubstitutor`, and a No-operation implementation to be used as reference for custom implementations:
+
+<!--codeinclude-->
+[Image Substitutor Interface](../../options.go) inside_block:imageSubstitutor
+[Noop Image Substitutor](../../container_test.go) inside_block:noopImageSubstitutor
+<!--/codeinclude-->
 
 Using the `WithImageSubstitutors` options, you could define your own substitutions to the container images. E.g. adding a prefix to the images so that they can be pulled from a Docker registry other than Docker Hub. This is the usual mechanism for using Docker image proxies, caches, etc.
 

--- a/docs/features/configuration.md
+++ b/docs/features/configuration.md
@@ -40,11 +40,16 @@ docker.tls.verify=1                         # Equivalent to the DOCKER_TLS_VERIF
 docker.cert.path=/some/path                 # Equivalent to the DOCKER_CERT_PATH environment variable
 ```
 
-### Disabling Ryuk
-Ryuk must be started as a privileged container.  
-If your environment already implements automatic cleanup of containers after the execution,
+### Configuring Ryuk, the resource reaper
+
+1. Ryuk must be started as a privileged container. For that, you can set the `TESTCONTAINERS_RYUK_CONTAINER_PRIVILEGED` **environment variable**, or the  `ryuk.container.privileged` **property** to `true`.
+1. If your environment already implements automatic cleanup of containers after the execution,
 but does not allow starting privileged containers, you can turn off the Ryuk container by setting
 `TESTCONTAINERS_RYUK_DISABLED` **environment variable** to `true`.
+1. You can change the default Docker image for Ryuk by setting the `TESTCONTAINERS_RYUK_CONTAINER_IMAGE` **environment variable**, or the `ryuk.container.image` **property**.
+1. You can specify the connection timeout for Ryuk by setting the `ryuk.connection.timeout` **property**. The default value is 1 minute.
+1. You can specify the reconnection timeout for Ryuk by setting the `ryuk.reconnection.timeout` **property**. The default value is 10 seconds.
+
 
 !!!info
     For more information about Ryuk, see [Garbage Collector](garbage_collector.md).

--- a/docs/features/configuration.md
+++ b/docs/features/configuration.md
@@ -46,7 +46,7 @@ docker.cert.path=/some/path                 # Equivalent to the DOCKER_CERT_PATH
 1. If your environment already implements automatic cleanup of containers after the execution,
 but does not allow starting privileged containers, you can turn off the Ryuk container by setting
 `TESTCONTAINERS_RYUK_DISABLED` **environment variable** to `true`.
-1. You can change the default Docker image for Ryuk by setting the `TESTCONTAINERS_RYUK_CONTAINER_IMAGE` **environment variable**, or the `ryuk.container.image` **property**.
+1. You can prepend the prefix for your own Docker registry for the Ryuk image, by setting the `TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX` **environment variable**, or the `hub.image.name.prefix` **property**.
 1. You can specify the connection timeout for Ryuk by setting the `ryuk.connection.timeout` **property**. The default value is 1 minute.
 1. You can specify the reconnection timeout for Ryuk by setting the `ryuk.reconnection.timeout` **property**. The default value is 10 seconds.
 

--- a/docs/features/configuration.md
+++ b/docs/features/configuration.md
@@ -40,13 +40,16 @@ docker.tls.verify=1                         # Equivalent to the DOCKER_TLS_VERIF
 docker.cert.path=/some/path                 # Equivalent to the DOCKER_CERT_PATH environment variable
 ```
 
-### Configuring Ryuk, the resource reaper
+## Customizing images
+
+Please read more about customizing images in the [Image name substitution](image_name_substitution.md) section.
+
+## Customizing Ryuk, the resource reaper
 
 1. Ryuk must be started as a privileged container. For that, you can set the `TESTCONTAINERS_RYUK_CONTAINER_PRIVILEGED` **environment variable**, or the  `ryuk.container.privileged` **property** to `true`.
 1. If your environment already implements automatic cleanup of containers after the execution,
 but does not allow starting privileged containers, you can turn off the Ryuk container by setting
 `TESTCONTAINERS_RYUK_DISABLED` **environment variable** to `true`.
-1. You can prepend the prefix for your own Docker registry for the Ryuk image, by setting the `TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX` **environment variable**, or the `hub.image.name.prefix` **property**.
 1. You can specify the connection timeout for Ryuk by setting the `ryuk.connection.timeout` **property**. The default value is 1 minute.
 1. You can specify the reconnection timeout for Ryuk by setting the `ryuk.reconnection.timeout` **property**. The default value is 10 seconds.
 

--- a/docs/features/image_name_substitution.md
+++ b/docs/features/image_name_substitution.md
@@ -31,7 +31,7 @@ Consider this if:
 In this case, image name references in code are **unchanged**.
 i.e. you would leave as-is:
 
-<!--codeinclude--> 
+<!--codeinclude-->
 [Unchanged direct Docker Hub image name](../../container_test.go) inside_block:directDockerHubReference
 <!--/codeinclude-->
 
@@ -39,7 +39,7 @@ You can then configure _Testcontainers for Go_ to apply a given prefix (e.g. `re
 
 * Setting the `TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX=registry.mycompany.com/mirror` environment variable.
 * Via config file, setting `hub.image.name.prefix` in the `~/.testcontainers.properties` file in your user home directory.
-    
+
 _Testcontainers for Go_ will automatically apply the prefix to every image that it pulls from Docker Hub - please verify that all [the required images](#images-used-by-testcontainers) exist in your registry.
 
 _Testcontainers for Go_ will not apply the prefix to:
@@ -59,7 +59,7 @@ Consider this if:
 
 In this case, image name references in code are **unchanged**. i.e. you would leave as-is:
 
-<!--codeinclude--> 
+<!--codeinclude-->
 [Unchanged direct Docker Hub image name](../../container_test.go) inside_block:directDockerHubReference
 <!--/codeinclude-->
 

--- a/docs/features/image_name_substitution.md
+++ b/docs/features/image_name_substitution.md
@@ -1,10 +1,95 @@
-In more locked down / secured environments, it can be problematic to pull images from Docker Hub and run them without additional precautions.
+# Image name substitution
 
-An image name substitutor converts a Docker image name, as may be specified in code, to an alternative name. This is intended to provide a way to override image names, for example to enforce pulling of images from a private registry.
+_Testcontainers for Go_ supports automatic substitution of Docker image names.
 
-_Testcontainers for Go_ exposes an interface to perform this operations: `ImageSubstitutor`, and a No-operation implementation to be used as reference for custom implementations:
+This allows the replacement of an image name specified in test code with an alternative name - for example, to replace the 
+name of a Docker Hub image dependency with an alternative hosted on a private image registry.
+
+This is advisable to avoid Docker Hub rate limiting, and some companies will prefer this for policy reasons.
+
+!!!info
+    As of November 2020 Docker Hub pulls are rate limited. As Testcontainers uses Docker Hub for standard images, some users may hit these rate limits and should mitigate accordingly. Suggested mitigations are noted in [this issue in Testcontainers for Java](https://github.com/testcontainers/testcontainers-java/issues/3099) at present.
+
+This page describes two approaches for image name substitution:
+
+* [Automatically modifying Docker Hub image names](#automatically-modifying-docker-hub-image-names), prefixing them with a private registry URL.
+* [Using an Image Name Substitutor](#developing-a-custom-function-for-transforming-image-names-on-the-fly), developing a custom function for transforming image names on the fly.
+
+!!!warning
+    It is assumed that you have already set up a private registry hosting [all the Docker images your build requires](../supported_docker_environment/image_registry_rate_limiting.md#which-images-are-used-by-testcontainers).
+
+## Automatically modifying Docker Hub image names
+
+_Testcontainers for Go_ can be configured to modify Docker Hub image names on the fly to apply a prefix string.
+
+Consider this if:
+
+* Developers and CI machines need to use different image names. For example, developers are able to pull images from Docker Hub, but CI machines need to pull from a private registry.
+* Your private registry has copies of images from Docker Hub where the names are predictable, and just adding a prefix is enough. 
+  For example, `registry.mycompany.com/mirror/mysql:8.0.24` can be derived from the original Docker Hub image name (`mysql:8.0.24`) with a consistent prefix string: `registry.mycompany.com/mirror`
+
+In this case, image name references in code are **unchanged**.
+i.e. you would leave as-is:
+
+<!--codeinclude--> 
+[Unchanged direct Docker Hub image name](../../container_test.go) inside_block:directDockerHubReference
+<!--/codeinclude-->
+
+You can then configure _Testcontainers for Go_ to apply a given prefix (e.g. `registry.mycompany.com/mirror`) to every image that it tries to pull from Docker Hub. Important to notice that **the prefix should not include a trailing slash**. This can be done in one of two ways:
+
+* Setting the `TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX=registry.mycompany.com/mirror` environment variable.
+* Via config file, setting `hub.image.name.prefix` in the `~/.testcontainers.properties` file in your user home directory.
+    
+_Testcontainers for Go_ will automatically apply the prefix to every image that it pulls from Docker Hub - please verify that all [the required images](#images-used-by-testcontainers) exist in your registry.
+
+_Testcontainers for Go_ will not apply the prefix to:
+
+* non-Hub image names (e.g. where another registry is set)
+* Docker Hub image names where the hub registry is explicitly part of the name (i.e. anything with a `docker.io` or `registry.hub.docker.com` host part)
+
+## Developing a custom function for transforming image names on the fly
+
+Consider this if:
+
+* You have complex rules about which private registry images should be used as substitutes, e.g.:
+    * non-deterministic mapping of names meaning that a [name prefix](#automatically-modifying-docker-hub-image-names) cannot be used, or
+    * rules depending upon developer identity or location, or
+* you wish to add audit logging of images used in the build, or
+* you wish to prevent accidental usage of images that are not on an approved list.
+
+In this case, image name references in code are **unchanged**. i.e. you would leave as-is:
+
+<!--codeinclude--> 
+[Unchanged direct Docker Hub image name](../../container_test.go) inside_block:directDockerHubReference
+<!--/codeinclude-->
+
+You can implement a custom image name substitutor by:
+
+* implementing the `ImageNameSubstitutor` interface, exposed by the `testcontainers` package.
+* configuring _Testcontainers for Go_ to use your custom implementation, defined at the `ContainerRequest` level.
+
+The following is an example image substitutor implementation prepending the `docker.io/` prefix, used in the tests:
 
 <!--codeinclude-->
 [Image Substitutor Interface](../../options.go) inside_block:imageSubstitutor
-[Noop Image Substitutor](../../container_test.go) inside_block:noopImageSubstitutor
+[Docker prefix Image Substitutor](../../container_test.go) inside_block:dockerImageSubstitutor
+[Applying the substitutor](../../container_test.go) inside_block:applyImageSubstitutors
 <!--/codeinclude-->
+
+## Images used by Testcontainers
+
+As of the current version of Testcontainers ({{latest_version}}):
+
+* every image directly used by your tests
+* images pulled by Testcontainers itself to support functionality:
+    * [`testcontainers/ryuk`](https://hub.docker.com/r/testcontainers/ryuk) - performs fail-safe cleanup of containers, and always required (unless [Ryuk is disabled](./configuration.md#customizing-ryuk-the-resource-reaper)).
+    * [`alpine`](https://hub.docker.com/r/_/alpine).
+    * [`Docker in Docker`](https://hub.docker.com/_/docker).
+    * [`nginx`](https://hub.docker.com/r/_/nginx).
+    * [`delayed nginx`](https://hub.docker.com/r/menedev/delayed-nginx).
+    * [`localstack`](https://hub.docker.com/r/localstack/localstack).
+    * [`mysql`](https://hub.docker.com/r/_/mysql).
+    * [`postgres`](https://hub.docker.com/r/_/postgres).
+    * [`postgis`](https://hub.docker.com/r/postgis/postgis).
+    * [`redis`](https://hub.docker.com/r/_/redis).
+    * [`registry`](https://hub.docker.com/r/_/registry).

--- a/docs/system_requirements/ci/bitbucket_pipelines.md
+++ b/docs/system_requirements/ci/bitbucket_pipelines.md
@@ -2,7 +2,7 @@
 
 To enable access to Docker in Bitbucket Pipelines, you need to add `docker` as a service on the step.
 
-Furthermore, Ryuk needs to be turned off since Bitbucket Pipelines does not allow starting privileged containers (see [Disabling Ryuk](../../features/configuration.md#disabling-ryuk)). This can either be done by setting a repository variable in Bitbucket's project settings or by explicitly exporting the variable on a step.
+Furthermore, Ryuk needs to be turned off since Bitbucket Pipelines does not allow starting privileged containers (see [Disabling Ryuk](../../features/configuration.md#customizing-ryuk-the-resource-reaper)). This can either be done by setting a repository variable in Bitbucket's project settings or by explicitly exporting the variable on a step.
 
 In some cases the memory available to Docker needs to be increased.
 

--- a/image_substitutors_test.go
+++ b/image_substitutors_test.go
@@ -7,19 +7,106 @@ import (
 )
 
 func TestPrependHubRegistrySubstitutor(t *testing.T) {
-	t.Run("should prepend the hub registry to the image name", func(t *testing.T) {
-		t.Setenv("TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX", "my-registry")
-		defer config.Reset()
+	resetConfigForTests := func() {
+		config.Reset()
+	}
 
-		s := newPrependHubRegistry()
+	t.Run("should prepend the hub registry to images from Docker Hub", func(t *testing.T) {
+		t.Run("plain image", func(t *testing.T) {
+			t.Setenv("TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX", "my-registry")
+			defer resetConfigForTests()
 
-		img, err := s.Substitute("foo")
-		if err != nil {
-			t.Fatal(err)
-		}
+			s := newPrependHubRegistry()
 
-		if img != "my-registry/foo" {
-			t.Errorf("expected my-registry/foo, got %s", img)
-		}
+			img, err := s.Substitute("foo:latest")
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if img != "my-registry/foo:latest" {
+				t.Errorf("expected my-registry/foo, got %s", img)
+			}
+		})
+		t.Run("image with user", func(t *testing.T) {
+			t.Setenv("TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX", "my-registry")
+			defer resetConfigForTests()
+
+			s := newPrependHubRegistry()
+
+			img, err := s.Substitute("user/foo:latest")
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if img != "my-registry/user/foo:latest" {
+				t.Errorf("expected my-registry/foo, got %s", img)
+			}
+		})
+
+		t.Run("image with organization and user", func(t *testing.T) {
+			t.Setenv("TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX", "my-registry")
+			defer resetConfigForTests()
+
+			s := newPrependHubRegistry()
+
+			img, err := s.Substitute("org/user/foo:latest")
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if img != "my-registry/org/user/foo:latest" {
+				t.Errorf("expected my-registry/org/foo:latest, got %s", img)
+			}
+		})
+	})
+
+	t.Run("should not prepend the hub registry to the image name", func(t *testing.T) {
+		t.Run("non-hub image", func(t *testing.T) {
+			t.Setenv("TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX", "my-registry")
+			defer resetConfigForTests()
+
+			s := newPrependHubRegistry()
+
+			img, err := s.Substitute("quay.io/foo:latest")
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if img != "quay.io/foo:latest" {
+				t.Errorf("expected quay.io/foo:latest, got %s", img)
+			}
+		})
+
+		t.Run("explicitly including docker.io", func(t *testing.T) {
+			t.Setenv("TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX", "my-registry")
+			defer resetConfigForTests()
+
+			s := newPrependHubRegistry()
+
+			img, err := s.Substitute("docker.io/foo:latest")
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if img != "docker.io/foo:latest" {
+				t.Errorf("expected docker.io/foo:latest, got %s", img)
+			}
+		})
+
+		t.Run("explicitly including registry.hub.docker.com", func(t *testing.T) {
+			t.Setenv("TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX", "my-registry")
+			defer resetConfigForTests()
+
+			s := newPrependHubRegistry()
+
+			img, err := s.Substitute("registry.hub.docker.com/foo:latest")
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if img != "registry.hub.docker.com/foo:latest" {
+				t.Errorf("expected registry.hub.docker.com/foo:latest, got %s", img)
+			}
+		})
 	})
 }

--- a/image_substitutors_test.go
+++ b/image_substitutors_test.go
@@ -1,0 +1,25 @@
+package testcontainers
+
+import (
+	"testing"
+
+	"github.com/testcontainers/testcontainers-go/internal/config"
+)
+
+func TestPrependHubRegistrySubstitutor(t *testing.T) {
+	t.Run("should prepend the hub registry to the image name", func(t *testing.T) {
+		t.Setenv("TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX", "my-registry")
+		defer config.Reset()
+
+		s := newPrependHubRegistry()
+
+		img, err := s.Substitute("foo")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if img != "my-registry/foo" {
+			t.Errorf("expected my-registry/foo, got %s", img)
+		}
+	})
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -11,6 +11,8 @@ import (
 	"github.com/magiconair/properties"
 )
 
+const ReaperDefaultImage = "docker.io/testcontainers/ryuk:0.5.1"
+
 var (
 	tcConfig     Config
 	tcConfigOnce *sync.Once = new(sync.Once)
@@ -23,6 +25,7 @@ type Config struct {
 	TLSVerify               int           `properties:"docker.tls.verify,default=0"`
 	CertPath                string        `properties:"docker.cert.path,default="`
 	RyukDisabled            bool          `properties:"ryuk.disabled,default=false"`
+	RyukImage               string        `properties:"ryuk.container.image,default=docker.io/testcontainers/ryuk:0.5.1"`
 	RyukPrivileged          bool          `properties:"ryuk.container.privileged,default=false"`
 	RyukReconnectionTimeout time.Duration `properties:"ryuk.reconnection.timeout,default=10s"`
 	RyukConnectionTimeout   time.Duration `properties:"ryuk.connection.timeout,default=1m"`
@@ -65,6 +68,11 @@ func read() Config {
 		ryukDisabledEnv := os.Getenv("TESTCONTAINERS_RYUK_DISABLED")
 		if parseBool(ryukDisabledEnv) {
 			config.RyukDisabled = ryukDisabledEnv == "true"
+		}
+
+		ryukContainerImageEnv := os.Getenv("TESTCONTAINERS_RYUK_CONTAINER_IMAGE")
+		if ryukContainerImageEnv != "" {
+			config.RyukImage = ryukContainerImageEnv
 		}
 
 		ryukPrivilegedEnv := os.Getenv("TESTCONTAINERS_RYUK_CONTAINER_PRIVILEGED")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -24,8 +24,8 @@ type Config struct {
 	Host                    string        `properties:"docker.host,default="`
 	TLSVerify               int           `properties:"docker.tls.verify,default=0"`
 	CertPath                string        `properties:"docker.cert.path,default="`
+	HubImageNamePrefix      string        `properties:"hub.image.name.prefix,default="`
 	RyukDisabled            bool          `properties:"ryuk.disabled,default=false"`
-	RyukImage               string        `properties:"ryuk.container.image,default=docker.io/testcontainers/ryuk:0.5.1"`
 	RyukPrivileged          bool          `properties:"ryuk.container.privileged,default=false"`
 	RyukReconnectionTimeout time.Duration `properties:"ryuk.reconnection.timeout,default=10s"`
 	RyukConnectionTimeout   time.Duration `properties:"ryuk.connection.timeout,default=1m"`
@@ -70,9 +70,9 @@ func read() Config {
 			config.RyukDisabled = ryukDisabledEnv == "true"
 		}
 
-		ryukContainerImageEnv := os.Getenv("TESTCONTAINERS_RYUK_CONTAINER_IMAGE")
-		if ryukContainerImageEnv != "" {
-			config.RyukImage = ryukContainerImageEnv
+		hubImageNamePrefix := os.Getenv("TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX")
+		if hubImageNamePrefix != "" {
+			config.HubImageNamePrefix = hubImageNamePrefix
 		}
 
 		ryukPrivilegedEnv := os.Getenv("TESTCONTAINERS_RYUK_CONTAINER_PRIVILEGED")

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -19,8 +19,8 @@ const (
 // unset environment variables to avoid side effects
 // execute this function before each test
 func resetTestEnv(t *testing.T) {
+	t.Setenv("TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX", "")
 	t.Setenv("TESTCONTAINERS_RYUK_DISABLED", "")
-	t.Setenv("TESTCONTAINERS_RYUK_CONTAINER_IMAGE", "")
 	t.Setenv("TESTCONTAINERS_RYUK_CONTAINER_PRIVILEGED", "")
 }
 
@@ -54,6 +54,8 @@ func TestReadConfig(t *testing.T) {
 func TestReadTCConfig(t *testing.T) {
 	resetTestEnv(t)
 
+	const defaultHubPrefix string = "registry.mycompany.com/mirror/"
+
 	t.Run("HOME is not set", func(t *testing.T) {
 		t.Setenv("HOME", "")
 		t.Setenv("USERPROFILE", "") // Windows support
@@ -69,16 +71,16 @@ func TestReadTCConfig(t *testing.T) {
 		t.Setenv("HOME", "")
 		t.Setenv("USERPROFILE", "") // Windows support
 		t.Setenv("TESTCONTAINERS_RYUK_DISABLED", "true")
-		t.Setenv("TESTCONTAINERS_RYUK_CONTAINER_IMAGE", "test-image")
+		t.Setenv("TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX", defaultHubPrefix)
 		t.Setenv("TESTCONTAINERS_RYUK_CONTAINER_PRIVILEGED", "true")
 
 		config := read()
 
 		expected := Config{
-			RyukDisabled:   true,
-			RyukImage:      "test-image",
-			RyukPrivileged: true,
-			Host:           "", // docker socket is empty at the properties file
+			HubImageNamePrefix: defaultHubPrefix,
+			RyukDisabled:       true,
+			RyukPrivileged:     true,
+			Host:               "", // docker socket is empty at the properties file
 		}
 
 		assert.Equal(t, expected, config)
@@ -113,14 +115,14 @@ func TestReadTCConfig(t *testing.T) {
 		t.Setenv("HOME", tmpDir)
 		t.Setenv("USERPROFILE", tmpDir) // Windows support
 		t.Setenv("TESTCONTAINERS_RYUK_DISABLED", "true")
-		t.Setenv("TESTCONTAINERS_RYUK_CONTAINER_IMAGE", "test-image")
+		t.Setenv("TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX", defaultHubPrefix)
 		t.Setenv("TESTCONTAINERS_RYUK_CONTAINER_PRIVILEGED", "true")
 
 		config := read()
 		expected := Config{
-			RyukDisabled:   true,
-			RyukImage:      "test-image",
-			RyukPrivileged: true,
+			HubImageNamePrefix: defaultHubPrefix,
+			RyukDisabled:       true,
+			RyukPrivileged:     true,
 		}
 
 		assert.Equal(t, expected, config)
@@ -131,7 +133,6 @@ func TestReadTCConfig(t *testing.T) {
 		defaultRyukReonnectionTimeout := 10 * time.Second
 		defaultConfig := Config{
 			RyukConnectionTimeout:   defaultRyukConnectionTimeout,
-			RyukImage:               ReaperDefaultImage,
 			RyukReconnectionTimeout: defaultRyukReonnectionTimeout,
 		}
 
@@ -148,7 +149,6 @@ func TestReadTCConfig(t *testing.T) {
 				Config{
 					Host:                    tcpDockerHost33293,
 					RyukConnectionTimeout:   defaultRyukConnectionTimeout,
-					RyukImage:               ReaperDefaultImage,
 					RyukReconnectionTimeout: defaultRyukReonnectionTimeout,
 				},
 			},
@@ -161,7 +161,6 @@ func TestReadTCConfig(t *testing.T) {
 				Config{
 					Host:                    tcpDockerHost4711,
 					RyukConnectionTimeout:   defaultRyukConnectionTimeout,
-					RyukImage:               ReaperDefaultImage,
 					RyukReconnectionTimeout: defaultRyukReonnectionTimeout,
 				},
 			},
@@ -177,7 +176,6 @@ func TestReadTCConfig(t *testing.T) {
 					Host:                    tcpDockerHost1234,
 					TLSVerify:               1,
 					RyukConnectionTimeout:   defaultRyukConnectionTimeout,
-					RyukImage:               ReaperDefaultImage,
 					RyukReconnectionTimeout: defaultRyukReonnectionTimeout,
 				},
 			},
@@ -187,7 +185,6 @@ func TestReadTCConfig(t *testing.T) {
 				map[string]string{},
 				Config{
 					RyukConnectionTimeout:   defaultRyukConnectionTimeout,
-					RyukImage:               ReaperDefaultImage,
 					RyukReconnectionTimeout: defaultRyukReonnectionTimeout,
 				},
 			},
@@ -200,7 +197,6 @@ func TestReadTCConfig(t *testing.T) {
 				Config{
 					Host:                    tcpDockerHost1234,
 					RyukConnectionTimeout:   defaultRyukConnectionTimeout,
-					RyukImage:               ReaperDefaultImage,
 					RyukReconnectionTimeout: defaultRyukReonnectionTimeout,
 				},
 			},
@@ -211,7 +207,6 @@ func TestReadTCConfig(t *testing.T) {
 				Config{
 					Host:                    tcpDockerHost33293,
 					RyukConnectionTimeout:   defaultRyukConnectionTimeout,
-					RyukImage:               ReaperDefaultImage,
 					RyukReconnectionTimeout: defaultRyukReonnectionTimeout,
 				},
 			},
@@ -232,7 +227,6 @@ func TestReadTCConfig(t *testing.T) {
 					Host:                    tcpDockerHost1234,
 					CertPath:                "/tmp/certs",
 					RyukConnectionTimeout:   defaultRyukConnectionTimeout,
-					RyukImage:               ReaperDefaultImage,
 					RyukReconnectionTimeout: defaultRyukReonnectionTimeout,
 				},
 			},
@@ -243,7 +237,6 @@ func TestReadTCConfig(t *testing.T) {
 				Config{
 					RyukDisabled:            true,
 					RyukConnectionTimeout:   defaultRyukConnectionTimeout,
-					RyukImage:               ReaperDefaultImage,
 					RyukReconnectionTimeout: defaultRyukReonnectionTimeout,
 				},
 			},
@@ -254,7 +247,6 @@ func TestReadTCConfig(t *testing.T) {
 				Config{
 					RyukPrivileged:          true,
 					RyukConnectionTimeout:   defaultRyukConnectionTimeout,
-					RyukImage:               ReaperDefaultImage,
 					RyukReconnectionTimeout: defaultRyukReonnectionTimeout,
 				},
 			},
@@ -265,7 +257,6 @@ func TestReadTCConfig(t *testing.T) {
 				map[string]string{},
 				Config{
 					RyukReconnectionTimeout: 13 * time.Second,
-					RyukImage:               ReaperDefaultImage,
 					RyukConnectionTimeout:   12 * time.Second,
 				},
 			},
@@ -278,7 +269,6 @@ func TestReadTCConfig(t *testing.T) {
 				Config{
 					RyukDisabled:            true,
 					RyukConnectionTimeout:   defaultRyukConnectionTimeout,
-					RyukImage:               ReaperDefaultImage,
 					RyukReconnectionTimeout: defaultRyukReonnectionTimeout,
 				},
 			},
@@ -291,7 +281,6 @@ func TestReadTCConfig(t *testing.T) {
 				Config{
 					RyukPrivileged:          true,
 					RyukConnectionTimeout:   defaultRyukConnectionTimeout,
-					RyukImage:               ReaperDefaultImage,
 					RyukReconnectionTimeout: defaultRyukReonnectionTimeout,
 				},
 			},
@@ -304,7 +293,6 @@ func TestReadTCConfig(t *testing.T) {
 				Config{
 					RyukDisabled:            true,
 					RyukConnectionTimeout:   defaultRyukConnectionTimeout,
-					RyukImage:               ReaperDefaultImage,
 					RyukReconnectionTimeout: defaultRyukReonnectionTimeout,
 				},
 			},
@@ -317,7 +305,6 @@ func TestReadTCConfig(t *testing.T) {
 				Config{
 					RyukDisabled:            true,
 					RyukConnectionTimeout:   defaultRyukConnectionTimeout,
-					RyukImage:               ReaperDefaultImage,
 					RyukReconnectionTimeout: defaultRyukReonnectionTimeout,
 				},
 			},
@@ -346,7 +333,6 @@ func TestReadTCConfig(t *testing.T) {
 				Config{
 					RyukPrivileged:          true,
 					RyukConnectionTimeout:   defaultRyukConnectionTimeout,
-					RyukImage:               ReaperDefaultImage,
 					RyukReconnectionTimeout: defaultRyukReonnectionTimeout,
 				},
 			},
@@ -359,7 +345,6 @@ func TestReadTCConfig(t *testing.T) {
 				Config{
 					RyukPrivileged:          true,
 					RyukConnectionTimeout:   defaultRyukConnectionTimeout,
-					RyukImage:               ReaperDefaultImage,
 					RyukReconnectionTimeout: defaultRyukReonnectionTimeout,
 				},
 			},
@@ -385,12 +370,10 @@ func TestReadTCConfig(t *testing.T) {
 				docker.tls.verify = ERROR`,
 				map[string]string{
 					"TESTCONTAINERS_RYUK_DISABLED":             "true",
-					"TESTCONTAINERS_RYUK_CONTAINER_IMAGE":      "test-image-env",
 					"TESTCONTAINERS_RYUK_CONTAINER_PRIVILEGED": "true",
 				},
 				Config{
 					RyukDisabled:   true,
-					RyukImage:      "test-image-env",
 					RyukPrivileged: true,
 				},
 			},
@@ -411,35 +394,35 @@ func TestReadTCConfig(t *testing.T) {
 				defaultConfig,
 			},
 			{
-				"With Ryuk container image set as a property",
-				`ryuk.container.image=test-image-props`,
+				"With Hub image name prefix set as a property",
+				`hub.image.name.prefix=` + defaultHubPrefix + `props/`,
 				map[string]string{},
 				Config{
-					RyukImage:               "test-image-props",
+					HubImageNamePrefix:      defaultHubPrefix + "props/",
 					RyukConnectionTimeout:   defaultRyukConnectionTimeout,
 					RyukReconnectionTimeout: defaultRyukReonnectionTimeout,
 				},
 			},
 			{
-				"With Ryuk container image set as env var",
+				"With Hub image name prefix set as env var",
 				``,
 				map[string]string{
-					"TESTCONTAINERS_RYUK_CONTAINER_IMAGE": "test-image-env",
+					"TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX": defaultHubPrefix + "env/",
 				},
 				Config{
-					RyukImage:               "test-image-env",
+					HubImageNamePrefix:      defaultHubPrefix + "env/",
 					RyukConnectionTimeout:   defaultRyukConnectionTimeout,
 					RyukReconnectionTimeout: defaultRyukReonnectionTimeout,
 				},
 			},
 			{
-				"With Ryuk container image set as env var and properties: Env var wins",
-				`ryuk.container.image=test-image-props`,
+				"With Hub image name prefix set as env var and properties: Env var wins",
+				`hub.image.name.prefix=` + defaultHubPrefix + `props/`,
 				map[string]string{
-					"TESTCONTAINERS_RYUK_CONTAINER_IMAGE": "test-image-env",
+					"TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX": defaultHubPrefix + "env/",
 				},
 				Config{
-					RyukImage:               "test-image-env",
+					HubImageNamePrefix:      defaultHubPrefix + "env/",
 					RyukConnectionTimeout:   defaultRyukConnectionTimeout,
 					RyukReconnectionTimeout: defaultRyukReonnectionTimeout,
 				},

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -20,6 +20,7 @@ const (
 // execute this function before each test
 func resetTestEnv(t *testing.T) {
 	t.Setenv("TESTCONTAINERS_RYUK_DISABLED", "")
+	t.Setenv("TESTCONTAINERS_RYUK_CONTAINER_IMAGE", "")
 	t.Setenv("TESTCONTAINERS_RYUK_CONTAINER_PRIVILEGED", "")
 }
 
@@ -68,12 +69,14 @@ func TestReadTCConfig(t *testing.T) {
 		t.Setenv("HOME", "")
 		t.Setenv("USERPROFILE", "") // Windows support
 		t.Setenv("TESTCONTAINERS_RYUK_DISABLED", "true")
+		t.Setenv("TESTCONTAINERS_RYUK_CONTAINER_IMAGE", "test-image")
 		t.Setenv("TESTCONTAINERS_RYUK_CONTAINER_PRIVILEGED", "true")
 
 		config := read()
 
 		expected := Config{
 			RyukDisabled:   true,
+			RyukImage:      "test-image",
 			RyukPrivileged: true,
 			Host:           "", // docker socket is empty at the properties file
 		}
@@ -110,11 +113,13 @@ func TestReadTCConfig(t *testing.T) {
 		t.Setenv("HOME", tmpDir)
 		t.Setenv("USERPROFILE", tmpDir) // Windows support
 		t.Setenv("TESTCONTAINERS_RYUK_DISABLED", "true")
+		t.Setenv("TESTCONTAINERS_RYUK_CONTAINER_IMAGE", "test-image")
 		t.Setenv("TESTCONTAINERS_RYUK_CONTAINER_PRIVILEGED", "true")
 
 		config := read()
 		expected := Config{
 			RyukDisabled:   true,
+			RyukImage:      "test-image",
 			RyukPrivileged: true,
 		}
 
@@ -126,6 +131,7 @@ func TestReadTCConfig(t *testing.T) {
 		defaultRyukReonnectionTimeout := 10 * time.Second
 		defaultConfig := Config{
 			RyukConnectionTimeout:   defaultRyukConnectionTimeout,
+			RyukImage:               ReaperDefaultImage,
 			RyukReconnectionTimeout: defaultRyukReonnectionTimeout,
 		}
 
@@ -142,6 +148,7 @@ func TestReadTCConfig(t *testing.T) {
 				Config{
 					Host:                    tcpDockerHost33293,
 					RyukConnectionTimeout:   defaultRyukConnectionTimeout,
+					RyukImage:               ReaperDefaultImage,
 					RyukReconnectionTimeout: defaultRyukReonnectionTimeout,
 				},
 			},
@@ -154,6 +161,7 @@ func TestReadTCConfig(t *testing.T) {
 				Config{
 					Host:                    tcpDockerHost4711,
 					RyukConnectionTimeout:   defaultRyukConnectionTimeout,
+					RyukImage:               ReaperDefaultImage,
 					RyukReconnectionTimeout: defaultRyukReonnectionTimeout,
 				},
 			},
@@ -169,6 +177,7 @@ func TestReadTCConfig(t *testing.T) {
 					Host:                    tcpDockerHost1234,
 					TLSVerify:               1,
 					RyukConnectionTimeout:   defaultRyukConnectionTimeout,
+					RyukImage:               ReaperDefaultImage,
 					RyukReconnectionTimeout: defaultRyukReonnectionTimeout,
 				},
 			},
@@ -178,6 +187,7 @@ func TestReadTCConfig(t *testing.T) {
 				map[string]string{},
 				Config{
 					RyukConnectionTimeout:   defaultRyukConnectionTimeout,
+					RyukImage:               ReaperDefaultImage,
 					RyukReconnectionTimeout: defaultRyukReonnectionTimeout,
 				},
 			},
@@ -190,6 +200,7 @@ func TestReadTCConfig(t *testing.T) {
 				Config{
 					Host:                    tcpDockerHost1234,
 					RyukConnectionTimeout:   defaultRyukConnectionTimeout,
+					RyukImage:               ReaperDefaultImage,
 					RyukReconnectionTimeout: defaultRyukReonnectionTimeout,
 				},
 			},
@@ -200,6 +211,7 @@ func TestReadTCConfig(t *testing.T) {
 				Config{
 					Host:                    tcpDockerHost33293,
 					RyukConnectionTimeout:   defaultRyukConnectionTimeout,
+					RyukImage:               ReaperDefaultImage,
 					RyukReconnectionTimeout: defaultRyukReonnectionTimeout,
 				},
 			},
@@ -220,6 +232,7 @@ func TestReadTCConfig(t *testing.T) {
 					Host:                    tcpDockerHost1234,
 					CertPath:                "/tmp/certs",
 					RyukConnectionTimeout:   defaultRyukConnectionTimeout,
+					RyukImage:               ReaperDefaultImage,
 					RyukReconnectionTimeout: defaultRyukReonnectionTimeout,
 				},
 			},
@@ -230,6 +243,7 @@ func TestReadTCConfig(t *testing.T) {
 				Config{
 					RyukDisabled:            true,
 					RyukConnectionTimeout:   defaultRyukConnectionTimeout,
+					RyukImage:               ReaperDefaultImage,
 					RyukReconnectionTimeout: defaultRyukReonnectionTimeout,
 				},
 			},
@@ -240,6 +254,7 @@ func TestReadTCConfig(t *testing.T) {
 				Config{
 					RyukPrivileged:          true,
 					RyukConnectionTimeout:   defaultRyukConnectionTimeout,
+					RyukImage:               ReaperDefaultImage,
 					RyukReconnectionTimeout: defaultRyukReonnectionTimeout,
 				},
 			},
@@ -250,6 +265,7 @@ func TestReadTCConfig(t *testing.T) {
 				map[string]string{},
 				Config{
 					RyukReconnectionTimeout: 13 * time.Second,
+					RyukImage:               ReaperDefaultImage,
 					RyukConnectionTimeout:   12 * time.Second,
 				},
 			},
@@ -262,6 +278,7 @@ func TestReadTCConfig(t *testing.T) {
 				Config{
 					RyukDisabled:            true,
 					RyukConnectionTimeout:   defaultRyukConnectionTimeout,
+					RyukImage:               ReaperDefaultImage,
 					RyukReconnectionTimeout: defaultRyukReonnectionTimeout,
 				},
 			},
@@ -274,6 +291,7 @@ func TestReadTCConfig(t *testing.T) {
 				Config{
 					RyukPrivileged:          true,
 					RyukConnectionTimeout:   defaultRyukConnectionTimeout,
+					RyukImage:               ReaperDefaultImage,
 					RyukReconnectionTimeout: defaultRyukReonnectionTimeout,
 				},
 			},
@@ -286,6 +304,7 @@ func TestReadTCConfig(t *testing.T) {
 				Config{
 					RyukDisabled:            true,
 					RyukConnectionTimeout:   defaultRyukConnectionTimeout,
+					RyukImage:               ReaperDefaultImage,
 					RyukReconnectionTimeout: defaultRyukReonnectionTimeout,
 				},
 			},
@@ -298,6 +317,7 @@ func TestReadTCConfig(t *testing.T) {
 				Config{
 					RyukDisabled:            true,
 					RyukConnectionTimeout:   defaultRyukConnectionTimeout,
+					RyukImage:               ReaperDefaultImage,
 					RyukReconnectionTimeout: defaultRyukReonnectionTimeout,
 				},
 			},
@@ -326,6 +346,7 @@ func TestReadTCConfig(t *testing.T) {
 				Config{
 					RyukPrivileged:          true,
 					RyukConnectionTimeout:   defaultRyukConnectionTimeout,
+					RyukImage:               ReaperDefaultImage,
 					RyukReconnectionTimeout: defaultRyukReonnectionTimeout,
 				},
 			},
@@ -338,6 +359,7 @@ func TestReadTCConfig(t *testing.T) {
 				Config{
 					RyukPrivileged:          true,
 					RyukConnectionTimeout:   defaultRyukConnectionTimeout,
+					RyukImage:               ReaperDefaultImage,
 					RyukReconnectionTimeout: defaultRyukReonnectionTimeout,
 				},
 			},
@@ -363,10 +385,12 @@ func TestReadTCConfig(t *testing.T) {
 				docker.tls.verify = ERROR`,
 				map[string]string{
 					"TESTCONTAINERS_RYUK_DISABLED":             "true",
+					"TESTCONTAINERS_RYUK_CONTAINER_IMAGE":      "test-image-env",
 					"TESTCONTAINERS_RYUK_CONTAINER_PRIVILEGED": "true",
 				},
 				Config{
 					RyukDisabled:   true,
+					RyukImage:      "test-image-env",
 					RyukPrivileged: true,
 				},
 			},
@@ -385,6 +409,40 @@ func TestReadTCConfig(t *testing.T) {
 					"TESTCONTAINERS_RYUK_CONTAINER_PRIVILEGED": "foo",
 				},
 				defaultConfig,
+			},
+			{
+				"With Ryuk container image set as a property",
+				`ryuk.container.image=test-image-props`,
+				map[string]string{},
+				Config{
+					RyukImage:               "test-image-props",
+					RyukConnectionTimeout:   defaultRyukConnectionTimeout,
+					RyukReconnectionTimeout: defaultRyukReonnectionTimeout,
+				},
+			},
+			{
+				"With Ryuk container image set as env var",
+				``,
+				map[string]string{
+					"TESTCONTAINERS_RYUK_CONTAINER_IMAGE": "test-image-env",
+				},
+				Config{
+					RyukImage:               "test-image-env",
+					RyukConnectionTimeout:   defaultRyukConnectionTimeout,
+					RyukReconnectionTimeout: defaultRyukReonnectionTimeout,
+				},
+			},
+			{
+				"With Ryuk container image set as env var and properties: Env var wins",
+				`ryuk.container.image=test-image-props`,
+				map[string]string{
+					"TESTCONTAINERS_RYUK_CONTAINER_IMAGE": "test-image-env",
+				},
+				Config{
+					RyukImage:               "test-image-env",
+					RyukConnectionTimeout:   defaultRyukConnectionTimeout,
+					RyukReconnectionTimeout: defaultRyukReonnectionTimeout,
+				},
 			},
 		}
 		for _, tt := range tests {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -54,7 +54,7 @@ func TestReadConfig(t *testing.T) {
 func TestReadTCConfig(t *testing.T) {
 	resetTestEnv(t)
 
-	const defaultHubPrefix string = "registry.mycompany.com/mirror/"
+	const defaultHubPrefix string = "registry.mycompany.com/mirror"
 
 	t.Run("HOME is not set", func(t *testing.T) {
 		t.Setenv("HOME", "")
@@ -395,10 +395,10 @@ func TestReadTCConfig(t *testing.T) {
 			},
 			{
 				"With Hub image name prefix set as a property",
-				`hub.image.name.prefix=` + defaultHubPrefix + `props/`,
+				`hub.image.name.prefix=` + defaultHubPrefix + `/props/`,
 				map[string]string{},
 				Config{
-					HubImageNamePrefix:      defaultHubPrefix + "props/",
+					HubImageNamePrefix:      defaultHubPrefix + "/props/",
 					RyukConnectionTimeout:   defaultRyukConnectionTimeout,
 					RyukReconnectionTimeout: defaultRyukReonnectionTimeout,
 				},
@@ -407,22 +407,22 @@ func TestReadTCConfig(t *testing.T) {
 				"With Hub image name prefix set as env var",
 				``,
 				map[string]string{
-					"TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX": defaultHubPrefix + "env/",
+					"TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX": defaultHubPrefix + "/env/",
 				},
 				Config{
-					HubImageNamePrefix:      defaultHubPrefix + "env/",
+					HubImageNamePrefix:      defaultHubPrefix + "/env/",
 					RyukConnectionTimeout:   defaultRyukConnectionTimeout,
 					RyukReconnectionTimeout: defaultRyukReonnectionTimeout,
 				},
 			},
 			{
 				"With Hub image name prefix set as env var and properties: Env var wins",
-				`hub.image.name.prefix=` + defaultHubPrefix + `props/`,
+				`hub.image.name.prefix=` + defaultHubPrefix + `/props/`,
 				map[string]string{
-					"TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX": defaultHubPrefix + "env/",
+					"TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX": defaultHubPrefix + "/env/",
 				},
 				Config{
-					HubImageNamePrefix:      defaultHubPrefix + "env/",
+					HubImageNamePrefix:      defaultHubPrefix + "/env/",
 					RyukConnectionTimeout:   defaultRyukConnectionTimeout,
 					RyukReconnectionTimeout: defaultRyukReonnectionTimeout,
 				},

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -40,10 +40,10 @@ nav:
     - Quickstart: quickstart.md
     - Features:
         - features/creating_container.md
+        - features/configuration.md
         - features/image_name_substitution.md
         - features/files_and_mounts.md
         - features/creating_networks.md
-        - features/configuration.md
         - features/networking.md
         - features/garbage_collector.md
         - features/build_from_dockerfile.md

--- a/network.go
+++ b/network.go
@@ -41,5 +41,5 @@ type NetworkRequest struct {
 
 	SkipReaper    bool              // Deprecated: The reaper is globally controlled by the .testcontainers.properties file or the TESTCONTAINERS_RYUK_DISABLED environment variable
 	ReaperImage   string            // Deprecated: use WithImageName ContainerOption instead. Alternative reaper registry
-	ReaperOptions []ContainerOption // Reaper options to use for this network
+	ReaperOptions []ContainerOption // Deprecated: the reaper is configured at the properties level, for an entire test session
 }

--- a/options.go
+++ b/options.go
@@ -11,6 +11,7 @@ import (
 	"github.com/docker/docker/api/types/network"
 
 	tcexec "github.com/testcontainers/testcontainers-go/exec"
+	"github.com/testcontainers/testcontainers-go/internal/config"
 	"github.com/testcontainers/testcontainers-go/wait"
 )
 
@@ -77,6 +78,35 @@ type ImageSubstitutor interface {
 }
 
 // }
+
+// prependHubRegistry represents a way to prepend a custom Hub registry to the image name,
+// using the HubImageNamePrefix configuration value
+type prependHubRegistry struct {
+	prefix string
+}
+
+// newPrependHubRegistry creates a new prependHubRegistry
+func newPrependHubRegistry() prependHubRegistry {
+	hubPrefix := config.Read().HubImageNamePrefix
+
+	return prependHubRegistry{
+		prefix: hubPrefix,
+	}
+}
+
+// Description returns the name of the type and a short description of how it modifies the image.
+func (p prependHubRegistry) Description() string {
+	return fmt.Sprintf("HubImageSubstitutor (prepends %s)", p.prefix)
+}
+
+// Substitute prepends the Hub prefix to the image name
+func (p prependHubRegistry) Substitute(image string) (string, error) {
+	if p.prefix == "" {
+		return image, nil
+	}
+
+	return fmt.Sprintf("%s/%s", p.prefix, image), nil
+}
 
 // WithImageSubstitutors sets the image substitutors for a container
 func WithImageSubstitutors(fn ...ImageSubstitutor) CustomizeRequestOption {

--- a/reaper.go
+++ b/reaper.go
@@ -217,7 +217,7 @@ func newReaper(ctx context.Context, sessionID string, provider ReaperProvider) (
 	tcConfig := provider.Config().Config
 
 	req := ContainerRequest{
-		Image:        fmt.Sprintf("%s%s", tcConfig.HubImageNamePrefix, config.ReaperDefaultImage),
+		Image:        config.ReaperDefaultImage,
 		ExposedPorts: []string{string(listeningPort)},
 		Labels:       testcontainersdocker.DefaultLabels(sessionID),
 		Privileged:   tcConfig.RyukPrivileged,

--- a/reaper.go
+++ b/reaper.go
@@ -29,14 +29,14 @@ const (
 	TestcontainerLabelSessionID = TestcontainerLabel + ".sessionId"
 	// Deprecated: it has been replaced by the internal testcontainersdocker.LabelReaper
 	TestcontainerLabelIsReaper = TestcontainerLabel + ".reaper"
-
-	ReaperDefaultImage = "docker.io/testcontainers/ryuk:0.5.1"
 )
 
 var (
-	reaperInstance *Reaper // We would like to create reaper only once
-	reaperMutex    sync.Mutex
-	reaperOnce     sync.Once
+	// Deprecated: it has been replaced by an internal value
+	ReaperDefaultImage = config.ReaperDefaultImage
+	reaperInstance     *Reaper // We would like to create reaper only once
+	reaperMutex        sync.Mutex
+	reaperOnce         sync.Once
 )
 
 // ReaperProvider represents a provider for the reaper to run itself with

--- a/reaper.go
+++ b/reaper.go
@@ -17,6 +17,7 @@ import (
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/go-connections/nat"
 
+	"github.com/testcontainers/testcontainers-go/internal/config"
 	"github.com/testcontainers/testcontainers-go/internal/testcontainersdocker"
 	"github.com/testcontainers/testcontainers-go/wait"
 )
@@ -216,7 +217,7 @@ func newReaper(ctx context.Context, sessionID string, provider ReaperProvider) (
 	tcConfig := provider.Config().Config
 
 	req := ContainerRequest{
-		Image:        tcConfig.RyukImage,
+		Image:        fmt.Sprintf("%s%s", tcConfig.HubImageNamePrefix, config.ReaperDefaultImage),
 		ExposedPorts: []string{string(listeningPort)},
 		Labels:       testcontainersdocker.DefaultLabels(sessionID),
 		Privileged:   tcConfig.RyukPrivileged,

--- a/reaper_test.go
+++ b/reaper_test.go
@@ -371,12 +371,12 @@ func Test_NewReaper(t *testing.T) {
 		{
 			name: "Reaper including custom Hub prefix",
 			req: createContainerRequest(func(req ContainerRequest) ContainerRequest {
-				req.Image = "registry.mycompany.com/mirror/" + config.ReaperDefaultImage
+				req.Image = config.ReaperDefaultImage
 				req.Privileged = true
 				return req
 			}),
 			config: TestcontainersConfig{Config: config.Config{
-				HubImageNamePrefix:      "registry.mycompany.com/mirror/",
+				HubImageNamePrefix:      "registry.mycompany.com/mirror",
 				RyukPrivileged:          true,
 				RyukConnectionTimeout:   time.Minute,
 				RyukReconnectionTimeout: 10 * time.Second,
@@ -385,7 +385,7 @@ func Test_NewReaper(t *testing.T) {
 		{
 			name: "Reaper including custom Hub prefix as env var",
 			req: createContainerRequest(func(req ContainerRequest) ContainerRequest {
-				req.Image = "registry.mycompany.com/mirror/" + config.ReaperDefaultImage
+				req.Image = config.ReaperDefaultImage
 				req.Privileged = true
 				return req
 			}),
@@ -395,7 +395,7 @@ func Test_NewReaper(t *testing.T) {
 				RyukReconnectionTimeout: 10 * time.Second,
 			}},
 			env: map[string]string{
-				"TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX": "registry.mycompany.com/mirror/",
+				"TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX": "registry.mycompany.com/mirror",
 			},
 		},
 	}

--- a/scripts/bump-reaper.sh
+++ b/scripts/bump-reaper.sh
@@ -30,20 +30,16 @@ function main() {
   if [[ "${DRY_RUN}" == "true" ]]; then
     echo "sed \"s/ReaperDefaultImage = \".*\"/ReaperDefaultImage = \"${escapedRyukVersion}\"/g\" ${REAPER_FILE} > ${REAPER_FILE}.tmp"
     echo "mv ${REAPER_FILE}.tmp ${REAPER_FILE}"
-    echo "sed \"s/ryuk.container.image,default=\".*\"/ryuk.container.image,default=\"${escapedRyukVersion}\"/g\" ${REAPER_FILE} > ${REAPER_FILE}.tmp"
-    echo "mv ${REAPER_FILE}.tmp ${REAPER_FILE}"
   else
     # replace using sed the version in the config.go file
     sed "s/ReaperDefaultImage = \".*\"/ReaperDefaultImage = \"${escapedRyukVersion}\"/g" ${REAPER_FILE} > ${REAPER_FILE}.tmp
-    mv ${REAPER_FILE}.tmp ${REAPER_FILE}
-    sed "s/ryuk.container.image,default=.*\"/ryuk.container.image,default=${escapedRyukVersion}\"/g" ${REAPER_FILE} > ${REAPER_FILE}.tmp
     mv ${REAPER_FILE}.tmp ${REAPER_FILE}
   fi
 }
 
 # This function reads the reaper.go file and extracts the current version.
 function extractCurrentVersion() {
-  cat "${REAPER_FILE}" | grep 'ryuk.container.image,default=' | cut -d '=' -f 2 | cut -d '"' -f 1
+  cat "${REAPER_FILE}" | grep 'ReaperDefaultImage = ' | cut -d '=' -f 2 | cut -d '"' -f 1
 }
 
 main "$@"

--- a/scripts/bump-reaper.sh
+++ b/scripts/bump-reaper.sh
@@ -14,7 +14,7 @@
 readonly CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 readonly DRY_RUN="${DRY_RUN:-true}"
 readonly ROOT_DIR="$(dirname "$CURRENT_DIR")"
-readonly REAPER_FILE="${ROOT_DIR}/reaper.go"
+readonly REAPER_FILE="${ROOT_DIR}/internal/config/config.go"
 
 function main() {
   echo "Updating Ryuk version:"
@@ -26,20 +26,24 @@ function main() {
   local escapedRyukVersion="${ryukVersion//\//\\/}"
   echo " - New: ${ryukVersion}"
 
-  # Bump the version in the version.go file
+  # Bump the version in the config.go file
   if [[ "${DRY_RUN}" == "true" ]]; then
     echo "sed \"s/ReaperDefaultImage = \".*\"/ReaperDefaultImage = \"${escapedRyukVersion}\"/g\" ${REAPER_FILE} > ${REAPER_FILE}.tmp"
     echo "mv ${REAPER_FILE}.tmp ${REAPER_FILE}"
+    echo "sed \"s/ryuk.container.image,default=\".*\"/ryuk.container.image,default=\"${escapedRyukVersion}\"/g\" ${REAPER_FILE} > ${REAPER_FILE}.tmp"
+    echo "mv ${REAPER_FILE}.tmp ${REAPER_FILE}"
   else
-    # replace using sed the version in the reaper.go file
+    # replace using sed the version in the config.go file
     sed "s/ReaperDefaultImage = \".*\"/ReaperDefaultImage = \"${escapedRyukVersion}\"/g" ${REAPER_FILE} > ${REAPER_FILE}.tmp
+    mv ${REAPER_FILE}.tmp ${REAPER_FILE}
+    sed "s/ryuk.container.image,default=.*\"/ryuk.container.image,default=${escapedRyukVersion}\"/g" ${REAPER_FILE} > ${REAPER_FILE}.tmp
     mv ${REAPER_FILE}.tmp ${REAPER_FILE}
   fi
 }
 
 # This function reads the reaper.go file and extracts the current version.
 function extractCurrentVersion() {
-  cat "${REAPER_FILE}" | grep 'ReaperDefaultImage = "' | cut -d '"' -f 2
+  cat "${REAPER_FILE}" | grep 'ryuk.container.image,default=' | cut -d '=' -f 2 | cut -d '"' -f 1
 }
 
 main "$@"


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
This PR does two major things:

1. It tries to simplify how the reaper is internally configured, and for that:
  - deprecates the reaper options defined in the container and network requests. This is needed because we do not want to configure the reaper per container, but instead, do that in one single place: the testcontainers configuration
  - moving the constant representing the Ryuk version to internal, as we do not want users to modify it but instead make it possible to define a custom prefix (see later)
  - removing ocurrences of the deprecated code at the test level, which they won't do anything to not collide with the new features.
2. It adds support for configuring a Docker Hub prefix to be prepended to any Docker Hub image, with:
  - the `TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX` env var, or
  - the `hub.image.name.prefix` property

_Testcontainers for Go_ will automatically apply the prefix to every image that it pulls from Docker Hub.

It will not apply the prefix to:
* non-Hub image names (e.g. where another registry is set)
* Docker Hub image names where the hub registry is explicitly part of the name (i.e. anything with a `docker.io` or `registry.hub.docker.com` host part)

The PR is adding a custom internal ImageSubstitutor, which is always appended to the user-defined image substitutor functions for a container request, so make sure it's always applied This substitutor will read the configuration to get the prefix, and will append it, when needed, to the image. Unit tests for it has been included.

The PR also improves the docs regarding image substitutors, listing all the images used in the tests.

Finally, the shell script to bump the reaper version has been updated, as the Go file for the Ryuk version has changed.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
First, alignment with the Java behavior. Second, create a consistent experience while pulling images from custom registries.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Relates #1719
- Closes #1893

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
