### PR TITLE
feat: support for waiting for response headers

### DIFF
--- a/docs/features/wait/http.md
+++ b/docs/features/wait/http.md
@@ -8,6 +8,8 @@ The HTTP wait strategy will check the result of an HTTP(S) request against the c
 - the HTTP request body to be sent.
 - the HTTP status code matcher as a function.
 - the HTTP response matcher as a function.
+- the HTTP headers to be used.
+- the HTTP response headers matcher as a function.
 - the TLS config to be used for HTTPS.
 - the startup timeout to be used in seconds, default is 60 seconds.
 - the poll interval to be used in milliseconds, default is 100 milliseconds.
@@ -40,4 +42,10 @@ Variations on the HTTP wait strategy are supported, including:
 
 <!--codeinclude-->
 [Waiting for an HTTP endpoint matching an HTTP status code](../../../wait/http_test.go) inside_block:waitForHTTPStatusCode
+<!--/codeinclude-->
+
+## Match for HTTP response headers
+
+<!--codeinclude-->
+[Waiting for an HTTP endpoint matching an HTTP response header](../../../wait/http_test.go) inside_block:waitForHTTPHeaders
 <!--/codeinclude-->

--- a/wait/testdata/main.go
+++ b/wait/testdata/main.go
@@ -45,6 +45,17 @@ func main() {
 		w.WriteHeader(http.StatusUnauthorized)
 	})
 
+	mux.HandleFunc("/headers", func(w http.ResponseWriter, req *http.Request) {
+		h := req.Header.Get("X-request-header")
+		if h != "" {
+			w.Header().Add("X-response-header", h)
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("headers"))
+		} else {
+			w.WriteHeader(http.StatusBadRequest)
+		}
+	})
+
 	mux.HandleFunc("/ping", func(w http.ResponseWriter, req *http.Request) {
 		data, _ := io.ReadAll(req.Body)
 		if bytes.Equal(data, []byte("ping")) {


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
This PR supports passing HTTP headers to the wait.ForHTTP strategy, including a matcher for response header.
<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
We would want to wait for a certain HTTP response header to be added to a response, or we would want to pass HTTP headers to the wait strategy, and that was not possible.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->


<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
