### PR TITLE
chore: use logger.PrintXX instead of fmt.PrintXX

### DIFF
--- a/file.go
+++ b/file.go
@@ -41,7 +41,7 @@ func tarDir(src string, fileMode int64) (*bytes.Buffer, error) {
 
 	buffer := &bytes.Buffer{}
 
-	fmt.Printf(">> creating TAR file from directory: %s\n", src)
+	Logger.Printf(">> creating TAR file from directory: %s\n", src)
 
 	// tar > gzip > buffer
 	zr := gzip.NewWriter(buffer)
@@ -59,7 +59,7 @@ func tarDir(src string, fileMode int64) (*bytes.Buffer, error) {
 
 		// if a symlink, skip file
 		if fi.Mode().Type() == os.ModeSymlink {
-			fmt.Printf(">> skipping symlink: %s\n", file)
+			Logger.Printf(">> skipping symlink: %s\n", file)
 			return nil
 		}
 

--- a/options.go
+++ b/options.go
@@ -33,7 +33,7 @@ func (opt CustomizeRequestOption) Customize(req *GenericContainerRequest) {
 func CustomizeRequest(src GenericContainerRequest) CustomizeRequestOption {
 	return func(req *GenericContainerRequest) {
 		if err := mergo.Merge(req, &src, mergo.WithOverride, mergo.WithAppendSlice); err != nil {
-			fmt.Printf("error merging container request, keeping the original one. Error: %v", err)
+			Logger.Printf("error merging container request, keeping the original one. Error: %v", err)
 			return
 		}
 	}

--- a/wait/host_port.go
+++ b/wait/host_port.go
@@ -122,7 +122,7 @@ func (hp *HostPortStrategy) WaitUntilReady(ctx context.Context, target StrategyT
 			}
 			port, err = target.MappedPort(ctx, internalPort)
 			if err != nil {
-				fmt.Printf("(%d) [%s] %s\n", i, port, err)
+				log.Printf("(%d) [%s] %s\n", i, port, err)
 			}
 		}
 	}


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?

Use logger for printing output instead of raw output to Stdout which causes issues with running tests.

## Why is it important?

Using raw Stdout via fmt.PrintXX methods corrupts the output when running tests and benchmarks.
