### PR TITLE
feat: support customizing the Docker build command

### DIFF
--- a/container.go
+++ b/container.go
@@ -65,6 +65,7 @@ type Container interface {
 
 // ImageBuildInfo defines what is needed to build an image
 type ImageBuildInfo interface {
+	BuildOptions() (types.ImageBuildOptions, error) // converts the ImageBuildInfo to a types.ImageBuildOptions
 	GetContext() (io.Reader, error)                 // the path to the build context
 	GetDockerfile() string                          // the relative path to the Dockerfile, including the fileitself
 	GetRepo() string                                // get repo label for image
@@ -72,7 +73,7 @@ type ImageBuildInfo interface {
 	ShouldPrintBuildLog() bool                      // allow build log to be printed to stdout
 	ShouldBuildImage() bool                         // return true if the image needs to be built
 	GetBuildArgs() map[string]*string               // return the environment args used to build the from Dockerfile
-	GetAuthConfigs() map[string]registry.AuthConfig // return the auth configs to be able to pull from an authenticated docker registry
+	GetAuthConfigs() map[string]registry.AuthConfig // Deprecated. Testcontainers will detect registry credentials automatically. Return the auth configs to be able to pull from an authenticated docker registry
 }
 
 // FromDockerfile represents the parameters needed to build an image from a Dockerfile
@@ -90,6 +91,10 @@ type FromDockerfile struct {
 	// container image. Useful for images that are built from a Dockerfile and take a
 	// long time to build. Keeping the image also Docker to reuse it.
 	KeepImage bool
+	// BuildOptionsModifier Modifier for the build options before image build. Use it for
+	// advanced configurations while building the image. Please consider that the modifier
+	// is called after the default build options are set.
+	BuildOptionsModifier func(*types.ImageBuildOptions)
 }
 
 type ContainerFile struct {
@@ -259,8 +264,13 @@ func (c *ContainerRequest) GetTag() string {
 	return strings.ToLower(t)
 }
 
+// Deprecated: Testcontainers will detect registry credentials automatically, and it will be removed in the next major release
 // GetAuthConfigs returns the auth configs to be able to pull from an authenticated docker registry
 func (c *ContainerRequest) GetAuthConfigs() map[string]registry.AuthConfig {
+	return getAuthConfigsFromDockerfile(c)
+}
+
+func getAuthConfigsFromDockerfile(c *ContainerRequest) map[string]registry.AuthConfig {
 	images, err := testcontainersdocker.ExtractImagesFromDockerfile(filepath.Join(c.Context, c.GetDockerfile()), c.GetBuildArgs())
 	if err != nil {
 		return map[string]registry.AuthConfig{}
@@ -289,6 +299,32 @@ func (c *ContainerRequest) ShouldKeepBuiltImage() bool {
 
 func (c *ContainerRequest) ShouldPrintBuildLog() bool {
 	return c.FromDockerfile.PrintBuildLog
+}
+
+// BuildOptions returns the image build options when building a Docker image from a Dockerfile.
+// It will apply some defaults and finally call the BuildOptionsModifier from the FromDockerfile struct,
+// if set.
+func (c *ContainerRequest) BuildOptions() (types.ImageBuildOptions, error) {
+	buildOptions := types.ImageBuildOptions{
+		BuildArgs:   c.GetBuildArgs(),
+		Dockerfile:  c.GetDockerfile(),
+		AuthConfigs: getAuthConfigsFromDockerfile(c),
+		Tags:        []string{fmt.Sprintf("%s:%s", c.GetRepo(), c.GetTag())},
+		Remove:      true,
+		ForceRemove: true,
+	}
+
+	buildContext, err := c.GetContext()
+	if err != nil {
+		return buildOptions, err
+	}
+	buildOptions.Context = buildContext
+
+	if c.FromDockerfile.BuildOptionsModifier != nil {
+		c.FromDockerfile.BuildOptionsModifier(&buildOptions)
+	}
+
+	return buildOptions, nil
 }
 
 func (c *ContainerRequest) validateContextAndImage() error {

--- a/container.go
+++ b/container.go
@@ -309,7 +309,6 @@ func (c *ContainerRequest) BuildOptions() (types.ImageBuildOptions, error) {
 	buildOptions := types.ImageBuildOptions{
 		BuildArgs:   c.GetBuildArgs(),
 		Dockerfile:  c.GetDockerfile(),
-		Tags:        []string{fmt.Sprintf("%s:%s", c.GetRepo(), c.GetTag())},
 		Remove:      true,
 		ForceRemove: true,
 	}
@@ -333,6 +332,15 @@ func (c *ContainerRequest) BuildOptions() (types.ImageBuildOptions, error) {
 
 	for registry, authConfig := range authsFromDockerfile {
 		buildOptions.AuthConfigs[registry] = authConfig
+	}
+
+	// make sure the first tag is the one defined in the ContainerRequest
+	tag := fmt.Sprintf("%s:%s", c.GetRepo(), c.GetTag())
+	if len(buildOptions.Tags) > 0 {
+		// prepend the tag
+		buildOptions.Tags = append([]string{tag}, buildOptions.Tags...)
+	} else {
+		buildOptions.Tags = []string{tag}
 	}
 
 	return buildOptions, nil

--- a/container.go
+++ b/container.go
@@ -307,21 +307,23 @@ func (c *ContainerRequest) ShouldPrintBuildLog() bool {
 // if set.
 func (c *ContainerRequest) BuildOptions() (types.ImageBuildOptions, error) {
 	buildOptions := types.ImageBuildOptions{
-		BuildArgs:   c.GetBuildArgs(),
-		Dockerfile:  c.GetDockerfile(),
 		Remove:      true,
 		ForceRemove: true,
 	}
+
+	if c.FromDockerfile.BuildOptionsModifier != nil {
+		c.FromDockerfile.BuildOptionsModifier(&buildOptions)
+	}
+
+	// apply mandatory values after the modifier
+	buildOptions.BuildArgs = c.GetBuildArgs()
+	buildOptions.Dockerfile = c.GetDockerfile()
 
 	buildContext, err := c.GetContext()
 	if err != nil {
 		return buildOptions, err
 	}
 	buildOptions.Context = buildContext
-
-	if c.FromDockerfile.BuildOptionsModifier != nil {
-		c.FromDockerfile.BuildOptionsModifier(&buildOptions)
-	}
 
 	// Make sure the auth configs from the Dockerfile are set right after the user-defined build options.
 	authsFromDockerfile := getAuthConfigsFromDockerfile(c)

--- a/docker.go
+++ b/docker.go
@@ -782,26 +782,11 @@ var _ ContainerProvider = (*DockerProvider)(nil)
 
 // BuildImage will build and image from context and Dockerfile, then return the tag
 func (p *DockerProvider) BuildImage(ctx context.Context, img ImageBuildInfo) (string, error) {
-	repoTag := fmt.Sprintf("%s:%s", img.GetRepo(), img.GetTag())
-
-	buildContext, err := img.GetContext()
-	if err != nil {
-		return "", err
-	}
-
-	buildOptions := types.ImageBuildOptions{
-		BuildArgs:   img.GetBuildArgs(),
-		Dockerfile:  img.GetDockerfile(),
-		AuthConfigs: img.GetAuthConfigs(),
-		Context:     buildContext,
-		Tags:        []string{repoTag},
-		Remove:      true,
-		ForceRemove: true,
-	}
+	buildOptions, err := img.BuildOptions()
 
 	var resp types.ImageBuildResponse
 	err = backoff.Retry(func() error {
-		resp, err = p.client.ImageBuild(ctx, buildContext, buildOptions)
+		resp, err = p.client.ImageBuild(ctx, buildOptions.Context, buildOptions)
 		if err != nil {
 			var enf errdefs.ErrNotFound
 			if errors.As(err, &enf) {
@@ -836,7 +821,8 @@ func (p *DockerProvider) BuildImage(ctx context.Context, img ImageBuildInfo) (st
 
 	_ = resp.Body.Close()
 
-	return repoTag, nil
+	// the first tag is the one we want
+	return buildOptions.Tags[0], nil
 }
 
 // CreateContainer fulfills a request for a container without starting it

--- a/docs/features/build_from_dockerfile.md
+++ b/docs/features/build_from_dockerfile.md
@@ -83,3 +83,14 @@ req := ContainerRequest{
 	},
 }
 ```
+
+## Advanced usage
+
+In the case you need to pass additional arguments to the `docker build` command, you can use the `BuildOptionsModifier` attribute in the `FromDockerfile` struct.
+
+This field holds a function that has access to Docker's ImageBuildOptions type, which is used to build the image. You can use this modifier **on your own risk** to modify the build options with as many options as you need.
+
+<!--codeinclude-->
+[Building From a Dockerfile including build options modifier](../../from_dockerfile_test.go) inside_block:buildFromDockerfileWithModifier
+[Dockerfile including target](../../testdata/target.Dockerfile)
+<!--/codeinclude-->

--- a/from_dockerfile_test.go
+++ b/from_dockerfile_test.go
@@ -160,3 +160,27 @@ func TestBuildImageFromDockerfile_Target(t *testing.T) {
 		})
 	}
 }
+
+func TestBuildImageFromDockerfile_TargetDoesNotExist(t *testing.T) {
+	// the context cancellation will happen with enough time for the build to fail.
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	_, err := GenericContainer(ctx, GenericContainerRequest{
+		ContainerRequest: ContainerRequest{
+			FromDockerfile: FromDockerfile{
+				Context:       "testdata",
+				Dockerfile:    "target.Dockerfile",
+				PrintBuildLog: true,
+				KeepImage:     false,
+				BuildOptionsModifier: func(buildOptions *types.ImageBuildOptions) {
+					buildOptions.Target = "target-foo"
+				},
+			},
+		},
+		Started: true,
+	})
+	require.Error(t, err)
+
+	assert.Contains(t, err.Error(), "failed to reach build target target-foo in Dockerfile")
+}

--- a/from_dockerfile_test.go
+++ b/from_dockerfile_test.go
@@ -191,7 +191,6 @@ func ExampleGenericContainer_buildFromDockerfile() {
 	fmt.Println(string(logs))
 
 	// Output: target2
-
 }
 
 func TestBuildImageFromDockerfile_TargetDoesNotExist(t *testing.T) {

--- a/testdata/target.Dockerfile
+++ b/testdata/target.Dockerfile
@@ -1,0 +1,8 @@
+FROM docker.io/alpine AS target0
+CMD ["echo", "target0"]
+
+FROM target0 AS target1
+CMD ["echo", "target1"]
+
+FROM target1 AS target2
+CMD ["echo", "target2"]


### PR DESCRIPTION
- break: add BuildOptions method in order to support advanced customisations at build time
- chore: add a test for not finding the given target in the Dockerfile
- chore: make sure the auth configs are always added
- docs: document the advanced usage

<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
This PR adds a new field to the `FromDockerfile` struct, in order to hold a customizer function that will be executed when building a Docker image. This customizer will have access to the `ImageBuildOptions` Docker type, allowing users to build the image with as many configuration as they need. Of course, under their own risk.

We were forced to add a new method to the `ImageBuildInfo` interface, `BuildOptions`, in order to call the customizer defined by the user.

This customizer causes the deprecation of the `GetAuthConfigs` method from the same interface, although it probably needed to be deprecated before, when the code added support to discover the registry auths automatically. In any case, we are doing it so, creating a private method that automatically extracts the auths from the Dockerfile. These auths will be appended after the build options modifier is applied, to avoid undesired mistakes from the user.

The same applies for the Build args, the Image tag, the Dockerfile path and the build context, which are applied after the modifier for the same reasons.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
Instead of adding fields for the build image options type, we prefer having a small reduced of fields/methods to it, and one single modifier function that allows the user to modify what they need. Of course, with power comes responsibility, so it's on their own risk to modify the build options with all the possible modifications.

Testcontainers for Go will keep the build args, the tag for the image, the Dockerfile and build context paths, automatically discovering the registry auths for the Dockerfile.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes #1926
- Relates #869

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
