### PR TITLE
fix(exec): updates the `Multiplexed` opt to combine stdout and stderr

### DIFF
--- a/docker_exec_test.go
+++ b/docker_exec_test.go
@@ -51,7 +51,6 @@ func TestExecWithOptions(t *testing.T) {
 			}
 
 			container, err := GenericContainer(ctx, GenericContainerRequest{
-				ProviderType:     providerType,
 				ContainerRequest: req,
 				Started:          true,
 			})
@@ -85,7 +84,6 @@ func TestExecWithMultiplexedResponse(t *testing.T) {
 	}
 
 	container, err := GenericContainer(ctx, GenericContainerRequest{
-		ProviderType:     providerType,
 		ContainerRequest: req,
 		Started:          true,
 	})
@@ -114,7 +112,6 @@ func TestExecWithNonMultiplexedResponse(t *testing.T) {
 	}
 
 	container, err := GenericContainer(ctx, GenericContainerRequest{
-		ProviderType:     providerType,
 		ContainerRequest: req,
 		Started:          true,
 	})

--- a/exec/processor.go
+++ b/exec/processor.go
@@ -82,10 +82,6 @@ func Multiplexed() ProcessOption {
 
 		<-done
 
-		if errBuff.Bytes() != nil {
-			opts.Reader = &errBuff
-		} else {
-			opts.Reader = &outBuff
-		}
+		opts.Reader = io.MultiReader(&outBuff, &errBuff)
 	})
 }


### PR DESCRIPTION
## What does this PR do?

Updates the `Multiplexed` option to combine the output of stdout and stderr, changing the previous behavior where stderr was preferred over stdout. Now, both streams are properly combined into a single stream.

## Why is it important?

Previously, the `Multiplexed` option prioritized stderr over stdout, potentially leading to unexpected results. By updating it to combine both stdout and stderr into a single stream, we ensure consistency and accuracy in handling the output of executed commands. This change prevents potential confusion or errors resulting from the previous preference for stderr over stdout.

## Related issues

- Relates #2451 
