### PR TITLE
chore: run make lint on new modules

### DIFF
--- a/modulegen/internal/main.go
+++ b/modulegen/internal/main.go
@@ -42,6 +42,10 @@ func Generate(moduleVar context.TestcontainersModuleVar, isModule bool) error {
 	if err != nil {
 		return fmt.Errorf(">> error checking generated code: %w", err)
 	}
+	err = tools.MakeLint(cmdDir)
+	if err != nil {
+		return fmt.Errorf(">> error linting code: %w", err)
+	}
 
 	fmt.Println("Please go to", cmdDir, "directory to check the results, where 'go mod tidy' and 'go vet' was executed to synchronize the dependencies")
 	fmt.Println("Commit the modified files and submit a pull request to include them into the project")

--- a/modulegen/internal/main.go
+++ b/modulegen/internal/main.go
@@ -34,20 +34,20 @@ func Generate(moduleVar context.TestcontainersModuleVar, isModule bool) error {
 	}
 
 	cmdDir := filepath.Join(ctx.RootDir, tcModule.ParentDir(), tcModule.Lower())
-	err = tools.GoModTidy(cmdDir)
-	if err != nil {
-		return fmt.Errorf(">> error synchronizing the dependencies: %w", err)
-	}
-	err = tools.GoVet(cmdDir)
-	if err != nil {
-		return fmt.Errorf(">> error checking generated code: %w", err)
-	}
-	err = tools.MakeLint(cmdDir)
-	if err != nil {
-		return fmt.Errorf(">> error linting code: %w", err)
+	lintCmds := []func(string) error{
+		tools.GoModTidy,
+		tools.GoVet,
+		tools.MakeLint,
 	}
 
-	fmt.Println("Please go to", cmdDir, "directory to check the results, where 'go mod tidy' and 'go vet' was executed to synchronize the dependencies")
+	for _, lintCmd := range lintCmds {
+		err = lintCmd(cmdDir)
+		if err != nil {
+			return err
+		}
+	}
+
+	fmt.Println("Please go to", cmdDir, "directory to check the results, where 'go mod tidy', 'go vet' and 'make lint' were executed")
 	fmt.Println("Commit the modified files and submit a pull request to include them into the project")
 	fmt.Println("Thanks!")
 	return nil

--- a/modulegen/internal/main.go
+++ b/modulegen/internal/main.go
@@ -47,8 +47,9 @@ func Generate(moduleVar context.TestcontainersModuleVar, isModule bool) error {
 		}
 	}
 
-	fmt.Println("Please go to", cmdDir, "directory to check the results, where 'go mod tidy', 'go vet' and 'make lint' were executed")
-	fmt.Println("Commit the modified files and submit a pull request to include them into the project")
+	fmt.Println("Please go to", cmdDir, "directory to check the results, where 'go mod tidy', 'go vet' and 'make lint' were executed.")
+	fmt.Println("🙏 Commit the modified files and submit a pull request to include them into the project.")
+	fmt.Println("Remember to run 'make lint' before submitting the pull request.")
 	fmt.Println("Thanks!")
 	return nil
 }

--- a/modulegen/internal/tools/exec.go
+++ b/modulegen/internal/tools/exec.go
@@ -12,8 +12,18 @@ func GoVet(cmdDir string) error {
 	return runGoCommand(cmdDir, "vet", "./...")
 }
 
+func MakeLint(cmdDir string) error {
+	return runMakeCommand(cmdDir, "lint")
+}
+
 func runGoCommand(cmdDir string, args ...string) error {
 	cmd := exec.Command("go", args...)
+	cmd.Dir = cmdDir
+	return cmd.Run()
+}
+
+func runMakeCommand(cmdDir string, args ...string) error {
+	cmd := exec.Command("make", args...)
 	cmd.Dir = cmdDir
 	return cmd.Run()
 }

--- a/modulegen/internal/tools/exec.go
+++ b/modulegen/internal/tools/exec.go
@@ -1,19 +1,29 @@
 package tools
 
 import (
+	"fmt"
 	"os/exec"
 )
 
 func GoModTidy(cmdDir string) error {
-	return runGoCommand(cmdDir, "mod", "tidy")
+	if err := runGoCommand(cmdDir, "mod", "tidy"); err != nil {
+		return fmt.Errorf(">> error synchronizing the dependencies: %w", err)
+	}
+	return nil
 }
 
 func GoVet(cmdDir string) error {
-	return runGoCommand(cmdDir, "vet", "./...")
+	if err := runGoCommand(cmdDir, "vet", "./..."); err != nil {
+		return fmt.Errorf(">> error checking generated code: %w", err)
+	}
+	return nil
 }
 
 func MakeLint(cmdDir string) error {
-	return runMakeCommand(cmdDir, "lint")
+	if err := runMakeCommand(cmdDir, "lint"); err != nil {
+		return fmt.Errorf(">> error synchronizing the dependencies: %w", err)
+	}
+	return nil
 }
 
 func runGoCommand(cmdDir string, args ...string) error {


### PR DESCRIPTION
- chore: run make lint for new modules
- chore: add readability in the generate function

<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
It automatically runs `make lint` on new modules created with the module generator tool.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
New module authors could contribute a module but forget to run the lint, ending up in failures in the CI.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Discovered while testing #2117 

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
