### PR TITLE
fix: consul race on HTTP port

### DIFF
--- a/modules/consul/consul.go
+++ b/modules/consul/consul.go
@@ -14,7 +14,7 @@ const (
 )
 
 const (
-	DefaultBaseImage = "docker.io/hashicorp/consul:1.18"
+	DefaultBaseImage = "docker.io/hashicorp/consul:1.15"
 )
 
 // ConsulContainer represents the Consul container type used in the module.

--- a/modules/consul/consul.go
+++ b/modules/consul/consul.go
@@ -14,7 +14,7 @@ const (
 )
 
 const (
-	DefaultBaseImage = "docker.io/hashicorp/consul:1.15"
+	DefaultBaseImage = "docker.io/hashicorp/consul:1.18"
 )
 
 // ConsulContainer represents the Consul container type used in the module.
@@ -70,6 +70,7 @@ func RunContainer(ctx context.Context, opts ...testcontainers.ContainerCustomize
 			Env: map[string]string{},
 			WaitingFor: wait.ForAll(
 				wait.ForLog("Consul agent running!"),
+				wait.ForListeningPort(defaultHttpApiPort+"/tcp"),
 			),
 		},
 		Started: true,

--- a/modules/consul/examples_test.go
+++ b/modules/consul/examples_test.go
@@ -16,7 +16,7 @@ func ExampleRunContainer() {
 	ctx := context.Background()
 
 	consulContainer, err := consul.RunContainer(ctx,
-		testcontainers.WithImage("docker.io/hashicorp/consul:1.15"),
+		testcontainers.WithImage("docker.io/hashicorp/consul:1.18"),
 	)
 	if err != nil {
 		log.Fatalf("failed to start container: %s", err)
@@ -46,7 +46,7 @@ func ExampleRunContainer_connect() {
 	ctx := context.Background()
 
 	consulContainer, err := consul.RunContainer(ctx,
-		testcontainers.WithImage("docker.io/hashicorp/consul:1.15"),
+		testcontainers.WithImage("docker.io/hashicorp/consul:1.18"),
 	)
 	if err != nil {
 		log.Fatalf("failed to start container: %s", err)

--- a/modules/consul/examples_test.go
+++ b/modules/consul/examples_test.go
@@ -16,7 +16,7 @@ func ExampleRunContainer() {
 	ctx := context.Background()
 
 	consulContainer, err := consul.RunContainer(ctx,
-		testcontainers.WithImage("docker.io/hashicorp/consul:1.18"),
+		testcontainers.WithImage("docker.io/hashicorp/consul:1.15"),
 	)
 	if err != nil {
 		log.Fatalf("failed to start container: %s", err)
@@ -46,7 +46,7 @@ func ExampleRunContainer_connect() {
 	ctx := context.Background()
 
 	consulContainer, err := consul.RunContainer(ctx,
-		testcontainers.WithImage("docker.io/hashicorp/consul:1.18"),
+		testcontainers.WithImage("docker.io/hashicorp/consul:1.15"),
 	)
 	if err != nil {
 		log.Fatalf("failed to start container: %s", err)


### PR DESCRIPTION
## What does this PR do?

Fixes a race where tests can fail due to trying to use the HTTP port before it is listening

## Why is it important?

I swapped out host-based consul in a private project with testcontainers, and all the tests failed until I swapped the health check to block until the port is ready

## Related issues

- Closes #2335

## How to test this PR

run `make test` in the modules/consul directory