### PR TITLE
fix: apply volume options only to volumes

### DIFF
--- a/docker_mounts.go
+++ b/docker_mounts.go
@@ -116,9 +116,13 @@ func mapToDockerMounts(containerMounts ContainerMounts) []mount.Mount {
 
 		if mountType == mount.TypeVolume {
 			if containerMount.VolumeOptions == nil {
-				containerMount.VolumeOptions = &mount.VolumeOptions{}
+				containerMount.VolumeOptions = &mount.VolumeOptions{
+					Labels: make(map[string]string),
+				}
 			}
-			containerMount.VolumeOptions.Labels = GenericLabels()
+			for k, v := range GenericLabels() {
+				containerMount.VolumeOptions.Labels[k] = v
+			}
 		}
 
 		mounts = append(mounts, containerMount)

--- a/docker_mounts.go
+++ b/docker_mounts.go
@@ -101,9 +101,6 @@ func mapToDockerMounts(containerMounts ContainerMounts) []mount.Mount {
 			Source:   m.Source.Source(),
 			ReadOnly: m.ReadOnly,
 			Target:   m.Target.Target(),
-			VolumeOptions: &mount.VolumeOptions{
-				Labels: GenericLabels(),
-			},
 		}
 
 		switch typedMounter := m.Source.(type) {
@@ -115,6 +112,13 @@ func mapToDockerMounts(containerMounts ContainerMounts) []mount.Mount {
 			Logger.Printf("Mount type %s is not supported by Testcontainers for Go", m.Source.Type())
 		default:
 			// The provided source type has no custom options
+		}
+
+		if mountType == mount.TypeVolume {
+			if containerMount.VolumeOptions == nil {
+				containerMount.VolumeOptions = &mount.VolumeOptions{}
+			}
+			containerMount.VolumeOptions.Labels = GenericLabels()
 		}
 
 		mounts = append(mounts, containerMount)

--- a/mounts_test.go
+++ b/mounts_test.go
@@ -45,6 +45,9 @@ func TestContainerMounts_PrepareMounts(t *testing.T) {
 		Labels: GenericLabels(),
 	}
 
+	expectedLabels := GenericLabels()
+	expectedLabels["hello"] = "world"
+
 	t.Parallel()
 	tests := []struct {
 		name   string
@@ -104,9 +107,7 @@ func TestContainerMounts_PrepareMounts(t *testing.T) {
 					Target: "/data",
 					VolumeOptions: &mount.VolumeOptions{
 						NoCopy: true,
-						Labels: map[string]string{
-							"hello": "world",
-						},
+						Labels: expectedLabels,
 					},
 				},
 			},
@@ -117,9 +118,8 @@ func TestContainerMounts_PrepareMounts(t *testing.T) {
 			mounts: ContainerMounts{{Source: GenericTmpfsMountSource{}, Target: "/data"}},
 			want: []mount.Mount{
 				{
-					Type:          mount.TypeTmpfs,
-					Target:        "/data",
-					VolumeOptions: volumeOptions,
+					Type:   mount.TypeTmpfs,
+					Target: "/data",
 				},
 			},
 		},
@@ -128,10 +128,9 @@ func TestContainerMounts_PrepareMounts(t *testing.T) {
 			mounts: ContainerMounts{{Source: GenericTmpfsMountSource{}, Target: "/data", ReadOnly: true}},
 			want: []mount.Mount{
 				{
-					Type:          mount.TypeTmpfs,
-					Target:        "/data",
-					ReadOnly:      true,
-					VolumeOptions: volumeOptions,
+					Type:     mount.TypeTmpfs,
+					Target:   "/data",
+					ReadOnly: true,
 				},
 			},
 		},
@@ -156,7 +155,6 @@ func TestContainerMounts_PrepareMounts(t *testing.T) {
 						SizeBytes: 50 * 1024 * 1024,
 						Mode:      0o644,
 					},
-					VolumeOptions: volumeOptions,
 				},
 			},
 		},

--- a/mounts_test.go
+++ b/mounts_test.go
@@ -124,7 +124,7 @@ func TestContainerMounts_PrepareMounts(t *testing.T) {
 			},
 		},
 		{
-			name:   "Single volume mount - read-only",
+			name:   "Single tmpfs mount - read-only",
 			mounts: ContainerMounts{{Source: GenericTmpfsMountSource{}, Target: "/data", ReadOnly: true}},
 			want: []mount.Mount{
 				{
@@ -136,7 +136,7 @@ func TestContainerMounts_PrepareMounts(t *testing.T) {
 			},
 		},
 		{
-			name: "Single volume mount - with options",
+			name: "Single tmpfs mount - with options",
 			mounts: ContainerMounts{
 				{
 					Source: DockerTmpfsMountSource{


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
This PR applies the testcontainers-go labels only to volumes, as it was applying them to all types of mounts, which is incorrect.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
Debugging another issue with Docker bind mounts I discovered this issue.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Caused by #2191

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
