### PR TITLE
enable golangci-lint for examples

### DIFF
--- a/.github/workflows/ci-test-go.yml
+++ b/.github/workflows/ci-test-go.yml
@@ -71,7 +71,7 @@ jobs:
 
       - name: golangci-lint
         # TODO: Remove each example/module once it passes the golangci-lint
-        if: ${{ inputs.platform == 'ubuntu-latest' && inputs.go-version == '1.20.x' && !contains(fromJSON('["examples/cockroachdb", "examples/toxiproxy", "modules/compose"]'), inputs.project-directory) }}
+        if: ${{ inputs.platform == 'ubuntu-latest' && inputs.go-version == '1.20.x' && !contains(fromJSON('["modules/compose"]'), inputs.project-directory) }}
         uses: golangci/golangci-lint-action@3a919529898de77ec3da873e3063ca4b10e7f5cc # v3
         with:
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version


### PR DESCRIPTION
## What does this PR do?

Enable golangci-lint for cockroachdb and toxiproxy examples and fix the raised issues

## Why is it important?

Linting helps examples staying maintenable.

Signed-off-by: Matthieu MOREL <matthieu.morel35@gmail.com>