### PR TITLE
fix(modules.gcloud): pass as ptr to allow request customization

### DIFF
--- a/modules/gcloud/bigquery.go
+++ b/modules/gcloud/bigquery.go
@@ -20,7 +20,7 @@ func RunBigQueryContainer(ctx context.Context, opts ...testcontainers.ContainerC
 		Started: true,
 	}
 
-	settings := applyOptions(req, opts)
+	settings := applyOptions(&req, opts)
 
 	req.Cmd = []string{"--project", settings.ProjectID}
 

--- a/modules/gcloud/bigtable.go
+++ b/modules/gcloud/bigtable.go
@@ -19,7 +19,7 @@ func RunBigTableContainer(ctx context.Context, opts ...testcontainers.ContainerC
 		Started: true,
 	}
 
-	settings := applyOptions(req, opts)
+	settings := applyOptions(&req, opts)
 
 	req.Cmd = []string{
 		"/bin/sh",

--- a/modules/gcloud/datastore.go
+++ b/modules/gcloud/datastore.go
@@ -19,7 +19,7 @@ func RunDatastoreContainer(ctx context.Context, opts ...testcontainers.Container
 		Started: true,
 	}
 
-	settings := applyOptions(req, opts)
+	settings := applyOptions(&req, opts)
 
 	req.Cmd = []string{
 		"/bin/sh",

--- a/modules/gcloud/firestore.go
+++ b/modules/gcloud/firestore.go
@@ -19,7 +19,7 @@ func RunFirestoreContainer(ctx context.Context, opts ...testcontainers.Container
 		Started: true,
 	}
 
-	settings := applyOptions(req, opts)
+	settings := applyOptions(&req, opts)
 
 	req.Cmd = []string{
 		"/bin/sh",

--- a/modules/gcloud/gcloud.go
+++ b/modules/gcloud/gcloud.go
@@ -69,13 +69,13 @@ func WithProjectID(projectID string) Option {
 }
 
 // applyOptions applies the options to the container request and returns the settings.
-func applyOptions(req testcontainers.GenericContainerRequest, opts []testcontainers.ContainerCustomizer) options {
+func applyOptions(req *testcontainers.GenericContainerRequest, opts []testcontainers.ContainerCustomizer) options {
 	settings := defaultOptions()
 	for _, opt := range opts {
 		if apply, ok := opt.(Option); ok {
 			apply(&settings)
 		}
-		opt.Customize(&req)
+		opt.Customize(req)
 	}
 
 	return settings

--- a/modules/gcloud/pubsub.go
+++ b/modules/gcloud/pubsub.go
@@ -19,7 +19,7 @@ func RunPubsubContainer(ctx context.Context, opts ...testcontainers.ContainerCus
 		Started: true,
 	}
 
-	settings := applyOptions(req, opts)
+	settings := applyOptions(&req, opts)
 
 	req.Cmd = []string{
 		"/bin/sh",

--- a/modules/gcloud/spanner.go
+++ b/modules/gcloud/spanner.go
@@ -18,7 +18,7 @@ func RunSpannerContainer(ctx context.Context, opts ...testcontainers.ContainerCu
 		Started: true,
 	}
 
-	settings := applyOptions(req, opts)
+	settings := applyOptions(&req, opts)
 
 	container, err := testcontainers.GenericContainer(ctx, req)
 	if err != nil {


### PR DESCRIPTION
## What does this PR do?

Fixes the GCloud modules to correctly pass the `GenericContainerRequest` into `applyOptions` as a pointer instead of copying the struct.

Currently, the modifications are done, but are thrown away because `req` is passed as a copy.

## Why is it important?

Currently, any container customizations will completely be wiped out as the `req` param is copied into `applyOptions`

## Related issues

- None found.

## How to test this PR

1. Start on the current `main` branch
2. Make an image modification (using `WithImage()`) verify that the image is NOT modified
3. Apply this PR
4. Redo the test from step 2 and verify that the image is now correctly modified