### PR TITLE
chore: use withEnv in localstack module

### DIFF
--- a/docs/modules/localstack.md
+++ b/docs/modules/localstack.md
@@ -51,12 +51,12 @@ By default, the image used is `localstack:1.4.0`.  If you need to use a differen
 It's possible to entirely override the default LocalStack container request:
 
 <!--codeinclude-->
-[Customize container request](../../modules/localstack/localstack_test.go) inside_block:withCustomContainerRequest
+[Customize container request](../../modules/localstack/examples_test.go) inside_block:withCustomContainerRequest
 <!--/codeinclude-->
 
 With simply passing the `testcontainers.CustomizeRequest` functional option to the `RunContainer` function, you'll be able to configure the LocalStack container with your own needs, as this new container request will be merged with the original one.
 
-In the above example you can check how it's possible to set certain environment variables that are needed by the tests, the most important ones are the AWS services you want to use. Besides, the container runs in a separate Docker network with an alias.
+In the above example you can check how it's possible to copy files that are needed by the tests. The `flagsFn` function is a helper function that converts Docker labels used by Ryuk to a string with the format requested by LocalStack.
 
 ## Accessing hostname-sensitive services
 

--- a/modules/localstack/localstack_test.go
+++ b/modules/localstack/localstack_test.go
@@ -154,21 +154,15 @@ func TestStartWithoutOverride(t *testing.T) {
 func TestStartV2WithNetwork(t *testing.T) {
 	ctx := context.Background()
 
-	// withCustomContainerRequest {
 	nw, err := network.New(ctx)
 	require.NoError(t, err)
 
 	localstack, err := RunContainer(
 		ctx,
 		network.WithNetwork([]string{"localstack"}, nw),
-		testcontainers.CustomizeRequest(testcontainers.GenericContainerRequest{
-			ContainerRequest: testcontainers.ContainerRequest{
-				Image: "localstack/localstack:2.0.0",
-				Env:   map[string]string{"SERVICES": "s3,sqs"},
-			},
-		}),
+		testcontainers.WithImage("localstack/localstack:2.0.0"),
+		testcontainers.WithEnv(map[string]string{"SERVICES": "s3,sqs"}),
 	)
-	// }
 	require.NoError(t, err)
 	assert.NotNil(t, localstack)
 


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
It uses `WithEnv` instead of the Override container request option, which is heavier.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
Simpler code
<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->


<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
