### PR TITLE
feat: Bump default postgres version

### DIFF
--- a/docs/modules/postgres.md
+++ b/docs/modules/postgres.md
@@ -41,7 +41,7 @@ When starting the Postgres container, you can pass options in a variadic way to 
 #### Image
 
 If you need to set a different Postgres Docker image, you can use `testcontainers.WithImage` with a valid Docker image
-for Postgres. E.g. `testcontainers.WithImage("docker.io/postgres:9.6")`.
+for Postgres. E.g. `testcontainers.WithImage("docker.io/postgres:16-alpine")`.
 
 {% include "../features/common_functional_options.md" %}
 

--- a/modules/postgres/examples_test.go
+++ b/modules/postgres/examples_test.go
@@ -21,7 +21,7 @@ func ExampleRunContainer() {
 	dbPassword := "password"
 
 	postgresContainer, err := postgres.RunContainer(ctx,
-		testcontainers.WithImage("docker.io/postgres:15.2-alpine"),
+		testcontainers.WithImage("docker.io/postgres:16-alpine"),
 		postgres.WithInitScripts(filepath.Join("testdata", "init-user-db.sh")),
 		postgres.WithConfigFile(filepath.Join("testdata", "my-postgres.conf")),
 		postgres.WithDatabase(dbName),

--- a/modules/postgres/postgres.go
+++ b/modules/postgres/postgres.go
@@ -13,7 +13,7 @@ import (
 const (
 	defaultUser          = "postgres"
 	defaultPassword      = "postgres"
-	defaultPostgresImage = "docker.io/postgres:11-alpine"
+	defaultPostgresImage = "docker.io/postgres:16-alpine"
 	defaultSnapshotName  = "migrated_template"
 )
 
@@ -26,10 +26,9 @@ type PostgresContainer struct {
 	snapshotName string
 }
 
-
 // MustConnectionString panics if the address cannot be determined.
 func (c *PostgresContainer) MustConnectionString(ctx context.Context, args ...string) string {
-	addr, err := c.ConnectionString(ctx,args...)
+	addr, err := c.ConnectionString(ctx, args...)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION


## What does this PR do?
Bump the default postgres image to latest.


## Why is it important?

The default image version was `11` that version is unsupported  https://www.postgresql.org/support/versioning/


## How to test this PR
Run the unit tests.


