### PR TITLE
Fix modulege template to succeed on make lint command

### DIFF
--- a/modulegen/_template/examples_test.go.tmpl
+++ b/modulegen/_template/examples_test.go.tmpl
@@ -28,7 +28,7 @@ func Example{{ $entrypoint }}() {
 
 	state, err := {{ $lower }}Container.State(ctx)
 	if err != nil {
-		log.Fatalf("failed to get container state: %s", err)
+		log.Fatalf("failed to get container state: %s", err) // nolint:gocritic
 	}
 
 	fmt.Println(state.Running)


### PR DESCRIPTION
## What does this PR do?

Added the `// nolint:gocritic` comment in the module `example_test.go` template
to make the `make lint` command succed and in consequence allow to create
modules without errors.

## Why is it important?

It is not critical, but it really confuses the module creator, also it requires
manual fix of the problem to be able to pass the linter check.

## How to test this PR

You can try to create a new module before and after the PR, you will see that
the before state is going to lead you to an error executing make lint, and the
new one passes properly.