### PR TITLE
chore: skip assertions for Docker Rootless

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,12 +41,11 @@ jobs:
       ryuk-disabled: false
 
   # The job below is a copy of the job above, but with ryuk disabled.
-  # It's executed in a secondary stage to avoid concurrency issues.
+  # It's executed in the first stage to avoid concurrency issues.
   test-reaper-off:
     # do not run this job if it's a PR from dependabot that is not approved yet
     if: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.state != 'approved' && github.triggering_actor == 'dependabot[bot]') }}
     name: "Test with reaper off"
-    needs: test
     strategy:
       matrix:
         go-version: [1.20.x, 1.x]
@@ -61,12 +60,11 @@ jobs:
       ryuk-disabled: true
 
   # The job below is a copy of the job above, but with Docker rootless.
-  # It's executed in a secondary stage to avoid concurrency issues.
+  # It's executed in the first stage to avoid concurrency issues.
   test-rootless-docker:
     # do not run this job if it's a PR from dependabot that is not approved yet
     if: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.state != 'approved' && github.triggering_actor == 'dependabot[bot]') }}
     name: "Test with Rootless Docker"
-    needs: test
     strategy:
       matrix:
         go-version: [1.20.x, 1.x]

--- a/docker_test.go
+++ b/docker_test.go
@@ -511,6 +511,7 @@ func TestContainerCreation(t *testing.T) {
 
 	if os.Getenv("XDG_RUNTIME_DIR") != "" {
 		t.Log("[Docker Rootless] do not assert that the container should have zero aliases in the bridge network")
+	} else {
 		if len(networkAliases["bridge"]) != 0 {
 			t.Errorf("Expected number of aliases for 'bridge' network %d. Got %d.", 0, len(networkAliases["bridge"]))
 		}

--- a/docker_test.go
+++ b/docker_test.go
@@ -511,10 +511,8 @@ func TestContainerCreation(t *testing.T) {
 
 	if os.Getenv("XDG_RUNTIME_DIR") != "" {
 		t.Log("[Docker Rootless] do not assert that the container should have zero aliases in the bridge network")
-	} else {
-		if len(networkAliases["bridge"]) != 0 {
-			t.Errorf("Expected number of aliases for 'bridge' network %d. Got %d.", 0, len(networkAliases["bridge"]))
-		}
+	} else if len(networkAliases["bridge"]) != 0 {
+		t.Errorf("Expected number of aliases for 'bridge' network %d. Got %d.", 0, len(networkAliases["bridge"]))
 	}
 }
 

--- a/docker_test.go
+++ b/docker_test.go
@@ -508,8 +508,12 @@ func TestContainerCreation(t *testing.T) {
 		fmt.Printf("%v", networkAliases)
 		t.Errorf("Expected number of connected networks %d. Got %d.", 0, len(networkAliases))
 	}
-	if len(networkAliases["bridge"]) != 0 {
-		t.Errorf("Expected number of aliases for 'bridge' network %d. Got %d.", 0, len(networkAliases["bridge"]))
+
+	if os.Getenv("XDG_RUNTIME_DIR") != "" {
+		t.Log("[Docker Rootless] do not assert that the container should have zero aliases in the bridge network")
+		if len(networkAliases["bridge"]) != 0 {
+			t.Errorf("Expected number of aliases for 'bridge' network %d. Got %d.", 0, len(networkAliases["bridge"]))
+		}
 	}
 }
 

--- a/from_dockerfile_test.go
+++ b/from_dockerfile_test.go
@@ -213,6 +213,4 @@ func TestBuildImageFromDockerfile_TargetDoesNotExist(t *testing.T) {
 		Started: true,
 	})
 	require.Error(t, err)
-
-	assert.Contains(t, err.Error(), "failed to reach build target target-foo in Dockerfile")
 }

--- a/modulegen/_template/ci.yml.tmpl
+++ b/modulegen/_template/ci.yml.tmpl
@@ -41,12 +41,11 @@ jobs:
       ryuk-disabled: false
 
   # The job below is a copy of the job above, but with ryuk disabled.
-  # It's executed in a secondary stage to avoid concurrency issues.
+  # It's executed in the first stage to avoid concurrency issues.
   test-reaper-off:
     # do not run this job if it's a PR from dependabot that is not approved yet
     if: {{ "${{ !(github.event_name == 'pull_request' && github.event.pull_request.state != 'approved' && github.triggering_actor == 'dependabot[bot]') }}" }}
     name: "Test with reaper off"
-    needs: test
     strategy:
       matrix:
         go-version: [1.20.x, 1.x]
@@ -61,12 +60,11 @@ jobs:
       ryuk-disabled: true
 
   # The job below is a copy of the job above, but with Docker rootless.
-  # It's executed in a secondary stage to avoid concurrency issues.
+  # It's executed in the first stage to avoid concurrency issues.
   test-rootless-docker:
     # do not run this job if it's a PR from dependabot that is not approved yet
     if: {{ "${{ !(github.event_name == 'pull_request' && github.event.pull_request.state != 'approved' && github.triggering_actor == 'dependabot[bot]') }}" }}
     name: "Test with Rootless Docker"
-    needs: test
     strategy:
       matrix:
         go-version: [1.20.x, 1.x]

--- a/modulegen/main_test.go
+++ b/modulegen/main_test.go
@@ -482,11 +482,11 @@ func assertModuleGithubWorkflowContent(t *testing.T, module context.Testcontaine
 
 	modulesList, err := ctx.GetModules()
 	require.NoError(t, err)
-	assert.Equal(t, "        module: ["+strings.Join(modulesList, ", ")+"]", data[108])
+	assert.Equal(t, "        module: ["+strings.Join(modulesList, ", ")+"]", data[106])
 
 	examplesList, err := ctx.GetExamples()
 	require.NoError(t, err)
-	assert.Equal(t, "        module: ["+strings.Join(examplesList, ", ")+"]", data[128])
+	assert.Equal(t, "        module: ["+strings.Join(examplesList, ", ")+"]", data[126])
 }
 
 // assert content go.mod


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
In this PR, we are removing an assertion by the error message, as it changed in upstream moby (see https://github.com/moby/moby/pull/46754/files and https://github.com/moby/buildkit/pull/4394).

At the same time, we are skipping an assertion only for Rootless mode, as it's causing a failure on Docker v25.0.0, but not on lower versions.

Finally, and for the sake of reducing the total build time of the pipelines, we are moving the no-reaper and the rootless pipelines from the second stage to the first one, so that the ~5min they take happen at the same time as the main `test` pipeline.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
We noticed that, since 3 days ago, the Github workers are including Docker v25.0.0 for rootless Docker, which causes the above error to appear.

The regular workers are still in v24.0.7, which will eventually change causing the errors for the entire test suite.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Relates to Buildkit: https://github.com/moby/buildkit/pull/4394
- Relates to Moby: https://github.com/moby/moby/pull/46754

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
