### PR TITLE
Add neo4j license agreement customization options

### DIFF
--- a/modules/neo4j/config.go
+++ b/modules/neo4j/config.go
@@ -115,3 +115,24 @@ func formatNeo4jConfig(name string) string {
 	result = strings.ReplaceAll(result, ".", "_")
 	return fmt.Sprintf("NEO4J_%s", result)
 }
+
+// WithAcceptCommercialLicenseAgreement sets the environment variable
+// NEO4J_ACCEPT_LICENSE_AGREEMENT to "yes", indicating that the user accepts
+// the commercial licence agreement of Neo4j Enterprise Edition. The license
+// agreement is available at https://neo4j.com/terms/licensing/.
+func WithAcceptCommercialLicenseAgreement() testcontainers.CustomizeRequestOption {
+	return func(req *testcontainers.GenericContainerRequest) {
+		req.Env["NEO4J_ACCEPT_LICENSE_AGREEMENT"] = "yes"
+	}
+}
+
+// WithAcceptEvaluationLicenseAgreement sets the environment variable
+// NEO4J_ACCEPT_LICENSE_AGREEMENT to "eval", indicating that the user accepts
+// the evaluation agreement of Neo4j Enterprise Edition. The evaluation
+// agreement is available at https://neo4j.com/terms/enterprise_us/. Please
+// read the terms of the evaluation agreement before you accept.
+func WithAcceptEvaluationLicenseAgreement() testcontainers.CustomizeRequestOption {
+	return func(req *testcontainers.GenericContainerRequest) {
+		req.Env["NEO4J_ACCEPT_LICENSE_AGREEMENT"] = "eval"
+	}
+}


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?

This PR adds the ability to use the Neo4j Enterprise Edition docker image by setting the correct environment variable.

## Why is it important?

Many production-ready users of Neo4j use the Enterprise edition. Some features can only be tested on the Enterprise edition.

## Related issues

I haven't opened a concomitant Issue, @mdelapenya let me know if I should open one.

## How to test this PR

Simply run a container with image tag `enterprise` (i.e. `neo4j:enterprise`) with the new option and see that the container does not crash immediately with the following error:

<details><summary>Details</summary>
<p>

```text
In order to use Neo4j Enterprise Edition you must accept the license agreement.
  
  The license agreement is available at https://neo4j.com/terms/licensing/
  If you have a support contract the following terms apply https://neo4j.com/terms/support-terms/
  
  If you do not have a commercial license and want to evaluate the Software
  please read the terms of the evaluation agreement before you accept.
  https://neo4j.com/terms/enterprise_us/
  
  (c) Neo4j Sweden AB. All Rights Reserved.
  Use of this Software without a proper commercial license, or evaluation license
  with Neo4j, Inc. or its affiliates is prohibited.
  Neo4j has the right to terminate your usage if you are not compliant.
  
  More information is also available at: https://neo4j.com/licensing/
  If you have further inquiries about licensing, please contact us via https://neo4j.com/contact-us/
  
  To accept the commercial license agreement set the environment variable
  NEO4J_ACCEPT_LICENSE_AGREEMENT=yes
  
  To accept the terms of the evaluation agreement set the environment variable
  NEO4J_ACCEPT_LICENSE_AGREEMENT=eval
  
  To do this you can use the following docker argument:
  
          --env=NEO4J_ACCEPT_LICENSE_AGREEMENT=<yes|eval>
```

</p>
</details> 
