### PR TITLE
Upgrade neo4j module to use features from v0.29.1 of testcontainers-go

### DIFF
--- a/docs/features/common_functional_options.md
+++ b/docs/features/common_functional_options.md
@@ -22,7 +22,7 @@ Using the `WithImageSubstitutors` options, you could define your own substitutio
 If you need to either pass additional environment variables to a container or override them, you can use `testcontainers.WithEnv` for example:
 
 ```golang
-postgres, err = postgresModule.RunContainer(ctx, testcontainers.WithEnv(map[string]string{"POSTGRES_INITDB_ARGS", "--no-sync"}))
+postgres, err = postgresModule.RunContainer(ctx, testcontainers.WithEnv(map[string]string{"POSTGRES_INITDB_ARGS": "--no-sync"}))
 ```
 
 #### WithLogConsumers

--- a/modules/neo4j/config.go
+++ b/modules/neo4j/config.go
@@ -123,9 +123,9 @@ func formatNeo4jConfig(name string) string {
 // the commercial licence agreement of Neo4j Enterprise Edition. The license
 // agreement is available at https://neo4j.com/terms/licensing/.
 func WithAcceptCommercialLicenseAgreement() testcontainers.CustomizeRequestOption {
-	return func(req *testcontainers.GenericContainerRequest) {
-		req.Env["NEO4J_ACCEPT_LICENSE_AGREEMENT"] = "yes"
-	}
+	return testcontainers.WithEnv(map[string]string{
+		"NEO4J_ACCEPT_LICENSE_AGREEMENT": "yes",
+	})
 }
 
 // WithAcceptEvaluationLicenseAgreement sets the environment variable
@@ -134,7 +134,7 @@ func WithAcceptCommercialLicenseAgreement() testcontainers.CustomizeRequestOptio
 // agreement is available at https://neo4j.com/terms/enterprise_us/. Please
 // read the terms of the evaluation agreement before you accept.
 func WithAcceptEvaluationLicenseAgreement() testcontainers.CustomizeRequestOption {
-	return func(req *testcontainers.GenericContainerRequest) {
-		req.Env["NEO4J_ACCEPT_LICENSE_AGREEMENT"] = "eval"
-	}
+	return testcontainers.WithEnv(map[string]string{
+		"NEO4J_ACCEPT_LICENSE_AGREEMENT": "eval",
+	})
 }


### PR DESCRIPTION
## What does this PR do?

This PR updates the implementation of neo4j enterprise to use the newly added `testcontainers.WithEnv` instead of directly accessing the environment of `req`, which is erroneous.

Also, this PR fixes a minor typo in the docs.

## Why is it important?

The `Env` map of `req` may be nil. Also, dog fooding our own API is a good practice.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->

## How to test this PR

I've tested that this PR does not break `neo4j` tests. I trust the CI other than that.
