### PR TITLE
fix: all mounts should contain the testcontainers labels

### DIFF
--- a/docker_mounts.go
+++ b/docker_mounts.go
@@ -101,6 +101,9 @@ func mapToDockerMounts(containerMounts ContainerMounts) []mount.Mount {
 			Source:   m.Source.Source(),
 			ReadOnly: m.ReadOnly,
 			Target:   m.Target.Target(),
+			VolumeOptions: &mount.VolumeOptions{
+				Labels: GenericLabels(),
+			},
 		}
 
 		switch typedMounter := m.Source.(type) {

--- a/mounts_test.go
+++ b/mounts_test.go
@@ -41,6 +41,10 @@ func TestVolumeMount(t *testing.T) {
 }
 
 func TestContainerMounts_PrepareMounts(t *testing.T) {
+	volumeOptions := &mount.VolumeOptions{
+		Labels: GenericLabels(),
+	}
+
 	t.Parallel()
 	tests := []struct {
 		name   string
@@ -57,9 +61,10 @@ func TestContainerMounts_PrepareMounts(t *testing.T) {
 			mounts: ContainerMounts{{Source: GenericVolumeMountSource{Name: "app-data"}, Target: "/data"}},
 			want: []mount.Mount{
 				{
-					Type:   mount.TypeVolume,
-					Source: "app-data",
-					Target: "/data",
+					Type:          mount.TypeVolume,
+					Source:        "app-data",
+					Target:        "/data",
+					VolumeOptions: volumeOptions,
 				},
 			},
 		},
@@ -68,10 +73,11 @@ func TestContainerMounts_PrepareMounts(t *testing.T) {
 			mounts: ContainerMounts{{Source: GenericVolumeMountSource{Name: "app-data"}, Target: "/data", ReadOnly: true}},
 			want: []mount.Mount{
 				{
-					Type:     mount.TypeVolume,
-					Source:   "app-data",
-					Target:   "/data",
-					ReadOnly: true,
+					Type:          mount.TypeVolume,
+					Source:        "app-data",
+					Target:        "/data",
+					ReadOnly:      true,
+					VolumeOptions: volumeOptions,
 				},
 			},
 		},
@@ -111,8 +117,9 @@ func TestContainerMounts_PrepareMounts(t *testing.T) {
 			mounts: ContainerMounts{{Source: GenericTmpfsMountSource{}, Target: "/data"}},
 			want: []mount.Mount{
 				{
-					Type:   mount.TypeTmpfs,
-					Target: "/data",
+					Type:          mount.TypeTmpfs,
+					Target:        "/data",
+					VolumeOptions: volumeOptions,
 				},
 			},
 		},
@@ -121,9 +128,10 @@ func TestContainerMounts_PrepareMounts(t *testing.T) {
 			mounts: ContainerMounts{{Source: GenericTmpfsMountSource{}, Target: "/data", ReadOnly: true}},
 			want: []mount.Mount{
 				{
-					Type:     mount.TypeTmpfs,
-					Target:   "/data",
-					ReadOnly: true,
+					Type:          mount.TypeTmpfs,
+					Target:        "/data",
+					ReadOnly:      true,
+					VolumeOptions: volumeOptions,
 				},
 			},
 		},
@@ -148,6 +156,7 @@ func TestContainerMounts_PrepareMounts(t *testing.T) {
 						SizeBytes: 50 * 1024 * 1024,
 						Mode:      0o644,
 					},
+					VolumeOptions: volumeOptions,
 				},
 			},
 		},


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
Adds the tescontainers-go labels to all the mounts.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
Otherwise, Ryuk won't remove them.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Relates #2163
- Relates https://github.com/testcontainers/moby-ryuk/issues/103

## How to test this PR

Run this test with and without the fix. Then monitor the volumes with `watch -n 1 docker volume ls`

```shell
go test -timeout 600s -run ^TestContainerCreationWithVolumeAndFileWritingToIt$ github.com/testcontainers/testcontainers-go -count=1 -v
```

After the fix, the `volumeName` volume should be pruned by Ryuk. Before it, not.

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
