### PR TITLE
feat: optimizes file copies to and from containers

### DIFF
--- a/file.go
+++ b/file.go
@@ -110,7 +110,7 @@ func tarDir(src string, fileMode int64) (*bytes.Buffer, error) {
 }
 
 // tarFile compress a single file using tar + gzip algorithms
-func tarFile(fileContent []byte, basePath string, fileMode int64) (*bytes.Buffer, error) {
+func tarFile(basePath string, fileContent func(tw io.Writer) error, fileContentSize int64, fileMode int64) (*bytes.Buffer, error) {
 	buffer := &bytes.Buffer{}
 
 	zr := gzip.NewWriter(buffer)
@@ -119,12 +119,12 @@ func tarFile(fileContent []byte, basePath string, fileMode int64) (*bytes.Buffer
 	hdr := &tar.Header{
 		Name: basePath,
 		Mode: fileMode,
-		Size: int64(len(fileContent)),
+		Size: fileContentSize,
 	}
 	if err := tw.WriteHeader(hdr); err != nil {
 		return buffer, err
 	}
-	if _, err := tw.Write(fileContent); err != nil {
+	if err := fileContent(tw); err != nil {
 		return buffer, err
 	}
 

--- a/file_test.go
+++ b/file_test.go
@@ -119,7 +119,10 @@ func Test_TarFile(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	buff, err := tarFile(b, "Docker.file", 0o755)
+	buff, err := tarFile("Docker.file", func(tw io.Writer) error {
+		_, err := tw.Write(b)
+		return err
+	}, int64(len(b)), 0o755)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
## What does this PR do?

This changes code interacting with file copies to and from the container to use optimized functions. Doing so reduces buffering and gives a chance for to use [Go 1.22's optimized paths for linux](https://github.com/golang/go/issues/58808).

## Why is it important?

I'm using rather large images in k3s. For example, nodejs images get easily over a GB each. I found this copy logic accounts for the majority of test fixture setup, in our case sometimes over a minute is spent here even when images are available locally.

## Related issues

Originally added in #347

## How to test this PR

you can use k3s and its `LoadImages` function which will hit all the paths here.

