### PR TITLE
fix: exec multiplexed to return stderr

### DIFF
--- a/exec/processor.go
+++ b/exec/processor.go
@@ -39,6 +39,10 @@ func Multiplexed() ProcessOption {
 
 		<-done
 
-		opts.Reader = &outBuff
+		if errBuff.Bytes() != nil {
+			opts.Reader = &errBuff
+		} else {
+			opts.Reader = &outBuff
+		}
 	})
 }

--- a/modules/compose/go.mod
+++ b/modules/compose/go.mod
@@ -129,7 +129,7 @@ require (
 	github.com/secure-systems-lab/go-securesystemslib v0.4.0 // indirect
 	github.com/serialx/hashring v0.0.0-20190422032157-8b2912629002 // indirect
 	github.com/shibumi/go-pathspec v1.3.0 // indirect
-	github.com/shirou/gopsutil/v3 v3.23.9 // indirect
+	github.com/shirou/gopsutil/v3 v3.23.10 // indirect
 	github.com/shoenig/go-m1cpu v0.1.6 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/spf13/cobra v1.7.0 // indirect

--- a/modules/compose/go.sum
+++ b/modules/compose/go.sum
@@ -546,6 +546,7 @@ github.com/shibumi/go-pathspec v1.3.0 h1:QUyMZhFo0Md5B8zV8x2tesohbb5kfbpTi9rBnKh
 github.com/shibumi/go-pathspec v1.3.0/go.mod h1:Xutfslp817l2I1cZvgcfeMQJG5QnU2lh5tVaaMCl3jE=
 github.com/shirou/gopsutil/v3 v3.23.9 h1:ZI5bWVeu2ep4/DIxB4U9okeYJ7zp/QLTO4auRb/ty/E=
 github.com/shirou/gopsutil/v3 v3.23.9/go.mod h1:x/NWSb71eMcjFIO0vhyGW5nZ7oSIgVjrCnADckb85GA=
+github.com/shirou/gopsutil/v3 v3.23.10/go.mod h1:JIE26kpucQi+innVlAUnIEOSBhBUkirr5b44yr55+WE=
 github.com/shoenig/go-m1cpu v0.1.6 h1:nxdKQNcEB6vzgA2E2bvzKIYRuNj7XNJ4S/aRSwKzFtM=
 github.com/shoenig/go-m1cpu v0.1.6/go.mod h1:1JJMcUBvfNwpq05QDQVAnx3gUHr9IYF7GNg9SUEw2VQ=
 github.com/shoenig/test v0.6.4 h1:kVTaSd7WLz5WZ2IaoM0RSzRsUD+m8wRR+5qvntpn4LU=


### PR DESCRIPTION
## What does this PR do?
This PR allows container command execution to return stderr, when the command execution produces an error.

## Why is it important?

It's important to get the output of a error when executing a command in a container, to facilitate the error debug.

## Related issues

- Closes #1932 
- Relates #1932 
