### PR TITLE
Elasticsearch disable CA retrieval when ssl is disabled

### DIFF
--- a/modules/elasticsearch/elasticsearch.go
+++ b/modules/elasticsearch/elasticsearch.go
@@ -126,6 +126,11 @@ func configureAddress(ctx context.Context, c *ElasticsearchContainer) (string, e
 // For that, it defines a post start hook that copies the certificate from the container to the host.
 // The certificate is only available since version 8, and will be located in a well-known location.
 func configureCertificate(settings *Options, req *testcontainers.GenericContainerRequest) error {
+	if value, ok := req.Env["xpack.security.http.ssl.enabled"]; ok {
+		if value == "false" {
+			return nil
+		}
+	}
 	if isAtLeastVersion(req.Image, 8) {
 		// The container needs a post ready hook to copy the certificate from the container to the host.
 		// This certificate is only available since version 8

--- a/modules/elasticsearch/elasticsearch.go
+++ b/modules/elasticsearch/elasticsearch.go
@@ -126,12 +126,22 @@ func configureAddress(ctx context.Context, c *ElasticsearchContainer) (string, e
 // For that, it defines a post start hook that copies the certificate from the container to the host.
 // The certificate is only available since version 8, and will be located in a well-known location.
 func configureCertificate(settings *Options, req *testcontainers.GenericContainerRequest) error {
-	if value, ok := req.Env["xpack.security.http.ssl.enabled"]; ok {
-		if value == "false" {
-			return nil
-		}
-	}
 	if isAtLeastVersion(req.Image, 8) {
+		// These configuration keys explicitly disable CA generation.
+		// If any are set we skip the file retrieval.
+		configKeys := []string{
+			"xpack.security.enabled",
+			"xpack.security.http.ssl.enabled",
+			"xpack.security.transport.ssl.enabled",
+		}
+		for _, configKey := range configKeys {
+			if value, ok := req.Env[configKey]; ok {
+				if value == "false" {
+					return nil
+				}
+			}
+		}
+
 		// The container needs a post ready hook to copy the certificate from the container to the host.
 		// This certificate is only available since version 8
 		req.LifecycleHooks[0].PostReadies = append(req.LifecycleHooks[0].PostReadies,

--- a/modules/elasticsearch/elasticsearch_test.go
+++ b/modules/elasticsearch/elasticsearch_test.go
@@ -163,7 +163,7 @@ func TestElasticsearch(t *testing.T) {
 	}
 }
 
-func TestElasticsearch8WithAndWithoutSSL(t *testing.T) {
+func TestElasticsearch8WithoutSSL(t *testing.T) {
 	tests := []struct {
 		name      string
 		configKey string

--- a/modules/elasticsearch/elasticsearch_test.go
+++ b/modules/elasticsearch/elasticsearch_test.go
@@ -163,6 +163,48 @@ func TestElasticsearch(t *testing.T) {
 	}
 }
 
+func TestElasticsearch8WithAndWithoutSSL(t *testing.T) {
+	t.Run("Elasticsearch 8 with SSL should provide CACert", func(t *testing.T) {
+		ctx := context.Background()
+		container, err := elasticsearch.RunContainer(ctx, testcontainers.WithImage(baseImage8))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		t.Cleanup(func() {
+			if err := container.Terminate(ctx); err != nil {
+				t.Fatalf("failed to terminate container: %s", err)
+			}
+		})
+
+		if len(container.Settings.CACert) == 0 {
+			t.Fatal("expected CA cert to not be empty")
+		}
+	})
+	t.Run("Elasticsearch 8 without SSL should not provide CACert", func(t *testing.T) {
+		ctx := context.Background()
+		container, err := elasticsearch.RunContainer(
+			ctx,
+			testcontainers.WithImage(baseImage8),
+			testcontainers.WithEnv(map[string]string{
+				"xpack.security.http.ssl.enabled": "false",
+			}))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		t.Cleanup(func() {
+			if err := container.Terminate(ctx); err != nil {
+				t.Fatalf("failed to terminate container: %s", err)
+			}
+		})
+
+		if len(container.Settings.CACert) > 0 {
+			t.Fatal("expected CA cert to be empty")
+		}
+	})
+}
+
 func TestElasticsearch8WithoutCredentials(t *testing.T) {
 	ctx := context.Background()
 


### PR DESCRIPTION
## What does this PR do?

This makes optional the retrieval of the Elasticsearch generated CA for version 8 when CA generation has been explicitly disabled.

## Why is it important?

While Elastic supports security on by default and users should use the CA and authentication, the container shouldn't fail if one of the TLS config option has been explicitly disabled.

## How to test this PR

Tests come with the PR.

## Follow-ups

Fixing this would allow to finish the adaptation of the [go-elasticsearch client integration tests to testcontainers](https://github.com/elastic/go-elasticsearch/pull/824)!