### PR TITLE
feature: allowing building of a target in multi-stage build

### DIFF
--- a/container.go
+++ b/container.go
@@ -75,6 +75,7 @@ type ImageBuildInfo interface {
 	ShouldBuildImage() bool                         // return true if the image needs to be built
 	GetBuildArgs() map[string]*string               // return the environment args used to build the from Dockerfile
 	GetAuthConfigs() map[string]registry.AuthConfig // Deprecated. Testcontainers will detect registry credentials automatically. Return the auth configs to be able to pull from an authenticated docker registry
+	GetTarget() string                              // get the build target for multi-stage builds
 }
 
 // FromDockerfile represents the parameters needed to build an image from a Dockerfile
@@ -144,6 +145,7 @@ type ContainerRequest struct {
 	EnpointSettingsModifier func(map[string]*network.EndpointSettings) // Modifier for the network settings before container creation
 	LifecycleHooks          []ContainerLifecycleHooks                  // define hooks to be executed during container lifecycle
 	LogConsumerCfg          *LogConsumerConfig                         // define the configuration for the log producer and its log consumers to follow the logs
+	Target                  string                                     // the build target to stop at for multi-stage builds
 }
 
 // containerOptions functional options for a container
@@ -190,6 +192,10 @@ func (c *ContainerRequest) Validate() error {
 	}
 
 	return nil
+}
+
+func (c *ContainerRequest) GetTarget() string {
+	return c.Target
 }
 
 // GetContext retrieve the build context for the request
@@ -355,6 +361,8 @@ func (c *ContainerRequest) BuildOptions() (types.ImageBuildOptions, error) {
 	} else {
 		buildOptions.Tags = []string{tag}
 	}
+
+	buildOptions.Target = c.GetTarget()
 
 	return buildOptions, nil
 }

--- a/testdata/multi-stage.Dockerfile
+++ b/testdata/multi-stage.Dockerfile
@@ -1,0 +1,7 @@
+FROM docker.io/alpine AS first_stage
+
+CMD 'echo first stage'
+
+FROM first_stage AS second_stage
+
+CMD 'echo second stage'


### PR DESCRIPTION
feature: if a Dockerfile specifies build stages, allow the user to set the target build stage in ContainerRequest

<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

Adds a `Target` option to `ContainerRequest` to allow a user to specify a multi-stage build stage.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

Many projects use multi-stage builds, we should enable those to be used via testcontainers-go

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- None


## How to test this PR

* automated tests handle this


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
