### PR TITLE
feat: support configuring Ryuk verbose mode at config level

### DIFF
--- a/docs/features/configuration.md
+++ b/docs/features/configuration.md
@@ -52,7 +52,7 @@ but does not allow starting privileged containers, you can turn off the Ryuk con
 `TESTCONTAINERS_RYUK_DISABLED` **environment variable** to `true`.
 1. You can specify the connection timeout for Ryuk by setting the `ryuk.connection.timeout` **property**. The default value is 1 minute.
 1. You can specify the reconnection timeout for Ryuk by setting the `ryuk.reconnection.timeout` **property**. The default value is 10 seconds.
-
+1. You can configure Ryuk to run in verbose mode by setting any of the `ryuk.verbose` **property** or the `TESTCONTAINERS_RYUK_VERBOSE` **environment variable**. The default value is `false`.
 
 !!!info
     For more information about Ryuk, see [Garbage Collector](garbage_collector.md).

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -29,6 +29,7 @@ type Config struct {
 	RyukPrivileged          bool          `properties:"ryuk.container.privileged,default=false"`
 	RyukReconnectionTimeout time.Duration `properties:"ryuk.reconnection.timeout,default=10s"`
 	RyukConnectionTimeout   time.Duration `properties:"ryuk.connection.timeout,default=1m"`
+	RyukVerbose             bool          `properties:"ryuk.verbose,default=false"`
 	TestcontainersHost      string        `properties:"tc.host,default="`
 }
 
@@ -78,6 +79,11 @@ func read() Config {
 		ryukPrivilegedEnv := os.Getenv("TESTCONTAINERS_RYUK_CONTAINER_PRIVILEGED")
 		if parseBool(ryukPrivilegedEnv) {
 			config.RyukPrivileged = ryukPrivilegedEnv == "true"
+		}
+
+		ryukVerboseEnv := os.Getenv("TESTCONTAINERS_RYUK_VERBOSE")
+		if parseBool(ryukVerboseEnv) {
+			config.RyukVerbose = ryukVerboseEnv == "true"
 		}
 
 		return config

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -22,6 +22,7 @@ func resetTestEnv(t *testing.T) {
 	t.Setenv("TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX", "")
 	t.Setenv("TESTCONTAINERS_RYUK_DISABLED", "")
 	t.Setenv("TESTCONTAINERS_RYUK_CONTAINER_PRIVILEGED", "")
+	t.Setenv("TESTCONTAINERS_RYUK_VERBOSE", "")
 }
 
 func TestReadConfig(t *testing.T) {
@@ -117,12 +118,14 @@ func TestReadTCConfig(t *testing.T) {
 		t.Setenv("TESTCONTAINERS_RYUK_DISABLED", "true")
 		t.Setenv("TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX", defaultHubPrefix)
 		t.Setenv("TESTCONTAINERS_RYUK_CONTAINER_PRIVILEGED", "true")
+		t.Setenv("TESTCONTAINERS_RYUK_VERBOSE", "true")
 
 		config := read()
 		expected := Config{
 			HubImageNamePrefix: defaultHubPrefix,
 			RyukDisabled:       true,
 			RyukPrivileged:     true,
+			RyukVerbose:        true,
 		}
 
 		assert.Equal(t, expected, config)
@@ -261,6 +264,16 @@ func TestReadTCConfig(t *testing.T) {
 				},
 			},
 			{
+				"With Ryuk verbose configured using properties",
+				`ryuk.verbose=true`,
+				map[string]string{},
+				Config{
+					RyukVerbose:             true,
+					RyukConnectionTimeout:   defaultRyukConnectionTimeout,
+					RyukReconnectionTimeout: defaultRyukReonnectionTimeout,
+				},
+			},
+			{
 				"With Ryuk disabled using an env var",
 				``,
 				map[string]string{
@@ -321,6 +334,46 @@ func TestReadTCConfig(t *testing.T) {
 				`ryuk.disabled=false`,
 				map[string]string{
 					"TESTCONTAINERS_RYUK_DISABLED": "false",
+				},
+				defaultConfig,
+			},
+			{
+				"With Ryuk verbose using an env var and properties. Env var wins (0)",
+				`ryuk.verbose=true`,
+				map[string]string{
+					"TESTCONTAINERS_RYUK_VERBOSE": "true",
+				},
+				Config{
+					RyukVerbose:             true,
+					RyukConnectionTimeout:   defaultRyukConnectionTimeout,
+					RyukReconnectionTimeout: defaultRyukReonnectionTimeout,
+				},
+			},
+			{
+				"With Ryuk verbose using an env var and properties. Env var wins (1)",
+				`ryuk.verbose=false`,
+				map[string]string{
+					"TESTCONTAINERS_RYUK_VERBOSE": "true",
+				},
+				Config{
+					RyukVerbose:             true,
+					RyukConnectionTimeout:   defaultRyukConnectionTimeout,
+					RyukReconnectionTimeout: defaultRyukReonnectionTimeout,
+				},
+			},
+			{
+				"With Ryuk verbose using an env var and properties. Env var wins (2)",
+				`ryuk.verbose=true`,
+				map[string]string{
+					"TESTCONTAINERS_RYUK_VERBOSE": "false",
+				},
+				defaultConfig,
+			},
+			{
+				"With Ryuk verbose using an env var and properties. Env var wins (3)",
+				`ryuk.verbose=false`,
+				map[string]string{
+					"TESTCONTAINERS_RYUK_VERBOSE": "false",
 				},
 				defaultConfig,
 			},

--- a/reaper.go
+++ b/reaper.go
@@ -236,6 +236,9 @@ func newReaper(ctx context.Context, sessionID string, provider ReaperProvider) (
 	if to := tcConfig.RyukReconnectionTimeout; to > time.Duration(0) {
 		req.Env["RYUK_RECONNECTION_TIMEOUT"] = to.String()
 	}
+	if tcConfig.RyukVerbose {
+		req.Env["RYUK_VERBOSE"] = "true"
+	}
 
 	// include reaper-specific labels to the reaper container
 	req.Labels[testcontainersdocker.LabelReaper] = "true"

--- a/reaper_test.go
+++ b/reaper_test.go
@@ -355,6 +355,19 @@ func Test_NewReaper(t *testing.T) {
 			}},
 		},
 		{
+			name: "configured verbose mode",
+			req: createContainerRequest(func(req ContainerRequest) ContainerRequest {
+				req.Env = map[string]string{
+					"RYUK_VERBOSE": "true",
+				}
+				return req
+			}),
+			config: TestcontainersConfig{Config: config.Config{
+				RyukPrivileged: true,
+				RyukVerbose:    true,
+			}},
+		},
+		{
 			name: "docker-host in context",
 			req: createContainerRequest(func(req ContainerRequest) ContainerRequest {
 				req.HostConfigModifier = func(hostConfig *container.HostConfig) {


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
It adds `ryuk.verbose` property to the Testcontainers property file to enable running Ryuk in verbose mode (see https://github.com/testcontainers/moby-ryuk/?tab=readme-ov-file#ryuk-configuration). It can be set there, or using the `TESTCONTAINERS_RYUK_VERBOSE=true` env var.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
There are situations where we need to debug Ryuk, like being terminated too early. With this change, we will be able to tell Ryuk to run in verbose mode from testcontainers-go.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- See https://github.com/testcontainers/moby-ryuk/pull/71

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
