### PR TITLE
bug:Fix AMQPS url

### DIFF
--- a/modules/rabbitmq/rabbitmq.go
+++ b/modules/rabbitmq/rabbitmq.go
@@ -48,7 +48,7 @@ func (c *RabbitMQContainer) AmqpURL(ctx context.Context) (string, error) {
 
 // AmqpURL returns the URL for AMQPS clients.
 func (c *RabbitMQContainer) AmqpsURL(ctx context.Context) (string, error) {
-	endpoint, err := c.PortEndpoint(ctx, nat.Port(DefaultAMQPPort), "")
+	endpoint, err := c.PortEndpoint(ctx, nat.Port(DefaultAMQPSPort), "")
 	if err != nil {
 		return "", err
 	}

--- a/modules/rabbitmq/rabbitmq_test.go
+++ b/modules/rabbitmq/rabbitmq_test.go
@@ -32,12 +32,30 @@ func TestRunContainer_connectUsingAmqp(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	amqpsURL, err := rabbitmqContainer.AmqpsURL(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !strings.HasPrefix(amqpsURL, "amqps") {
+		t.Fatal(fmt.Errorf("AMQPS Url should begin with `amqps`"))
+	}
+
 	amqpConnection, err := amqp.Dial(amqpURL)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	if err = amqpConnection.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	amqpsConnection, err := amqp.Dial(amqpsURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err = amqpsConnection.Close(); err != nil {
 		t.Fatal(err)
 	}
 }


### PR DESCRIPTION
Fixes AQMPS url

## What does this PR do?

Fixes the AMQPS URL. Adds test.

## Why is it important?

User reported an issue - https://github.com/testcontainers/testcontainers-go/issues/2457

## Related issues

- Closes #2457


## How to test this PR

Will include unit-tests covering aqmps/tls


This currently won't work, while the AMQPS url is fixed it looks like container doesn't support TLS. I'll see if I can resolve that without too much difficulty.
