### PR TITLE
GenericContainer: in case of error: return a reference to the failed container

### DIFF
--- a/generic.go
+++ b/generic.go
@@ -74,7 +74,8 @@ func GenericContainer(ctx context.Context, req GenericContainerRequest) (Contain
 		c, err = provider.CreateContainer(ctx, req.ContainerRequest)
 	}
 	if err != nil {
-		return nil, fmt.Errorf("%w: failed to create container", err)
+		// At this point `c` might not be nil. Give the caller an opportunity to call Destroy on the container.
+		return c, fmt.Errorf("%w: failed to create container", err)
 	}
 
 	if req.Started && !c.IsRunning() {


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
`GenericContainer` function: in case of error: return a reference to the failed container. This way, the caller has an opportunity to clean things up and call Destroy on the failed container.


## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->
If a `WaitStrategy` fails (timeouts for instance, context canceled, etc.), we may still want to return a reference to the running container so that the caller can Destroy() it and not leave half-healthy containers around.

