### PR TITLE
fix: Amqps function returns amqps url instead of amqp url

### DIFF
--- a/modules/rabbitmq/rabbitmq.go
+++ b/modules/rabbitmq/rabbitmq.go
@@ -48,7 +48,7 @@ func (c *RabbitMQContainer) AmqpURL(ctx context.Context) (string, error) {
 
 // AmqpURL returns the URL for AMQPS clients.
 func (c *RabbitMQContainer) AmqpsURL(ctx context.Context) (string, error) {
-	endpoint, err := c.PortEndpoint(ctx, nat.Port(DefaultAMQPPort), "")
+	endpoint, err := c.PortEndpoint(ctx, nat.Port(DefaultAMQPSPort), "")
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
## What does this PR do?
Fixes the AmqpsURL function to return an AMQPS URL instead of AMQP URL.

## Why is it important?
This fix is essential as it ensures that our tests accurately reflect real-world conditions by returning the correct AMQPS URL, thereby enhancing the reliability and effectiveness of our testing environment.

## Related issues
- Closes #2457
