### PR TITLE
fix: Recreate Ryuk container if terminated

### DIFF
--- a/reaper.go
+++ b/reaper.go
@@ -145,10 +145,8 @@ func reuseOrCreateReaper(ctx context.Context, sessionID string, provider ReaperP
 			if !errdefs.IsNotFound(err) {
 				return nil, err
 			}
-		} else {
-			if state.Running {
-				return reaperInstance, nil
-			}
+		} else if state.Running {
+			return reaperInstance, nil
 		}
 		// else: the reaper instance has been terminated, so we need to create a new one
 		reaperOnce = sync.Once{}

--- a/reaper.go
+++ b/reaper.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"context"
 	"fmt"
-	"github.com/docker/docker/errdefs"
 	"math/rand"
 	"net"
 	"regexp"
@@ -16,6 +15,7 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/filters"
+	"github.com/docker/docker/errdefs"
 	"github.com/docker/go-connections/nat"
 
 	"github.com/testcontainers/testcontainers-go/internal/config"

--- a/reaper_test.go
+++ b/reaper_test.go
@@ -505,26 +505,26 @@ func Test_RecreateReaperIfTerminated(t *testing.T) {
 
 	provider, _ := ProviderDocker.GetProvider()
 	ctx := context.Background()
-	reaper, err := reuseOrCreateReaper(context.WithValue(ctx, testcontainersdocker.DockerHostContextKey, provider.(*DockerProvider).host), testSessionID, provider)
+	reaper, err := reuseOrCreateReaper(context.WithValue(ctx, core.DockerHostContextKey, provider.(*DockerProvider).host), testSessionID, provider)
 	assert.NoError(t, err, "creating the Reaper should not error")
 
 	terminate, err := reaper.Connect()
 	assert.NoError(t, err, "connecting to Reaper should be successful")
 	terminate <- true
 
-	// wait for reaper to timeout and terminate
+	// Wait for ryuk's default timeout (10s) + 1s to allow for a graceful shutdown/cleanup of the container.
 	time.Sleep(11 * time.Second)
 
-	recreatedRepear, err := reuseOrCreateReaper(context.WithValue(ctx, testcontainersdocker.DockerHostContextKey, provider.(*DockerProvider).host), testSessionID, provider)
+	recreatedReaper, err := reuseOrCreateReaper(context.WithValue(ctx, core.DockerHostContextKey, provider.(*DockerProvider).host), testSessionID, provider)
 	assert.NoError(t, err, "creating the Reaper should not error")
-	assert.NotEqual(t, reaper.container.GetContainerID(), recreatedRepear.container.GetContainerID(), "expected different container ID")
+	assert.NotEqual(t, reaper.container.GetContainerID(), recreatedReaper.container.GetContainerID(), "expected different container ID")
 
-	terminate, err = recreatedRepear.Connect()
+	terminate, err = recreatedReaper.Connect()
 	defer func(term chan bool) {
 		term <- true
 	}(terminate)
 	assert.NoError(t, err, "connecting to Reaper should be successful")
-	terminateContainerOnEnd(t, ctx, recreatedRepear.container)
+	terminateContainerOnEnd(t, ctx, recreatedReaper.container)
 }
 
 func TestReaper_reuseItFromOtherTestProgramUsingDocker(t *testing.T) {


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->
Fixes ryuk recreation such that a new container is spun up if the previous container has terminated and been removed. This involves checking for ErrNotFound during the Ryuk state check, triggering the creation of a new ryuk container if this error is returned.

It is essential to reset `reaperOnce`. Without resetting, no attempt to create a new reaper will be made.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->
* Test suites that exceed the ryuk timeout fail because a new container is not created.
* Relying on clients to extend timeout as a workaround adds unnecessary work for end users.

## Related issues

- Closes #1671 

## How to test this PR
Run test `Test_RecreateReaperIfTerminated` to validate changes.

Or run the following test suite with env variable `SLEEP=11s`. Without changes made in this PR `TestC` would fail, but with them all tests pass.
```go
package foo

import (
	"context"
	"os"
	"testing"
	"time"

	"github.com/testcontainers/testcontainers-go/modules/redpanda"
)

func TestA(t *testing.T) {
	ctx := context.Background()
	tc, err := redpanda.RunContainer(ctx)
	if err != nil {
		t.Fatal(err)
	}
	t.Cleanup(func() { tc.Terminate(ctx) })
}

func TestB(t *testing.T) {
	d := os.Getenv("SLEEP")
	if d == "" {
		return
	}
	dur, err := time.ParseDuration(d)
	if err != nil {
		t.Fatal(err)
	}
	time.Sleep(dur)
}

func TestC(t *testing.T) {
	ctx := context.Background()
	tc, err := redpanda.RunContainer(ctx)
	if err != nil {
		t.Fatal(err)
	}
	t.Cleanup(func() { tc.Terminate(ctx) })
}
```

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
