### PR TITLE
chore(ci): do not fail fast main tests in different Go versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
     uses: ./.github/workflows/ci-test-go.yml
     with:
       go-version: ${{ matrix.go-version }}
-      fail-fast: false
+      fail-fast: true
       platform: ${{ matrix.platform }}
       project-directory: "."
       rootless-docker: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
     uses: ./.github/workflows/ci-test-go.yml
     with:
       go-version: ${{ matrix.go-version }}
-      fail-fast: true
+      fail-fast: false
       platform: ${{ matrix.platform }}
       project-directory: "."
       rootless-docker: false
@@ -52,7 +52,7 @@ jobs:
     uses: ./.github/workflows/ci-test-go.yml
     with:
       go-version: ${{ matrix.go-version }}
-      fail-fast: true
+      fail-fast: false
       platform: "ubuntu-latest"
       project-directory: "."
       rootless-docker: false
@@ -72,7 +72,7 @@ jobs:
     uses: ./.github/workflows/ci-test-go.yml
     with:
       go-version: ${{ matrix.go-version }}
-      fail-fast: true
+      fail-fast: false
       platform: "ubuntu-latest"
       project-directory: "."
       rootless-docker: true

--- a/modulegen/_template/ci.yml.tmpl
+++ b/modulegen/_template/ci.yml.tmpl
@@ -33,7 +33,7 @@ jobs:
     uses: ./.github/workflows/ci-test-go.yml
     with:
       go-version: {{ "${{ matrix.go-version }}" }}
-      fail-fast: true
+      fail-fast: false
       platform: {{ "${{ matrix.platform }}" }}
       project-directory: "."
       rootless-docker: false
@@ -52,7 +52,7 @@ jobs:
     uses: ./.github/workflows/ci-test-go.yml
     with:
       go-version: {{ "${{ matrix.go-version }}" }}
-      fail-fast: true
+      fail-fast: false
       platform: "ubuntu-latest"
       project-directory: "."
       rootless-docker: false
@@ -72,7 +72,7 @@ jobs:
     uses: ./.github/workflows/ci-test-go.yml
     with:
       go-version: {{ "${{ matrix.go-version }}" }}
-      fail-fast: true
+      fail-fast: false
       platform: "ubuntu-latest"
       project-directory: "."
       rootless-docker: true

--- a/modulegen/_template/ci.yml.tmpl
+++ b/modulegen/_template/ci.yml.tmpl
@@ -33,7 +33,7 @@ jobs:
     uses: ./.github/workflows/ci-test-go.yml
     with:
       go-version: {{ "${{ matrix.go-version }}" }}
-      fail-fast: false
+      fail-fast: true
       platform: {{ "${{ matrix.platform }}" }}
       project-directory: "."
       rootless-docker: false


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
This PR removes the fail-fast situation when a CI build fails, making all the build in the following matrices to continue:

- main job
- reaper-off
- rootless docker

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
Many times the failure could be caused for some flakiness in that particular build, and its sibling could not be affected.

We run all the tests in the two current releases of Go, so if it fails in Go 1.20.x we still want to continue the execution for Go 1.21.x 

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->


<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
