### PR TITLE
feat(modules.mongodb): add replica set support via opts

### DIFF
--- a/docs/modules/mongodb.md
+++ b/docs/modules/mongodb.md
@@ -58,6 +58,12 @@ It is used in conjunction with `WithUsername` to set a username and its password
 
 E.g. `testcontainers.WithPassword("mymongopwd")`.
 
+## WithReplicaSet
+
+- Not available until the next release of testcontainers-go <a href="https://github.com/testcontainers/testcontainers-go"><span class="tc-version">:material-tag: main</span></a>
+
+The `WithReplicaSet` functional option configures the container to run a single-node MongoDB replica set named `rs`. The MongoDB container will wait until the replica set is ready.
+
 {% include "../features/common_functional_options.md" %}
 
 ### Container Methods

--- a/docs/modules/mongodb.md
+++ b/docs/modules/mongodb.md
@@ -58,7 +58,7 @@ It is used in conjunction with `WithUsername` to set a username and its password
 
 E.g. `testcontainers.WithPassword("mymongopwd")`.
 
-## WithReplicaSet
+#### WithReplicaSet
 
 - Not available until the next release of testcontainers-go <a href="https://github.com/testcontainers/testcontainers-go"><span class="tc-version">:material-tag: main</span></a>
 

--- a/modules/mongodb/mongodb_test.go
+++ b/modules/mongodb/mongodb_test.go
@@ -14,50 +14,70 @@ import (
 
 func TestMongoDB(t *testing.T) {
 	type tests struct {
-		name  string
-		image string
+		name string
+		opts []testcontainers.ContainerCustomizer
 	}
 	testCases := []tests{
 		{
-			name:  "From Docker Hub",
-			image: "mongo:6",
+			name: "From Docker Hub",
+			opts: []testcontainers.ContainerCustomizer{
+				testcontainers.WithImage("mongo:6"),
+			},
 		},
 		{
-			name:  "Community Server",
-			image: "mongodb/mongodb-community-server:7.0.2-ubi8",
+			name: "Community Server",
+			opts: []testcontainers.ContainerCustomizer{
+				testcontainers.WithImage("mongodb/mongodb-community-server:7.0.2-ubi8"),
+			},
 		},
 		{
-			name:  "Enterprise Server",
-			image: "mongodb/mongodb-enterprise-server:7.0.0-ubi8",
+			name: "Enterprise Server",
+			opts: []testcontainers.ContainerCustomizer{
+				testcontainers.WithImage("mongodb/mongodb-enterprise-server:7.0.0-ubi8"),
+			},
+		},
+		{
+			name: "With Replica set and mongo:4",
+			opts: []testcontainers.ContainerCustomizer{
+				testcontainers.WithImage("mongo:4"),
+				mongodb.WithReplicaSet(),
+			},
+		},
+		{
+			name: "With Replica set and mongo:6",
+			opts: []testcontainers.ContainerCustomizer{
+				testcontainers.WithImage("mongo:6"),
+				mongodb.WithReplicaSet(),
+			},
 		},
 	}
 
 	for _, tc := range testCases {
-		image := tc.image
-		t.Run(image, func(t *testing.T) {
-			t.Parallel()
+		tc := tc
+		t.Run(tc.name, func(tt *testing.T) {
+			tt.Parallel()
 
 			ctx := context.Background()
 
-			mongodbContainer, err := mongodb.RunContainer(ctx, testcontainers.WithImage(image))
+			mongodbContainer, err := mongodb.RunContainer(ctx, tc.opts...)
 			if err != nil {
-				t.Fatalf("failed to start container: %s", err)
+				tt.Fatalf("failed to start container: %s", err)
 			}
 
 			defer func() {
 				if err := mongodbContainer.Terminate(ctx); err != nil {
-					t.Fatalf("failed to terminate container: %s", err)
+					tt.Fatalf("failed to terminate container: %s", err)
 				}
 			}()
 
 			endpoint, err := mongodbContainer.ConnectionString(ctx)
 			if err != nil {
-				t.Fatalf("failed to get connection string: %s", err)
+				tt.Fatalf("failed to get connection string: %s", err)
 			}
 
 			mongoClient, err := mongo.Connect(ctx, options.Client().ApplyURI(endpoint))
 			if err != nil {
-				t.Fatalf("failed to connect to MongoDB: %s", err)
+				tt.Fatalf("failed to connect to MongoDB: %s", err)
 			}
 
 			err = mongoClient.Ping(ctx, nil)
@@ -66,7 +86,7 @@ func TestMongoDB(t *testing.T) {
 			}
 
 			if mongoClient.Database("test").Name() != "test" {
-				t.Fatalf("failed to connect to the correct database")
+				tt.Fatalf("failed to connect to the correct database")
 			}
 		})
 	}


### PR DESCRIPTION
## What does this PR do?

Implementing a `WithReplicaSet` function to configure the container to run with a default single-node replica set named "rs". This function appends "--replSet rs" to `req.Cmd` to initialize MongoDB in preparation to receive a replica set. Additionally, after execution, it initializes the replica set using "rs.initiate()", configuring the current host as the PRIMARY.

## Why is it important?

I've been utilizing testcontainers to test my service environment, which necessitates a replica set to execute transactions. As I've developed this functionality for internal use, I believe it would be beneficial to others as well.

## Related issues

This PR closes #2138. Additionally, I noticed that there is another PR, #2139, which also aims to implement this feature. However, it has not been updated for a while, and this branch has certain differences, such as utilizing both `mongosh` and `mongo` to ensure version compatibility.

## How to test this PR

I've tested this in a production environment, so it should work fine. Additionally, I've added new test cases to `TestMongoDB`.

## Follow-ups

Maybe adding a sharding option would be great.