### PR TITLE
fix(modules/rabbitmq): update container image to 3.12.11 to allow connections without passing admin credentials

### DIFF
--- a/modules/rabbitmq/examples_test.go
+++ b/modules/rabbitmq/examples_test.go
@@ -18,7 +18,7 @@ func ExampleRunContainer() {
 	ctx := context.Background()
 
 	rabbitmqContainer, err := rabbitmq.RunContainer(ctx,
-		testcontainers.WithImage("rabbitmq:3.7.25-management-alpine"),
+		testcontainers.WithImage("rabbitmq:3.12.11-management-alpine"),
 		rabbitmq.WithAdminUsername("admin"),
 		rabbitmq.WithAdminPassword("password"),
 	)

--- a/modules/rabbitmq/rabbitmq.go
+++ b/modules/rabbitmq/rabbitmq.go
@@ -69,7 +69,7 @@ func (c *RabbitMQContainer) HttpsURL(ctx context.Context) (string, error) {
 // RunContainer creates an instance of the RabbitMQ container type
 func RunContainer(ctx context.Context, opts ...testcontainers.ContainerCustomizer) (*RabbitMQContainer, error) {
 	req := testcontainers.ContainerRequest{
-		Image: "rabbitmq:3.7.25-management-alpine",
+		Image: "rabbitmq:3.12.11-management-alpine",
 		Env: map[string]string{
 			"RABBITMQ_DEFAULT_USER": defaultUser,
 			"RABBITMQ_DEFAULT_PASS": defaultPassword,


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->
Updates rabbitmq image to `3.12.11-management-alpine`.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

The RabbitMQ module was broken if used without passing in an admin username that is not guest and would fail with the error `user 'guest' can only connect via localhost` (see #1702). It appears this issue no longer happens on 3.12.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes #1702

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
