### PR TITLE
docs: fix comment corruption

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -18,8 +18,9 @@ var (
 	tcConfigOnce *sync.Once = new(sync.Once)
 )
 
-// Config represents the configuration for Testcontainers
 // testcontainersConfig {
+
+// Config represents the configuration for Testcontainers
 type Config struct {
 	Host                    string        `properties:"docker.host,default="`
 	TLSVerify               int           `properties:"docker.tls.verify,default=0"`

--- a/logconsumer.go
+++ b/logconsumer.go
@@ -7,6 +7,7 @@ const StdoutLog = "STDOUT"
 const StderrLog = "STDERR"
 
 // logStruct {
+
 // Log represents a message that was created by a process,
 // LogType is either "STDOUT" or "STDERR",
 // Content is the byte contents of the message itself
@@ -18,6 +19,7 @@ type Log struct {
 // }
 
 // logConsumerInterface {
+
 // LogConsumer represents any object that can
 // handle a Log, it is up to the LogConsumer instance
 // what to do with the log

--- a/modules/couchbase/couchbase.go
+++ b/modules/couchbase/couchbase.go
@@ -20,6 +20,7 @@ import (
 
 const (
 	// containerPorts {
+
 	MGMT_PORT     = "8091"
 	MGMT_SSL_PORT = "18091"
 
@@ -40,6 +41,7 @@ const (
 
 	KV_PORT     = "11210"
 	KV_SSL_PORT = "11207"
+
 	// }
 )
 

--- a/modules/couchbase/storage_mode.go
+++ b/modules/couchbase/storage_mode.go
@@ -6,6 +6,7 @@ package couchbase
 type indexStorageMode string
 
 // storageTypes {
+
 const (
 	// MemoryOptimized sets the cluster-wide index storage mode to use memory optimized global
 	// secondary indexes which can perform index maintenance and index scan faster at in-memory speeds.

--- a/modules/neo4j/config.go
+++ b/modules/neo4j/config.go
@@ -12,12 +12,14 @@ type LabsPlugin string
 
 const (
 	// labsPlugins {
+
 	Apoc             LabsPlugin = "apoc"
 	ApocCore         LabsPlugin = "apoc-core"
 	Bloom            LabsPlugin = "bloom"
 	GraphDataScience LabsPlugin = "graph-data-science"
 	NeoSemantics     LabsPlugin = "n10s"
 	Streams          LabsPlugin = "streams"
+
 	// }
 )
 

--- a/options.go
+++ b/options.go
@@ -82,6 +82,7 @@ func WithImage(image string) CustomizeRequestOption {
 }
 
 // imageSubstitutor {
+
 // ImageSubstitutor represents a way to substitute container image names
 type ImageSubstitutor interface {
 	// Description returns the name of the type and a short description of how it modifies the image.

--- a/testing.go
+++ b/testing.go
@@ -41,6 +41,7 @@ func SkipIfDockerDesktop(t *testing.T, ctx context.Context) {
 }
 
 // exampleLogConsumer {
+
 // StdoutLogConsumer is a LogConsumer that prints the log to stdout
 type StdoutLogConsumer struct{}
 


### PR DESCRIPTION
## What does this PR do?

Fix doc generation comments being included package documentation by ensuring they are separated by a blank line.

## Why is it important?

So that package documentation doesn't have processing information in them which is confusing to users.
