### PR TITLE
chore(milvus): embed etcd should use default ports

### DIFF
--- a/modules/milvus/milvus.go
+++ b/modules/milvus/milvus.go
@@ -57,7 +57,6 @@ func RunContainer(ctx context.Context, opts ...testcontainers.ContainerCustomize
 					// Otherwise the milvus container will panic on startup.
 					createDefaultEmbedEtcdConfig,
 				},
-				PostStarts: []testcontainers.ContainerHook{regenerateEmbedEtcdConfig},
 			},
 		},
 	}
@@ -125,26 +124,6 @@ func createDefaultEmbedEtcdConfig(ctx context.Context, c testcontainers.Containe
 	err = c.CopyFileToContainer(ctx, defaultEmbedEtcdConfigPath, embedEtcdContainerPath, 0o644)
 	if err != nil {
 		return fmt.Errorf("can't copy %s to container: %w", defaultEmbedEtcdConfigPath, err)
-	}
-
-	return nil
-}
-
-// regenerateEmbedEtcdConfig updates the embed etcd config file with the mapped port
-func regenerateEmbedEtcdConfig(ctx context.Context, c testcontainers.Container) error {
-	containerPort, err := c.MappedPort(ctx, "2379/tcp")
-	if err != nil {
-		return fmt.Errorf("failed to get mapped port: %w", err)
-	}
-
-	embedEtcdConfig, err := renderEmbedEtcdConfig(containerPort.Int())
-	if err != nil {
-		return fmt.Errorf("failed to embed etcd config: %w", err)
-	}
-
-	err = c.CopyToContainer(ctx, embedEtcdConfig, embedEtcdContainerPath, 600)
-	if err != nil {
-		return fmt.Errorf("failed to copy embedEtcd.yaml into container: %w", err)
 	}
 
 	return nil


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
This PR removes the rendering of the etcd config template using the random exposed ports, and the applications won't use the embed etcd.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
Because it's internal to milvus, let's keep it with the default values.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Continues #2245

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
