### PR TITLE
fix: remove docker.io from Ryuk image name

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -11,7 +11,7 @@ import (
 	"github.com/magiconair/properties"
 )
 
-const ReaperDefaultImage = "docker.io/testcontainers/ryuk:0.6.0"
+const ReaperDefaultImage = "testcontainers/ryuk:0.6.0"
 
 var (
 	tcConfig     Config


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
It removes the `docker.io/` prefix from the default Ryuk image, to adhere to the docs in https://golang.testcontainers.org/features/image_name_substitution/#automatically-modifying-docker-hub-image-names

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
It will make Ryuk configurable with the `TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX` env var or the `hub.image.name.prefix` property,
allowing developers to put Ryuk on their own registries if/when needed.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes #2045
- Closes #2044
- Caused by https://github.com/testcontainers/testcontainers-go/pull/1928

## How to test this PR

Update the `~/.testcontainers.properties` with:

```properties
hub.image.name.prefix=registry.mycompany.com/mirror
```

Then run a test in the project: because the prefix points to a non-existent registry, the test will fail because Ryuk cannot be found,
meaning that the prefix was applied to Ryuk.

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
