### PR TITLE
Add method for getting Weaviate's gRPC port

### DIFF
--- a/modules/weaviate/examples_test.go
+++ b/modules/weaviate/examples_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/weaviate/weaviate-go-client/v4/weaviate"
+	"github.com/weaviate/weaviate-go-client/v4/weaviate/grpc"
 
 	"github.com/testcontainers/testcontainers-go"
 	tcweaviate "github.com/testcontainers/testcontainers-go/modules/weaviate"
@@ -17,7 +18,7 @@ func ExampleRunContainer() {
 	// runWeaviateContainer {
 	ctx := context.Background()
 
-	weaviateContainer, err := tcweaviate.RunContainer(ctx, testcontainers.WithImage("semitechnologies/weaviate:1.23.9"))
+	weaviateContainer, err := tcweaviate.RunContainer(ctx, testcontainers.WithImage("semitechnologies/weaviate:1.24.1"))
 	if err != nil {
 		log.Fatalf("failed to start container: %s", err)
 	}
@@ -58,7 +59,12 @@ func ExampleRunContainer_connectWithClient() {
 
 	scheme, host, err := weaviateContainer.HttpHostAddress(ctx)
 	if err != nil {
-		log.Fatalf("failed to get schema and host: %s", err) // nolint:gocritic
+		log.Fatalf("failed to get http schema and host: %s", err) // nolint:gocritic
+	}
+
+	grpcHost, err := weaviateContainer.GrpcHostAddress(ctx)
+	if err != nil {
+		log.Fatalf("failed to get gRPC host: %s", err) // nolint:gocritic
 	}
 
 	connectionClient := &http.Client{}
@@ -68,8 +74,12 @@ func ExampleRunContainer_connectWithClient() {
 	}
 
 	cli := weaviate.New(weaviate.Config{
-		Scheme:           scheme,
-		Host:             host,
+		Scheme: scheme,
+		Host:   host,
+		GrpcConfig: &grpc.Config{
+			Secured: false, // set true if gRPC connection is secured
+			Host:    grpcHost,
+		},
 		Headers:          headers,
 		AuthConfig:       nil, // put here the weaviate auth.Config, if you need it
 		ConnectionClient: connectionClient,

--- a/modules/weaviate/go.mod
+++ b/modules/weaviate/go.mod
@@ -5,6 +5,7 @@ go 1.21
 require (
 	github.com/testcontainers/testcontainers-go v0.29.1
 	github.com/weaviate/weaviate-go-client/v4 v4.12.1
+	google.golang.org/grpc v1.59.0
 )
 
 require (
@@ -76,7 +77,6 @@ require (
 	golang.org/x/tools v0.13.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20230822172742-b8732ec3820d // indirect
-	google.golang.org/grpc v1.59.0 // indirect
 	google.golang.org/protobuf v1.31.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/modules/weaviate/weaviate.go
+++ b/modules/weaviate/weaviate.go
@@ -17,7 +17,7 @@ type WeaviateContainer struct {
 // RunContainer creates an instance of the Weaviate container type
 func RunContainer(ctx context.Context, opts ...testcontainers.ContainerCustomizer) (*WeaviateContainer, error) {
 	req := testcontainers.ContainerRequest{
-		Image:        "semitechnologies/weaviate:1.23.9",
+		Image:        "semitechnologies/weaviate:1.24.1",
 		Cmd:          []string{"--host", "0.0.0.0", "--scheme", "http", "--port", "8080"},
 		ExposedPorts: []string{"8080/tcp", "50051/tcp"},
 		Env: map[string]string{
@@ -65,4 +65,20 @@ func (c *WeaviateContainer) HttpHostAddress(ctx context.Context) (string, string
 	}
 
 	return "http", fmt.Sprintf("%s:%s", host, containerPort.Port()), nil
+}
+
+// GrpcHostAddress returns the gRPC host of the Weaviate container.
+// At the moment, it only supports unsecured gRPC connection.
+func (c *WeaviateContainer) GrpcHostAddress(ctx context.Context) (string, error) {
+	containerPort, err := c.MappedPort(ctx, "50051/tcp")
+	if err != nil {
+		return "", fmt.Errorf("failed to get container port: %w", err)
+	}
+
+	host, err := c.Host(ctx)
+	if err != nil {
+		return "", fmt.Errorf("failed to get container host")
+	}
+
+	return fmt.Sprintf("%s:%s", host, containerPort.Port()), nil
 }


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?

This PR adds a convenience `GrpcHostAddress` method to Weaviate module, to get the `gRPC` host.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?

In addition to our REST API Weaviate is also exposing `gRPC API` which greatly improves performance. It would be nice to have 

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Related issues

none

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->

## How to test this PR

There are tests added to the Weaviate module package that test `gRPC` connection.

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
