### PR TITLE
Go install gotestsum and golangci-lint 

### DIFF
--- a/.github/workflows/ci-test-go.yml
+++ b/.github/workflows/ci-test-go.yml
@@ -104,9 +104,7 @@ jobs:
         if: ${{ inputs.run-tests }}
         working-directory: ./${{ inputs.project-directory }}
         timeout-minutes: 30
-        run: |
-            go install gotest.tools/gotestsum@latest
-            make test-unit
+        run: make test-unit
 
       - name: Upload SonarCloud files
         if: ${{ github.ref_name == 'main' && github.repository_owner == 'testcontainers' && inputs.run-tests && !inputs.rootless-docker }}

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -50,9 +50,7 @@ jobs:
 
       - name: go test
         timeout-minutes: 30
-        run: |
-          go install gotest.tools/gotestsum@latest
-          gotestsum --format short-verbose --rerun-fails=5 --packages="./..."  --junitfile TEST-unit.xml -- -timeout=30m
+        run: make test-unit
 
       - name: Create success status
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1

--- a/commons-test.mk
+++ b/commons-test.mk
@@ -1,4 +1,15 @@
 ROOT_DIR:=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
+GOBIN= $(GOPATH)/bin
+
+define go_install
+    go install $(1)
+endef
+
+$(GOBIN)/golangci-lint:
+	$(call go_install,github.com/golangci/golangci-lint/cmd/golangci-lint@v1.55.2)
+
+$(GOBIN)/gotestsum:
+	$(call go_install,gotest.tools/gotestsum@latest)
 
 .PHONY: dependencies-scan
 dependencies-scan:
@@ -6,11 +17,11 @@ dependencies-scan:
 	go list -json -m all | docker run --rm -i sonatypecommunity/nancy:latest sleuth --skip-update-check
 
 .PHONY: lint
-lint:
+lint: $(GOBIN)/golangci-lint
 	golangci-lint run --out-format=github-actions --path-prefix=. --verbose -c $(ROOT_DIR)/.golangci.yml --fix
 
 .PHONY: test-%
-test-%:
+test-%: $(GOBIN)/gotestsum
 	@echo "Running $* tests..."
 	gotestsum \
 		--format short-verbose \
@@ -26,8 +37,7 @@ tools:
 	go mod download
 
 .PHONY: test-tools
-test-tools:
-	go install gotest.tools/gotestsum@latest
+test-tools: $(GOBIN)/gotestsum
 
 .PHONY: tools-tidy
 tools-tidy:

--- a/commons-test.mk
+++ b/commons-test.mk
@@ -11,6 +11,14 @@ $(GOBIN)/golangci-lint:
 $(GOBIN)/gotestsum:
 	$(call go_install,gotest.tools/gotestsum@latest)
 
+.PHONY: install
+install: $(GOBIN)/golangci-lint $(GOBIN)/gotestsum
+
+.PHONY: clean
+clean:
+	rm $(GOBIN)/golangci-lint
+	rm $(GOBIN)/gotestsum
+
 .PHONY: dependencies-scan
 dependencies-scan:
 	@echo ">> Scanning dependencies in $(CURDIR)..."


### PR DESCRIPTION
## What does this PR do?

Define Makefile targets to install golangci-lint and gotestsum 

## Why is it important?

Helps having the right requirements to make different targets work.
