### PR TITLE
feat: copy files to the container and create directories as needed upon request

### DIFF
--- a/docker.go
+++ b/docker.go
@@ -603,7 +603,7 @@ func (c *DockerContainer) CopyToContainer(ctx context.Context, fileContent []byt
 		return err
 	}
 
-	err = c.provider.client.CopyToContainer(ctx, c.ID, filepath.Dir(containerFilePath), buffer, types.CopyToContainerOptions{})
+	err = c.provider.client.CopyToContainer(ctx, c.ID, "/", buffer, types.CopyToContainerOptions{})
 	if err != nil {
 		return err
 	}

--- a/docker_test.go
+++ b/docker_test.go
@@ -1351,7 +1351,6 @@ func TestDockerContainerCopyFileToContainer(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-
 			nginxC, err := GenericContainer(ctx, GenericContainerRequest{
 				ProviderType: providerType,
 				ContainerRequest: ContainerRequest{

--- a/docker_test.go
+++ b/docker_test.go
@@ -1335,27 +1335,45 @@ func readHostname(tb testing.TB, containerId string) string {
 func TestDockerContainerCopyFileToContainer(t *testing.T) {
 	ctx := context.Background()
 
-	nginxC, err := GenericContainer(ctx, GenericContainerRequest{
-		ProviderType: providerType,
-		ContainerRequest: ContainerRequest{
-			Image:        nginxImage,
-			ExposedPorts: []string{nginxDefaultPort},
-			WaitingFor:   wait.ForListeningPort(nginxDefaultPort),
+	tests := []struct {
+		name           string
+		copiedFileName string
+	}{
+		{
+			name:           "success copy",
+			copiedFileName: "/hello_copy.sh",
 		},
-		Started: true,
-	})
-
-	require.NoError(t, err)
-	terminateContainerOnEnd(t, ctx, nginxC)
-
-	copiedFileName := "hello_copy.sh"
-	_ = nginxC.CopyFileToContainer(ctx, filepath.Join(".", "testdata", "hello.sh"), "/"+copiedFileName, 700)
-	c, _, err := nginxC.Exec(ctx, []string{"bash", copiedFileName})
-	if err != nil {
-		t.Fatal(err)
+		{
+			name:           "success copy with dir",
+			copiedFileName: "/test/hello_copy.sh",
+		},
 	}
-	if c != 0 {
-		t.Fatalf("File %s should exist, expected return code 0, got %v", copiedFileName, c)
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+
+			nginxC, err := GenericContainer(ctx, GenericContainerRequest{
+				ProviderType: providerType,
+				ContainerRequest: ContainerRequest{
+					Image:        nginxImage,
+					ExposedPorts: []string{nginxDefaultPort},
+					WaitingFor:   wait.ForListeningPort(nginxDefaultPort),
+				},
+				Started: true,
+			})
+
+			require.NoError(t, err)
+			terminateContainerOnEnd(t, ctx, nginxC)
+
+			_ = nginxC.CopyFileToContainer(ctx, filepath.Join(".", "testdata", "hello.sh"), tc.copiedFileName, 700)
+			c, _, err := nginxC.Exec(ctx, []string{"bash", tc.copiedFileName})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if c != 0 {
+				t.Fatalf("File %s should exist, expected return code 0, got %v", tc.copiedFileName, c)
+			}
+		})
 	}
 }
 
@@ -1532,32 +1550,51 @@ func TestDockerCreateContainerWithDirs(t *testing.T) {
 func TestDockerContainerCopyToContainer(t *testing.T) {
 	ctx := context.Background()
 
-	nginxC, err := GenericContainer(ctx, GenericContainerRequest{
-		ProviderType: providerType,
-		ContainerRequest: ContainerRequest{
-			Image:        nginxImage,
-			ExposedPorts: []string{nginxDefaultPort},
-			WaitingFor:   wait.ForListeningPort(nginxDefaultPort),
+	tests := []struct {
+		name           string
+		copiedFileName string
+	}{
+		{
+			name:           "success copy",
+			copiedFileName: "hello_copy.sh",
 		},
-		Started: true,
-	})
-
-	require.NoError(t, err)
-	terminateContainerOnEnd(t, ctx, nginxC)
-
-	copiedFileName := "hello_copy.sh"
-
-	fileContent, err := os.ReadFile(filepath.Join(".", "testdata", "hello.sh"))
-	if err != nil {
-		t.Fatal(err)
+		{
+			name:           "success copy with dir",
+			copiedFileName: "/test/hello_copy.sh",
+		},
 	}
-	_ = nginxC.CopyToContainer(ctx, fileContent, "/"+copiedFileName, 700)
-	c, _, err := nginxC.Exec(ctx, []string{"bash", copiedFileName})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if c != 0 {
-		t.Fatalf("File %s should exist, expected return code 0, got %v", copiedFileName, c)
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			nginxC, err := GenericContainer(ctx, GenericContainerRequest{
+				ProviderType: providerType,
+				ContainerRequest: ContainerRequest{
+					Image:        nginxImage,
+					ExposedPorts: []string{nginxDefaultPort},
+					WaitingFor:   wait.ForListeningPort(nginxDefaultPort),
+				},
+				Started: true,
+			})
+
+			require.NoError(t, err)
+			terminateContainerOnEnd(t, ctx, nginxC)
+
+			fileContent, err := os.ReadFile(filepath.Join(".", "testdata", "hello.sh"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			err = nginxC.CopyToContainer(ctx, fileContent, tc.copiedFileName, 700)
+			if err != nil {
+				t.Fatal(err)
+			}
+			c, _, err := nginxC.Exec(ctx, []string{"bash", tc.copiedFileName})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if c != 0 {
+				t.Fatalf("File %s should exist, expected return code 0, got %v", tc.copiedFileName, c)
+			}
+		})
 	}
 }
 

--- a/file.go
+++ b/file.go
@@ -117,7 +117,7 @@ func tarFile(fileContent []byte, basePath string, fileMode int64) (*bytes.Buffer
 	tw := tar.NewWriter(zr)
 
 	hdr := &tar.Header{
-		Name: filepath.Base(basePath),
+		Name: basePath,
 		Mode: fileMode,
 		Size: int64(len(fileContent)),
 	}


### PR DESCRIPTION
## What does this PR do?

It adds the ability to create directories as needed upon request when a copy file request has a directory that doesn't exist, similar to how the Testcontainers Java implementation behaves.

## Why is it important?

Because, in many containers, to customize or import something, you may need a directory that doesn't exist in the image.

## Related issues

- Closes #1336
