### PR TITLE
redpanda: set entrypoint to the custom entrypoint file

### DIFF
--- a/modules/redpanda/redpanda.go
+++ b/modules/redpanda/redpanda.go
@@ -72,9 +72,8 @@ func RunContainer(ctx context.Context, opts ...testcontainers.ContainerCustomize
 				defaultAdminAPIPort,
 				defaultSchemaRegistryPort,
 			},
-			Entrypoint: []string{},
+			Entrypoint: []string{entrypointFile},
 			Cmd: []string{
-				entrypointFile,
 				"redpanda",
 				"start",
 				"--mode=dev-container",


### PR DESCRIPTION
## What does this PR do?

Redpanda module has a custom entrypoint file `/entrypoint-tc.sh` that waits until the actual Redpanda broker node config file is mounted.
Then proceeds to call the normal Redpanda entryfile `/entrypoint.sh`.

The current implementation of the module sets the entrypoint file into the `Cmd` of the `ContainerRequest`. 
This seems to work with `Docker`, but does not work with `Podman`.

This results in an error when starting the container:

```sh
+ '[' '' = true ']'
+ exec /usr/bin/rpk /entrypoint-tc.sh redpanda start --mode=dev-container --smp=1 --memory=1G
Error: unknown command "/entrypoint-tc.sh" for "rpk"
Run 'rpk --help' for usage.
```

Since the intent is to override the entrypoint, we should be setting `Entrypoint` property as this is more appropriate.

In more detail, if we inspect the Docker container:

```json
{
    "Id": "52d5be52543a60e793fa4920fd81794fe646fff06d917c96d56cbdf164475925",
    "Created": "2024-03-12T18:42:46.003923967Z",
    "Path": "/entrypoint-tc.sh",
    "Args": [
        "redpanda",
        "start",
        "--mode=dev-container",
        "--smp=1",
        "--memory=1G"
    ],
    ...
    "Config": {
        "Hostname": "52d5be52543a",
        "Domainname": "",
        "User": "root:root",
        "AttachStdin": false,
        "AttachStdout": false,
        "AttachStderr": false,
        "ExposedPorts": {
            "8081/tcp": {},
            "8082/tcp": {},
            "9092/tcp": {},
            "9644/tcp": {}
        },
        "Tty": false,
        "OpenStdin": false,
        "StdinOnce": false,
        "Env": [
            "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
            "EDITOR=vi"
        ],
        "Cmd": [
            "/entrypoint-tc.sh",
            "redpanda",
            "start",
            "--mode=dev-container",
            "--smp=1",
            "--memory=1G"
        ],
        "Image": "redpandadata/redpanda:v23.3.2",
        "Volumes": {
            "/var/lib/redpanda/data": {}
        },
        "WorkingDir": "",
        "Entrypoint": [],
        "OnBuild": null,
        "Labels": {
            "org.opencontainers.image.authors": "Redpanda Data <hi@redpanda.com>",
            "org.testcontainers": "true",
            "org.testcontainers.lang": "go",
            "org.testcontainers.sessionId": "353c39fb1e5c8ee2313ec527210b4ab8fcda2274b067bd4d2360bff88574f774",
            "org.testcontainers.version": "0.28.0"
        }
    },
    ...
}
```

But if we inspect the Podman container:

```json
{
  "Id": "3f9bb85cc4761e06082d7add0c02937439eba3d05ec1febf48ad09667b7abae5",
  "Created": "2024-03-12T19:05:31.255025847Z",
  "Path": "/entrypoint.sh",
  "Args": [
    "/entrypoint-tc.sh",
    "redpanda",
    "start",
    "--mode=dev-container",
    "--smp=1",
    "--memory=1G"
  ],
...
"Config": {
    "Hostname": "3f9bb85cc476",
    "Domainname": "",
    "User": "root:root",
    "AttachStdin": false,
    "AttachStdout": false,
    "AttachStderr": false,
    "ExposedPorts": {
      "8081/tcp": {},
      "8082/tcp": {},
      "9092/tcp": {},
      "9644/tcp": {}
    },
    "Tty": false,
    "OpenStdin": false,
    "StdinOnce": false,
    "Env": [
      "container=podman",
      "EDITOR=vi",
      "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
      "HOME=/root",
      "HOSTNAME=3f9bb85cc476"
    ],
    "Cmd": [
      "/entrypoint-tc.sh",
      "redpanda",
      "start",
      "--mode=dev-container",
      "--smp=1",
      "--memory=1G"
    ],
    "Image": "docker.io/redpandadata/redpanda:v23.3.2",
    "Volumes": null,
    "WorkingDir": "/",
    "Entrypoint": [
      "/entrypoint.sh"
    ],
    "OnBuild": null,
    "Labels": {
      "org.opencontainers.image.authors": "Redpanda Data <hi@redpanda.com>",
      "org.testcontainers": "true",
      "org.testcontainers.lang": "go",
      "org.testcontainers.sessionId": "acef449fb3c94d212abe04df036b9e045292ce128eaf4a666f3d7340f9e421ad",
      "org.testcontainers.version": "0.28.0"
    },
    "StopSignal": "15",
    "StopTimeout": 10
  },
  ...
}
```

We can see the Entrypoint for Podman container includes the stock Redpanda `entrypoint.sh`. 

## Why is it important?

It is more correct to override entrypoint this way.

## How to test this PR

I have tested this change using Docker, and also using Podman, without changing code under test.

`TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE`, `TESTCONTAINERS_RYUK_CONTAINER_PRIVILEGED`, and `DOCKER_HOST` env vars were set to accommodate proper running of Ryuk, and test environment. I ran into issues https://github.com/testcontainers/testcontainers-go/issues/2264 and https://github.com/testcontainers/testcontainers-go/issues/538.

