### PR TITLE
chore: lookup exposed ports in the image from Config, not from ContainerConfig

### DIFF
--- a/lifecycle.go
+++ b/lifecycle.go
@@ -333,6 +333,10 @@ func (p *DockerProvider) preCreateContainerHook(ctx context.Context, req Contain
 		for p := range image.ContainerConfig.ExposedPorts {
 			exposedPorts = append(exposedPorts, string(p))
 		}
+		// also check the image config, as the container config will be deprecated in the future
+		for p := range image.Config.ExposedPorts {
+			exposedPorts = append(exposedPorts, string(p))
+		}
 	}
 
 	exposedPortSet, exposedPortMap, err := nat.ParsePortSpecs(exposedPorts)

--- a/lifecycle.go
+++ b/lifecycle.go
@@ -330,10 +330,6 @@ func (p *DockerProvider) preCreateContainerHook(ctx context.Context, req Contain
 		if err != nil {
 			return err
 		}
-		for p := range image.ContainerConfig.ExposedPorts {
-			exposedPorts = append(exposedPorts, string(p))
-		}
-		// also check the image config, as the container config will be deprecated in the future
 		for p := range image.Config.ExposedPorts {
 			exposedPorts = append(exposedPorts, string(p))
 		}


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
This PR uses the Docker type `image.Config` to the lookup of the exposed ports from the underlying image. 


<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
If there are no exposed ports in the container request, the code  previously checked the Docker type `image.ContainerConfig`. There are recent errors in the GH actions regarding this: exposed ports being moved from `image.ContainerConfig` to `image.Config`, because it has been deprecated and depending on how the images were built it could be the case that the `ContainerConfig` field comes empty (e.g. images built with buildkit).

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Relates to https://github.com/moby/moby/pull/46939

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
