### PR TITLE
chore: check that the new version is not empty

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -47,6 +47,11 @@ function main() {
 
   # Get the version to bump to from the semver-tool and the bump type
   local newVersion=$(docker run --rm --platform=linux/amd64 -i "${DOCKER_IMAGE_SEMVER}" bump "${BUMP_TYPE}" "${vVersion}")
+  if [[ "${newVersion}" == "" ]]; then
+    echo "Failed to bump the version. Please check the semver-tool image and the bump type."
+    exit 1
+  fi
+
   echo "Producing a ${BUMP_TYPE} bump of the version, from ${version} to ${newVersion}"
 
   # Bump the version in the version.go file

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -29,6 +29,13 @@ function main() {
   local vVersion="v${version}"
   echo "Current version: ${vVersion}"
 
+  # Get the version to bump to from the semver-tool and the bump type
+  local newVersion=$(docker run --rm --platform=linux/amd64 -i "${DOCKER_IMAGE_SEMVER}" bump "${BUMP_TYPE}" "${vVersion}")
+  if [[ "${newVersion}" == "" ]]; then
+    echo "Failed to bump the version. Please check the semver-tool image and the bump type."
+    exit 1
+  fi
+
   # Commit the project in the current state
   gitCommitVersion "${vVersion}"
 
@@ -44,13 +51,6 @@ function main() {
       tagModule "${module_tag}"
     done
   done
-
-  # Get the version to bump to from the semver-tool and the bump type
-  local newVersion=$(docker run --rm --platform=linux/amd64 -i "${DOCKER_IMAGE_SEMVER}" bump "${BUMP_TYPE}" "${vVersion}")
-  if [[ "${newVersion}" == "" ]]; then
-    echo "Failed to bump the version. Please check the semver-tool image and the bump type."
-    exit 1
-  fi
 
   echo "Producing a ${BUMP_TYPE} bump of the version, from ${version} to ${newVersion}"
 


### PR DESCRIPTION

<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
It adds a check for the new image after the bump: if it's empty, it will stop the release the soonest.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
This has been an issue when the underlying container runtime has a different platform, causing the bump process to fail, resulting in a blank value for the new version.
That causes a commit with an invalid value.

Therefore, we are forced to produce a new patch release (to adhere to semver), as all the git tags for the modules will point to a version that is incorrect: being the version empty will mean that the Docker labels added to the containers will be empty, and the HTTP headers used to interact with the Docker client will add an empty value to the testcontainers-go version of the User-Agent header.  

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- See https://github.com/testcontainers/testcontainers-go/commit/e48323c39590887b51802446db123ba427e7cd2d

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
