### PR TITLE
feat: WithLogger ContainerCustomizer support

### DIFF
--- a/docs/features/common_functional_options.md
+++ b/docs/features/common_functional_options.md
@@ -31,6 +31,26 @@ func (g *TestLogConsumer) Accept(l Log) {
 }
 ```
 
+#### WithLogger
+
+- Not available until the next release of testcontainers-go <a href="https://github.com/testcontainers/testcontainers-go"><span class="tc-version">:material-tag: main</span></a>
+
+If you need to either pass logger to a container, you can use `testcontainers.WithLogger`.
+
+In this example we also use `TestLogger` which writes to the passed in `testing.TB` using `Logf`.
+The result is that we capture all logging from the container into the test context meaning its
+hidden behind `go test -v` and is associated with the relevant test, providing the user with
+useful context instead of appearing out of band.
+
+```golang
+func TestHandler(t *testing.T) {
+    logger := TestLogger(t)
+    _, err := postgresModule.RunContainer(ctx, testcontainers.WithLogger(logger))
+    require.NoError(t, err)
+    // Do something with container.
+}
+```
+
 Please read the [Following Container Logs](/features/follow_logs) documentation for more information about creating log consumers.
 
 #### Wait Strategies

--- a/docs/features/common_functional_options.md
+++ b/docs/features/common_functional_options.md
@@ -37,6 +37,9 @@ func (g *TestLogConsumer) Accept(l Log) {
 
 If you need to either pass logger to a container, you can use `testcontainers.WithLogger`.
 
+!!!info
+	Consider calling this before other "With" functions as these may generate logs.
+
 In this example we also use `TestLogger` which writes to the passed in `testing.TB` using `Logf`.
 The result is that we capture all logging from the container into the test context meaning its
 hidden behind `go test -v` and is associated with the relevant test, providing the user with

--- a/logger_test.go
+++ b/logger_test.go
@@ -1,0 +1,31 @@
+package testcontainers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestWithLogger(t *testing.T) {
+	logger := TestLogger(t)
+	logOpt := WithLogger(logger)
+	t.Run("container", func(t *testing.T) {
+		var req GenericContainerRequest
+		logOpt.Customize(&req)
+		require.Equal(t, logger, req.Logger)
+	})
+
+	t.Run("provider", func(t *testing.T) {
+		var opts GenericProviderOptions
+		logOpt.ApplyGenericTo(&opts)
+		require.Equal(t, logger, opts.Logger)
+	})
+
+	t.Run("docker", func(t *testing.T) {
+		opts := &DockerProviderOptions{
+			GenericProviderOptions: &GenericProviderOptions{},
+		}
+		logOpt.ApplyDockerTo(opts)
+		require.Equal(t, logger, opts.Logger)
+	})
+}


### PR DESCRIPTION
## What does this PR do?

Add support to use `WithLogger` as a `ContainerCustomizer` so that callers have an easy way to configure the logger of a container.

Add tests for `WithLogger`.

Validate `Logger` and `LoggerOption` implement the required interfaces.

Also fix a comment typo and remove an unneeded return.

## Why is it important?

Allows users to easily configure container loggers which is useful when using modules e.g. postgres or redis.

## How to test this PR

```shell
go test -run=^TestWithLogger$
```