### PR TITLE
chore: do not read config but instead pass the hub prefix to the prependHub modifier

### DIFF
--- a/docker.go
+++ b/docker.go
@@ -899,7 +899,7 @@ func (p *DockerProvider) CreateContainer(ctx context.Context, req ContainerReque
 	}
 
 	// always append the hub substitutor after the user-defined ones
-	req.ImageSubstitutors = append(req.ImageSubstitutors, newPrependHubRegistry())
+	req.ImageSubstitutors = append(req.ImageSubstitutors, newPrependHubRegistry(tcConfig.HubImageNamePrefix))
 
 	for _, is := range req.ImageSubstitutors {
 		modifiedTag, err := is.Substitute(imageName)

--- a/image_substitutors_test.go
+++ b/image_substitutors_test.go
@@ -2,21 +2,12 @@ package testcontainers
 
 import (
 	"testing"
-
-	"github.com/testcontainers/testcontainers-go/internal/config"
 )
 
 func TestPrependHubRegistrySubstitutor(t *testing.T) {
-	resetConfigForTests := func() {
-		config.Reset()
-	}
-
 	t.Run("should prepend the hub registry to images from Docker Hub", func(t *testing.T) {
 		t.Run("plain image", func(t *testing.T) {
-			t.Setenv("TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX", "my-registry")
-			defer resetConfigForTests()
-
-			s := newPrependHubRegistry()
+			s := newPrependHubRegistry("my-registry")
 
 			img, err := s.Substitute("foo:latest")
 			if err != nil {
@@ -28,10 +19,7 @@ func TestPrependHubRegistrySubstitutor(t *testing.T) {
 			}
 		})
 		t.Run("image with user", func(t *testing.T) {
-			t.Setenv("TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX", "my-registry")
-			defer resetConfigForTests()
-
-			s := newPrependHubRegistry()
+			s := newPrependHubRegistry("my-registry")
 
 			img, err := s.Substitute("user/foo:latest")
 			if err != nil {
@@ -44,10 +32,7 @@ func TestPrependHubRegistrySubstitutor(t *testing.T) {
 		})
 
 		t.Run("image with organization and user", func(t *testing.T) {
-			t.Setenv("TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX", "my-registry")
-			defer resetConfigForTests()
-
-			s := newPrependHubRegistry()
+			s := newPrependHubRegistry("my-registry")
 
 			img, err := s.Substitute("org/user/foo:latest")
 			if err != nil {
@@ -62,10 +47,7 @@ func TestPrependHubRegistrySubstitutor(t *testing.T) {
 
 	t.Run("should not prepend the hub registry to the image name", func(t *testing.T) {
 		t.Run("non-hub image", func(t *testing.T) {
-			t.Setenv("TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX", "my-registry")
-			defer resetConfigForTests()
-
-			s := newPrependHubRegistry()
+			s := newPrependHubRegistry("my-registry")
 
 			img, err := s.Substitute("quay.io/foo:latest")
 			if err != nil {
@@ -78,10 +60,7 @@ func TestPrependHubRegistrySubstitutor(t *testing.T) {
 		})
 
 		t.Run("explicitly including docker.io", func(t *testing.T) {
-			t.Setenv("TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX", "my-registry")
-			defer resetConfigForTests()
-
-			s := newPrependHubRegistry()
+			s := newPrependHubRegistry("my-registry")
 
 			img, err := s.Substitute("docker.io/foo:latest")
 			if err != nil {
@@ -94,10 +73,7 @@ func TestPrependHubRegistrySubstitutor(t *testing.T) {
 		})
 
 		t.Run("explicitly including registry.hub.docker.com", func(t *testing.T) {
-			t.Setenv("TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX", "my-registry")
-			defer resetConfigForTests()
-
-			s := newPrependHubRegistry()
+			s := newPrependHubRegistry("my-registry")
 
 			img, err := s.Substitute("registry.hub.docker.com/foo:latest")
 			if err != nil {

--- a/options.go
+++ b/options.go
@@ -10,7 +10,6 @@ import (
 	"github.com/docker/docker/api/types/network"
 
 	tcexec "github.com/testcontainers/testcontainers-go/exec"
-	"github.com/testcontainers/testcontainers-go/internal/config"
 	"github.com/testcontainers/testcontainers-go/internal/testcontainersdocker"
 	"github.com/testcontainers/testcontainers-go/wait"
 )
@@ -86,9 +85,7 @@ type prependHubRegistry struct {
 }
 
 // newPrependHubRegistry creates a new prependHubRegistry
-func newPrependHubRegistry() prependHubRegistry {
-	hubPrefix := config.Read().HubImageNamePrefix
-
+func newPrependHubRegistry(hubPrefix string) prependHubRegistry {
 	return prependHubRegistry{
 		prefix: hubPrefix,
 	}


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
It removes the need to read the config from the prependHubRegistry image substitutor, and instead receives the prefix from the conf.
<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
It makes the tests not depend on the singleton config, but instead in the prefix to be used. As a consequence, the unit tests are not flaky anymore.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Caused by #1928

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
