### PR TITLE
Use nat.Port type instead of string; fix #1985

### DIFF
--- a/container_test.go
+++ b/container_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/docker/docker/api/types/container"
+	"github.com/docker/go-connections/nat"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -474,7 +475,7 @@ func TestShouldStartContainersInParallel(t *testing.T) {
 				t.Fatalf("could not start container: %v", err)
 			}
 			// mappedPort {
-			port, err := container.MappedPort(ctx, nginxDefaultPort)
+			port, err := container.MappedPort(ctx, nat.Port(nginxDefaultPort))
 			// }
 			if err != nil {
 				t.Fatalf("could not get mapped port: %v", err)


### PR DESCRIPTION
See #1985  
MappedPort takes a nat.Port as an argument but it got a string value instead.

<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
Converted the port variable to a nat.Port type, so that it can be used with MappedPort
<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
The documenation on https://golang.testcontainers.org/features/networking/ is wrong. And it takes the snippet from this code line. 

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Related issues
#1985

Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #1985

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
