### PR TITLE
Fix Dockerfile not located when added to dockerignore

### DIFF
--- a/container.go
+++ b/container.go
@@ -194,6 +194,8 @@ func (c *ContainerRequest) Validate() error {
 
 // GetContext retrieve the build context for the request
 func (c *ContainerRequest) GetContext() (io.Reader, error) {
+	var includes []string = []string{"."}
+
 	if c.ContextArchive != nil {
 		return c.ContextArchive, nil
 	}
@@ -209,7 +211,14 @@ func (c *ContainerRequest) GetContext() (io.Reader, error) {
 	if err != nil {
 		return nil, err
 	}
-	buildContext, err := archive.TarWithOptions(c.Context, &archive.TarOptions{ExcludePatterns: excluded})
+
+	dockerIgnoreLocation := filepath.Join(abs, ".dockerignore")
+	includes = append(includes, dockerIgnoreLocation, c.GetDockerfile())
+
+	buildContext, err := archive.TarWithOptions(
+		c.Context,
+		&archive.TarOptions{ExcludePatterns: excluded, IncludeFiles: includes},
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/container_test.go
+++ b/container_test.go
@@ -502,7 +502,7 @@ func TestParseDockerIgnore(t *testing.T) {
 		{
 			filePath:         "./testdata",
 			expectedErr:      nil,
-			expectedExcluded: []string(nil),
+			expectedExcluded: []string{"Dockerfile", "echo.Dockerfile"},
 		},
 	}
 

--- a/testdata/.dockerignore
+++ b/testdata/.dockerignore
@@ -1,0 +1,2 @@
+Dockerfile
+echo.Dockerfile


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?

When the user adds `Dockerfile` to the `.dockerignore` file, `testcontainers` is not able to build the image with error:

`Error response from daemon: Cannot locate specified Dockerfile`

This is because `testcontainers` doesn't include the `Dockerfile` to the `buildcontext` on purpose, it only expects to do so, if it is not included on the `ignorefile`. The docker client doesn't this either, the Docker cli is aware of this and maintainers have addressed this limitation in this [PR](https://github.com/moby/moby/pull/8748) long ago as the have tweaked the client to include both files to the build context.

To fix this, I added the `.dockerignore` file in the current context and the target `Dockefile` to the Build Context.

```go
includes = append(includes, dockerIgnoreLocation, c.GetDockerfile())
```

`archive.TarOptions` struct has a key on it to include files to the archive:

```go
buildContext, err := archive.TarWithOptions(
	c.Context,
	&archive.TarOptions{ExcludePatterns: excluded, IncludeFiles: includes},
)
```

## Why is it important?

The motivation is that some developers don't want to include the `Dockerfile` to the result image to keep it as minimal as possible.

## Related issues

Closes #2203 

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
