### PR TITLE
Retry failed calls to MappedPort to workaround inspect problem

### DIFF
--- a/docker.go
+++ b/docker.go
@@ -158,6 +158,16 @@ func (c *DockerContainer) Host(ctx context.Context) (string, error) {
 
 // MappedPort gets externally mapped port for a container port
 func (c *DockerContainer) MappedPort(ctx context.Context, port nat.Port) (nat.Port, error) {
+	var mappedPort nat.Port
+	err := backoff.Retry(func() (err error) {
+		mappedPort, err = c.mappedPort(ctx, port)
+		return
+	}, backoff.WithContext(backoff.NewExponentialBackOff(), ctx))
+
+	return mappedPort, err
+}
+
+func (c *DockerContainer) mappedPort(ctx context.Context, port nat.Port) (nat.Port, error) {
 	inspect, err := c.inspectContainer(ctx)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
## What does this PR do?

Add a retry loop to the `MappedPort` call in the docker package.

## Why is it important?

After some investigation into https://github.com/testcontainers/testcontainers-go/issues/605, it looks like Docker will sometimes return information from `inspectContainer` that doesn't include the `NetworkSettings`. This makes requests to `GenericContainer` fail intermittently.

## Related issues

- Closes https://github.com/testcontainers/testcontainers-go/issues/605