### PR TITLE
Fix race condition when looking up reaper (ryuk) container

### DIFF
--- a/docker.go
+++ b/docker.go
@@ -49,11 +49,6 @@ const (
 	packagePath   = "github.com/testcontainers/testcontainers-go"
 
 	logStoppedForOutOfSyncMessage = "Stopping log consumer: Headers out of sync"
-
-	healthStatusNone      = ""          // default status for a container with no healthcheck
-	healthStatusHealthy   = "healthy"   // healthy container
-	healthStatusStarting  = "starting"  // starting container
-	healthStatusUnhealthy = "unhealthy" // unhealthy container
 )
 
 var createContainerFailDueToNameConflictRegex = regexp.MustCompile("Conflict. The container name .* is already in use by container .*")

--- a/generic_test.go
+++ b/generic_test.go
@@ -134,7 +134,7 @@ func TestGenericReusableContainerInSubprocess(t *testing.T) {
 			output := createReuseContainerInSubprocess(t)
 
 			// check is reuse container with WaitingFor work correctly.
-			require.True(t, strings.Contains(output, "🚧 Waiting for container id"))
+			require.True(t, strings.Contains(output, "⏳ Waiting for container id"))
 			require.True(t, strings.Contains(output, "🔔 Container is ready"))
 		}()
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -278,7 +278,7 @@ func TestReadTCConfig(t *testing.T) {
 				``,
 				map[string]string{
 					"TESTCONTAINERS_RYUK_RECONNECTION_TIMEOUT": "13s",
-					"TESTCONTAINERS_RYUK_CONNECTION_TIMEOUT": "12s",
+					"TESTCONTAINERS_RYUK_CONNECTION_TIMEOUT":   "12s",
 				},
 				Config{
 					RyukReconnectionTimeout: 13 * time.Second,
@@ -291,7 +291,7 @@ func TestReadTCConfig(t *testing.T) {
 	ryuk.reconnection.timeout=23s`,
 				map[string]string{
 					"TESTCONTAINERS_RYUK_RECONNECTION_TIMEOUT": "13s",
-					"TESTCONTAINERS_RYUK_CONNECTION_TIMEOUT": "12s",
+					"TESTCONTAINERS_RYUK_CONNECTION_TIMEOUT":   "12s",
 				},
 				Config{
 					RyukReconnectionTimeout: 13 * time.Second,

--- a/lifecycle.go
+++ b/lifecycle.go
@@ -207,7 +207,7 @@ var defaultReadinessHook = func() ContainerLifecycleHooks {
 				// if a Wait Strategy has been specified, wait before returning
 				if dockerContainer.WaitingFor != nil {
 					dockerContainer.logger.Printf(
-						"🚧 Waiting for container id %s image: %s. Waiting for: %+v",
+						"⏳ Waiting for container id %s image: %s. Waiting for: %+v",
 						dockerContainer.ID[:12], dockerContainer.Image, dockerContainer.WaitingFor,
 					)
 					if err := dockerContainer.WaitingFor.WaitUntilReady(ctx, c); err != nil {

--- a/reaper.go
+++ b/reaper.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"fmt"
+	"github.com/docker/docker/api/types"
 	"math/rand"
 	"net"
 	"strings"
@@ -117,8 +118,11 @@ func lookUpReaperContainer(ctx context.Context, sessionID string) (*DockerContai
 			return err
 		}
 
-		if r.healthStatus != healthStatusHealthy && r.healthStatus != healthStatusNone {
-			return fmt.Errorf("container %s is not healthy, wanted status=%s, got status=%s", resp[0].ID[:8], healthStatusHealthy, r.healthStatus)
+		// if a health status is present on the container, and the container is not healthy, error
+		if r.healthStatus != "" {
+			if r.healthStatus != types.Healthy && r.healthStatus != types.NoHealthcheck {
+				return fmt.Errorf("container %s is not healthy, wanted status=%s, got status=%s", resp[0].ID[:8], types.Healthy, r.healthStatus)
+			}
 		}
 
 		reaperContainer = r

--- a/reaper.go
+++ b/reaper.go
@@ -117,6 +117,10 @@ func lookUpReaperContainer(ctx context.Context, sessionID string) (*DockerContai
 			return err
 		}
 
+		if r.healthStatus != healthStatusHealthy && r.healthStatus != healthStatusNone {
+			return fmt.Errorf("container %s is not healthy, wanted status=%s, got status=%s", resp[0].ID[:8], healthStatusHealthy, r.healthStatus)
+		}
+
 		reaperContainer = r
 
 		return nil

--- a/reaper.go
+++ b/reaper.go
@@ -171,7 +171,7 @@ func reuseOrCreateReaper(ctx context.Context, sessionID string, provider ReaperP
 			return nil, err
 		}
 
-		Logger.Printf("⏳  Waiting for Reaper port to be ready")
+		Logger.Printf("⏳ Waiting for Reaper port to be ready")
 
 		var containerJson *types.ContainerJSON
 

--- a/reaper.go
+++ b/reaper.go
@@ -173,26 +173,6 @@ func reuseOrCreateReaper(ctx context.Context, sessionID string, provider ReaperP
 			return nil, err
 		}
 
-		Logger.Printf("⏳ Waiting for Reaper port to be ready")
-
-		var containerJson *types.ContainerJSON
-
-		if containerJson, err = reaperContainer.Inspect(ctx); err != nil {
-			return nil, fmt.Errorf("failed to inspect reaper container %s: %w", reaperContainer.ID[:8], err)
-		}
-
-		if containerJson != nil && containerJson.NetworkSettings != nil {
-			for port := range containerJson.NetworkSettings.Ports {
-				err := wait.ForListeningPort(port).
-					WithPollInterval(100*time.Millisecond).
-					WaitUntilReady(ctx, reaperContainer)
-				if err != nil {
-					return nil, fmt.Errorf("failed waiting for reaper container %s port %s/%s to be ready: %w",
-						reaperContainer.ID[:8], port.Proto(), port.Port(), err)
-				}
-			}
-		}
-
 		return reaperInstance, nil
 	}
 
@@ -223,6 +203,27 @@ func reuseReaperContainer(ctx context.Context, sessionID string, provider Reaper
 	if err != nil {
 		return nil, err
 	}
+
+	Logger.Printf("⏳ Waiting for Reaper port to be ready")
+
+	var containerJson *types.ContainerJSON
+
+	if containerJson, err = reaperContainer.Inspect(ctx); err != nil {
+		return nil, fmt.Errorf("failed to inspect reaper container %s: %w", reaperContainer.ID[:8], err)
+	}
+
+	if containerJson != nil && containerJson.NetworkSettings != nil {
+		for port := range containerJson.NetworkSettings.Ports {
+			err := wait.ForListeningPort(port).
+				WithPollInterval(100*time.Millisecond).
+				WaitUntilReady(ctx, reaperContainer)
+			if err != nil {
+				return nil, fmt.Errorf("failed waiting for reaper container %s port %s/%s to be ready: %w",
+					reaperContainer.ID[:8], port.Proto(), port.Port(), err)
+			}
+		}
+	}
+
 	return &Reaper{
 		Provider:  provider,
 		SessionID: sessionID,

--- a/reaper.go
+++ b/reaper.go
@@ -170,6 +170,27 @@ func reuseOrCreateReaper(ctx context.Context, sessionID string, provider ReaperP
 		if err != nil {
 			return nil, err
 		}
+
+		Logger.Printf("⏳  Waiting for Reaper port to be ready")
+
+		var containerJson *types.ContainerJSON
+
+		if containerJson, err = reaperContainer.Inspect(ctx); err != nil {
+			return nil, fmt.Errorf("failed to inspect reaper container %s: %w", reaperContainer.ID[:8], err)
+		}
+
+		if containerJson != nil && containerJson.NetworkSettings != nil {
+			for port := range containerJson.NetworkSettings.Ports {
+				err := wait.ForListeningPort(port).
+					WithPollInterval(100*time.Millisecond).
+					WaitUntilReady(ctx, reaperContainer)
+				if err != nil {
+					return nil, fmt.Errorf("failed waiting for reaper container %s port %s/%s to be ready: %w",
+						reaperContainer.ID[:8], port.Proto(), port.Port(), err)
+				}
+			}
+		}
+
 		return reaperInstance, nil
 	}
 

--- a/reaper.go
+++ b/reaper.go
@@ -10,9 +10,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/docker/docker/api/types"
-
 	"github.com/cenkalti/backoff/v4"
+	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/errdefs"


### PR DESCRIPTION
## What does this PR do?

Updates [`lookUpReaperContainer`](https://github.com/testcontainers/testcontainers-go/blob/main/reaper.go#L66) to consider the [health](https://docs.docker.com/reference/dockerfile/#healthcheck) of the ryuk container.

* If the ryuk container advertises a health status, `lookUpReaperContainer` will require a healthy container before returning.
* If the ryuk container does not advertise a status, the `lookUpReaperContainer` will return the container.

## Why is it important?

The ryuk container can be exposed by the Docker API before it is ready to accept connections, resulting in messages like:

```
2024/04/21 22:25:10 🔥 Reaper obtained from Docker for this test session 99998b629eea57023f49aefc9eda5406c84ce4c91d0c6005c1b8c00dcbbce0d7
2024/04/21 22:25:10 failed to start container: dial tcp 127.0.0.1:32917: connect: connection refused: Connecting to Ryuk on localhost:32917 failed: connecting to reaper failed: failed to create container
```

Tests will fail when they would otherwise pass.

This is especially the case in Go, where test binaries are run in parallel, one for each package.  If multiple packages use `testcontainers`, they can obtain a reaper instance from the Docker API before the container is ready to serve connections, leading to dialing errors like `connect: connection refused`.

The current workaround is to run test binaries serially, e.g., `go test -p 1 ./...`, which is not optimal, even for modest codebases.

## Related issues

See complementary PR, which adds a `HEALTHCHECK` to the ryuk container: https://github.com/testcontainers/moby-ryuk/pull/128

## How to test this PR

### To recreate the initial problem and run the workaround

Clone this [test case repo](https://github.com/emetsger/testcontainers-ryuk-testcase) and run `go test -count=1 -v ./...` and observe the errors.

Run `go test -count=1 -p 1 -v ./...` and tests should pass.

### To test the fix

Clone [moby-ryuk](https://github.com/testcontainers/moby-ryuk), apply [pull/128](https://github.com/testcontainers/moby-ryuk/pull/128), then build a new ryuk container, and tag it:

1. `docker build -f linux/Dockerfile -t local/ryuk .`
2. `docker tag local/ryuk testcontainers/ryuk:0.7.0`

Check out this branch/PR locally.

Clone the [test case repo](https://github.com/emetsger/testcontainers-ryuk-testcase) and update `go.mod` to point to this branch via a replace, e.g.:
* `replace github.com/testcontainers/testcontainers-go => /Users/esm/workspaces/testcontainers-go`

Running `go test -count=1 -v ./...` should pass.