### PR TITLE
adds gotestsum to install tools

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 include ./commons-test.mk
 
 .PHONY: test-all
-test-all: tools test-unit
+test-all: tools test-tools test-unit
 
 .PHONY: test-examples
 test-examples:

--- a/commons-test.mk
+++ b/commons-test.mk
@@ -25,6 +25,10 @@ test-%:
 tools:
 	go mod download
 
+.PHONY: test-tools
+test-tools:
+	go install gotest.tools/gotestsum@latest
+
 .PHONY: tools-tidy
 tools-tidy:
 	go mod tidy


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?

Adds installation for `gotestsum` as required by make target

## Why is it important?
Minor change to help new contributors contribute

1. checkout this PR
2. set your `GOPATH` envvar to a new directory
3. run `make test-all` or `make test-tools`

