### PR TITLE
generic.go: GenericContainer(): clearer error message

### DIFF
--- a/container_test.go
+++ b/container_test.go
@@ -320,7 +320,7 @@ func Test_GetLogsFromFailedContainer(t *testing.T) {
 		Started:          true,
 	})
 
-	if err != nil && err.Error() != "container exited with code 0: failed to start container" {
+	if err != nil && err.Error() != "failed to start container: container exited with code 0" {
 		t.Fatal(err)
 	} else if err == nil {
 		terminateContainerOnEnd(t, ctx, c)

--- a/generic.go
+++ b/generic.go
@@ -79,7 +79,7 @@ func GenericContainer(ctx context.Context, req GenericContainerRequest) (Contain
 
 	if req.Started && !c.IsRunning() {
 		if err := c.Start(ctx); err != nil {
-			return c, fmt.Errorf("%w: failed to start container", err)
+			return c, fmt.Errorf("failed to start container: %w", err)
 		}
 	}
 	return c, nil


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?

Clearer error message `generic.go: GenericContainer()` function

## Why is it important?

It's customary to prefix an actual Go error with a generic message explaining the error context. 

It looks like it's already done this way [everywhere](https://github.com/search?q=repo%3Atestcontainers%2Ftestcontainers-go%20%22failed%20to%20start%20container%22&type=code) else in the code base, but not here.

