### PR TITLE
feat: expose Redpanda's listener in the docker network

### DIFF
--- a/docs/modules/redpanda.md
+++ b/docs/modules/redpanda.md
@@ -51,6 +51,26 @@ for Redpanda. E.g. `testcontainers.WithImage("docker.redpanda.com/redpandadata/r
 
 If you need to enable TLS use `WithTLS` with a valid PEM encoded certificate and key.
 
+#### Additional Listener
+
+There are scenarios where additional listeners are needed, for example if you
+want to consume/from another container in the same network
+
+You can use the `WithListener` option to add a listener to the Redpanda container.
+<!--codeinclude-->
+[Register additional listener](../../modules/redpanda/redpanda_test.go) inside_block:withListenerRP
+<!--/codeinclude-->
+
+Container defined in the same network
+<!--codeinclude-->
+[Start Kcat container](../../modules/redpanda/redpanda_test.go) inside_block:withListenerKcat
+<!--/codeinclude-->
+
+Produce messages using the new registered listener
+<!--codeinclude-->
+[Produce/consume via registered listener](../../modules/redpanda/redpanda_test.go) inside_block:withListenerExec
+<!--/codeinclude-->
+
 ### Container Methods
 
 The Redpanda container exposes the following methods:

--- a/modules/redpanda/mounts/redpanda.yaml.tpl
+++ b/modules/redpanda/mounts/redpanda.yaml.tpl
@@ -19,6 +19,13 @@ redpanda:
       port: 9093
       authentication_method: {{ if .KafkaAPI.EnableAuthorization }}sasl{{ else }}none{{ end }}
 
+  {{ range .KafkaAPI.Listeners }}
+    - address: 0.0.0.0
+      name: {{ .Address }}
+      port: {{ .Port }}
+      authentication_method: {{ .AuthenticationMethod }}
+  {{ end }}
+
   advertised_kafka_api:
     - address: {{ .KafkaAPI.AdvertisedHost }}
       name: external
@@ -26,6 +33,12 @@ redpanda:
     - address: 127.0.0.1
       name: internal
       port: 9093
+ {{ range .KafkaAPI.Listeners }} 
+    - address: {{ .Address }}
+      name: {{ .Address }}
+      port: {{ .Port }}
+  {{ end }} 
+  
 
 {{ if .EnableTLS }}
   admin_api_tls:

--- a/modules/redpanda/redpanda_test.go
+++ b/modules/redpanda/redpanda_test.go
@@ -13,12 +13,13 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/testcontainers/testcontainers-go"
-	"github.com/testcontainers/testcontainers-go/network"
 	"github.com/twmb/franz-go/pkg/kadm"
 	"github.com/twmb/franz-go/pkg/kerr"
 	"github.com/twmb/franz-go/pkg/kgo"
 	"github.com/twmb/franz-go/pkg/sasl/scram"
+
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/network"
 )
 
 func TestRedpanda(t *testing.T) {
@@ -362,7 +363,7 @@ func TestRedpandaListener_InvalidPort(t *testing.T) {
 	RPNetwork, err := network.New(ctx, network.WithCheckDuplicate())
 	require.NoError(t, err)
 
-	// 2. Attemp Start Redpanda container
+	// 2. Attempt Start Redpanda container
 	_, err = RunContainer(ctx,
 		testcontainers.WithImage("redpandadata/redpanda:v23.2.18"),
 		WithListener("redpanda:99092"),
@@ -383,7 +384,7 @@ func TestRedpandaListener_InvalidPort(t *testing.T) {
 func TestRedpandaListener_NoNetwork(t *testing.T) {
 	ctx := context.Background()
 
-	// 1. Attemp Start Redpanda container
+	// 1. Attempt Start Redpanda container
 	_, err := RunContainer(ctx,
 		testcontainers.WithImage("redpandadata/redpanda:v23.2.18"),
 		WithListener("redpanda:99092"),

--- a/modules/redpanda/redpanda_test.go
+++ b/modules/redpanda/redpanda_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
+	"io"
 	"net/http"
 	"strings"
 	"testing"
@@ -12,6 +13,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/network"
 	"github.com/twmb/franz-go/pkg/kadm"
 	"github.com/twmb/franz-go/pkg/kerr"
 	"github.com/twmb/franz-go/pkg/kgo"
@@ -276,6 +279,112 @@ func TestRedpandaWithTLS(t *testing.T) {
 	// Test produce to unknown topic
 	results := kafkaCl.ProduceSync(ctx, &kgo.Record{Topic: "test", Value: []byte("test message")})
 	require.Error(t, results.FirstErr(), kerr.UnknownTopicOrPartition)
+}
+
+func TestRedpandaListener_Simple(t *testing.T) {
+	ctx := context.Background()
+	// 1. Create network
+	rpNetwork, err := network.New(ctx, network.WithCheckDuplicate())
+	require.NoError(t, err)
+
+	// 2. Start Redpanda container
+	container, err := RunContainer(ctx,
+		testcontainers.WithImage("redpandadata/redpanda:v23.2.18"),
+		network.WithNetwork([]string{"redpanda-host"}, rpNetwork),
+		WithListener("redpanda:29092"), WithAutoCreateTopics(),
+	)
+	require.NoError(t, err)
+
+	// 3. Start KCat container
+	kcat, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
+		ContainerRequest: testcontainers.ContainerRequest{
+			Image: "confluentinc/cp-kcat:7.4.1",
+			Networks: []string{
+				rpNetwork.Name,
+			},
+			Entrypoint: []string{
+				"sh",
+			},
+			Cmd: []string{
+				"-c",
+				"tail -f /dev/null",
+			},
+		},
+		Started: true,
+	})
+
+	require.NoError(t, err)
+
+	// 4. Copy message to kcat
+	err = kcat.CopyToContainer(ctx, []byte("Message produced by kcat"), "/tmp/msgs.txt", 700)
+	require.NoError(t, err)
+
+	// 5. Produce mesaage to Redpanda
+	_, _, err = kcat.Exec(ctx, []string{"kcat", "-b", "redpanda:29092", "-t", "msgs", "-P", "-l", "/tmp/msgs.txt"})
+
+	require.NoError(t, err)
+
+	// 6. Consume message from Redpanda
+	_, stdout, err := kcat.Exec(ctx, []string{"kcat", "-b", "redpanda:29092", "-C", "-t", "msgs", "-c", "1"})
+	require.NoError(t, err)
+
+	// 7. Read Message from stdout
+	out, err := io.ReadAll(stdout)
+	require.NoError(t, err)
+
+	require.Contains(t, string(out), "Message produced by kcat")
+
+	t.Cleanup(func() {
+		if err := kcat.Terminate(ctx); err != nil {
+			t.Fatalf("failed to terminate kcat container: %s", err)
+		}
+		if err := container.Terminate(ctx); err != nil {
+			t.Fatalf("failed to terminate redpanda container: %s", err)
+		}
+
+		if err := rpNetwork.Remove(ctx); err != nil {
+			t.Fatalf("failed to remove network: %s", err)
+		}
+	})
+}
+
+func TestRedpandaListener_InvalidPort(t *testing.T) {
+	ctx := context.Background()
+
+	// 1. Create network
+	RPNetwork, err := network.New(ctx, network.WithCheckDuplicate())
+	require.NoError(t, err)
+
+	// 2. Attemp Start Redpanda container
+	_, err = RunContainer(ctx,
+		testcontainers.WithImage("redpandadata/redpanda:v23.2.18"),
+		WithListener("redpanda:99092"),
+		network.WithNetwork([]string{"redpanda-host"}, RPNetwork),
+	)
+
+	require.Error(t, err)
+
+	require.Contains(t, err.Error(), "invalid port on listener redpanda:99092")
+
+	t.Cleanup(func() {
+		if err := RPNetwork.Remove(ctx); err != nil {
+			t.Fatalf("failed to remove network: %s", err)
+		}
+	})
+}
+
+func TestRedpandaListener_NoNetwork(t *testing.T) {
+	ctx := context.Background()
+
+	// 1. Attemp Start Redpanda container
+	_, err := RunContainer(ctx,
+		testcontainers.WithImage("redpandadata/redpanda:v23.2.18"),
+		WithListener("redpanda:99092"),
+	)
+
+	require.Error(t, err)
+
+	require.Contains(t, err.Error(), "container must be attached to at least one network")
 }
 
 // localhostCert is a PEM-encoded TLS cert with SAN IPs

--- a/modules/redpanda/redpanda_test.go
+++ b/modules/redpanda/redpanda_test.go
@@ -283,19 +283,23 @@ func TestRedpandaWithTLS(t *testing.T) {
 
 func TestRedpandaListener_Simple(t *testing.T) {
 	ctx := context.Background()
+
 	// 1. Create network
 	rpNetwork, err := network.New(ctx, network.WithCheckDuplicate())
 	require.NoError(t, err)
 
 	// 2. Start Redpanda container
+	// withListenerRP {
 	container, err := RunContainer(ctx,
 		testcontainers.WithImage("redpandadata/redpanda:v23.2.18"),
 		network.WithNetwork([]string{"redpanda-host"}, rpNetwork),
 		WithListener("redpanda:29092"), WithAutoCreateTopics(),
 	)
+	// }
 	require.NoError(t, err)
 
 	// 3. Start KCat container
+	// withListenerKcat {
 	kcat, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
 		ContainerRequest: testcontainers.ContainerRequest{
 			Image: "confluentinc/cp-kcat:7.4.1",
@@ -312,6 +316,7 @@ func TestRedpandaListener_Simple(t *testing.T) {
 		},
 		Started: true,
 	})
+	// }
 
 	require.NoError(t, err)
 
@@ -319,8 +324,10 @@ func TestRedpandaListener_Simple(t *testing.T) {
 	err = kcat.CopyToContainer(ctx, []byte("Message produced by kcat"), "/tmp/msgs.txt", 700)
 	require.NoError(t, err)
 
-	// 5. Produce mesaage to Redpanda
+	// 5. Produce message to Redpanda
+	// withListenerExec {
 	_, _, err = kcat.Exec(ctx, []string{"kcat", "-b", "redpanda:29092", "-t", "msgs", "-P", "-l", "/tmp/msgs.txt"})
+	// }
 
 	require.NoError(t, err)
 


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->
Add a new `WithListener` function to allow adding new listeners to the advertised listeners so connection within the docker networks is possible

## What does this PR do? 

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->
- Added a method to add new listener to the containers
- Validate the listener
- Iterate over the networks and add the new listeners as alias so it can be easily accessible.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

Currently there is no way to access the Kafka Api from another container in the same docker network, at least not an obvious one, so as [Redpanda docs suggests](https://docs.redpanda.com/current/manage/security/listener-configuration/#advertise-a-listener) adding an extra advertise listener allows access to the Kafka endpoint from within the docker network so it can be consume from another test-container. 
## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- 

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
