### PR TITLE
lint: enable testifylint

### DIFF
--- a/.github/workflows/ci-test-go.yml
+++ b/.github/workflows/ci-test-go.yml
@@ -75,7 +75,7 @@ jobs:
         uses: golangci/golangci-lint-action@3a919529898de77ec3da873e3063ca4b10e7f5cc # v3
         with:
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
-          version: v1.54.1
+          version: v1.55.2
           # Optional: working directory, useful for monorepos
           working-directory: ${{ inputs.project-directory }}
           # Optional: golangci-lint command line arguments.

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,6 +6,7 @@ linters:
     - gofumpt
     - misspell
     - nonamedreturns
+    - testifylint
 
 linters-settings:
   errorlint:
@@ -23,5 +24,20 @@ linters-settings:
       - standard
       - default
       - prefix(github.com/testcontainers)
+  testifylint:
+    disable:
+      - compares
+      - float-compare
+      - go-require
+    enable:
+      - bool-compare
+      - empty
+      - error-is-as
+      - error-nil
+      - expected-actual
+      - len
+      - require-error
+      - suite-dont-use-pkg
+      - suite-extra-assert-call
 run:
   timeout: 5m

--- a/docker_auth_test.go
+++ b/docker_auth_test.go
@@ -29,14 +29,14 @@ func TestGetDockerConfig(t *testing.T) {
 	// Verify that the default docker config file exists before any test in this suite runs.
 	// Then, we can safely run the tests that rely on it.
 	defaultCfg, err := dockercfg.LoadDefaultConfig()
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.NotEmpty(t, defaultCfg)
 
 	t.Run("without DOCKER_CONFIG env var retrieves default", func(t *testing.T) {
 		t.Setenv("DOCKER_CONFIG", "")
 
 		cfg, err := getDockerConfig()
-		require.Nil(t, err)
+		require.NoError(t, err)
 		require.NotEmpty(t, cfg)
 
 		assert.Equal(t, defaultCfg, cfg)
@@ -46,7 +46,7 @@ func TestGetDockerConfig(t *testing.T) {
 		t.Setenv("DOCKER_CONFIG", filepath.Join(testDockerConfigDirPath, "non-existing"))
 
 		cfg, err := getDockerConfig()
-		require.NotNil(t, err)
+		require.Error(t, err)
 		require.Empty(t, cfg)
 	})
 
@@ -54,10 +54,10 @@ func TestGetDockerConfig(t *testing.T) {
 		t.Setenv("DOCKER_CONFIG", testDockerConfigDirPath)
 
 		cfg, err := getDockerConfig()
-		require.Nil(t, err)
+		require.NoError(t, err)
 		require.NotEmpty(t, cfg)
 
-		assert.Equal(t, 3, len(cfg.AuthConfigs))
+		assert.Len(t, cfg.AuthConfigs, 3)
 
 		authCfgs := cfg.AuthConfigs
 
@@ -82,10 +82,10 @@ func TestGetDockerConfig(t *testing.T) {
 		t.Setenv("DOCKER_CONFIG", testDockerConfigDirPath)
 
 		cfg, err := getDockerConfig()
-		require.Nil(t, err)
+		require.NoError(t, err)
 		require.NotEmpty(t, cfg)
 
-		assert.Equal(t, 1, len(cfg.AuthConfigs))
+		assert.Len(t, cfg.AuthConfigs, 1)
 
 		authCfgs := cfg.AuthConfigs
 
@@ -108,7 +108,7 @@ func TestGetDockerConfig(t *testing.T) {
 		}`)
 
 		registry, cfg, err := DockerImageAuth(context.Background(), exampleAuth+"/my/image:latest")
-		require.Nil(t, err)
+		require.NoError(t, err)
 		require.NotEmpty(t, cfg)
 
 		assert.Equal(t, exampleAuth, registry)
@@ -130,7 +130,7 @@ func TestGetDockerConfig(t *testing.T) {
 		}`)
 
 		registry, cfg, err := DockerImageAuth(context.Background(), imageReg+imagePath)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		require.NotEmpty(t, cfg)
 
 		assert.Equal(t, imageReg, registry)
@@ -277,14 +277,14 @@ func TestCreateContainerFromPrivateRegistry(t *testing.T) {
 		ContainerRequest: req,
 		Started:          true,
 	})
-	require.Nil(t, err)
+	require.NoError(t, err)
 	terminateContainerOnEnd(t, ctx, redisContainer)
 }
 
 func prepareLocalRegistryWithAuth(t *testing.T) {
 	ctx := context.Background()
 	wd, err := os.Getwd()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	// copyDirectoryToContainer {
 	req := ContainerRequest{
 		Image:        "registry:2",
@@ -316,13 +316,13 @@ func prepareLocalRegistryWithAuth(t *testing.T) {
 	}
 
 	registryC, err := GenericContainer(ctx, genContainerReq)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	t.Cleanup(func() {
 		removeImageFromLocalCache(t, "localhost:5001/redis:5.0-alpine")
 	})
 	t.Cleanup(func() {
-		assert.NoError(t, registryC.Terminate(context.Background()))
+		require.NoError(t, registryC.Terminate(context.Background()))
 	})
 
 	_, cancel := context.WithCancel(context.Background())

--- a/docker_test.go
+++ b/docker_test.go
@@ -299,7 +299,7 @@ func TestContainerStateAfterTermination(t *testing.T) {
 		}
 
 		state, err := nginx.State(ctx)
-		assert.Error(t, err, "expected error from container inspect.")
+		require.Error(t, err, "expected error from container inspect.")
 
 		assert.Nil(t, state, "expected nil container inspect.")
 	})
@@ -312,7 +312,7 @@ func TestContainerStateAfterTermination(t *testing.T) {
 		}
 
 		state, err := nginx.State(ctx)
-		assert.NoError(t, err, "unexpected error from container inspect before container termination.")
+		require.NoError(t, err, "unexpected error from container inspect before container termination.")
 
 		assert.NotNil(t, state, "unexpected nil container inspect before container termination.")
 
@@ -323,7 +323,7 @@ func TestContainerStateAfterTermination(t *testing.T) {
 		}
 
 		state, err = nginx.State(ctx)
-		assert.Error(t, err, "expected error from container inspect after container termination.")
+		require.Error(t, err, "expected error from container inspect after container termination.")
 
 		assert.NotNil(t, state, "unexpected nil container inspect after container termination.")
 	})
@@ -1261,7 +1261,7 @@ func TestContainerCustomPlatformImage(t *testing.T) {
 
 		terminateContainerOnEnd(t, ctx, c)
 
-		assert.Error(t, err)
+		require.Error(t, err)
 	})
 
 	t.Run("specific platform should be propagated", func(t *testing.T) {
@@ -1285,10 +1285,10 @@ func TestContainerCustomPlatformImage(t *testing.T) {
 		defer dockerCli.Close()
 
 		ctr, err := dockerCli.ContainerInspect(ctx, c.GetContainerID())
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		img, _, err := dockerCli.ImageInspectWithRaw(ctx, ctr.Image)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, "linux", img.Os)
 		assert.Equal(t, "amd64", img.Architecture)
 	})
@@ -1478,7 +1478,7 @@ func TestDockerCreateContainerWithDirs(t *testing.T) {
 	hostDirName := "testdata"
 
 	abs, err := filepath.Abs(filepath.Join(".", hostDirName))
-	assert.Nil(t, err)
+	require.NoError(t, err)
 
 	tests := []struct {
 		name     string
@@ -1998,7 +1998,7 @@ func TestDockerProviderFindContainerByName(t *testing.T) {
 	terminateContainerOnEnd(t, ctx, c2)
 
 	c, err := provider.findContainerByName(ctx, "test")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	require.NotNil(t, c)
 	assert.Contains(t, c.Names, c1Name)
 }
@@ -2049,9 +2049,9 @@ func TestImageBuiltFromDockerfile_KeepBuiltImage(t *testing.T) {
 			require.NoError(t, err, "terminate container should not fail")
 			_, _, err = cli.ImageInspectWithRaw(ctx, containerImage)
 			if tt.keepBuiltImage {
-				assert.Nil(t, err, "image should still exist")
+				require.NoError(t, err, "image should still exist")
 			} else {
-				assert.NotNil(t, err, "image should not exist anymore")
+				require.Error(t, err, "image should not exist anymore")
 			}
 		})
 	}

--- a/file_test.go
+++ b/file_test.go
@@ -44,9 +44,9 @@ func Test_IsDir(t *testing.T) {
 		t.Run(test.filepath, func(t *testing.T) {
 			result, err := isDir(test.filepath)
 			if test.err != nil {
-				assert.NotNil(t, err, "expected error")
+				require.Error(t, err, "expected error")
 			} else {
-				assert.Nil(t, err, "not expected error")
+				require.NoError(t, err, "not expected error")
 			}
 			assert.Equal(t, test.expected, result)
 		})
@@ -71,7 +71,7 @@ func Test_TarDir(t *testing.T) {
 			src := originalSrc
 			if test.abs {
 				absSrc, err := filepath.Abs(src)
-				require.Nil(t, err)
+				require.NoError(t, err)
 
 				src = absSrc
 			}

--- a/from_dockerfile_test.go
+++ b/from_dockerfile_test.go
@@ -34,11 +34,11 @@ func TestBuildImageFromDockerfile(t *testing.T) {
 		},
 		// }
 	})
-	assert.Nil(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "test-repo:test-tag", tag)
 
 	_, _, err = cli.ImageInspectWithRaw(ctx, tag)
-	assert.Nil(t, err)
+	require.NoError(t, err)
 
 	t.Cleanup(func() {
 		_, err := cli.ImageRemove(ctx, tag, types.ImageRemoveOptions{
@@ -69,11 +69,11 @@ func TestBuildImageFromDockerfile_NoRepo(t *testing.T) {
 			Repo:       "test-repo",
 		},
 	})
-	assert.Nil(t, err)
+	require.NoError(t, err)
 	assert.True(t, strings.HasPrefix(tag, "test-repo:"))
 
 	_, _, err = cli.ImageInspectWithRaw(ctx, tag)
-	assert.Nil(t, err)
+	require.NoError(t, err)
 
 	t.Cleanup(func() {
 		_, err := cli.ImageRemove(ctx, tag, types.ImageRemoveOptions{
@@ -104,11 +104,11 @@ func TestBuildImageFromDockerfile_NoTag(t *testing.T) {
 			Tag:        "test-tag",
 		},
 	})
-	assert.Nil(t, err)
+	require.NoError(t, err)
 	assert.True(t, strings.HasSuffix(tag, ":test-tag"))
 
 	_, _, err = cli.ImageInspectWithRaw(ctx, tag)
-	assert.Nil(t, err)
+	require.NoError(t, err)
 
 	t.Cleanup(func() {
 		_, err := cli.ImageRemove(ctx, tag, types.ImageRemoveOptions{

--- a/internal/core/docker_host_test.go
+++ b/internal/core/docker_host_test.go
@@ -146,7 +146,7 @@ func TestExtractDockerHost(t *testing.T) {
 			setupTestcontainersProperties(t, content)
 
 			socket, err := testcontainersHostFromProperties(context.Background())
-			require.Nil(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, testRemoteHost, socket)
 		})
 
@@ -165,10 +165,10 @@ func TestExtractDockerHost(t *testing.T) {
 			tmpSocket := filepath.Join(tmpDir, "docker.sock")
 			t.Setenv("DOCKER_HOST", tmpSocket)
 			err := createTmpDockerSocket(tmpDir)
-			require.Nil(t, err)
+			require.NoError(t, err)
 
 			socket, err := dockerHostFromEnv(context.Background())
-			require.Nil(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, tmpSocket, socket)
 		})
 
@@ -187,10 +187,10 @@ func TestExtractDockerHost(t *testing.T) {
 			tmpSocket := filepath.Join(tmpDir, "docker.sock")
 			t.Setenv("TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE", tmpSocket)
 			err := createTmpDockerSocket(tmpDir)
-			require.Nil(t, err)
+			require.NoError(t, err)
 
 			socket, err := dockerSocketOverridePath(context.Background())
-			require.Nil(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, tmpSocket, socket)
 		})
 
@@ -208,7 +208,7 @@ func TestExtractDockerHost(t *testing.T) {
 			ctx := context.Background()
 
 			socket, err := dockerHostFromContext(context.WithValue(ctx, DockerHostContextKey, DockerSocketSchema+"/this/is/a/sample.sock"))
-			require.Nil(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, "/this/is/a/sample.sock", socket)
 		})
 
@@ -232,7 +232,7 @@ func TestExtractDockerHost(t *testing.T) {
 			tmpSocket := setupDockerSocket(t)
 
 			socket, err := dockerSocketPath(context.Background())
-			require.Nil(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, tmpSocket, socket)
 		})
 
@@ -243,7 +243,7 @@ func TestExtractDockerHost(t *testing.T) {
 			setupTestcontainersProperties(t, content)
 
 			socket, err := dockerHostFromProperties(context.Background())
-			require.Nil(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, tmpSocket, socket)
 		})
 
@@ -426,7 +426,7 @@ func TestInAContainer(t *testing.T) {
 		f := filepath.Join(tmpDir, ".dockerenv-b")
 
 		testFile, err := os.Create(f)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		defer testFile.Close()
 
 		assert.True(t, inAContainer(f))
@@ -472,7 +472,7 @@ func setupDockerSocket(t *testing.T) string {
 	tmpDir := t.TempDir()
 	tmpSocket := filepath.Join(tmpDir, "docker.sock")
 	err := createTmpDockerSocket(filepath.Dir(tmpSocket))
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	DockerSocketPath = tmpSocket
 	DockerSocketPathWithSchema = tmpSchema + tmpSocket
@@ -503,7 +503,7 @@ func setupTestcontainersProperties(t *testing.T, content string) {
 	tmpDir := t.TempDir()
 	homeDir := filepath.Join(tmpDir, "home")
 	err := createTmpDir(homeDir)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	t.Setenv("HOME", homeDir)
 	t.Setenv("USERPROFILE", homeDir) // Windows support
 

--- a/internal/core/docker_rootless_test.go
+++ b/internal/core/docker_rootless_test.go
@@ -96,10 +96,10 @@ func TestRootlessDockerSocketPath(t *testing.T) {
 		tmpDir := t.TempDir()
 		t.Setenv("XDG_RUNTIME_DIR", tmpDir)
 		err := createTmpDockerSocket(tmpDir)
-		require.Nil(t, err)
+		require.NoError(t, err)
 
 		socketPath, err := rootlessDockerSocketPath(context.Background())
-		require.Nil(t, err)
+		require.NoError(t, err)
 		assert.NotEmpty(t, socketPath)
 	})
 
@@ -114,11 +114,11 @@ func TestRootlessDockerSocketPath(t *testing.T) {
 
 		runDir := filepath.Join(tmpDir, ".docker", "run")
 		err := createTmpDockerSocket(runDir)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		t.Setenv("HOME", tmpDir)
 
 		socketPath, err := rootlessDockerSocketPath(context.Background())
-		require.Nil(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, DockerSocketSchema+runDir+"/docker.sock", socketPath)
 	})
 
@@ -133,11 +133,11 @@ func TestRootlessDockerSocketPath(t *testing.T) {
 
 		desktopDir := filepath.Join(tmpDir, ".docker", "desktop")
 		err := createTmpDockerSocket(desktopDir)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		t.Setenv("HOME", tmpDir)
 
 		socketPath, err := rootlessDockerSocketPath(context.Background())
-		require.Nil(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, DockerSocketSchema+desktopDir+"/docker.sock", socketPath)
 	})
 
@@ -151,7 +151,7 @@ func TestRootlessDockerSocketPath(t *testing.T) {
 
 		homeDir := filepath.Join(tmpDir, "home")
 		err := createTmpDir(homeDir)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		t.Setenv("HOME", homeDir)
 
 		baseRunDir = tmpDir
@@ -163,10 +163,10 @@ func TestRootlessDockerSocketPath(t *testing.T) {
 		uid := os.Getuid()
 		runDir := filepath.Join(tmpDir, "user", fmt.Sprintf("%d", uid))
 		err = createTmpDockerSocket(runDir)
-		require.Nil(t, err)
+		require.NoError(t, err)
 
 		socketPath, err := rootlessDockerSocketPath(context.Background())
-		require.Nil(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, DockerSocketSchema+runDir+"/docker.sock", socketPath)
 	})
 
@@ -178,14 +178,14 @@ func TestRootlessDockerSocketPath(t *testing.T) {
 		setupRootlessNotFound(t)
 
 		socketPath, err := rootlessDockerSocketPath(context.Background())
-		assert.ErrorIs(t, err, ErrRootlessDockerNotFound)
+		require.ErrorIs(t, err, ErrRootlessDockerNotFound)
 		assert.Empty(t, socketPath)
 
 		// the wrapped error includes all the locations that were checked
-		assert.ErrorContains(t, err, ErrRootlessDockerNotFoundXDGRuntimeDir.Error())
-		assert.ErrorContains(t, err, ErrRootlessDockerNotFoundHomeRunDir.Error())
-		assert.ErrorContains(t, err, ErrRootlessDockerNotFoundHomeDesktopDir.Error())
-		assert.ErrorContains(t, err, ErrRootlessDockerNotFoundRunDir.Error())
+		require.ErrorContains(t, err, ErrRootlessDockerNotFoundXDGRuntimeDir.Error())
+		require.ErrorContains(t, err, ErrRootlessDockerNotFoundHomeRunDir.Error())
+		require.ErrorContains(t, err, ErrRootlessDockerNotFoundHomeDesktopDir.Error())
+		require.ErrorContains(t, err, ErrRootlessDockerNotFoundRunDir.Error())
 	})
 }
 
@@ -199,21 +199,21 @@ func setupRootlessNotFound(t *testing.T) {
 
 	xdgRuntimeDir := filepath.Join(tmpDir, "xdg-runtime-dir")
 	err := createTmpDir(xdgRuntimeDir)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	t.Setenv("XDG_RUNTIME_DIR", xdgRuntimeDir)
 
 	homeDir := filepath.Join(tmpDir, "home")
 	err = createTmpDir(homeDir)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	t.Setenv("HOME", homeDir)
 
 	homeRunDir := filepath.Join(homeDir, ".docker", "run")
 	err = createTmpDir(homeRunDir)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	baseRunDir = tmpDir
 	uid := os.Getuid()
 	runDir := filepath.Join(tmpDir, "run", "user", fmt.Sprintf("%d", uid))
 	err = createTmpDir(runDir)
-	require.Nil(t, err)
+	require.NoError(t, err)
 }

--- a/lifecycle_test.go
+++ b/lifecycle_test.go
@@ -23,7 +23,7 @@ func TestPreCreateModifierHook(t *testing.T) {
 	ctx := context.Background()
 
 	provider, err := NewDockerProvider()
-	require.Nil(t, err)
+	require.NoError(t, err)
 	defer provider.Close()
 
 	t.Run("No exposed ports", func(t *testing.T) {
@@ -71,7 +71,7 @@ func TestPreCreateModifierHook(t *testing.T) {
 		inputNetworkingConfig := &network.NetworkingConfig{}
 
 		err = provider.preCreateContainerHook(ctx, req, inputConfig, inputHostConfig, inputNetworkingConfig)
-		require.Nil(t, err)
+		require.NoError(t, err)
 
 		// assertions
 
@@ -151,7 +151,7 @@ func TestPreCreateModifierHook(t *testing.T) {
 		inputNetworkingConfig := &network.NetworkingConfig{}
 
 		err = provider.preCreateContainerHook(ctx, req, inputConfig, inputHostConfig, inputNetworkingConfig)
-		require.Nil(t, err)
+		require.NoError(t, err)
 
 		// assertions
 
@@ -192,7 +192,7 @@ func TestPreCreateModifierHook(t *testing.T) {
 		inputNetworkingConfig := &network.NetworkingConfig{}
 
 		err = provider.preCreateContainerHook(ctx, req, inputConfig, inputHostConfig, inputNetworkingConfig)
-		require.Nil(t, err)
+		require.NoError(t, err)
 
 		// assertions
 
@@ -209,7 +209,7 @@ func TestPreCreateModifierHook(t *testing.T) {
 		net, err := provider.CreateNetwork(ctx, NetworkRequest{
 			Name: networkName,
 		})
-		require.Nil(t, err)
+		require.NoError(t, err)
 		defer func() {
 			err := net.Remove(ctx)
 			if err != nil {
@@ -220,7 +220,7 @@ func TestPreCreateModifierHook(t *testing.T) {
 		dockerNetwork, err := provider.GetNetwork(ctx, NetworkRequest{
 			Name: networkName,
 		})
-		require.Nil(t, err)
+		require.NoError(t, err)
 
 		req := ContainerRequest{
 			Image:    nginxAlpineImage, // alpine image does expose port 80
@@ -238,7 +238,7 @@ func TestPreCreateModifierHook(t *testing.T) {
 		inputNetworkingConfig := &network.NetworkingConfig{}
 
 		err = provider.preCreateContainerHook(ctx, req, inputConfig, inputHostConfig, inputNetworkingConfig)
-		require.Nil(t, err)
+		require.NoError(t, err)
 
 		// assertions
 
@@ -261,7 +261,7 @@ func TestPreCreateModifierHook(t *testing.T) {
 		net, err := provider.CreateNetwork(ctx, NetworkRequest{
 			Name: networkName,
 		})
-		require.Nil(t, err)
+		require.NoError(t, err)
 		defer func() {
 			err := net.Remove(ctx)
 			if err != nil {
@@ -272,7 +272,7 @@ func TestPreCreateModifierHook(t *testing.T) {
 		dockerNetwork, err := provider.GetNetwork(ctx, NetworkRequest{
 			Name: networkName,
 		})
-		require.Nil(t, err)
+		require.NoError(t, err)
 
 		req := ContainerRequest{
 			Image:    nginxAlpineImage, // alpine image does expose port 80
@@ -287,7 +287,7 @@ func TestPreCreateModifierHook(t *testing.T) {
 		inputNetworkingConfig := &network.NetworkingConfig{}
 
 		err = provider.preCreateContainerHook(ctx, req, inputConfig, inputHostConfig, inputNetworkingConfig)
-		require.Nil(t, err)
+		require.NoError(t, err)
 
 		// assertions
 
@@ -328,11 +328,11 @@ func TestPreCreateModifierHook(t *testing.T) {
 		inputNetworkingConfig := &network.NetworkingConfig{}
 
 		err = provider.preCreateContainerHook(ctx, req, inputConfig, inputHostConfig, inputNetworkingConfig)
-		require.Nil(t, err)
+		require.NoError(t, err)
 
 		// assertions
-		assert.Equal(t, inputHostConfig.PortBindings["80/tcp"][0].HostIP, "localhost")
-		assert.Equal(t, inputHostConfig.PortBindings["80/tcp"][0].HostPort, "8080")
+		assert.Equal(t, "localhost", inputHostConfig.PortBindings["80/tcp"][0].HostIP)
+		assert.Equal(t, "8080", inputHostConfig.PortBindings["80/tcp"][0].HostPort)
 	})
 }
 
@@ -543,18 +543,18 @@ func TestLifecycleHooks(t *testing.T) {
 				Reuse:            tt.reuse,
 				Started:          true,
 			})
-			require.Nil(t, err)
+			require.NoError(t, err)
 			require.NotNil(t, c)
 
 			duration := 1 * time.Second
 			err = c.Stop(ctx, &duration)
-			require.Nil(t, err)
+			require.NoError(t, err)
 
 			err = c.Start(ctx)
-			require.Nil(t, err)
+			require.NoError(t, err)
 
 			err = c.Terminate(ctx)
-			require.Nil(t, err)
+			require.NoError(t, err)
 
 			lifecycleHooksIsHonouredFn(t, ctx, c, prints)
 		})
@@ -587,20 +587,20 @@ func TestLifecycleHooks_WithDefaultLogger(t *testing.T) {
 		ContainerRequest: req,
 		Started:          true,
 	})
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.NotNil(t, c)
 
 	duration := 1 * time.Second
 	err = c.Stop(ctx, &duration)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	err = c.Start(ctx)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	err = c.Terminate(ctx)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
-	require.Equal(t, 10, len(dl.data))
+	require.Len(t, dl.data, 10)
 }
 
 func TestLifecycleHooks_WithMultipleHooks(t *testing.T) {
@@ -620,20 +620,20 @@ func TestLifecycleHooks_WithMultipleHooks(t *testing.T) {
 		ContainerRequest: req,
 		Started:          true,
 	})
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.NotNil(t, c)
 
 	duration := 1 * time.Second
 	err = c.Stop(ctx, &duration)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	err = c.Start(ctx)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	err = c.Terminate(ctx)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
-	require.Equal(t, 20, len(dl.data))
+	require.Len(t, dl.data, 20)
 }
 
 type linesTestLogger struct {
@@ -706,7 +706,7 @@ func TestPrintContainerLogsOnError(t *testing.T) {
 }
 
 func lifecycleHooksIsHonouredFn(t *testing.T, ctx context.Context, container Container, prints []string) {
-	require.Equal(t, 20, len(prints))
+	require.Len(t, prints, 20)
 
 	assert.True(t, strings.HasPrefix(prints[0], "pre-create hook 1: "))
 	assert.True(t, strings.HasPrefix(prints[1], "pre-create hook 2: "))

--- a/logconsumer_test.go
+++ b/logconsumer_test.go
@@ -99,7 +99,7 @@ func Test_LogConsumerGetsCalled(t *testing.T) {
 	case <-time.After(5 * time.Second):
 		t.Fatal("never received final log message")
 	}
-	assert.Nil(t, c.StopLogProducer())
+	require.NoError(t, c.StopLogProducer())
 	assert.Equal(t, []string{"ready\n", "echo hello\n", "echo there\n"}, g.Msgs)
 
 	terminateContainerOnEnd(t, ctx, c)
@@ -162,7 +162,7 @@ func Test_ShouldRecognizeLogTypes(t *testing.T) {
 	require.NoError(t, err)
 
 	<-g.Ack
-	assert.Nil(t, c.StopLogProducer())
+	require.NoError(t, c.StopLogProducer())
 
 	assert.Equal(t, map[string]string{
 		StdoutLog: "echo this-is-stdout\n",
@@ -217,11 +217,11 @@ func Test_MultipleLogConsumers(t *testing.T) {
 
 	<-first.Done
 	<-second.Done
-	assert.Nil(t, c.StopLogProducer())
+	require.NoError(t, c.StopLogProducer())
 
 	assert.Equal(t, []string{"ready\n", "echo mlem\n"}, first.Msgs)
 	assert.Equal(t, []string{"ready\n", "echo mlem\n"}, second.Msgs)
-	assert.Nil(t, c.Terminate(ctx))
+	require.NoError(t, c.Terminate(ctx))
 }
 
 func Test_StartStop(t *testing.T) {
@@ -256,23 +256,23 @@ func Test_StartStop(t *testing.T) {
 	require.NoError(t, c.StopLogProducer(), "nothing should happen even if the producer is not started")
 
 	require.NoError(t, c.StartLogProducer(ctx))
-	require.Equal(t, <-g.Accepted, "ready\n")
+	require.Equal(t, "ready\n", <-g.Accepted)
 
 	require.Error(t, c.StartLogProducer(ctx), "log producer is already started")
 
 	_, err = http.Get(ep + "/stdout?echo=mlem")
 	require.NoError(t, err)
-	require.Equal(t, <-g.Accepted, "echo mlem\n")
+	require.Equal(t, "echo mlem\n", <-g.Accepted)
 
 	require.NoError(t, c.StopLogProducer())
 
 	require.NoError(t, c.StartLogProducer(ctx))
-	require.Equal(t, <-g.Accepted, "ready\n")
-	require.Equal(t, <-g.Accepted, "echo mlem\n")
+	require.Equal(t, "ready\n", <-g.Accepted)
+	require.Equal(t, "echo mlem\n", <-g.Accepted)
 
 	_, err = http.Get(ep + "/stdout?echo=mlem2")
 	require.NoError(t, err)
-	require.Equal(t, <-g.Accepted, "echo mlem2\n")
+	require.Equal(t, "echo mlem2\n", <-g.Accepted)
 
 	_, err = http.Get(ep + "/stdout?echo=" + lastMessage)
 	require.NoError(t, err)
@@ -287,7 +287,7 @@ func Test_StartStop(t *testing.T) {
 		"echo mlem\n",
 		"echo mlem2\n",
 	}, g.Msgs)
-	assert.Nil(t, c.Terminate(ctx))
+	require.NoError(t, c.Terminate(ctx))
 }
 
 func TestContainerLogWithErrClosed(t *testing.T) {

--- a/modulegen/context_test.go
+++ b/modulegen/context_test.go
@@ -53,7 +53,7 @@ func TestExamplesHasDependabotEntry(t *testing.T) {
 		for _, exampleUpdate := range exampleUpdates {
 			dependabotDir := "/examples/" + example
 
-			assert.Equal(t, exampleUpdate.Schedule.Interval, "monthly")
+			assert.Equal(t, "monthly", exampleUpdate.Schedule.Interval)
 
 			if dependabotDir == exampleUpdate.Directory {
 				found = true
@@ -86,7 +86,7 @@ func TestModulesHasDependabotEntry(t *testing.T) {
 		for _, moduleUpdate := range moduleUpdates {
 			dependabotDir := "/modules/" + module
 
-			assert.Equal(t, moduleUpdate.Schedule.Interval, "monthly")
+			assert.Equal(t, "monthly", moduleUpdate.Schedule.Interval)
 
 			if dependabotDir == moduleUpdate.Directory {
 				found = true

--- a/modulegen/main_test.go
+++ b/modulegen/main_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/testcontainers/testcontainers-go/modulegen/internal"
 	"github.com/testcontainers/testcontainers-go/modulegen/internal/context"
@@ -160,14 +161,14 @@ func TestGenerateWrongModuleName(t *testing.T) {
 	githubWorkflowsTmp := tmpCtx.GithubWorkflowsDir()
 
 	err := os.MkdirAll(examplesTmp, 0o777)
-	assert.Nil(t, err)
+	require.NoError(t, err)
 	err = os.MkdirAll(examplesDocTmp, 0o777)
-	assert.Nil(t, err)
+	require.NoError(t, err)
 	err = os.MkdirAll(githubWorkflowsTmp, 0o777)
-	assert.Nil(t, err)
+	require.NoError(t, err)
 
 	err = copyInitialMkdocsConfig(t, tmpCtx)
-	assert.Nil(t, err)
+	require.NoError(t, err)
 
 	tests := []struct {
 		name string
@@ -191,7 +192,7 @@ func TestGenerateWrongModuleName(t *testing.T) {
 		}
 
 		err = internal.GenerateFiles(tmpCtx, module)
-		assert.Error(t, err)
+		require.Error(t, err)
 	}
 }
 
@@ -202,14 +203,14 @@ func TestGenerateWrongModuleTitle(t *testing.T) {
 	githubWorkflowsTmp := tmpCtx.GithubWorkflowsDir()
 
 	err := os.MkdirAll(examplesTmp, 0o777)
-	assert.Nil(t, err)
+	require.NoError(t, err)
 	err = os.MkdirAll(examplesDocTmp, 0o777)
-	assert.Nil(t, err)
+	require.NoError(t, err)
 	err = os.MkdirAll(githubWorkflowsTmp, 0o777)
-	assert.Nil(t, err)
+	require.NoError(t, err)
 
 	err = copyInitialMkdocsConfig(t, tmpCtx)
-	assert.Nil(t, err)
+	require.NoError(t, err)
 
 	tests := []struct {
 		title string
@@ -234,7 +235,7 @@ func TestGenerateWrongModuleTitle(t *testing.T) {
 		}
 
 		err = internal.GenerateFiles(tmpCtx, module)
-		assert.Error(t, err)
+		require.Error(t, err)
 	}
 }
 
@@ -245,23 +246,23 @@ func TestGenerate(t *testing.T) {
 	githubWorkflowsTmp := tmpCtx.GithubWorkflowsDir()
 
 	err := os.MkdirAll(examplesTmp, 0o777)
-	assert.Nil(t, err)
+	require.NoError(t, err)
 	err = os.MkdirAll(examplesDocTmp, 0o777)
-	assert.Nil(t, err)
+	require.NoError(t, err)
 	err = os.MkdirAll(githubWorkflowsTmp, 0o777)
-	assert.Nil(t, err)
+	require.NoError(t, err)
 
 	err = copyInitialMkdocsConfig(t, tmpCtx)
-	assert.Nil(t, err)
+	require.NoError(t, err)
 
 	originalConfig, err := mkdocs.ReadConfig(tmpCtx.MkdocsConfigFile())
-	assert.Nil(t, err)
+	require.NoError(t, err)
 
 	err = copyInitialDependabotConfig(t, tmpCtx)
-	assert.Nil(t, err)
+	require.NoError(t, err)
 
 	originalDependabotConfigUpdates, err := dependabot.GetUpdates(tmpCtx.DependabotConfigFile())
-	assert.Nil(t, err)
+	require.NoError(t, err)
 
 	module := context.TestcontainersModule{
 		Name:      "foodb4tw",
@@ -272,21 +273,21 @@ func TestGenerate(t *testing.T) {
 	moduleNameLower := module.Lower()
 
 	err = internal.GenerateFiles(tmpCtx, module)
-	assert.Nil(t, err)
+	require.NoError(t, err)
 
 	moduleDirPath := filepath.Join(examplesTmp, moduleNameLower)
 
 	moduleDirFileInfo, err := os.Stat(moduleDirPath)
-	assert.Nil(t, err) // error nil implies the file exist
+	require.NoError(t, err) // error nil implies the file exist
 	assert.True(t, moduleDirFileInfo.IsDir())
 
 	moduleDocFile := filepath.Join(examplesDocTmp, moduleNameLower+".md")
 	_, err = os.Stat(moduleDocFile)
-	assert.Nil(t, err) // error nil implies the file exist
+	require.NoError(t, err) // error nil implies the file exist
 
 	mainWorkflowFile := filepath.Join(githubWorkflowsTmp, "ci.yml")
 	_, err = os.Stat(mainWorkflowFile)
-	assert.Nil(t, err) // error nil implies the file exist
+	require.NoError(t, err) // error nil implies the file exist
 
 	assertModuleDocContent(t, module, moduleDocFile)
 	assertModuleGithubWorkflowContent(t, module, mainWorkflowFile)
@@ -308,23 +309,23 @@ func TestGenerateModule(t *testing.T) {
 	githubWorkflowsTmp := tmpCtx.GithubWorkflowsDir()
 
 	err := os.MkdirAll(modulesTmp, 0o777)
-	assert.Nil(t, err)
+	require.NoError(t, err)
 	err = os.MkdirAll(modulesDocTmp, 0o777)
-	assert.Nil(t, err)
+	require.NoError(t, err)
 	err = os.MkdirAll(githubWorkflowsTmp, 0o777)
-	assert.Nil(t, err)
+	require.NoError(t, err)
 
 	err = copyInitialMkdocsConfig(t, tmpCtx)
-	assert.Nil(t, err)
+	require.NoError(t, err)
 
 	originalConfig, err := mkdocs.ReadConfig(tmpCtx.MkdocsConfigFile())
-	assert.Nil(t, err)
+	require.NoError(t, err)
 
 	err = copyInitialDependabotConfig(t, tmpCtx)
-	assert.Nil(t, err)
+	require.NoError(t, err)
 
 	originalDependabotConfigUpdates, err := dependabot.GetUpdates(tmpCtx.DependabotConfigFile())
-	assert.Nil(t, err)
+	require.NoError(t, err)
 
 	module := context.TestcontainersModule{
 		Name:      "foodb",
@@ -335,21 +336,21 @@ func TestGenerateModule(t *testing.T) {
 	moduleNameLower := module.Lower()
 
 	err = internal.GenerateFiles(tmpCtx, module)
-	assert.Nil(t, err)
+	require.NoError(t, err)
 
 	moduleDirPath := filepath.Join(modulesTmp, moduleNameLower)
 
 	moduleDirFileInfo, err := os.Stat(moduleDirPath)
-	assert.Nil(t, err) // error nil implies the file exist
+	require.NoError(t, err) // error nil implies the file exist
 	assert.True(t, moduleDirFileInfo.IsDir())
 
 	moduleDocFile := filepath.Join(modulesDocTmp, moduleNameLower+".md")
 	_, err = os.Stat(moduleDocFile)
-	assert.Nil(t, err) // error nil implies the file exist
+	require.NoError(t, err) // error nil implies the file exist
 
 	mainWorkflowFile := filepath.Join(githubWorkflowsTmp, "ci.yml")
 	_, err = os.Stat(mainWorkflowFile)
-	assert.Nil(t, err) // error nil implies the file exist
+	require.NoError(t, err) // error nil implies the file exist
 
 	assertModuleDocContent(t, module, moduleDocFile)
 	assertModuleGithubWorkflowContent(t, module, mainWorkflowFile)
@@ -367,9 +368,9 @@ func TestGenerateModule(t *testing.T) {
 // assert content in the Dependabot descriptor file
 func assertDependabotUpdates(t *testing.T, module context.TestcontainersModule, originalConfigUpdates dependabot.Updates, tmpCtx context.Context) {
 	modules, err := dependabot.GetUpdates(tmpCtx.DependabotConfigFile())
-	assert.Nil(t, err)
+	require.NoError(t, err)
 
-	assert.Equal(t, len(originalConfigUpdates)+1, len(modules))
+	assert.Len(t, modules, len(originalConfigUpdates)+1)
 
 	// the module should be in the dependabot updates
 	found := false
@@ -398,22 +399,22 @@ func assertDependabotUpdates(t *testing.T, module context.TestcontainersModule, 
 // assert content module file in the docs
 func assertModuleDocContent(t *testing.T, module context.TestcontainersModule, moduleDocFile string) {
 	content, err := os.ReadFile(moduleDocFile)
-	assert.Nil(t, err)
+	require.NoError(t, err)
 
 	lower := module.Lower()
 	title := module.Title()
 
 	data := sanitiseContent(content)
 	assert.Equal(t, data[0], "# "+title)
-	assert.Equal(t, data[2], `Not available until the next release of testcontainers-go <a href="https://github.com/testcontainers/testcontainers-go"><span class="tc-version">:material-tag: main</span></a>`)
-	assert.Equal(t, data[4], "## Introduction")
+	assert.Equal(t, `Not available until the next release of testcontainers-go <a href="https://github.com/testcontainers/testcontainers-go"><span class="tc-version">:material-tag: main</span></a>`, data[2])
+	assert.Equal(t, "## Introduction", data[4])
 	assert.Equal(t, data[6], "The Testcontainers module for "+title+".")
-	assert.Equal(t, data[8], "## Adding this module to your project dependencies")
+	assert.Equal(t, "## Adding this module to your project dependencies", data[8])
 	assert.Equal(t, data[10], "Please run the following command to add the "+title+" module to your Go dependencies:")
 	assert.Equal(t, data[13], "go get github.com/testcontainers/testcontainers-go/"+module.ParentDir()+"/"+lower)
-	assert.Equal(t, data[18], "<!--codeinclude-->")
+	assert.Equal(t, "<!--codeinclude-->", data[18])
 	assert.Equal(t, data[19], "[Creating a "+title+" container](../../"+module.ParentDir()+"/"+lower+"/examples_test.go) inside_block:run"+title+"Container")
-	assert.Equal(t, data[20], "<!--/codeinclude-->")
+	assert.Equal(t, "<!--/codeinclude-->", data[20])
 	assert.Equal(t, data[24], "The "+title+" module exposes one entrypoint function to create the "+title+" container, and this function receives two parameters:")
 	assert.True(t, strings.HasSuffix(data[27], "(*"+title+"Container, error)"))
 	assert.Equal(t, "for "+title+". E.g. `testcontainers.WithImage(\""+module.Image+"\")`.", data[40])
@@ -422,7 +423,7 @@ func assertModuleDocContent(t *testing.T, module context.TestcontainersModule, m
 // assert content module test
 func assertExamplesTestContent(t *testing.T, module context.TestcontainersModule, examplesTestFile string) {
 	content, err := os.ReadFile(examplesTestFile)
-	assert.Nil(t, err)
+	require.NoError(t, err)
 
 	lower := module.Lower()
 	entrypoint := module.Entrypoint()
@@ -430,20 +431,20 @@ func assertExamplesTestContent(t *testing.T, module context.TestcontainersModule
 
 	data := sanitiseContent(content)
 	assert.Equal(t, data[0], "package "+lower+"_test")
-	assert.Equal(t, data[6], "\t\"github.com/testcontainers/testcontainers-go\"")
+	assert.Equal(t, "\t\"github.com/testcontainers/testcontainers-go\"", data[6])
 	assert.Equal(t, data[7], "\t\"github.com/testcontainers/testcontainers-go/modules/"+lower+"\"")
 	assert.Equal(t, data[10], "func Example"+entrypoint+"() {")
 	assert.Equal(t, data[11], "\t// run"+title+"Container {")
 	assert.Equal(t, data[14], "\t"+lower+"Container, err := "+lower+"."+entrypoint+"(ctx, testcontainers.WithImage(\""+module.Image+"\"))")
-	assert.Equal(t, data[32], "\tfmt.Println(state.Running)")
-	assert.Equal(t, data[34], "\t// Output:")
-	assert.Equal(t, data[35], "\t// true")
+	assert.Equal(t, "\tfmt.Println(state.Running)", data[32])
+	assert.Equal(t, "\t// Output:", data[34])
+	assert.Equal(t, "\t// true", data[35])
 }
 
 // assert content module test
 func assertModuleTestContent(t *testing.T, module context.TestcontainersModule, exampleTestFile string) {
 	content, err := os.ReadFile(exampleTestFile)
-	assert.Nil(t, err)
+	require.NoError(t, err)
 
 	data := sanitiseContent(content)
 	assert.Equal(t, data[0], "package "+module.Lower())
@@ -454,7 +455,7 @@ func assertModuleTestContent(t *testing.T, module context.TestcontainersModule, 
 // assert content module
 func assertModuleContent(t *testing.T, module context.TestcontainersModule, exampleFile string) {
 	content, err := os.ReadFile(exampleFile)
-	assert.Nil(t, err)
+	require.NoError(t, err)
 
 	lower := module.Lower()
 	containerName := module.ContainerName()
@@ -474,24 +475,24 @@ func assertModuleContent(t *testing.T, module context.TestcontainersModule, exam
 // assert content GitHub workflow for the module
 func assertModuleGithubWorkflowContent(t *testing.T, module context.TestcontainersModule, moduleWorkflowFile string) {
 	content, err := os.ReadFile(moduleWorkflowFile)
-	assert.Nil(t, err)
+	require.NoError(t, err)
 
 	data := sanitiseContent(content)
 	ctx := getTestRootContext(t)
 
 	modulesList, err := ctx.GetModules()
-	assert.Nil(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "        module: ["+strings.Join(modulesList, ", ")+"]", data[108])
 
 	examplesList, err := ctx.GetExamples()
-	assert.Nil(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "        module: ["+strings.Join(examplesList, ", ")+"]", data[128])
 }
 
 // assert content go.mod
 func assertGoModContent(t *testing.T, module context.TestcontainersModule, tcVersion string, goModFile string) {
 	content, err := os.ReadFile(goModFile)
-	assert.Nil(t, err)
+	require.NoError(t, err)
 
 	data := sanitiseContent(content)
 	assert.Equal(t, "module github.com/testcontainers/testcontainers-go/"+module.ParentDir()+"/"+module.Lower(), data[0])
@@ -502,7 +503,7 @@ func assertGoModContent(t *testing.T, module context.TestcontainersModule, tcVer
 // assert content Makefile
 func assertMakefileContent(t *testing.T, module context.TestcontainersModule, makefile string) {
 	content, err := os.ReadFile(makefile)
-	assert.Nil(t, err)
+	require.NoError(t, err)
 
 	data := sanitiseContent(content)
 	assert.Equal(t, data[4], "\t$(MAKE) test-"+module.Lower())
@@ -511,7 +512,7 @@ func assertMakefileContent(t *testing.T, module context.TestcontainersModule, ma
 // assert content in the nav items from mkdocs.yml
 func assertMkdocsNavItems(t *testing.T, module context.TestcontainersModule, originalConfig *mkdocs.Config, tmpCtx context.Context) {
 	config, err := mkdocs.ReadConfig(tmpCtx.MkdocsConfigFile())
-	assert.Nil(t, err)
+	require.NoError(t, err)
 
 	parentDir := module.ParentDir()
 
@@ -522,7 +523,7 @@ func assertMkdocsNavItems(t *testing.T, module context.TestcontainersModule, ori
 		expectedEntries = originalConfig.Nav[3].Modules
 	}
 
-	assert.Equal(t, len(expectedEntries)+1, len(navItems))
+	assert.Len(t, navItems, len(expectedEntries)+1)
 
 	// the module should be in the nav
 	found := false

--- a/modulegen/mkdocs_test.go
+++ b/modulegen/mkdocs_test.go
@@ -51,9 +51,9 @@ func TestReadMkDocsConfig(t *testing.T) {
 	// nav bar
 	nav := config.Nav
 	assert.Equal(t, "index.md", nav[0].Home)
-	assert.Greater(t, len(nav[2].Features), 0)
-	assert.Greater(t, len(nav[3].Modules), 0)
-	assert.Greater(t, len(nav[4].Examples), 0)
+	assert.NotEmpty(t, nav[2].Features)
+	assert.NotEmpty(t, nav[3].Modules)
+	assert.NotEmpty(t, nav[4].Examples)
 }
 
 func TestNavItems(t *testing.T) {
@@ -64,7 +64,7 @@ func TestNavItems(t *testing.T) {
 	require.NoError(t, err)
 
 	// we have to remove the index.md file from the examples docs
-	assert.Equal(t, len(examplesDocs)-1, len(examples))
+	assert.Len(t, examples, len(examplesDocs)-1)
 
 	// all example modules exist in the documentation
 	for _, example := range examples {

--- a/modules/cassandra/cassandra_test.go
+++ b/modules/cassandra/cassandra_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/gocql/gocql"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type Test struct {
@@ -24,13 +25,13 @@ func TestCassandra(t *testing.T) {
 
 	// Clean up the container after the test is complete
 	t.Cleanup(func() {
-		assert.NoError(t, container.Terminate(ctx))
+		require.NoError(t, container.Terminate(ctx))
 	})
 
 	// connectionString {
 	connectionHost, err := container.ConnectionHost(ctx)
 	// }
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	cluster := gocql.NewCluster(connectionHost)
 	session, err := cluster.CreateSession()
@@ -41,16 +42,16 @@ func TestCassandra(t *testing.T) {
 
 	// perform assertions
 	err = session.Query("CREATE KEYSPACE test_keyspace WITH REPLICATION = {'class' : 'SimpleStrategy', 'replication_factor' : 1}").Exec()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	err = session.Query("CREATE TABLE test_keyspace.test_table (id int PRIMARY KEY, name text)").Exec()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	err = session.Query("INSERT INTO test_keyspace.test_table (id, name) VALUES (1, 'NAME')").Exec()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	var test Test
 	err = session.Query("SELECT id, name FROM test_keyspace.test_table WHERE id=1").Scan(&test.Id, &test.Name)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, Test{Id: 1, Name: "NAME"}, test)
 }
 
@@ -64,11 +65,11 @@ func TestCassandraWithConfigFile(t *testing.T) {
 
 	// Clean up the container after the test is complete
 	t.Cleanup(func() {
-		assert.NoError(t, container.Terminate(ctx))
+		require.NoError(t, container.Terminate(ctx))
 	})
 
 	connectionHost, err := container.ConnectionHost(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	cluster := gocql.NewCluster(connectionHost)
 	session, err := cluster.CreateSession()
@@ -79,7 +80,7 @@ func TestCassandraWithConfigFile(t *testing.T) {
 
 	var result string
 	err = session.Query("SELECT cluster_name FROM system.local").Scan(&result)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "My Cluster", result)
 }
 
@@ -96,13 +97,13 @@ func TestCassandraWithInitScripts(t *testing.T) {
 
 		// Clean up the container after the test is complete
 		t.Cleanup(func() {
-			assert.NoError(t, container.Terminate(ctx))
+			require.NoError(t, container.Terminate(ctx))
 		})
 
 		// connectionHost {
 		connectionHost, err := container.ConnectionHost(ctx)
 		// }
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		cluster := gocql.NewCluster(connectionHost)
 		session, err := cluster.CreateSession()
@@ -113,7 +114,7 @@ func TestCassandraWithInitScripts(t *testing.T) {
 
 		var test Test
 		err = session.Query("SELECT id, name FROM test_keyspace.test_table WHERE id=1").Scan(&test.Id, &test.Name)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, Test{Id: 1, Name: "NAME"}, test)
 	})
 
@@ -127,11 +128,11 @@ func TestCassandraWithInitScripts(t *testing.T) {
 
 		// Clean up the container after the test is complete
 		t.Cleanup(func() {
-			assert.NoError(t, container.Terminate(ctx))
+			require.NoError(t, container.Terminate(ctx))
 		})
 
 		connectionHost, err := container.ConnectionHost(ctx)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		cluster := gocql.NewCluster(connectionHost)
 		session, err := cluster.CreateSession()
@@ -142,7 +143,7 @@ func TestCassandraWithInitScripts(t *testing.T) {
 
 		var test Test
 		err = session.Query("SELECT id, name FROM init_sh_keyspace.test_table WHERE id=1").Scan(&test.Id, &test.Name)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, Test{Id: 1, Name: "NAME"}, test)
 	})
 }

--- a/modules/clickhouse/clickhouse_test.go
+++ b/modules/clickhouse/clickhouse_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
 	"github.com/cenkalti/backoff/v4"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/testcontainers/testcontainers-go"
 )
@@ -33,11 +34,11 @@ func TestClickHouseDefaultConfig(t *testing.T) {
 
 	// Clean up the container after the test is complete
 	t.Cleanup(func() {
-		assert.NoError(t, container.Terminate(ctx))
+		require.NoError(t, container.Terminate(ctx))
 	})
 
 	connectionHost, err := container.ConnectionHost(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	conn, err := ch.Open(&ch.Options{
 		Addr: []string{connectionHost},
@@ -47,12 +48,12 @@ func TestClickHouseDefaultConfig(t *testing.T) {
 			Password: container.password,
 		},
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, conn)
 	defer conn.Close()
 
 	err = conn.Ping(context.Background())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestClickHouseConnectionHost(t *testing.T) {
@@ -69,13 +70,13 @@ func TestClickHouseConnectionHost(t *testing.T) {
 
 	// Clean up the container after the test is complete
 	t.Cleanup(func() {
-		assert.NoError(t, container.Terminate(ctx))
+		require.NoError(t, container.Terminate(ctx))
 	})
 
 	// connectionHost {
 	connectionHost, err := container.ConnectionHost(ctx)
 	// }
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	conn, err := ch.Open(&ch.Options{
 		Addr: []string{connectionHost},
@@ -85,13 +86,13 @@ func TestClickHouseConnectionHost(t *testing.T) {
 			Password: password,
 		},
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, conn)
 	defer conn.Close()
 
 	// perform assertions
 	data, err := performCRUD(conn)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Len(t, data, 1)
 }
 
@@ -105,25 +106,25 @@ func TestClickHouseDSN(t *testing.T) {
 
 	// Clean up the container after the test is complete
 	t.Cleanup(func() {
-		assert.NoError(t, container.Terminate(ctx))
+		require.NoError(t, container.Terminate(ctx))
 	})
 
 	// connectionString {
 	connectionString, err := container.ConnectionString(ctx, "debug=true")
 	// }
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	opts, err := ch.ParseDSN(connectionString)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	conn, err := ch.Open(opts)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, conn)
 	defer conn.Close()
 
 	// perform assertions
 	data, err := performCRUD(conn)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Len(t, data, 1)
 }
 
@@ -144,11 +145,11 @@ func TestClickHouseWithInitScripts(t *testing.T) {
 
 	// Clean up the container after the test is complete
 	t.Cleanup(func() {
-		assert.NoError(t, container.Terminate(ctx))
+		require.NoError(t, container.Terminate(ctx))
 	})
 
 	connectionHost, err := container.ConnectionHost(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	conn, err := ch.Open(&ch.Options{
 		Addr: []string{connectionHost},
@@ -158,13 +159,13 @@ func TestClickHouseWithInitScripts(t *testing.T) {
 			Password: password,
 		},
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, conn)
 	defer conn.Close()
 
 	// perform assertions
 	data, err := getAllRows(conn)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Len(t, data, 1)
 }
 
@@ -192,11 +193,11 @@ func TestClickHouseWithConfigFile(t *testing.T) {
 
 			// Clean up the container after the test is complete
 			t.Cleanup(func() {
-				assert.NoError(t, container.Terminate(ctx))
+				require.NoError(t, container.Terminate(ctx))
 			})
 
 			connectionHost, err := container.ConnectionHost(ctx)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			conn, err := ch.Open(&ch.Options{
 				Addr: []string{connectionHost},
@@ -206,13 +207,13 @@ func TestClickHouseWithConfigFile(t *testing.T) {
 					// Password: password, // --> password is not required
 				},
 			})
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.NotNil(t, conn)
 			defer conn.Close()
 
 			// perform assertions
 			data, err := performCRUD(conn)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Len(t, data, 1)
 		})
 	}

--- a/modules/localstack/localstack_test.go
+++ b/modules/localstack/localstack_test.go
@@ -42,7 +42,7 @@ func TestConfigureDockerHost(t *testing.T) {
 			req.Env[tt.envVar] = "foo"
 
 			reason, err := configureDockerHost(req, tt.envVar)
-			assert.Nil(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, "explicitly as environment variable", reason)
 		})
 
@@ -57,19 +57,19 @@ func TestConfigureDockerHost(t *testing.T) {
 			}
 
 			reason, err := configureDockerHost(req, tt.envVar)
-			assert.Nil(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, "to match last network alias on container with non-default network", reason)
 			assert.Equal(t, "foo3", req.Env[tt.envVar])
 		})
 
 		t.Run("HOSTNAME_EXTERNAL matches the daemon host because there are no aliases", func(t *testing.T) {
 			dockerProvider, err := testcontainers.NewDockerProvider()
-			assert.Nil(t, err)
+			require.NoError(t, err)
 			defer dockerProvider.Close()
 
 			// because the daemon host could be a remote one, we need to get it from the provider
 			expectedDaemonHost, err := dockerProvider.DaemonHost(context.Background())
-			assert.Nil(t, err)
+			require.NoError(t, err)
 
 			req := generateContainerRequest()
 
@@ -77,7 +77,7 @@ func TestConfigureDockerHost(t *testing.T) {
 			req.NetworkAliases = map[string][]string{}
 
 			reason, err := configureDockerHost(req, tt.envVar)
-			assert.Nil(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, "to match host-routable address for container", reason)
 			assert.Equal(t, expectedDaemonHost, req.Env[tt.envVar])
 		})
@@ -124,11 +124,11 @@ func TestRunContainer(t *testing.T) {
 		)
 
 		t.Run("Localstack:"+tt.version+" - multiple services exposed on same port", func(t *testing.T) {
-			require.Nil(t, err)
+			require.NoError(t, err)
 			assert.NotNil(t, container)
 
 			rawPorts, err := container.Ports(ctx)
-			require.Nil(t, err)
+			require.NoError(t, err)
 
 			ports := 0
 			// only one port is exposed among all the ports in the container
@@ -147,7 +147,7 @@ func TestStartWithoutOverride(t *testing.T) {
 	ctx := context.Background()
 
 	container, err := RunContainer(ctx)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, container)
 }
 
@@ -156,7 +156,7 @@ func TestStartV2WithNetwork(t *testing.T) {
 
 	// withCustomContainerRequest {
 	nw, err := network.New(ctx)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	localstack, err := RunContainer(
 		ctx,
@@ -169,7 +169,7 @@ func TestStartV2WithNetwork(t *testing.T) {
 		}),
 	)
 	// }
-	require.Nil(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, localstack)
 
 	networkName := nw.Name
@@ -201,6 +201,6 @@ func TestStartV2WithNetwork(t *testing.T) {
 		},
 		Started: true,
 	})
-	require.Nil(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, cli)
 }

--- a/modules/localstack/v1/s3_test.go
+++ b/modules/localstack/v1/s3_test.go
@@ -63,10 +63,10 @@ func TestS3(t *testing.T) {
 	ctx := context.Background()
 
 	container, err := localstack.RunContainer(ctx)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	session, err := awsSession(ctx, container)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	s3Uploader := s3manager.NewUploader(session)
 
@@ -80,7 +80,7 @@ func TestS3(t *testing.T) {
 		outputBucket, err := s3API.CreateBucket(&s3.CreateBucketInput{
 			Bucket: aws.String(bucketName),
 		})
-		require.Nil(t, err)
+		require.NoError(t, err)
 		assert.NotNil(t, outputBucket)
 
 		// put object
@@ -94,16 +94,16 @@ func TestS3(t *testing.T) {
 			ContentType:        aws.String("application/text"),
 			ContentDisposition: aws.String("attachment"),
 		})
-		require.Nil(t, err)
+		require.NoError(t, err)
 		assert.NotNil(t, outputObject)
 
 		t.Run("List Buckets", func(t *testing.T) {
 			output, err := s3API.ListBuckets(nil)
-			require.Nil(t, err)
+			require.NoError(t, err)
 			assert.NotNil(t, output)
 
 			buckets := output.Buckets
-			assert.Equal(t, 1, len(buckets))
+			assert.Len(t, buckets, 1)
 			assert.Equal(t, bucketName, *buckets[0].Name)
 		})
 
@@ -111,12 +111,12 @@ func TestS3(t *testing.T) {
 			output, err := s3API.ListObjects(&s3.ListObjectsInput{
 				Bucket: aws.String(bucketName),
 			})
-			require.Nil(t, err)
+			require.NoError(t, err)
 			assert.NotNil(t, output)
 
 			objects := output.Contents
 
-			assert.Equal(t, 1, len(objects))
+			assert.Len(t, objects, 1)
 			assert.Equal(t, s3Key1, *objects[0].Key)
 			assert.Equal(t, int64(len(body1)), *objects[0].Size)
 		})

--- a/modules/localstack/v2/s3_test.go
+++ b/modules/localstack/v2/s3_test.go
@@ -74,10 +74,10 @@ func TestS3(t *testing.T) {
 	ctx := context.Background()
 
 	container, err := localstack.RunContainer(ctx)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	s3Client, err := s3Client(ctx, container)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	t.Run("S3 operations", func(t *testing.T) {
 		bucketName := "localstack-bucket"
@@ -86,7 +86,7 @@ func TestS3(t *testing.T) {
 		outputBucket, err := s3Client.CreateBucket(ctx, &s3.CreateBucketInput{
 			Bucket: aws.String(bucketName),
 		})
-		require.Nil(t, err)
+		require.NoError(t, err)
 		assert.NotNil(t, outputBucket)
 
 		// put object
@@ -100,16 +100,16 @@ func TestS3(t *testing.T) {
 			ContentType:        aws.String("application/text"),
 			ContentDisposition: aws.String("attachment"),
 		})
-		require.Nil(t, err)
+		require.NoError(t, err)
 		assert.NotNil(t, outputObject)
 
 		t.Run("List Buckets", func(t *testing.T) {
 			output, err := s3Client.ListBuckets(ctx, &s3.ListBucketsInput{})
-			require.Nil(t, err)
+			require.NoError(t, err)
 			assert.NotNil(t, output)
 
 			buckets := output.Buckets
-			assert.Equal(t, 1, len(buckets))
+			assert.Len(t, buckets, 1)
 			assert.Equal(t, bucketName, *buckets[0].Name)
 		})
 
@@ -117,12 +117,12 @@ func TestS3(t *testing.T) {
 			output, err := s3Client.ListObjectsV2(ctx, &s3.ListObjectsV2Input{
 				Bucket: aws.String(bucketName),
 			})
-			require.Nil(t, err)
+			require.NoError(t, err)
 			assert.NotNil(t, output)
 
 			objects := output.Contents
 
-			assert.Equal(t, 1, len(objects))
+			assert.Len(t, objects, 1)
 			assert.Equal(t, s3Key1, *objects[0].Key)
 			assert.Equal(t, aws.Int64(int64(len(body1))), objects[0].Size)
 		})

--- a/modules/postgres/postgres_test.go
+++ b/modules/postgres/postgres_test.go
@@ -76,25 +76,25 @@ func TestPostgres(t *testing.T) {
 			// explicitly set sslmode=disable because the container is not configured to use TLS
 			connStr, err := container.ConnectionString(ctx, "sslmode=disable", "application_name=test")
 			// }
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			// Ensure connection string is using generic format
 			id, err := container.MappedPort(ctx, "5432/tcp")
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, fmt.Sprintf("postgres://%s:%s@%s:%s/%s?sslmode=disable&application_name=test", user, password, "localhost", id.Port(), dbname), connStr)
 
 			// perform assertions
 			db, err := sql.Open("postgres", connStr)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.NotNil(t, db)
 			defer db.Close()
 
 			result, err := db.Exec("CREATE TABLE IF NOT EXISTS test (id int, name varchar(255));")
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.NotNil(t, result)
 
 			result, err = db.Exec("INSERT INTO test (id, name) VALUES (1, 'test');")
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.NotNil(t, result)
 		})
 	}
@@ -165,10 +165,10 @@ func TestWithConfigFile(t *testing.T) {
 
 	// explicitly set sslmode=disable because the container is not configured to use TLS
 	connStr, err := container.ConnectionString(ctx, "sslmode=disable")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	db, err := sql.Open("postgres", connStr)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, db)
 	defer db.Close()
 }
@@ -196,15 +196,15 @@ func TestWithInitScript(t *testing.T) {
 
 	// explicitly set sslmode=disable because the container is not configured to use TLS
 	connStr, err := container.ConnectionString(ctx, "sslmode=disable")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	db, err := sql.Open("postgres", connStr)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, db)
 	defer db.Close()
 
 	// database created in init script. See testdata/init-user-db.sh
 	result, err := db.Exec("SELECT * FROM testdb;")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, result)
 }

--- a/modules/redpanda/redpanda_test.go
+++ b/modules/redpanda/redpanda_test.go
@@ -141,7 +141,7 @@ func TestRedpandaWithAuthentication(t *testing.T) {
 		kafkaAdmCl := kadm.NewClient(kafkaCl)
 		_, err = kafkaAdmCl.CreateTopic(ctx, 1, 1, nil, "test-2")
 		require.Error(t, err)
-		assert.ErrorContains(t, err, "TOPIC_AUTHORIZATION_FAILED")
+		require.ErrorContains(t, err, "TOPIC_AUTHORIZATION_FAILED")
 		kafkaCl.Close()
 	}
 
@@ -159,7 +159,7 @@ func TestRedpandaWithAuthentication(t *testing.T) {
 		kafkaAdmCl := kadm.NewClient(kafkaCl)
 		_, err = kafkaAdmCl.Metadata(ctx)
 		require.Error(t, err)
-		assert.ErrorContains(t, err, "SASL_AUTHENTICATION_FAILED")
+		require.ErrorContains(t, err, "SASL_AUTHENTICATION_FAILED")
 	}
 
 	// Test Schema Registry API

--- a/mounts_test.go
+++ b/mounts_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/docker/docker/api/types/mount"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestVolumeMount(t *testing.T) {
@@ -180,15 +181,15 @@ func TestCreateContainerWithVolume(t *testing.T) {
 		ContainerRequest: req,
 		Started:          true,
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	terminateContainerOnEnd(t, ctx, c)
 
 	// Check if volume is created
 	client, err := NewDockerClientWithOpts(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer client.Close()
 
 	volume, err := client.VolumeInspect(ctx, "test-volume")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "test-volume", volume.Name)
 }

--- a/network/network_test.go
+++ b/network/network_test.go
@@ -241,10 +241,10 @@ func TestContainerWithReaperNetwork(t *testing.T) {
 
 	for i := 0; i < maxNetworksCount; i++ {
 		n, err := network.New(ctx)
-		assert.Nil(t, err)
+		require.NoError(t, err)
 		// use t.Cleanup to run after terminateContainerOnEnd
 		t.Cleanup(func() {
-			assert.NoError(t, n.Remove(ctx))
+			require.NoError(t, n.Remove(ctx))
 		})
 
 		networks = append(networks, n.Name)
@@ -273,12 +273,12 @@ func TestContainerWithReaperNetwork(t *testing.T) {
 	containerId := nginx.GetContainerID()
 
 	cli, err := testcontainers.NewDockerClientWithOpts(ctx)
-	assert.Nil(t, err)
+	require.NoError(t, err)
 	defer cli.Close()
 
 	cnt, err := cli.ContainerInspect(ctx, containerId)
-	assert.Nil(t, err)
-	assert.Equal(t, maxNetworksCount, len(cnt.NetworkSettings.Networks))
+	require.NoError(t, err)
+	assert.Len(t, cnt.NetworkSettings.Networks, maxNetworksCount)
 	assert.NotNil(t, cnt.NetworkSettings.Networks[networks[0]])
 	assert.NotNil(t, cnt.NetworkSettings.Networks[networks[1]])
 }
@@ -334,8 +334,8 @@ func TestMultipleContainersInTheNewNetwork(t *testing.T) {
 	rNets, err := c2.Networks(ctx)
 	require.NoError(t, err)
 
-	assert.Equal(t, 1, len(pNets))
-	assert.Equal(t, 1, len(rNets))
+	assert.Len(t, pNets, 1)
+	assert.Len(t, rNets, 1)
 
 	assert.Equal(t, networkName, pNets[0])
 	assert.Equal(t, networkName, rNets[0])
@@ -422,10 +422,10 @@ func TestWithNetwork(t *testing.T) {
 
 		network.WithNetwork([]string{"alias"}, nw)(&req)
 
-		assert.Equal(t, 1, len(req.Networks))
+		assert.Len(t, req.Networks, 1)
 		assert.Equal(t, networkName, req.Networks[0])
 
-		assert.Equal(t, 1, len(req.NetworkAliases))
+		assert.Len(t, req.NetworkAliases, 1)
 		assert.Equal(t, map[string][]string{networkName: {"alias"}}, req.NetworkAliases)
 	}
 
@@ -468,10 +468,10 @@ func TestWithSyntheticNetwork(t *testing.T) {
 
 	network.WithNetwork([]string{"alias"}, nw)(&req)
 
-	assert.Equal(t, 1, len(req.Networks))
+	assert.Len(t, req.Networks, 1)
 	assert.Equal(t, networkName, req.Networks[0])
 
-	assert.Equal(t, 1, len(req.NetworkAliases))
+	assert.Len(t, req.NetworkAliases, 1)
 	assert.Equal(t, map[string][]string{networkName: {"alias"}}, req.NetworkAliases)
 
 	// verify that the network is created only once
@@ -485,7 +485,7 @@ func TestWithSyntheticNetwork(t *testing.T) {
 		Filters: args,
 	})
 	require.NoError(t, err)
-	assert.Len(t, resources, 0) // no Docker network was created
+	assert.Empty(t, resources) // no Docker network was created
 
 	c, err := testcontainers.GenericContainer(context.Background(), req)
 	require.NoError(t, err)
@@ -506,11 +506,11 @@ func TestWithNewNetwork(t *testing.T) {
 		network.WithLabels(map[string]string{"this-is-a-test": "value"}),
 	)(&req)
 
-	assert.Equal(t, 1, len(req.Networks))
+	assert.Len(t, req.Networks, 1)
 
 	networkName := req.Networks[0]
 
-	assert.Equal(t, 1, len(req.NetworkAliases))
+	assert.Len(t, req.NetworkAliases, 1)
 	assert.Equal(t, map[string][]string{networkName: {"alias"}}, req.NetworkAliases)
 
 	client, err := testcontainers.NewDockerClientWithOpts(context.Background())
@@ -554,6 +554,6 @@ func TestWithNewNetworkContextTimeout(t *testing.T) {
 	)(&req)
 
 	// we do not want to fail, just skip the network creation
-	assert.Equal(t, 0, len(req.Networks))
-	assert.Equal(t, 0, len(req.NetworkAliases))
+	assert.Empty(t, req.Networks)
+	assert.Empty(t, req.NetworkAliases)
 }

--- a/options_test.go
+++ b/options_test.go
@@ -53,7 +53,7 @@ func TestOverrideContainerRequest(t *testing.T) {
 
 	// toBeMergedRequest should not be changed
 	assert.Equal(t, "", toBeMergedRequest.Env["BAR"])
-	assert.Equal(t, 1, len(toBeMergedRequest.ExposedPorts))
+	assert.Len(t, toBeMergedRequest.ExposedPorts, 1)
 	assert.Equal(t, "67890/tcp", toBeMergedRequest.ExposedPorts[0])
 
 	// req should be merged with toBeMergedRequest
@@ -80,8 +80,8 @@ func TestWithStartupCommand(t *testing.T) {
 
 	testcontainers.WithStartupCommand(testExec)(&req)
 
-	assert.Equal(t, 1, len(req.LifecycleHooks))
-	assert.Equal(t, 1, len(req.LifecycleHooks[0].PostStarts))
+	assert.Len(t, req.LifecycleHooks, 1)
+	assert.Len(t, req.LifecycleHooks[0].PostStarts, 1)
 
 	c, err := testcontainers.GenericContainer(context.Background(), req)
 	require.NoError(t, err)

--- a/reaper_test.go
+++ b/reaper_test.go
@@ -435,7 +435,7 @@ func Test_NewReaper(t *testing.T) {
 
 			_, err := reuseOrCreateReaper(test.ctx, testSessionID, provider)
 			// we should have errored out see mockReaperProvider.RunContainer
-			assert.EqualError(t, err, "expected")
+			require.EqualError(t, err, "expected")
 
 			assert.Equal(t, test.req.Image, provider.req.Image, "expected image doesn't match the submitted request")
 			assert.Equal(t, test.req.ExposedPorts, provider.req.ExposedPorts, "expected exposed ports don't match the submitted request")
@@ -446,7 +446,7 @@ func Test_NewReaper(t *testing.T) {
 
 			// checks for reaper's preCreationCallback fields
 			assert.Equal(t, container.NetworkMode(Bridge), provider.hostConfig.NetworkMode, "expected networkMode doesn't match the submitted request")
-			assert.Equal(t, true, provider.hostConfig.AutoRemove, "expected networkMode doesn't match the submitted request")
+			assert.True(t, provider.hostConfig.AutoRemove, "expected networkMode doesn't match the submitted request")
 		})
 	}
 }
@@ -469,10 +469,10 @@ func Test_ReaperReusedIfHealthy(t *testing.T) {
 
 	provider, _ := ProviderDocker.GetProvider()
 	reaper, err := reuseOrCreateReaper(context.WithValue(ctx, core.DockerHostContextKey, provider.(*DockerProvider).host), testSessionID, provider)
-	assert.NoError(t, err, "creating the Reaper should not error")
+	require.NoError(t, err, "creating the Reaper should not error")
 
 	reaperReused, err := reuseOrCreateReaper(context.WithValue(ctx, core.DockerHostContextKey, provider.(*DockerProvider).host), testSessionID, provider)
-	assert.NoError(t, err, "reusing the Reaper should not error")
+	require.NoError(t, err, "reusing the Reaper should not error")
 	// assert that the internal state of both reaper instances is the same
 	assert.Equal(t, reaper.SessionID, reaperReused.SessionID, "expecting the same SessionID")
 	assert.Equal(t, reaper.Endpoint, reaperReused.Endpoint, "expecting the same reaper endpoint")
@@ -484,7 +484,7 @@ func Test_ReaperReusedIfHealthy(t *testing.T) {
 	defer func(term chan bool) {
 		term <- true
 	}(terminate)
-	assert.NoError(t, err, "connecting to Reaper should be successful")
+	require.NoError(t, err, "connecting to Reaper should be successful")
 
 	if !wasReaperRunning {
 		terminateContainerOnEnd(t, ctx, reaper.container)
@@ -506,24 +506,24 @@ func Test_RecreateReaperIfTerminated(t *testing.T) {
 	provider, _ := ProviderDocker.GetProvider()
 	ctx := context.Background()
 	reaper, err := reuseOrCreateReaper(context.WithValue(ctx, core.DockerHostContextKey, provider.(*DockerProvider).host), testSessionID, provider)
-	assert.NoError(t, err, "creating the Reaper should not error")
+	require.NoError(t, err, "creating the Reaper should not error")
 
 	terminate, err := reaper.Connect()
-	assert.NoError(t, err, "connecting to Reaper should be successful")
+	require.NoError(t, err, "connecting to Reaper should be successful")
 	terminate <- true
 
 	// Wait for ryuk's default timeout (10s) + 1s to allow for a graceful shutdown/cleanup of the container.
 	time.Sleep(11 * time.Second)
 
 	recreatedReaper, err := reuseOrCreateReaper(context.WithValue(ctx, core.DockerHostContextKey, provider.(*DockerProvider).host), testSessionID, provider)
-	assert.NoError(t, err, "creating the Reaper should not error")
+	require.NoError(t, err, "creating the Reaper should not error")
 	assert.NotEqual(t, reaper.container.GetContainerID(), recreatedReaper.container.GetContainerID(), "expected different container ID")
 
 	terminate, err = recreatedReaper.Connect()
 	defer func(term chan bool) {
 		term <- true
 	}(terminate)
-	assert.NoError(t, err, "connecting to Reaper should be successful")
+	require.NoError(t, err, "connecting to Reaper should be successful")
 	terminateContainerOnEnd(t, ctx, recreatedReaper.container)
 }
 
@@ -554,14 +554,14 @@ func TestReaper_reuseItFromOtherTestProgramUsingDocker(t *testing.T) {
 
 	provider, _ := ProviderDocker.GetProvider()
 	reaper, err := reuseOrCreateReaper(context.WithValue(ctx, core.DockerHostContextKey, provider.(*DockerProvider).host), testSessionID, provider)
-	assert.NoError(t, err, "creating the Reaper should not error")
+	require.NoError(t, err, "creating the Reaper should not error")
 
 	// explicitly reset the reaperInstance to nil to simulate another test program in the same session accessing the same reaper
 	reaperInstance = nil
 	reaperOnce = sync.Once{}
 
 	reaperReused, err := reuseOrCreateReaper(context.WithValue(ctx, core.DockerHostContextKey, provider.(*DockerProvider).host), testSessionID, provider)
-	assert.NoError(t, err, "reusing the Reaper should not error")
+	require.NoError(t, err, "reusing the Reaper should not error")
 	// assert that the internal state of both reaper instances is the same
 	assert.Equal(t, reaper.SessionID, reaperReused.SessionID, "expecting the same SessionID")
 	assert.Equal(t, reaper.Endpoint, reaperReused.Endpoint, "expecting the same reaper endpoint")
@@ -573,7 +573,7 @@ func TestReaper_reuseItFromOtherTestProgramUsingDocker(t *testing.T) {
 	defer func(term chan bool) {
 		term <- true
 	}(terminate)
-	assert.NoError(t, err, "connecting to Reaper should be successful")
+	require.NoError(t, err, "connecting to Reaper should be successful")
 
 	if !wasReaperRunning {
 		terminateContainerOnEnd(t, ctx, reaper.container)

--- a/wait/health_test.go
+++ b/wait/health_test.go
@@ -2,14 +2,13 @@ package wait
 
 import (
 	"context"
-	"errors"
 	"io"
 	"testing"
 	"time"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/go-connections/nat"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	tcexec "github.com/testcontainers/testcontainers-go/exec"
 )
@@ -54,8 +53,8 @@ func TestWaitForHealthTimesOutForUnhealthy(t *testing.T) {
 	wg := NewHealthStrategy().WithStartupTimeout(100 * time.Millisecond)
 	err := wg.WaitUntilReady(context.Background(), target)
 
-	assert.NotNil(t, err)
-	assert.True(t, errors.Is(err, context.DeadlineExceeded))
+	require.Error(t, err)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
 }
 
 // TestWaitForHealthSucceeds ensures that a healthy container always succeeds.
@@ -69,7 +68,7 @@ func TestWaitForHealthSucceeds(t *testing.T) {
 	wg := NewHealthStrategy().WithStartupTimeout(100 * time.Millisecond)
 	err := wg.WaitUntilReady(context.Background(), target)
 
-	assert.Nil(t, err)
+	require.NoError(t, err)
 }
 
 // TestWaitForHealthWithNil checks that an initial `nil` Health will not cause a panic,
@@ -93,7 +92,7 @@ func TestWaitForHealthWithNil(t *testing.T) {
 	}(target)
 
 	err := wg.WaitUntilReady(context.Background(), target)
-	assert.Nil(t, err)
+	require.NoError(t, err)
 }
 
 // TestWaitFailsForNilHealth checks that Health always nil fails (but will NOT cause a panic)
@@ -109,8 +108,8 @@ func TestWaitFailsForNilHealth(t *testing.T) {
 		WithPollInterval(100 * time.Millisecond)
 
 	err := wg.WaitUntilReady(context.Background(), target)
-	assert.NotNil(t, err)
-	assert.True(t, errors.Is(err, context.DeadlineExceeded))
+	require.Error(t, err)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
 }
 
 func TestWaitForHealthFailsDueToOOMKilledContainer(t *testing.T) {
@@ -124,8 +123,8 @@ func TestWaitForHealthFailsDueToOOMKilledContainer(t *testing.T) {
 		WithPollInterval(100 * time.Millisecond)
 
 	err := wg.WaitUntilReady(context.Background(), target)
-	assert.NotNil(t, err)
-	assert.EqualError(t, err, "container crashed with out-of-memory (OOMKilled)")
+	require.Error(t, err)
+	require.EqualError(t, err, "container crashed with out-of-memory (OOMKilled)")
 }
 
 func TestWaitForHealthFailsDueToExitedContainer(t *testing.T) {
@@ -140,8 +139,8 @@ func TestWaitForHealthFailsDueToExitedContainer(t *testing.T) {
 		WithPollInterval(100 * time.Millisecond)
 
 	err := wg.WaitUntilReady(context.Background(), target)
-	assert.NotNil(t, err)
-	assert.EqualError(t, err, "container exited with code 1")
+	require.Error(t, err)
+	require.EqualError(t, err, "container exited with code 1")
 }
 
 func TestWaitForHealthFailsDueToUnexpectedContainerStatus(t *testing.T) {
@@ -155,6 +154,6 @@ func TestWaitForHealthFailsDueToUnexpectedContainerStatus(t *testing.T) {
 		WithPollInterval(100 * time.Millisecond)
 
 	err := wg.WaitUntilReady(context.Background(), target)
-	assert.NotNil(t, err)
-	assert.EqualError(t, err, "unexpected container status \"dead\"")
+	require.Error(t, err)
+	require.EqualError(t, err, "unexpected container status \"dead\"")
 }


### PR DESCRIPTION
## What does this PR do?

Setup testifylint linter and apply it’s recommandations .
It also requires at least golangci-lint 1.55 to be working so it is now 1.55.2

## Why is it important?

This will help using testify as it help configuring the test tool with the best practices.


Signed-off-by: Matthieu MOREL <matthieu.morel35@gmail.com>