### PR TITLE
pin Docker images version

### DIFF
--- a/docs/features/build_from_dockerfile.md
+++ b/docs/features/build_from_dockerfile.md
@@ -17,7 +17,7 @@ image will be built with a random name and tag.
 If your Dockerfile expects build args: 
 
 ```Dockerfile
-FROM alpine
+FROM alpine@sha256:51b67269f354137895d43f3b3d810bfacd3945438e94dc5ac55fdac340352f48
 
 ARG FOO
 

--- a/modules/redis/testdata/Dockerfile
+++ b/modules/redis/testdata/Dockerfile
@@ -1,1 +1,1 @@
-FROM docker.io/redis:5.0-alpine
+FROM docker.io/redis:5.0-alpine@sha256:1a3c609295332f1ce603948142a132656c92a08149d7096e203058533c415b8c

--- a/testdata/Dockerfile
+++ b/testdata/Dockerfile
@@ -1,1 +1,1 @@
-FROM docker.io/redis:5.0-alpine
+FROM docker.io/redis:5.0-alpine@sha256:1a3c609295332f1ce603948142a132656c92a08149d7096e203058533c415b8c

--- a/wait/testdata/Dockerfile
+++ b/wait/testdata/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18-alpine as builder
+FROM golang:1.18-alpine@sha256:77f25981bd57e60a510165f3be89c901aec90453fd0f1c5a45691f6cb1528807 as builder
 WORKDIR /app
 COPY . .
 RUN mkdir -p dist


### PR DESCRIPTION
## What does this PR do?

Pin Docker images version

## Why is it important?

Helps improve OSSF score

Signed-off-by: Matthieu MOREL <matthieu.morel35@gmail.com>