### PR TITLE
fix: deprecate BindMounts correctly

### DIFF
--- a/docker_mounts.go
+++ b/docker_mounts.go
@@ -3,6 +3,7 @@ package testcontainers
 import "github.com/docker/docker/api/types/mount"
 
 var mountTypeMapping = map[MountType]mount.Type{
+	MountTypeBind:   mount.TypeBind, // Deprecated, it will be removed in a future release
 	MountTypeVolume: mount.TypeVolume,
 	MountTypeTmpfs:  mount.TypeTmpfs,
 	MountTypePipe:   mount.TypeNamedPipe,


### PR DESCRIPTION

<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
It brings back the BindMount type to the mounts mapping, as it was removed in https://github.com/testcontainers/testcontainers-go/pull/1907/files#diff-f8dd512f57a3d3bc890983ea0164e44d1aa69034527ccf41217f0f2807a76917L6

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
The BindMount type needs to exist in the mapping until the type is
finally removed, otherwise the deprecation path is broken for those
using the BindMount type before the final removal.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Completes #1907
- Closes #2179 

## How to test this PR

1. Fetch this branch
2. Clone https://github.com/srabraham/demobindmount
3. Update go.mod to replace the testcontainers-go dependency to use the local branch
4. Run `go mod tidy && go run main.go` in the repro project.

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
