### PR TITLE
Adding LogConsumers and LogProducer start as part of the GenericRequest

### DIFF
--- a/container.go
+++ b/container.go
@@ -142,6 +142,8 @@ type ContainerRequest struct {
 	HostConfigModifier      func(*container.HostConfig)                // Modifier for the host config before container creation
 	EnpointSettingsModifier func(map[string]*network.EndpointSettings) // Modifier for the network settings before container creation
 	LifecycleHooks          []ContainerLifecycleHooks                  // define hooks to be executed during container lifecycle
+	LogProducer             bool                                       // enable the log producer
+	LogConsumers            []LogConsumer                              // define log consumers to follow the logs
 }
 
 // containerOptions functional options for a container

--- a/docker.go
+++ b/docker.go
@@ -1020,6 +1020,16 @@ func (p *DockerProvider) CreateContainer(ctx context.Context, req ContainerReque
 				},
 			},
 			PostStarts: []ContainerHook{
+				func(ctx context.Context, c Container) error {
+					for _, consumer := range req.LogConsumers {
+						c.FollowOutput(consumer)
+					}
+
+					if req.LogProducer {
+						return c.StartLogProducer(ctx)
+					}
+					return nil
+				},
 				// first post-start hook is to wait for the container to be ready
 				func(ctx context.Context, c Container) error {
 					dockerContainer := c.(*DockerContainer)


### PR DESCRIPTION
## What does this PR do?

This PR adds the posibility of configuring the LogProducer and the LogConsumers directly in the GenericRequest config of the container.

## Why is it important?

This provides better ergnomoics in the library giving a better understanding of the expected container behavior looking only at the container request, and also provides an easier way to initialize the logging process, without the need of calling the FollowLogs or StartLogProducer methods as separate calls after the creation of the container.

## Related issues

- Closes #525

## How to test this PR

I included a test for this in the code. But if you want to test it manually you need to create a new GenericRequest that contains the LogConsumers and LogProducer settings, and verify that the LogConsumers are behaving as expected, that means that the log are process since the beginning of the container execution.