### PR TITLE
docs: include MongoDB's username and password options into the docs

### DIFF
--- a/docs/modules/mongodb.md
+++ b/docs/modules/mongodb.md
@@ -37,8 +37,26 @@ When starting the MongoDB container, you can pass options in a variadic way to c
 
 #### Image
 
-If you need to set a different MongoDB Docker image, you can use `testcontainers.WithImage` with a valid Docker image
+If you need to set a different MongoDB Docker image, you can use `testcontainers.WithUsername` with a valid Docker image
 for MongoDB. E.g. `testcontainers.WithImage("mongo:6")`.
+
+#### WithUsername
+
+- Not available until the next release of testcontainers-go <a href="https://github.com/testcontainers/testcontainers-go"><span class="tc-version">:material-tag: main</span></a>
+
+This functional option sets the initial username to be created when the container starts.
+It is used in conjunction with `WithPassword` to set a username and its password, creating the specified user with superuser power.
+
+E.g. `testcontainers.WithUsername("mymongouser")`.
+
+#### WithPassword
+
+- Not available until the next release of testcontainers-go <a href="https://github.com/testcontainers/testcontainers-go"><span class="tc-version">:material-tag: main</span></a>
+
+This functional option sets the initial password to be created when the container starts.
+It is used in conjunction with `WithUsername` to set a username and its password, setting the password for the superuser power.
+
+E.g. `testcontainers.WithPassword("mymongopwd")`.
 
 {% include "../features/common_functional_options.md" %}
 

--- a/docs/modules/mongodb.md
+++ b/docs/modules/mongodb.md
@@ -37,7 +37,7 @@ When starting the MongoDB container, you can pass options in a variadic way to c
 
 #### Image
 
-If you need to set a different MongoDB Docker image, you can use `testcontainers.WithUsername` with a valid Docker image
+If you need to set a different MongoDB Docker image, you can use `testcontainers.WithImage` with a valid Docker image
 for MongoDB. E.g. `testcontainers.WithImage("mongo:6")`.
 
 #### WithUsername

--- a/modules/mongodb/mongodb.go
+++ b/modules/mongodb/mongodb.go
@@ -66,7 +66,7 @@ func WithUsername(username string) testcontainers.CustomizeRequestOption {
 
 // WithPassword sets the initial password of the user to be created when the container starts
 // It is used in conjunction with WithUsername to set a username and its password.
-// This environment variable sets the superuser password for MongoDB.
+// It will set the superuser password for MongoDB.
 func WithPassword(password string) testcontainers.CustomizeRequestOption {
 	return func(req *testcontainers.GenericContainerRequest) {
 		req.Env["MONGO_INITDB_ROOT_PASSWORD"] = password

--- a/scripts/pre-release.sh
+++ b/scripts/pre-release.sh
@@ -71,14 +71,14 @@ function bumpVersion() {
     make "tidy-${directory}"
   done
 
-  cd "${ROOT_DIR}/docs/modules"
+  cd "${ROOT_DIR}/docs"
 
   versionEscapingDots="${versionToBumpWithoutV/./\.}"
   NON_RELEASED_STRING='Not available until the next release of testcontainers-go <a href=\"https:\/\/github.com\/testcontainers\/testcontainers-go\"><span class=\"tc-version\">:material-tag: main<\/span><\/a>'
   RELEASED_STRING="Since testcontainers-go <a href=\\\"https:\/\/github.com\/testcontainers\/testcontainers-go\/releases\/tag\/v${versionEscapingDots}\\\"><span class=\\\"tc-version\\\">:material-tag: v${versionEscapingDots}<\/span><\/a>"
 
-  # Update the since-version in those modules that were added in the current version
-  ls | grep -v "index.md" | while read -r module_file; do
+  # find all markdown files, and for each of them, replace the release string
+  find . -name "*.md" | while read -r module_file; do
     if [[ "${DRY_RUN}" == "true" ]]; then
       echo "sed \"s/${NON_RELEASED_STRING}/${RELEASED_STRING}/g\" ${module_file} > ${module_file}.tmp"
       echo "mv ${module_file}.tmp ${module_file}"
@@ -87,15 +87,6 @@ function bumpVersion() {
       mv ${module_file}.tmp ${module_file}
     fi
   done
-
-  readonly commonFile="${ROOT_DIR}/docs/features/common_functional_options.md"
-  if [[ "${DRY_RUN}" == "true" ]]; then
-    echo "sed \"s/${NON_RELEASED_STRING}/${RELEASED_STRING}/g\" ${commonFile} > ${commonFile}.tmp"
-    echo "mv ${commonFile}.tmp ${commonFile}"
-  else
-    sed "s/${NON_RELEASED_STRING}/${RELEASED_STRING}/g" ${commonFile} > ${commonFile}.tmp
-    mv ${commonFile}.tmp ${commonFile}
-  fi
 }
 
 # This function reads the version.go file and extracts the current version.


### PR DESCRIPTION
- docs: include mongodb options into the docs
- chore: apply introduced-when string to all markdown files from the docs

<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
It adds the new two functional options for MongoDB to the module's docs.

It also modifies the shell script for the pre-release to locate all the markdown files to replace the introduced-at string.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
We are seeing more places where the introduced-at string is required, so instead of applying to modules, we apply it to all the markdown files.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Completes #1910

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
