### PR TITLE
chore(docker_mounts): stop doing misleading logging

### DIFF
--- a/docker_mounts.go
+++ b/docker_mounts.go
@@ -107,8 +107,10 @@ func mapToDockerMounts(containerMounts ContainerMounts) []mount.Mount {
 			containerMount.VolumeOptions = typedMounter.GetVolumeOptions()
 		case TmpfsMounter:
 			containerMount.TmpfsOptions = typedMounter.GetTmpfsOptions()
-		default:
+		case BindMounter:
 			Logger.Printf("Mount type %s is not supported by Testcontainers for Go", m.Source.Type())
+		default:
+			// The provided source type has no custom options
 		}
 
 		mounts = append(mounts, containerMount)


### PR DESCRIPTION
As things are, the logger statement here always triggers for normal use cases. For example, if I start a container with this `mount: testcontainers.VolumeMount("some-vol", "/some/dir")`

then I get this weird message in my logs
`Mount type %!s(testcontainers.MountType=1) is not supported by Testcontainers for Go`

because a GenericVolumeMountSource doesn't have an implementation of `GetVolumeOptions() *mount.VolumeOptions`

I suggest removing that logging, as in this PR, because it's going to be purely confusing for 99% of users.


## What does this PR do?

removes bad logging

## Why is it important?

because it was confusing before
