### PR TITLE
feat: authenticate docker on PullImage

### DIFF
--- a/modules/k3s/k3s_test.go
+++ b/modules/k3s/k3s_test.go
@@ -7,6 +7,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kwait "k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
 
@@ -16,7 +17,9 @@ import (
 )
 
 func Test_LoadImages(t *testing.T) {
-	ctx := context.Background()
+	// Give up to three minutes to run this test
+	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(3*time.Minute))
+	defer cancel()
 
 	k3sContainer, err := k3s.RunContainer(ctx,
 		testcontainers.WithImage("docker.io/rancher/k3s:v1.27.1-k3s1"),
@@ -53,20 +56,20 @@ func Test_LoadImages(t *testing.T) {
 	}
 
 	// ensure nginx image is available locally
-	err = provider.PullImage(context.Background(), "nginx")
+	err = provider.PullImage(ctx, "nginx")
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	t.Run("Test load image not available", func(t *testing.T) {
-		err := k3sContainer.LoadImages(context.Background(), "fake.registry/fake:non-existing")
+		err := k3sContainer.LoadImages(ctx, "fake.registry/fake:non-existing")
 		if err == nil {
 			t.Fatal("should had failed")
 		}
 	})
 
 	t.Run("Test load image in cluster", func(t *testing.T) {
-		err := k3sContainer.LoadImages(context.Background(), "nginx")
+		err := k3sContainer.LoadImages(ctx, "nginx")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -90,21 +93,39 @@ func Test_LoadImages(t *testing.T) {
 			},
 		}
 
-		_, err = k8s.CoreV1().Pods("default").Create(context.Background(), pod, metav1.CreateOptions{})
+		_, err = k8s.CoreV1().Pods("default").Create(ctx, pod, metav1.CreateOptions{})
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		time.Sleep(1 * time.Second)
-		pod, err = k8s.CoreV1().Pods("default").Get(context.Background(), "test-pod", metav1.GetOptions{})
+		err = kwait.PollUntilContextCancel(ctx, time.Second, true, func(ctx context.Context) (bool, error) {
+			state, err := getTestPodState(ctx, k8s)
+			if err != nil {
+				return false, err
+			}
+			return state.Running != nil, nil
+		})
 		if err != nil {
 			t.Fatal(err)
 		}
-		waiting := pod.Status.ContainerStatuses[0].State.Waiting
-		if waiting != nil && waiting.Reason == "ErrImageNeverPull" {
-			t.Fatal("Image was not loaded")
+
+		state, err := getTestPodState(ctx, k8s)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if state.Running == nil {
+			t.Fatalf("Unexpected status %v", state)
 		}
 	})
+}
+
+func getTestPodState(ctx context.Context, k8s *kubernetes.Clientset) (state corev1.ContainerState, err error) {
+	var pod *corev1.Pod
+	pod, err = k8s.CoreV1().Pods("default").Get(ctx, "test-pod", metav1.GetOptions{})
+	if err != nil || len(pod.Status.ContainerStatuses) == 0 {
+		return
+	}
+	return pod.Status.ContainerStatuses[0].State, nil
 }
 
 func Test_APIServerReady(t *testing.T) {
@@ -169,7 +190,7 @@ func Test_WithManifestOption(t *testing.T) {
 	k3sContainer, err := k3s.RunContainer(ctx,
 		testcontainers.WithImage("docker.io/rancher/k3s:v1.27.1-k3s1"),
 		k3s.WithManifest("nginx-manifest.yaml"),
-		testcontainers.WithWaitStrategy(wait.ForExec([]string{"kubectl", "wait", "pod", "nginx","--for=condition=Ready"})),
+		testcontainers.WithWaitStrategy(wait.ForExec([]string{"kubectl", "wait", "pod", "nginx", "--for=condition=Ready"})),
 	)
 	if err != nil {
 		t.Fatal(err)

--- a/modules/k3s/k3s_test.go
+++ b/modules/k3s/k3s_test.go
@@ -2,6 +2,7 @@ package k3s_test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -102,6 +103,9 @@ func Test_LoadImages(t *testing.T) {
 			state, err := getTestPodState(ctx, k8s)
 			if err != nil {
 				return false, err
+			}
+			if state.Terminated != nil {
+				return false, fmt.Errorf("pod terminated: %v", state.Terminated)
 			}
 			return state.Running != nil, nil
 		})


### PR DESCRIPTION
## What does this PR do?

This authenticates on PullImage and improves the k3s LoadImages test so that a failure to start the pod will fail the test.

## Why is it important?

I'm using k3s with private images, so I want to use the `LoadImages` feature. The instructions to do this included running `PullImage` first, which works on anonymous images, but not authenticated ones. By re-using the same auth code used to run a container, I can now use the `LoadImages` feature in k3s with private images.

While trying to figure out what was wrong I used `Test_LoadImages` which is quite nice, but accidentally had a problem where a container can fail to run, yet still pass the test. This lost me time, so I figured I would improve it for the next person.

## Related issues

maybe #1685?

## How to test this PR

Change the image in Test_LoadImages from "nginx" to a privately hosted image (like a private github repository). Before, it would fail to pull, and now it won't.