### PR TITLE
Fix: HTTP wait strategy does not take query params into account

### DIFF
--- a/wait/http.go
+++ b/wait/http.go
@@ -264,11 +264,12 @@ func (ws *HTTPStrategy) WaitUntilReady(ctx context.Context, target StrategyTarge
 	client := http.Client{Transport: tripper, Timeout: time.Second}
 	address := net.JoinHostPort(ipAddress, strconv.Itoa(mappedPort.Int()))
 
-	endpoint := url.URL{
-		Scheme: proto,
-		Host:   address,
-		Path:   ws.Path,
+	endpoint, err := url.Parse(ws.Path)
+	if err != nil {
+		return err
 	}
+	endpoint.Scheme = proto
+	endpoint.Host = address
 
 	if ws.UserInfo != nil {
 		endpoint.User = ws.UserInfo

--- a/wait/http_test.go
+++ b/wait/http_test.go
@@ -300,6 +300,87 @@ func TestHTTPStrategyWaitUntilReady(t *testing.T) {
 	}
 }
 
+func TestHTTPStrategyWaitUntilReadyWithQueryString(t *testing.T) {
+	workdir, err := os.Getwd()
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	capath := filepath.Join(workdir, "testdata", "root.pem")
+	cafile, err := os.ReadFile(capath)
+	if err != nil {
+		t.Errorf("can't load ca file: %v", err)
+		return
+	}
+
+	certpool := x509.NewCertPool()
+	if !certpool.AppendCertsFromPEM(cafile) {
+		t.Errorf("the ca file isn't valid")
+		return
+	}
+
+	tlsconfig := &tls.Config{RootCAs: certpool, ServerName: "testcontainer.go.test"}
+	dockerReq := testcontainers.ContainerRequest{
+		FromDockerfile: testcontainers.FromDockerfile{
+			Context: filepath.Join(workdir, "testdata"),
+		},
+
+		ExposedPorts: []string{"6443/tcp"},
+		WaitingFor: wait.NewHTTPStrategy("/query-params-ping?v=pong").WithTLS(true, tlsconfig).
+			WithStartupTimeout(time.Second * 10).WithPort("6443/tcp").
+			WithResponseMatcher(func(body io.Reader) bool {
+				data, _ := io.ReadAll(body)
+				return bytes.Equal(data, []byte("pong"))
+			}),
+	}
+
+	container, err := testcontainers.GenericContainer(context.Background(),
+		testcontainers.GenericContainerRequest{ContainerRequest: dockerReq, Started: true})
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	defer container.Terminate(context.Background()) // nolint: errcheck
+
+	host, err := container.Host(context.Background())
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	port, err := container.MappedPort(context.Background(), "6443/tcp")
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	client := http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: tlsconfig,
+			Proxy:           http.ProxyFromEnvironment,
+			DialContext: (&net.Dialer{
+				Timeout:   time.Second,
+				KeepAlive: 30 * time.Second,
+				DualStack: true,
+			}).DialContext,
+			ForceAttemptHTTP2:     true,
+			MaxIdleConns:          100,
+			IdleConnTimeout:       90 * time.Second,
+			TLSHandshakeTimeout:   10 * time.Second,
+			ExpectContinueTimeout: 1 * time.Second,
+		},
+	}
+	resp, err := client.Get(fmt.Sprintf("https://%s:%s", host, port.Port()))
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("status code isn't ok: %s", resp.Status)
+		return
+	}
+}
+
 func TestHTTPStrategyWaitUntilReadyNoBasicAuth(t *testing.T) {
 	workdir, err := os.Getwd()
 	if err != nil {

--- a/wait/testdata/main.go
+++ b/wait/testdata/main.go
@@ -45,6 +45,17 @@ func main() {
 		w.WriteHeader(http.StatusUnauthorized)
 	})
 
+	mux.HandleFunc("/query-params-ping", func(w http.ResponseWriter, req *http.Request) {
+		v := req.URL.Query().Get("v")
+		if v == "" {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("pong"))
+	})
+
 	mux.HandleFunc("/headers", func(w http.ResponseWriter, req *http.Request) {
 		h := req.Header.Get("X-request-header")
 		if h != "" {


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

When specifying a wait strategy using HTTP with query params, they are not sent to the container.
For example, to ensure the elasticmq container is ready, as advised in [this issue](https://github.com/softwaremill/elasticmq/issues/776), one must
poll the `/?Action=ListQueues` endpoint.
Currently this returns a 400 Bad request because the query parameters are not sent correctly to the endpoint.

The way the fix work is to parse the given path to create a `url.URL` instance and update the fields with the other values. This way the query parameters and the path are correclty handled.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->
Here is a reproduction with the elasticmq container:

```go
req := testcontainers.ContainerRequest{
	Image:        "softwaremill/elasticmq-native:1.5.7",
	ExposedPorts: []string{"9324/tcp"},
	WaitingFor:   wait.ForHTTP("/?Action=ListQueues").WithPort("9324").WithStartupTimeout(3 * time.Second),
}

genericContainerReq := testcontainers.GenericContainerRequest{
	ContainerRequest: req,
	Started:          true,
}

c, err := testcontainers.GenericContainer(ctx, genericContainerReq)
if err != nil {
	return fmt.Errorf("failed to start repos-new elasticmq container: %w", err)
}
```


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
