### PR TITLE
chore: do not panic in testable examples

### DIFF
--- a/container_test.go
+++ b/container_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log"
 	"strings"
 	"testing"
 	"time"
@@ -525,13 +526,13 @@ func ExampleGenericContainer_withSubstitutors() {
 	})
 	// }
 	if err != nil {
-		panic(err)
+		log.Fatalf("could not start container: %v", err)
 	}
 
 	defer func() {
 		err := container.Terminate(ctx)
 		if err != nil {
-			panic(err)
+			log.Fatalf("could not terminate container: %v", err)
 		}
 	}()
 

--- a/docker_test.go
+++ b/docker_test.go
@@ -987,7 +987,7 @@ func ExampleDockerProvider_CreateContainer() {
 
 	state, err := nginxC.State(ctx)
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to get container state: %s", err)
 	}
 
 	fmt.Println(state.Running)
@@ -1019,7 +1019,7 @@ func ExampleContainer_Host() {
 
 	state, err := nginxC.State(ctx)
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to get container state: %s", err)
 	}
 
 	fmt.Println(state.Running)
@@ -1047,7 +1047,7 @@ func ExampleContainer_Start() {
 
 	state, err := nginxC.State(ctx)
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to get container state: %s", err)
 	}
 
 	fmt.Println(state.Running)
@@ -1075,7 +1075,7 @@ func ExampleContainer_Stop() {
 	timeout := 10 * time.Second
 	err := nginxC.Stop(ctx, &timeout)
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to stop container: %s", err)
 	}
 
 	fmt.Println("Container has been stopped")
@@ -1109,7 +1109,7 @@ func ExampleContainer_MappedPort() {
 
 	state, err := nginxC.State(ctx)
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to get container state: %s", err)
 	}
 
 	fmt.Println(state.Running)

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -37,11 +37,11 @@ func TestWithRedis(t *testing.T) {
 		Started:          true,
 	})
 	if err != nil {
-		panic(err)
+		log.Fatalf("Could not start redis: %s", err)
 	}
 	defer func() {
 		if err := redisC.Terminate(ctx); err != nil {
-			panic(err)
+			log.Fatalf("Could not stop redis: %s", err)
 		}
 	}()
 }

--- a/from_dockerfile_test.go
+++ b/from_dockerfile_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"log"
 	"strings"
 	"testing"
 	"time"
@@ -175,17 +176,17 @@ func ExampleGenericContainer_buildFromDockerfile() {
 	})
 	// }
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to start container: %v", err)
 	}
 
 	r, err := c.Logs(ctx)
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to get logs: %v", err)
 	}
 
 	logs, err := io.ReadAll(r)
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to read logs: %v", err)
 	}
 
 	fmt.Println(string(logs))

--- a/modulegen/_template/examples_test.go.tmpl
+++ b/modulegen/_template/examples_test.go.tmpl
@@ -14,20 +14,20 @@ func Example{{ $entrypoint }}() {
 
 	{{ $lower }}Container, err := {{ $lower }}.{{ $entrypoint }}(ctx, testcontainers.WithImage("{{ $image }}"))
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to start container: %s", err)
 	}
 
 	// Clean up the container
 	defer func() {
 		if err := {{ $lower }}Container.Terminate(ctx); err != nil {
-			panic(err)
+			log.Fatalf("failed to terminate container: %s", err)
 		}
 	}()
 	// }
 
 	state, err := {{ $lower }}Container.State(ctx)
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to get container state: %s", err)
 	}
 
 	fmt.Println(state.Running)

--- a/modules/artemis/examples_test.go
+++ b/modules/artemis/examples_test.go
@@ -3,6 +3,7 @@ package artemis_test
 import (
 	"context"
 	"fmt"
+	"log"
 
 	"github.com/go-stomp/stomp/v3"
 
@@ -19,18 +20,18 @@ func ExampleRunContainer() {
 		artemis.WithCredentials("test", "test"),
 	)
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to start container: %s", err)
 	}
 	defer func() {
 		if err := artemisContainer.Terminate(ctx); err != nil {
-			panic(err)
+			log.Fatalf("failed to terminate container: %s", err)
 		}
 	}()
 	// }
 
 	state, err := artemisContainer.State(ctx)
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to get container state: %s", err)
 	}
 
 	fmt.Println(state.Running)
@@ -39,7 +40,7 @@ func ExampleRunContainer() {
 	// Get broker endpoint.
 	host, err := artemisContainer.BrokerEndpoint(ctx)
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to get broker endpoint: %s", err)
 	}
 
 	// containerUser {
@@ -52,11 +53,11 @@ func ExampleRunContainer() {
 	// Connect to Artemis via STOMP.
 	conn, err := stomp.Dial("tcp", host, stomp.ConnOpt.Login(user, pass))
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to connect to Artemis: %s", err)
 	}
 	defer func() {
 		if err := conn.Disconnect(); err != nil {
-			panic(err)
+			log.Fatalf("failed to disconnect from Artemis: %s", err)
 		}
 	}()
 	// }

--- a/modules/cassandra/examples_test.go
+++ b/modules/cassandra/examples_test.go
@@ -3,6 +3,7 @@ package cassandra_test
 import (
 	"context"
 	"fmt"
+	"log"
 	"path/filepath"
 
 	"github.com/gocql/gocql"
@@ -21,40 +22,40 @@ func ExampleRunContainer() {
 		cassandra.WithConfigFile(filepath.Join("testdata", "config.yaml")),
 	)
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to start container: %s", err)
 	}
 
 	// Clean up the container
 	defer func() {
 		if err := cassandraContainer.Terminate(ctx); err != nil {
-			panic(err)
+			log.Fatalf("failed to terminate container: %s", err)
 		}
 	}()
 	// }
 
 	state, err := cassandraContainer.State(ctx)
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to get container state: %s", err)
 	}
 
 	fmt.Println(state.Running)
 
 	connectionHost, err := cassandraContainer.ConnectionHost(ctx)
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to get connection host: %s", err)
 	}
 
 	cluster := gocql.NewCluster(connectionHost)
 	session, err := cluster.CreateSession()
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to create session: %s", err)
 	}
 	defer session.Close()
 
 	var version string
 	err = session.Query("SELECT release_version FROM system.local").Scan(&version)
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to query: %s", err)
 	}
 
 	fmt.Println(version)

--- a/modules/clickhouse/examples_test.go
+++ b/modules/clickhouse/examples_test.go
@@ -3,6 +3,7 @@ package clickhouse_test
 import (
 	"context"
 	"fmt"
+	"log"
 	"path/filepath"
 	"strings"
 
@@ -29,30 +30,30 @@ func ExampleRunContainer() {
 		clickhouse.WithConfigFile(filepath.Join("testdata", "config.xml")),
 	)
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to start container: %s", err)
 	}
 	defer func() {
 		if err := clickHouseContainer.Terminate(ctx); err != nil {
-			panic(err)
+			log.Fatalf("failed to terminate container: %s", err)
 		}
 	}()
 	// }
 
 	state, err := clickHouseContainer.State(ctx)
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to get container state: %s", err)
 	}
 
 	fmt.Println(state.Running)
 
 	connectionString, err := clickHouseContainer.ConnectionString(ctx)
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to get connection string: %s", err)
 	}
 
 	opts, err := ch.ParseDSN(connectionString)
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to parse DSN: %s", err)
 	}
 
 	fmt.Println(strings.HasPrefix(opts.ClientInfo.String(), "clickhouse-go/"))

--- a/modules/cockroachdb/examples_test.go
+++ b/modules/cockroachdb/examples_test.go
@@ -3,6 +3,7 @@ package cockroachdb_test
 import (
 	"context"
 	"fmt"
+	"log"
 	"net/url"
 
 	"github.com/testcontainers/testcontainers-go/modules/cockroachdb"
@@ -14,30 +15,30 @@ func ExampleRunContainer() {
 
 	cockroachdbContainer, err := cockroachdb.RunContainer(ctx)
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to start container: %s", err)
 	}
 
 	// Clean up the container
 	defer func() {
 		if err := cockroachdbContainer.Terminate(ctx); err != nil {
-			panic(err)
+			log.Fatalf("failed to terminate container: %s", err)
 		}
 	}()
 	// }
 
 	state, err := cockroachdbContainer.State(ctx)
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to get container state: %s", err)
 	}
 	fmt.Println(state.Running)
 
 	addr, err := cockroachdbContainer.ConnectionString(ctx)
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to get connection string: %s", err)
 	}
 	u, err := url.Parse(addr)
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to parse connection string: %s", err)
 	}
 	u.Host = fmt.Sprintf("%s:%s", u.Hostname(), "xxx")
 	fmt.Println(u.String())

--- a/modules/couchbase/examples_test.go
+++ b/modules/couchbase/examples_test.go
@@ -3,6 +3,7 @@ package couchbase_test
 import (
 	"context"
 	"fmt"
+	"log"
 
 	"github.com/couchbase/gocb/v2"
 
@@ -28,25 +29,25 @@ func ExampleRunContainer() {
 		couchbase.WithBuckets(bucket),
 	)
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to start container: %s", err)
 	}
 	defer func() {
 		if err := couchbaseContainer.Terminate(ctx); err != nil {
-			panic(err)
+			log.Fatalf("failed to terminate container: %s", err)
 		}
 	}()
 	// }
 
 	state, err := couchbaseContainer.State(ctx)
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to get container state: %s", err)
 	}
 
 	fmt.Println(state.Running)
 
 	connectionString, err := couchbaseContainer.ConnectionString(ctx)
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to get connection string: %s", err)
 	}
 
 	cluster, err := gocb.Connect(connectionString, gocb.ClusterOptions{
@@ -54,12 +55,12 @@ func ExampleRunContainer() {
 		Password: couchbaseContainer.Password(),
 	})
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to connect to cluster: %s", err)
 	}
 
 	buckets, err := cluster.Buckets().GetAllBuckets(nil)
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to get buckets: %s", err)
 	}
 
 	fmt.Println(len(buckets))

--- a/modules/elasticsearch/examples_test.go
+++ b/modules/elasticsearch/examples_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log"
 	"strings"
 
 	es "github.com/elastic/go-elasticsearch/v8"
@@ -17,18 +18,18 @@ func ExampleRunContainer() {
 	ctx := context.Background()
 	elasticsearchContainer, err := elasticsearch.RunContainer(ctx, testcontainers.WithImage("docker.elastic.co/elasticsearch/elasticsearch:8.9.0"))
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to start container: %s", err)
 	}
 	defer func() {
 		if err := elasticsearchContainer.Terminate(ctx); err != nil {
-			panic(err)
+			log.Fatalf("failed to terminate container: %s", err)
 		}
 	}()
 	// }
 
 	state, err := elasticsearchContainer.State(ctx)
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to get container state: %s", err)
 	}
 
 	fmt.Println(state.Running)
@@ -46,12 +47,12 @@ func ExampleRunContainer_withUsingPassword() {
 		elasticsearch.WithPassword("foo"),
 	)
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to start container: %s", err)
 	}
 	defer func() {
 		err := elasticsearchContainer.Terminate(ctx)
 		if err != nil {
-			panic(err)
+			log.Fatalf("failed to terminate container: %s", err)
 		}
 	}()
 	// }
@@ -73,12 +74,12 @@ func ExampleRunContainer_connectUsingElasticsearchClient() {
 		elasticsearch.WithPassword("foo"),
 	)
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to start container: %s", err)
 	}
 	defer func() {
 		err := elasticsearchContainer.Terminate(ctx)
 		if err != nil {
-			panic(err)
+			log.Fatalf("failed to terminate container: %s", err)
 		}
 	}()
 
@@ -93,19 +94,19 @@ func ExampleRunContainer_connectUsingElasticsearchClient() {
 
 	esClient, err := es.NewClient(cfg)
 	if err != nil {
-		panic(err)
+		log.Fatalf("error creating the client: %s", err)
 	}
 
 	resp, err := esClient.Info()
 	if err != nil {
-		panic(err)
+		log.Fatalf("error getting response: %s", err)
 	}
 	defer resp.Body.Close()
 	// }
 
 	var esResp ElasticsearchResponse
 	if err := json.NewDecoder(resp.Body).Decode(&esResp); err != nil {
-		panic(err)
+		log.Fatalf("error decoding response: %s", err)
 	}
 
 	fmt.Println(esResp.Tagline)

--- a/modules/gcloud/bigquery_test.go
+++ b/modules/gcloud/bigquery_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log"
 
 	"cloud.google.com/go/bigquery"
 	"google.golang.org/api/iterator"
@@ -26,13 +27,13 @@ func ExampleRunBigQueryContainer() {
 		gcloud.WithProjectID("bigquery-project"),
 	)
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to run container: %v", err)
 	}
 
 	// Clean up the container
 	defer func() {
 		if err := bigQueryContainer.Terminate(ctx); err != nil {
-			panic(err)
+			log.Fatalf("failed to terminate container: %v", err)
 		}
 	}()
 	// }
@@ -49,7 +50,7 @@ func ExampleRunBigQueryContainer() {
 
 	client, err := bigquery.NewClient(ctx, projectID, opts...)
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to create bigquery client: %v", err)
 	}
 	defer client.Close()
 	// }
@@ -57,13 +58,13 @@ func ExampleRunBigQueryContainer() {
 	createFnQuery := client.Query("CREATE FUNCTION testr(arr ARRAY<STRUCT<name STRING, val INT64>>) AS ((SELECT SUM(IF(elem.name = \"foo\",elem.val,null)) FROM UNNEST(arr) AS elem))")
 	_, err = createFnQuery.Read(ctx)
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to create function: %v", err)
 	}
 
 	selectQuery := client.Query("SELECT testr([STRUCT<name STRING, val INT64>(\"foo\", 10), STRUCT<name STRING, val INT64>(\"bar\", 40), STRUCT<name STRING, val INT64>(\"foo\", 20)])")
 	it, err := selectQuery.Read(ctx)
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to read query: %v", err)
 	}
 
 	var val []bigquery.Value
@@ -73,7 +74,7 @@ func ExampleRunBigQueryContainer() {
 			break
 		}
 		if err != nil {
-			panic(err)
+			log.Fatalf("failed to iterate: %v", err)
 		}
 	}
 

--- a/modules/gcloud/bigtable_test.go
+++ b/modules/gcloud/bigtable_test.go
@@ -3,6 +3,7 @@ package gcloud_test
 import (
 	"context"
 	"fmt"
+	"log"
 
 	"cloud.google.com/go/bigtable"
 	"google.golang.org/api/option"
@@ -23,13 +24,13 @@ func ExampleRunBigTableContainer() {
 		gcloud.WithProjectID("bigtable-project"),
 	)
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to run container: %v", err)
 	}
 
 	// Clean up the container
 	defer func() {
 		if err := bigTableContainer.Terminate(ctx); err != nil {
-			panic(err)
+			log.Fatalf("failed to terminate container: %v", err)
 		}
 	}()
 	// }
@@ -49,24 +50,24 @@ func ExampleRunBigTableContainer() {
 	}
 	adminClient, err := bigtable.NewAdminClient(ctx, projectId, instanceId, options...)
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to create admin client: %v", err)
 	}
 	defer adminClient.Close()
 	// }
 
 	err = adminClient.CreateTable(ctx, tableName)
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to create table: %v", err)
 	}
 	err = adminClient.CreateColumnFamily(ctx, tableName, "name")
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to create column family: %v", err)
 	}
 
 	// bigTableClient {
 	client, err := bigtable.NewClient(ctx, projectId, instanceId, options...)
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to create client: %v", err)
 	}
 	defer client.Close()
 	// }
@@ -77,12 +78,12 @@ func ExampleRunBigTableContainer() {
 	mut.Set("name", "firstName", bigtable.Now(), []byte("Gopher"))
 	err = tbl.Apply(ctx, "1", mut)
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to apply mutation: %v", err)
 	}
 
 	row, err := tbl.ReadRow(ctx, "1", bigtable.RowFilter(bigtable.FamilyFilter("name")))
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to read row: %v", err)
 	}
 
 	fmt.Println(string(row["name"][0].Value))

--- a/modules/gcloud/datastore_test.go
+++ b/modules/gcloud/datastore_test.go
@@ -3,6 +3,7 @@ package gcloud_test
 import (
 	"context"
 	"fmt"
+	"log"
 
 	"cloud.google.com/go/datastore"
 	"google.golang.org/api/option"
@@ -23,13 +24,13 @@ func ExampleRunDatastoreContainer() {
 		gcloud.WithProjectID("datastore-project"),
 	)
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to run container: %v", err)
 	}
 
 	// Clean up the container
 	defer func() {
 		if err := datastoreContainer.Terminate(ctx); err != nil {
-			panic(err)
+			log.Fatalf("failed to terminate container: %v", err)
 		}
 	}()
 	// }
@@ -45,7 +46,7 @@ func ExampleRunDatastoreContainer() {
 
 	dsClient, err := datastore.NewClient(ctx, projectID, options...)
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to create client: %v", err)
 	}
 	defer dsClient.Close()
 	// }
@@ -60,13 +61,13 @@ func ExampleRunDatastoreContainer() {
 	}
 	_, err = dsClient.Put(ctx, k, &data)
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to put data: %v", err)
 	}
 
 	saved := Task{}
 	err = dsClient.Get(ctx, k, &saved)
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to get data: %v", err)
 	}
 
 	fmt.Println(saved.Description)

--- a/modules/gcloud/firestore_test.go
+++ b/modules/gcloud/firestore_test.go
@@ -3,6 +3,7 @@ package gcloud_test
 import (
 	"context"
 	"fmt"
+	"log"
 
 	"cloud.google.com/go/firestore"
 	"google.golang.org/api/option"
@@ -33,13 +34,13 @@ func ExampleRunFirestoreContainer() {
 		gcloud.WithProjectID("firestore-project"),
 	)
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to run container: %v", err)
 	}
 
 	// Clean up the container
 	defer func() {
 		if err := firestoreContainer.Terminate(ctx); err != nil {
-			panic(err)
+			log.Fatalf("failed to terminate container: %v", err)
 		}
 	}()
 	// }
@@ -49,13 +50,13 @@ func ExampleRunFirestoreContainer() {
 
 	conn, err := grpc.Dial(firestoreContainer.URI, grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithPerRPCCredentials(emulatorCreds{}))
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to dial: %v", err)
 	}
 
 	options := []option.ClientOption{option.WithGRPCConn(conn)}
 	client, err := firestore.NewClient(ctx, projectID, options...)
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to create client: %v", err)
 	}
 	defer client.Close()
 	// }
@@ -74,17 +75,17 @@ func ExampleRunFirestoreContainer() {
 	}
 	_, err = docRef.Create(ctx, data)
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to create document: %v", err)
 	}
 
 	docsnap, err := docRef.Get(ctx)
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to get document: %v", err)
 	}
 
 	var saved Person
 	if err := docsnap.DataTo(&saved); err != nil {
-		panic(err)
+		log.Fatalf("failed to convert data: %v", err)
 	}
 
 	fmt.Println(saved.Firstname, saved.Lastname)

--- a/modules/gcloud/pubsub_test.go
+++ b/modules/gcloud/pubsub_test.go
@@ -3,6 +3,7 @@ package gcloud_test
 import (
 	"context"
 	"fmt"
+	"log"
 
 	"cloud.google.com/go/pubsub"
 	"google.golang.org/api/option"
@@ -23,13 +24,13 @@ func ExampleRunPubsubContainer() {
 		gcloud.WithProjectID("pubsub-project"),
 	)
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to run container: %v", err)
 	}
 
 	// Clean up the container
 	defer func() {
 		if err := pubsubContainer.Terminate(ctx); err != nil {
-			panic(err)
+			log.Fatalf("failed to terminate container: %v", err)
 		}
 	}()
 	// }
@@ -39,30 +40,30 @@ func ExampleRunPubsubContainer() {
 
 	conn, err := grpc.Dial(pubsubContainer.URI, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to dial: %v", err)
 	}
 
 	options := []option.ClientOption{option.WithGRPCConn(conn)}
 	client, err := pubsub.NewClient(ctx, projectID, options...)
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to create client: %v", err)
 	}
 	defer client.Close()
 	// }
 
 	topic, err := client.CreateTopic(ctx, "greetings")
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to create topic: %v", err)
 	}
 	subscription, err := client.CreateSubscription(ctx, "subscription",
 		pubsub.SubscriptionConfig{Topic: topic})
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to create subscription: %v", err)
 	}
 	result := topic.Publish(ctx, &pubsub.Message{Data: []byte("Hello World")})
 	_, err = result.Get(ctx)
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to publish message: %v", err)
 	}
 
 	var data []byte
@@ -73,7 +74,7 @@ func ExampleRunPubsubContainer() {
 		defer cancel()
 	})
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to receive message: %v", err)
 	}
 
 	fmt.Println(string(data))

--- a/modules/gcloud/spanner_test.go
+++ b/modules/gcloud/spanner_test.go
@@ -3,6 +3,7 @@ package gcloud_test
 import (
 	"context"
 	"fmt"
+	"log"
 
 	"cloud.google.com/go/spanner"
 	database "cloud.google.com/go/spanner/admin/database/apiv1"
@@ -28,13 +29,13 @@ func ExampleRunSpannerContainer() {
 		gcloud.WithProjectID("spanner-project"),
 	)
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to run container: %v", err)
 	}
 
 	// Clean up the container
 	defer func() {
 		if err := spannerContainer.Terminate(ctx); err != nil {
-			panic(err)
+			log.Fatalf("failed to terminate container: %v", err)
 		}
 	}()
 	// }
@@ -56,7 +57,7 @@ func ExampleRunSpannerContainer() {
 
 	instanceAdmin, err := instance.NewInstanceAdminClient(ctx, options...)
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to create instance admin client: %v", err)
 	}
 	defer instanceAdmin.Close()
 	// }
@@ -69,18 +70,18 @@ func ExampleRunSpannerContainer() {
 		},
 	})
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to create instance: %v", err)
 	}
 
 	_, err = instanceOp.Wait(ctx)
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to wait for instance creation: %v", err)
 	}
 
 	// spannerDBAdminClient {
 	c, err := database.NewDatabaseAdminClient(ctx, options...)
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to create admin client: %v", err)
 	}
 	defer c.Close()
 	// }
@@ -93,17 +94,17 @@ func ExampleRunSpannerContainer() {
 		},
 	})
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to create database: %v", err)
 	}
 	_, err = databaseOp.Wait(ctx)
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to wait for database creation: %v", err)
 	}
 
 	db := fmt.Sprintf("projects/%s/instances/%s/databases/%s", projectId, instanceId, databaseName)
 	client, err := spanner.NewClient(ctx, db, options...)
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to create client: %v", err)
 	}
 	defer client.Close()
 
@@ -113,18 +114,18 @@ func ExampleRunSpannerContainer() {
 			[]interface{}{"Go", "Gopher"}),
 	})
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to apply mutation: %v", err)
 	}
 	row, err := client.Single().ReadRow(ctx, "Languages",
 		spanner.Key{"Go"}, []string{"mascot"})
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to read row: %v", err)
 	}
 
 	var mascot string
 	err = row.ColumnByName("Mascot", &mascot)
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to read column: %v", err)
 	}
 
 	fmt.Println(mascot)

--- a/modules/inbucket/examples_test.go
+++ b/modules/inbucket/examples_test.go
@@ -3,6 +3,7 @@ package inbucket_test
 import (
 	"context"
 	"fmt"
+	"log"
 
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/modules/inbucket"
@@ -14,20 +15,20 @@ func ExampleRunContainer() {
 
 	inbucketContainer, err := inbucket.RunContainer(ctx, testcontainers.WithImage("inbucket/inbucket:sha-2d409bb"))
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to start container: %s", err)
 	}
 
 	// Clean up the container
 	defer func() {
 		if err := inbucketContainer.Terminate(ctx); err != nil {
-			panic(err)
+			log.Fatalf("failed to terminate container: %s", err)
 		}
 	}()
 	// }
 
 	state, err := inbucketContainer.State(ctx)
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to get container state: %s", err)
 	}
 
 	fmt.Println(state.Running)

--- a/modules/k3s/k3s_example_test.go
+++ b/modules/k3s/k3s_example_test.go
@@ -3,6 +3,7 @@ package k3s_test
 import (
 	"context"
 	"fmt"
+	"log"
 
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -20,42 +21,42 @@ func ExampleRunContainer() {
 		testcontainers.WithImage("docker.io/rancher/k3s:v1.27.1-k3s1"),
 	)
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to start container: %s", err)
 	}
 
 	// Clean up the container
 	defer func() {
 		if err := k3sContainer.Terminate(ctx); err != nil {
-			panic(err)
+			log.Fatalf("failed to terminate container: %s", err)
 		}
 	}()
 	// }
 
 	state, err := k3sContainer.State(ctx)
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to get container state: %s", err)
 	}
 
 	fmt.Println(state.Running)
 
 	kubeConfigYaml, err := k3sContainer.GetKubeConfig(ctx)
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to get kubeconfig: %s", err)
 	}
 
 	restcfg, err := clientcmd.RESTConfigFromKubeConfig(kubeConfigYaml)
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to create rest config: %s", err)
 	}
 
 	k8s, err := kubernetes.NewForConfig(restcfg)
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to create k8s client: %s", err)
 	}
 
 	nodes, err := k8s.CoreV1().Nodes().List(ctx, v1.ListOptions{})
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to list nodes: %s", err)
 	}
 
 	fmt.Println(len(nodes.Items))

--- a/modules/k6/examples_test.go
+++ b/modules/k6/examples_test.go
@@ -3,6 +3,7 @@ package k6_test
 import (
 	"context"
 	"fmt"
+	"log"
 	"path/filepath"
 
 	"github.com/testcontainers/testcontainers-go"
@@ -29,12 +30,12 @@ func ExampleRunContainer() {
 	}
 	httpbin, err := testcontainers.GenericContainer(ctx, gcr)
 	if err != nil {
-		panic(fmt.Errorf("failed to create httpbin container %w", err))
+		log.Fatalf("failed to start container: %s", err)
 	}
 
 	defer func() {
 		if err := httpbin.Terminate(ctx); err != nil {
-			panic(fmt.Errorf("failed to terminate container: %w", err))
+			log.Fatalf("failed to terminate container: %s", err)
 		}
 	}()
 	// }
@@ -42,13 +43,13 @@ func ExampleRunContainer() {
 	// getHTTPBinIP {
 	httpbinIP, err := httpbin.ContainerIP(ctx)
 	if err != nil {
-		panic(fmt.Errorf("failed to get httpbin IP: %w", err))
+		log.Fatalf("failed to get container IP: %s", err)
 	}
 	// }
 
 	absPath, err := filepath.Abs(filepath.Join("scripts", "httpbin.js"))
 	if err != nil {
-		panic(fmt.Errorf("failed to get path to test script: %w", err))
+		log.Fatalf("failed to get absolute path to test script: %s", err)
 	}
 
 	// runK6Container {
@@ -60,12 +61,12 @@ func ExampleRunContainer() {
 		k6.SetEnvVar("HTTPBIN", httpbinIP),
 	)
 	if err != nil {
-		panic(fmt.Errorf("failed to start k6 container: %w", err))
+		log.Fatalf("failed to start container: %s", err)
 	}
 
 	defer func() {
 		if err := k6.Terminate(ctx); err != nil {
-			panic(fmt.Errorf("failed to terminate container: %w", err))
+			log.Fatalf("failed to terminate container: %s", err)
 		}
 	}()
 	//}
@@ -73,7 +74,7 @@ func ExampleRunContainer() {
 	// assert the result of the test
 	state, err := k6.State(ctx)
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to get container state: %s", err)
 	}
 
 	fmt.Println(state.ExitCode)

--- a/modules/kafka/examples_test.go
+++ b/modules/kafka/examples_test.go
@@ -3,6 +3,7 @@ package kafka_test
 import (
 	"context"
 	"fmt"
+	"log"
 
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/modules/kafka"
@@ -17,20 +18,20 @@ func ExampleRunContainer() {
 		testcontainers.WithImage("confluentinc/confluent-local:7.5.0"),
 	)
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to start container: %s", err)
 	}
 
 	// Clean up the container after
 	defer func() {
 		if err := kafkaContainer.Terminate(ctx); err != nil {
-			panic(err)
+			log.Fatalf("failed to terminate container: %s", err)
 		}
 	}()
 	// }
 
 	state, err := kafkaContainer.State(ctx)
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to get container state: %s", err)
 	}
 
 	fmt.Println(kafkaContainer.ClusterID)

--- a/modules/localstack/examples_test.go
+++ b/modules/localstack/examples_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log"
 	"net/http"
 	"path/filepath"
 	"strings"
@@ -26,20 +27,20 @@ func ExampleRunContainer() {
 		testcontainers.WithImage("localstack/localstack:1.4.0"),
 	)
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to start container: %s", err)
 	}
 
 	// Clean up the container
 	defer func() {
 		if err := localstackContainer.Terminate(ctx); err != nil {
-			panic(err)
+			log.Fatalf("failed to terminate container: %s", err)
 		}
 	}()
 	// }
 
 	state, err := localstackContainer.State(ctx)
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to get container state: %s", err)
 	}
 
 	fmt.Println(state.Running)
@@ -54,7 +55,7 @@ func ExampleRunContainer_withNetwork() {
 
 	newNetwork, err := network.New(ctx, network.WithCheckDuplicate())
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to create network: %s", err)
 	}
 
 	nwName := newNetwork.Name
@@ -71,20 +72,20 @@ func ExampleRunContainer_withNetwork() {
 		}),
 	)
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to start container: %s", err)
 	}
 	// }
 
 	// Clean up the container
 	defer func() {
 		if err := localstackContainer.Terminate(ctx); err != nil {
-			panic(err)
+			log.Fatalf("failed to terminate container: %s", err)
 		}
 	}()
 
 	networks, err := localstackContainer.Networks(ctx)
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to get container networks: %s", err)
 	}
 
 	fmt.Println(len(networks))
@@ -107,7 +108,7 @@ func ExampleRunContainer_legacyMode() {
 		}),
 	)
 	if err == nil {
-		panic(err)
+		log.Fatalf("expected an error, got nil")
 	}
 
 	fmt.Println(err)
@@ -150,12 +151,12 @@ func ExampleRunContainer_usingLambdas() {
 		}),
 	)
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to start container: %s", err)
 	}
 	defer func() {
 		err := container.Terminate(ctx)
 		if err != nil {
-			panic(err)
+			log.Fatalf("failed to terminate container: %s", err)
 		}
 	}()
 
@@ -179,7 +180,7 @@ func ExampleRunContainer_usingLambdas() {
 	for _, cmd := range lambdaCommands {
 		_, _, err := container.Exec(ctx, cmd)
 		if err != nil {
-			panic(err)
+			log.Fatalf("failed to execute command %v: %s", cmd, err)
 		}
 	}
 
@@ -189,13 +190,13 @@ func ExampleRunContainer_usingLambdas() {
 	}
 	_, reader, err := container.Exec(ctx, cmd, exec.Multiplexed())
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to execute command %v: %s", cmd, err)
 	}
 
 	buf := new(bytes.Buffer)
 	_, err = buf.ReadFrom(reader)
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to read from reader: %s", err)
 	}
 
 	content := buf.Bytes()
@@ -213,7 +214,7 @@ func ExampleRunContainer_usingLambdas() {
 	v := &FunctionURLConfig{}
 	err = json.Unmarshal(content, v)
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to unmarshal content: %s", err)
 	}
 
 	httpClient := http.Client{
@@ -225,19 +226,19 @@ func ExampleRunContainer_usingLambdas() {
 
 	mappedPort, err := container.MappedPort(ctx, "4566/tcp")
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to get mapped port: %s", err)
 	}
 
 	functionURL = strings.ReplaceAll(functionURL, "4566", mappedPort.Port())
 
 	resp, err := httpClient.Post(functionURL, "application/json", bytes.NewBufferString(`{"num1": "10", "num2": "10"}`))
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to send request to lambda function: %s", err)
 	}
 
 	jsonResponse, err := io.ReadAll(resp.Body)
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to read response body: %s", err)
 	}
 
 	fmt.Println(string(jsonResponse))

--- a/modules/mariadb/examples_test.go
+++ b/modules/mariadb/examples_test.go
@@ -3,6 +3,7 @@ package mariadb_test
 import (
 	"context"
 	"fmt"
+	"log"
 	"path/filepath"
 
 	"github.com/testcontainers/testcontainers-go"
@@ -22,20 +23,20 @@ func ExampleRunContainer() {
 		mariadb.WithPassword(""),
 	)
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to start container: %s", err)
 	}
 
 	// Clean up the container
 	defer func() {
 		if err := mariadbContainer.Terminate(ctx); err != nil {
-			panic(err)
+			log.Fatalf("failed to terminate container: %s", err)
 		}
 	}()
 	// }
 
 	state, err := mariadbContainer.State(ctx)
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to get container state: %s", err)
 	}
 
 	fmt.Println(state.Running)

--- a/modules/minio/examples_test.go
+++ b/modules/minio/examples_test.go
@@ -3,6 +3,7 @@ package minio_test
 import (
 	"context"
 	"fmt"
+	"log"
 
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/modules/minio"
@@ -14,20 +15,20 @@ func ExampleRunContainer() {
 
 	minioContainer, err := minio.RunContainer(ctx, testcontainers.WithImage("minio/minio:RELEASE.2024-01-16T16-07-38Z"))
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to start container: %s", err)
 	}
 
 	// Clean up the container
 	defer func() {
 		if err := minioContainer.Terminate(ctx); err != nil {
-			panic(err)
+			log.Fatalf("failed to terminate container: %s", err)
 		}
 	}()
 	// }
 
 	state, err := minioContainer.State(ctx)
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to get container state: %s", err)
 	}
 
 	fmt.Println(state.Running)

--- a/modules/mockserver/examples_test.go
+++ b/modules/mockserver/examples_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"log"
 	"net/http"
 	"strings"
 
@@ -19,20 +20,20 @@ func ExampleRunContainer() {
 
 	mockserverContainer, err := mockserver.RunContainer(ctx, testcontainers.WithImage("mockserver/mockserver:5.15.0"))
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to start container: %s", err)
 	}
 
 	// Clean up the container
 	defer func() {
 		if err := mockserverContainer.Terminate(ctx); err != nil {
-			panic(err)
+			log.Fatalf("failed to terminate container: %s", err)
 		}
 	}()
 	// }
 
 	state, err := mockserverContainer.State(ctx)
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to get container state: %s", err)
 	}
 
 	fmt.Println(state.Running)
@@ -47,19 +48,19 @@ func ExampleRunContainer_connect() {
 
 	mockserverContainer, err := mockserver.RunContainer(ctx, testcontainers.WithImage("mockserver/mockserver:5.15.0"))
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to start container: %s", err)
 	}
 
 	// Clean up the container
 	defer func() {
 		if err := mockserverContainer.Terminate(ctx); err != nil {
-			panic(err)
+			log.Fatalf("failed to terminate container: %s", err)
 		}
 	}()
 
 	url, err := mockserverContainer.URL(ctx)
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to get container URL: %s", err)
 	}
 	ms := client.NewClientURL(url)
 	// }
@@ -71,18 +72,18 @@ func ExampleRunContainer_connect() {
 	requestMatcher = requestMatcher.WithJSONFields(map[string]interface{}{"name": "Tools"})
 	err = ms.RegisterExpectation(client.NewExpectation(requestMatcher).WithResponse(client.NewResponseOK().WithJSONBody(map[string]any{"test": "value"})))
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to register expectation: %s", err)
 	}
 
 	httpClient := &http.Client{}
 	resp, err := httpClient.Post(url+"/api/categories", "application/json", strings.NewReader(`{"name": "Tools"}`))
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to send request: %s", err)
 	}
 
 	buf, err := io.ReadAll(resp.Body)
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to read response: %s", err)
 	}
 	resp.Body.Close()
 

--- a/modules/mongodb/mongodb_test.go
+++ b/modules/mongodb/mongodb_test.go
@@ -3,6 +3,7 @@ package mongodb_test
 import (
 	"context"
 	"fmt"
+	"log"
 	"strings"
 
 	"go.mongodb.org/mongo-driver/mongo"
@@ -19,20 +20,20 @@ func ExampleRunContainer() {
 
 	mongodbContainer, err := mongodb.RunContainer(ctx, testcontainers.WithImage("mongo:6"))
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to start container: %s", err)
 	}
 
 	// Clean up the container
 	defer func() {
 		if err := mongodbContainer.Terminate(ctx); err != nil {
-			panic(err)
+			log.Fatalf("failed to terminate container: %s", err)
 		}
 	}()
 	// }
 
 	state, err := mongodbContainer.State(ctx)
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to get container state: %s", err)
 	}
 
 	fmt.Println(state.Running)
@@ -47,30 +48,30 @@ func ExampleRunContainer_connect() {
 
 	mongodbContainer, err := mongodb.RunContainer(ctx, testcontainers.WithImage("mongo:6"))
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to start container: %s", err)
 	}
 
 	// Clean up the container
 	defer func() {
 		if err := mongodbContainer.Terminate(ctx); err != nil {
-			panic(err)
+			log.Fatalf("failed to terminate container: %s", err)
 		}
 	}()
 
 	endpoint, err := mongodbContainer.ConnectionString(ctx)
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to get connection string: %s", err)
 	}
 
 	mongoClient, err := mongo.Connect(ctx, options.Client().ApplyURI(endpoint))
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to connect to MongoDB: %s", err)
 	}
 	// }
 
 	err = mongoClient.Ping(ctx, nil)
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to ping MongoDB: %s", err)
 	}
 
 	fmt.Println(mongoClient.Database("test").Name())
@@ -89,29 +90,29 @@ func ExampleRunContainer_withCredentials() {
 		testcontainers.WithWaitStrategy(wait.ForLog("Waiting for connections")),
 	)
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to start container: %s", err)
 	}
 
 	// Clean up the container
 	defer func() {
 		if err := container.Terminate(ctx); err != nil {
-			panic(err)
+			log.Fatalf("failed to terminate container: %s", err)
 		}
 	}()
 
 	connStr, err := container.ConnectionString(ctx)
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to get connection string: %s", err)
 	}
 
 	mongoClient, err := mongo.Connect(ctx, options.Client().ApplyURI(connStr))
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to connect to MongoDB: %s", err)
 	}
 
 	err = mongoClient.Ping(ctx, nil)
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to ping MongoDB: %s", err)
 	}
 	fmt.Println(strings.Split(connStr, "@")[0])
 

--- a/modules/mssql/examples_test.go
+++ b/modules/mssql/examples_test.go
@@ -3,6 +3,7 @@ package mssql_test
 import (
 	"context"
 	"fmt"
+	"log"
 
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/modules/mssql"
@@ -20,20 +21,20 @@ func ExampleRunContainer() {
 		mssql.WithPassword(password),
 	)
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to start container: %s", err)
 	}
 
 	// Clean up the container
 	defer func() {
 		if err := mssqlContainer.Terminate(ctx); err != nil {
-			panic(err)
+			log.Fatalf("failed to terminate container: %s", err)
 		}
 	}()
 	// }
 
 	state, err := mssqlContainer.State(ctx)
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to get container state: %s", err)
 	}
 
 	fmt.Println(state.Running)

--- a/modules/mysql/examples_test.go
+++ b/modules/mysql/examples_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"log"
 	"path/filepath"
 
 	"github.com/testcontainers/testcontainers-go"
@@ -23,20 +24,20 @@ func ExampleRunContainer() {
 		mysql.WithScripts(filepath.Join("testdata", "schema.sql")),
 	)
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to start container: %s", err)
 	}
 
 	// Clean up the container
 	defer func() {
 		if err := mysqlContainer.Terminate(ctx); err != nil {
-			panic(err)
+			log.Fatalf("failed to terminate container: %s", err)
 		}
 	}()
 	// }
 
 	state, err := mysqlContainer.State(ctx)
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to get container state: %s", err)
 	}
 
 	fmt.Println(state.Running)
@@ -57,12 +58,12 @@ func ExampleRunContainer_connect() {
 		mysql.WithScripts(filepath.Join("testdata", "schema.sql")),
 	)
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to start container: %s", err)
 	}
 
 	defer func() {
 		if err := mysqlContainer.Terminate(ctx); err != nil {
-			panic(err)
+			log.Fatalf("failed to terminate container: %s", err)
 		}
 	}()
 
@@ -70,23 +71,23 @@ func ExampleRunContainer_connect() {
 
 	db, err := sql.Open("mysql", connectionString)
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to connect to MySQL: %s", err)
 	}
 	defer db.Close()
 
 	if err = db.Ping(); err != nil {
-		panic(err)
+		log.Fatalf("failed to ping MySQL: %s", err)
 	}
 	stmt, err := db.Prepare("SELECT @@GLOBAL.tmpdir")
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to prepare statement: %s", err)
 	}
 	defer stmt.Close()
 	row := stmt.QueryRow()
 	tmpDir := ""
 	err = row.Scan(&tmpDir)
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to scan row: %s", err)
 	}
 
 	fmt.Println(tmpDir)

--- a/modules/nats/examples_test.go
+++ b/modules/nats/examples_test.go
@@ -3,6 +3,7 @@ package nats_test
 import (
 	"context"
 	"fmt"
+	"log"
 
 	natsgo "github.com/nats-io/nats.go"
 
@@ -18,20 +19,20 @@ func ExampleRunContainer() {
 		testcontainers.WithImage("nats:2.9"),
 	)
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to start container: %s", err)
 	}
 
 	// Clean up the container
 	defer func() {
 		if err := natsContainer.Terminate(ctx); err != nil {
-			panic(err)
+			log.Fatalf("failed to terminate container: %s", err)
 		}
 	}()
 	// }
 
 	state, err := natsContainer.State(ctx)
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to get container state: %s", err)
 	}
 
 	fmt.Println(state.Running)
@@ -46,24 +47,24 @@ func ExampleRunContainer_connectWithCredentials() {
 
 	container, err := nats.RunContainer(ctx, nats.WithUsername("foo"), nats.WithPassword("bar"))
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to start container: %s", err)
 	}
 
 	// Clean up the container
 	defer func() {
 		if err := container.Terminate(ctx); err != nil {
-			panic(err)
+			log.Fatalf("failed to terminate container: %s", err)
 		}
 	}()
 
 	uri, err := container.ConnectionString(ctx)
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to get connection string: %s", err)
 	}
 
 	nc, err := natsgo.Connect(uri, natsgo.UserInfo(container.User, container.Password))
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to connect to NATS: %s", err)
 	}
 	defer nc.Close()
 	// }

--- a/modules/neo4j/examples_test.go
+++ b/modules/neo4j/examples_test.go
@@ -3,6 +3,7 @@ package neo4j_test
 import (
 	"context"
 	"fmt"
+	"log"
 
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/modules/neo4j"
@@ -21,20 +22,20 @@ func ExampleRunContainer() {
 		neo4j.WithNeo4jSetting("dbms.tx_log.rotation.size", "42M"),
 	)
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to start container: %s", err)
 	}
 
 	// Clean up the container
 	defer func() {
 		if err := neo4jContainer.Terminate(ctx); err != nil {
-			panic(err)
+			log.Fatalf("failed to terminate container: %s", err)
 		}
 	}()
 	// }
 
 	state, err := neo4jContainer.State(ctx)
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to get container state: %s", err)
 	}
 
 	fmt.Println(state.Running)

--- a/modules/openldap/examples_test.go
+++ b/modules/openldap/examples_test.go
@@ -3,6 +3,7 @@ package openldap_test
 import (
 	"context"
 	"fmt"
+	"log"
 
 	"github.com/go-ldap/ldap/v3"
 
@@ -16,20 +17,20 @@ func ExampleRunContainer() {
 
 	openldapContainer, err := openldap.RunContainer(ctx, testcontainers.WithImage("bitnami/openldap:2.6.6"))
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to start container: %s", err)
 	}
 
 	// Clean up the container
 	defer func() {
 		if err := openldapContainer.Terminate(ctx); err != nil {
-			panic(err)
+			log.Fatalf("failed to terminate container: %s", err)
 		}
 	}()
 	// }
 
 	state, err := openldapContainer.State(ctx)
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to get container state: %s", err)
 	}
 
 	fmt.Println(state.Running)
@@ -44,31 +45,31 @@ func ExampleRunContainer_connect() {
 
 	openldapContainer, err := openldap.RunContainer(ctx, testcontainers.WithImage("bitnami/openldap:2.6.6"))
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to start container: %s", err)
 	}
 
 	// Clean up the container
 	defer func() {
 		if err := openldapContainer.Terminate(ctx); err != nil {
-			panic(err)
+			log.Fatalf("failed to terminate container: %s", err)
 		}
 	}()
 
 	connectionString, err := openldapContainer.ConnectionString(ctx)
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to get connection string: %s", err)
 	}
 
 	client, err := ldap.DialURL(connectionString)
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to connect to LDAP server: %s", err)
 	}
 	defer client.Close()
 
 	// First bind with a read only user
 	err = client.Bind("cn=admin,dc=example,dc=org", "adminpassword")
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to bind to LDAP server: %s", err)
 	}
 
 	// Search for the given username
@@ -82,11 +83,11 @@ func ExampleRunContainer_connect() {
 
 	sr, err := client.Search(searchRequest)
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to search LDAP server: %s", err)
 	}
 
 	if len(sr.Entries) != 1 {
-		panic("User does not exist or too many entries returned")
+		log.Fatal("User does not exist or too many entries returned")
 	}
 
 	fmt.Println(sr.Entries[0].DN)

--- a/modules/postgres/examples_test.go
+++ b/modules/postgres/examples_test.go
@@ -3,6 +3,7 @@ package postgres_test
 import (
 	"context"
 	"fmt"
+	"log"
 	"path/filepath"
 	"time"
 
@@ -32,20 +33,20 @@ func ExampleRunContainer() {
 				WithStartupTimeout(5*time.Second)),
 	)
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to start container: %s", err)
 	}
 
 	// Clean up the container
 	defer func() {
 		if err := postgresContainer.Terminate(ctx); err != nil {
-			panic(err)
+			log.Fatalf("failed to terminate container: %s", err)
 		}
 	}()
 	// }
 
 	state, err := postgresContainer.State(ctx)
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to get container state: %s", err)
 	}
 
 	fmt.Println(state.Running)

--- a/modules/pulsar/examples_test.go
+++ b/modules/pulsar/examples_test.go
@@ -3,6 +3,7 @@ package pulsar_test
 import (
 	"context"
 	"fmt"
+	"log"
 
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/modules/pulsar"
@@ -16,20 +17,20 @@ func ExampleRunContainer() {
 		testcontainers.WithImage("docker.io/apachepulsar/pulsar:2.10.2"),
 	)
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to start container: %s", err)
 	}
 
 	// Clean up the container
 	defer func() {
 		if err := pulsarContainer.Terminate(ctx); err != nil {
-			panic(err)
+			log.Fatalf("failed to terminate container: %s", err)
 		}
 	}()
 	// }
 
 	state, err := pulsarContainer.State(ctx)
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to get container state: %s", err)
 	}
 
 	fmt.Println(state.Running)

--- a/modules/rabbitmq/examples_test.go
+++ b/modules/rabbitmq/examples_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"log"
 	"path/filepath"
 	"strings"
 
@@ -23,20 +24,20 @@ func ExampleRunContainer() {
 		rabbitmq.WithAdminPassword("password"),
 	)
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to start container: %s", err)
 	}
 
 	// Clean up the container
 	defer func() {
 		if err := rabbitmqContainer.Terminate(ctx); err != nil {
-			panic(err)
+			log.Fatalf("failed to terminate container: %s", err)
 		}
 	}()
 	// }
 
 	state, err := rabbitmqContainer.State(ctx)
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to get container state: %s", err)
 	}
 
 	fmt.Println(state.Running)
@@ -54,27 +55,27 @@ func ExampleRunContainer_connectUsingAmqp() {
 		rabbitmq.WithAdminPassword("password"),
 	)
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to start container: %s", err)
 	}
 	defer func() {
 		if err := rabbitmqContainer.Terminate(ctx); err != nil {
-			panic(err)
+			log.Fatalf("failed to terminate container: %s", err)
 		}
 	}()
 
 	amqpURL, err := rabbitmqContainer.AmqpURL(ctx)
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to get AMQP URL: %s", err)
 	}
 
 	amqpConnection, err := amqp.Dial(amqpURL)
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to connect to RabbitMQ: %s", err)
 	}
 	defer func() {
 		err := amqpConnection.Close()
 		if err != nil {
-			panic(err)
+			log.Fatalf("failed to close connection: %s", err)
 		}
 	}()
 
@@ -102,19 +103,19 @@ func ExampleRunContainer_withSSL() {
 		rabbitmq.WithSSL(sslSettings),
 	)
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to start container: %s", err)
 	}
 	// }
 
 	defer func() {
 		if err := rabbitmqContainer.Terminate(ctx); err != nil {
-			panic(err)
+			log.Fatalf("failed to terminate container: %s", err)
 		}
 	}()
 
 	state, err := rabbitmqContainer.State(ctx)
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to get container state: %s", err)
 	}
 
 	fmt.Println(state.Running)
@@ -136,12 +137,12 @@ func ExampleRunContainer_withPlugins() {
 		),
 	)
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to start container: %s", err)
 	}
 
 	defer func() {
 		if err := rabbitmqContainer.Terminate(ctx); err != nil {
-			panic(err)
+			log.Fatalf("failed to terminate container: %s", err)
 		}
 	}()
 
@@ -158,23 +159,23 @@ func ExampleRunContainer_withCustomConfigFile() {
 		testcontainers.WithImage("rabbitmq:3.7.25-management-alpine"),
 	)
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to start container: %s", err)
 	}
 
 	defer func() {
 		if err := rabbitmqContainer.Terminate(ctx); err != nil {
-			panic(err)
+			log.Fatalf("failed to terminate container: %s", err)
 		}
 	}()
 
 	logs, err := rabbitmqContainer.Logs(ctx)
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to get logs: %s", err)
 	}
 
 	bytes, err := io.ReadAll(logs)
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to read logs: %s", err)
 	}
 
 	fmt.Println(strings.Contains(string(bytes), "config file(s) : /etc/rabbitmq/rabbitmq-testcontainers.conf"))
@@ -190,12 +191,12 @@ func assertPlugins(container testcontainers.Container, plugins ...string) bool {
 
 		_, out, err := container.Exec(ctx, []string{"rabbitmq-plugins", "is_enabled", plugin})
 		if err != nil {
-			panic(err)
+			log.Fatalf("failed to execute command: %s", err)
 		}
 
 		check, err := io.ReadAll(out)
 		if err != nil {
-			panic(err)
+			log.Fatalf("failed to read output: %s", err)
 		}
 
 		if !strings.Contains(string(check), plugin+" is enabled") {

--- a/modules/redis/examples_test.go
+++ b/modules/redis/examples_test.go
@@ -3,6 +3,7 @@ package redis_test
 import (
 	"context"
 	"fmt"
+	"log"
 	"path/filepath"
 
 	"github.com/testcontainers/testcontainers-go"
@@ -20,20 +21,20 @@ func ExampleRunContainer() {
 		redis.WithConfigFile(filepath.Join("testdata", "redis7.conf")),
 	)
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to start container: %s", err)
 	}
 
 	// Clean up the container
 	defer func() {
 		if err := redisContainer.Terminate(ctx); err != nil {
-			panic(err)
+			log.Fatalf("failed to terminate container: %s", err)
 		}
 	}()
 	// }
 
 	state, err := redisContainer.State(ctx)
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to get container state: %s", err)
 	}
 
 	fmt.Println(state.Running)

--- a/modules/redpanda/examples_test.go
+++ b/modules/redpanda/examples_test.go
@@ -3,6 +3,7 @@ package redpanda_test
 import (
 	"context"
 	"fmt"
+	"log"
 
 	"github.com/testcontainers/testcontainers-go/modules/redpanda"
 )
@@ -21,20 +22,20 @@ func ExampleRunContainer() {
 		redpanda.WithEnableSchemaRegistryHTTPBasicAuth(),
 	)
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to start container: %s", err)
 	}
 
 	// Clean up the container
 	defer func() {
 		if err := redpandaContainer.Terminate(ctx); err != nil {
-			panic(err)
+			log.Fatalf("failed to terminate container: %s", err)
 		}
 	}()
 	// }
 
 	state, err := redpandaContainer.State(ctx)
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to get container state: %s", err)
 	}
 
 	fmt.Println(state.Running)

--- a/modules/vault/examples_test.go
+++ b/modules/vault/examples_test.go
@@ -3,6 +3,7 @@ package vault_test
 import (
 	"context"
 	"fmt"
+	"log"
 
 	"github.com/testcontainers/testcontainers-go/exec"
 	"github.com/testcontainers/testcontainers-go/modules/vault"
@@ -14,20 +15,20 @@ func ExampleRunContainer() {
 
 	vaultContainer, err := vault.RunContainer(ctx)
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to start container: %s", err)
 	}
 
 	// Clean up the container
 	defer func() {
 		if err := vaultContainer.Terminate(ctx); err != nil {
-			panic(err)
+			log.Fatalf("failed to terminate container: %s", err)
 		}
 	}()
 	// }
 
 	state, err := vaultContainer.State(ctx)
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to get container state: %s", err)
 	}
 
 	fmt.Println(state.Running)
@@ -42,20 +43,20 @@ func ExampleRunContainer_withToken() {
 
 	vaultContainer, err := vault.RunContainer(ctx, vault.WithToken("MyToKeN"))
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to start container: %s", err)
 	}
 
 	// Clean up the container
 	defer func() {
 		if err := vaultContainer.Terminate(ctx); err != nil {
-			panic(err)
+			log.Fatalf("failed to terminate container: %s", err)
 		}
 	}()
 	// }
 
 	state, err := vaultContainer.State(ctx)
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to get container state: %s", err)
 	}
 
 	fmt.Println(state.Running)
@@ -65,7 +66,7 @@ func ExampleRunContainer_withToken() {
 	}
 	exitCode, _, err := vaultContainer.Exec(ctx, cmds, exec.Multiplexed())
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to execute command: %s", err)
 	}
 
 	fmt.Println(exitCode)
@@ -87,20 +88,20 @@ func ExampleRunContainer_withInitCommand() {
 		"write secret/testing top_secret=password123", // Create a secret
 	))
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to start container: %s", err)
 	}
 
 	// Clean up the container
 	defer func() {
 		if err := vaultContainer.Terminate(ctx); err != nil {
-			panic(err)
+			log.Fatalf("failed to terminate container: %s", err)
 		}
 	}()
 	// }
 
 	state, err := vaultContainer.State(ctx)
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to get container state: %s", err)
 	}
 
 	fmt.Println(state.Running)

--- a/network/network_test.go
+++ b/network/network_test.go
@@ -41,7 +41,7 @@ func ExampleNew() {
 	}
 	defer func() {
 		if err := net.Remove(ctx); err != nil {
-			panic(err)
+			log.Fatalf("failed to remove network: %s", err)
 		}
 	}()
 

--- a/wait/exec_test.go
+++ b/wait/exec_test.go
@@ -30,7 +30,7 @@ func ExampleExecStrategy() {
 		Started:          true,
 	})
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to start container: %s", err)
 	}
 
 	defer func() {
@@ -41,7 +41,7 @@ func ExampleExecStrategy() {
 
 	state, err := localstack.State(ctx)
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to get container state: %s", err)
 	}
 
 	fmt.Println(state.Running)

--- a/wait/http_test.go
+++ b/wait/http_test.go
@@ -37,7 +37,7 @@ func ExampleHTTPStrategy() {
 		Started:          true,
 	})
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to start container: %s", err)
 	}
 	// }
 
@@ -49,7 +49,7 @@ func ExampleHTTPStrategy() {
 
 	state, err := c.State(ctx)
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to get container state: %s", err)
 	}
 
 	fmt.Println(state.Running)
@@ -72,7 +72,7 @@ func ExampleHTTPStrategy_WithPort() {
 		Started:          true,
 	})
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to start container: %s", err)
 	}
 	// }
 
@@ -84,7 +84,7 @@ func ExampleHTTPStrategy_WithPort() {
 
 	state, err := c.State(ctx)
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to get container state: %s", err)
 	}
 
 	fmt.Println(state.Running)
@@ -106,7 +106,7 @@ func ExampleHTTPStrategy_WithForcedIPv4LocalHost() {
 		Started:          true,
 	})
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to start container: %s", err)
 	}
 
 	defer func() {
@@ -117,7 +117,7 @@ func ExampleHTTPStrategy_WithForcedIPv4LocalHost() {
 
 	state, err := c.State(ctx)
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to get container state: %s", err)
 	}
 
 	fmt.Println(state.Running)
@@ -140,7 +140,7 @@ func ExampleHTTPStrategy_WithBasicAuth() {
 		Started:          true,
 	})
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to start container: %s", err)
 	}
 	// }
 
@@ -152,7 +152,7 @@ func ExampleHTTPStrategy_WithBasicAuth() {
 
 	state, err := gogs.State(ctx)
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to get container state: %s", err)
 	}
 
 	fmt.Println(state.Running)


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
This PR replaces all the panics in the Example functions with `log.Fatalf` calls, including a descriptive message.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
`gotestsum` is used on CI to run the tests, including a flag to perform retries. If a panic happens, then it's not recoverable from `gotestsum`,
therefore we need a way to allow the retries, and log.Fatal makes it possible.
 
<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->


<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
