### PR TITLE
fix: handle dockerignore exclusions properly

### DIFF
--- a/container.go
+++ b/container.go
@@ -226,8 +226,12 @@ func (c *ContainerRequest) GetContext() (io.Reader, error) {
 		return nil, err
 	}
 
-	dockerIgnoreLocation := filepath.Join(abs, ".dockerignore")
-	includes = append(includes, dockerIgnoreLocation, c.GetDockerfile())
+	if len(excluded) > 0 {
+		// only add .dockerignore if it exists including files to ignore
+		includes = append(includes, filepath.Join(abs, ".dockerignore"))
+	}
+
+	includes = append(includes, c.GetDockerfile())
 
 	buildContext, err := archive.TarWithOptions(
 		c.Context,

--- a/container.go
+++ b/container.go
@@ -228,7 +228,7 @@ func (c *ContainerRequest) GetContext() (io.Reader, error) {
 
 	if len(excluded) > 0 {
 		// only add .dockerignore if it exists including files to ignore
-		includes = append(includes, filepath.Join(abs, ".dockerignore"))
+		includes = append(includes, filepath.Join(".dockerignore"))
 	}
 
 	includes = append(includes, c.GetDockerfile())

--- a/container.go
+++ b/container.go
@@ -221,13 +221,13 @@ func (c *ContainerRequest) GetContext() (io.Reader, error) {
 	}
 	c.Context = abs
 
-	excluded, err := parseDockerIgnore(abs)
+	dockerIgnoreExists, excluded, err := parseDockerIgnore(abs)
 	if err != nil {
 		return nil, err
 	}
 
-	if len(excluded) > 0 {
-		// only add .dockerignore if it exists including files to ignore
+	if dockerIgnoreExists {
+		// only add .dockerignore if it exists
 		includes = append(includes, filepath.Join(".dockerignore"))
 	}
 
@@ -244,18 +244,24 @@ func (c *ContainerRequest) GetContext() (io.Reader, error) {
 	return buildContext, nil
 }
 
-func parseDockerIgnore(targetDir string) ([]string, error) {
+// parseDockerIgnore returns if the file exists, the excluded files and an error if any
+func parseDockerIgnore(targetDir string) (bool, []string, error) {
 	// based on https://github.com/docker/cli/blob/master/cli/command/image/build/dockerignore.go#L14
 	fileLocation := filepath.Join(targetDir, ".dockerignore")
 	var excluded []string
+	exists := false
 	if f, openErr := os.Open(fileLocation); openErr == nil {
+		defer f.Close()
+
+		exists = true
+
 		var err error
 		excluded, err = ignorefile.ReadAll(f)
 		if err != nil {
-			return excluded, fmt.Errorf("error reading .dockerignore: %w", err)
+			return true, excluded, fmt.Errorf("error reading .dockerignore: %w", err)
 		}
 	}
-	return excluded, nil
+	return exists, excluded, nil
 }
 
 // GetBuildArgs returns the env args to be used when creating from Dockerfile

--- a/container_ignore_test.go
+++ b/container_ignore_test.go
@@ -11,23 +11,32 @@ import (
 func TestParseDockerIgnore(t *testing.T) {
 	testCases := []struct {
 		filePath         string
+		exists           bool
 		expectedErr      error
 		expectedExcluded []string
 	}{
 		{
 			filePath:         "./testdata/dockerignore",
 			expectedErr:      nil,
+			exists:           true,
 			expectedExcluded: []string{"vendor", "foo", "bar"},
 		},
 		{
 			filePath:         "./testdata",
 			expectedErr:      nil,
+			exists:           true,
 			expectedExcluded: []string{"Dockerfile", "echo.Dockerfile"},
+		},
+		{
+			filePath:         "./testdata/data",
+			expectedErr:      nil,
+			expectedExcluded: nil, // it's nil because the parseDockerIgnore function uses the zero value of a slice
 		},
 	}
 
 	for _, testCase := range testCases {
-		excluded, err := parseDockerIgnore(testCase.filePath)
+		exists, excluded, err := parseDockerIgnore(testCase.filePath)
+		assert.Equal(t, testCase.exists, exists)
 		assert.Equal(t, testCase.expectedErr, err)
 		assert.Equal(t, testCase.expectedExcluded, excluded)
 	}

--- a/docs/features/build_from_dockerfile.md
+++ b/docs/features/build_from_dockerfile.md
@@ -33,7 +33,6 @@ You can specify them like:
 If you would like to send a build context that you created in code (maybe you have a dynamic Dockerfile), you can
 send the build context as an `io.Reader` since the Docker Daemon accepts it as a tar file, you can use the [tar](https://golang.org/pkg/archive/tar/) package to create your context.
 
-
 To do this you would use the `ContextArchive` attribute in the `FromDockerfile` struct.
 
 ```go
@@ -51,6 +50,15 @@ fromDockerfile := testcontainers.FromDockerfile{
 
 **Please Note** if you specify a `ContextArchive` this will cause _Testcontainers for Go_ to ignore the path passed
 in to `Context`.
+
+## Ignoring files in the build context
+
+The same as Docker has a `.dockerignore` file to ignore files in the build context, _Testcontainers for Go_ also supports this feature.
+A `.dockerignore` living in the root of the build context will be used to filter out files that should not be sent to the Docker daemon.
+The `.dockerignore` file won't be sent to the Docker daemon either.
+
+!!! note
+    At this moment, _Testcontainers for Go_ does not support Dockerfile-specific `.dockerignore` files.
 
 ## Images requiring auth
 


### PR DESCRIPTION
- **chore: only include the dockerignore if it contains ignore files**
- **fix: the inclusions must be relative to the context**
- **docs: document the dockerignore feature**

<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
This PR is fixing a cosmetic change in the logs of the library, which showed an error while building the Docker build context for the dockerignore file, as it was built with an absolute path instead of using the relative to the build context one.

At the same time, and discovered while running the tests, we were always adding the dockerignore file to the exclusions list, which is incorrect: we want to exclude it if and only if it exists.

Finally we are documenting the dockerignore file.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
There was an ugly log error showing that the tar file was incorrect becuase of the dockerignore file having an absolute path. Now the logic to exclude the dockerignore file is correct.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Caused by #2272

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->
There are a few tests that cover this feature, any using FromDockerfile. To name some:

- in the core: TestBuildContainerFromDockerfile
- in the docker registry module: ExampleRunContainer_withAuthentication

Running those tests will cover the changes in this PR.

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
