### PR TITLE
feat: support passing io.Reader for compose files when creating a compose instance

### DIFF
--- a/docs/features/docker_compose.md
+++ b/docs/features/docker_compose.md
@@ -53,7 +53,24 @@ func TestSomething(t *testing.T) {
 }
 ```
 
-Use the advanced `NewDockerComposeWith(...)` constructor allowing you to specify an identifier:
+Use the advanced `NewDockerComposeWith(...)` constructor allowing you to customise the compose execution with options:
+
+- `StackIdentifier`: the identifier for the stack, which is used to name the network and containers. If not passed, a random identifier is generated.
+- `WithStackFiles`: specify the Docker Compose stack files to use, as a variadic argument of string paths where the stack files are located.
+- `WithStackReaders`: specify the Docker Compose stack files to use, as a variadic argument of `io.Reader` instances. It will create a temporary file in the temp dir of the given O.S., that will be removed after the `Down` method is called. You can use both `WithComposeStackFiles` and `WithComposeStackReaders` at the same time.
+
+#### Compose Up options
+
+- `RemoveOrphans`: remove orphaned containers after the stack is stopped.
+- `Wait`: will wait until the containers reached the running|healthy state.
+
+#### Compose Down options
+
+- `RemoveImages`: remove images after the stack is stopped. The `RemoveImagesAll` option will remove all images, while `RemoveImagesLocal` will remove only the images that don't have a tag.
+- `RemoveOrphans`: remove orphaned containers after the stack is stopped.
+- `RemoveVolumes`: remove volumes after the stack is stopped.
+
+#### Example
 
 ```go
 package example_test

--- a/docs/features/docker_compose.md
+++ b/docs/features/docker_compose.md
@@ -20,7 +20,7 @@ Because `compose` v2 is implemented in Go it's possible for _Testcontainers for 
 use [`github.com/docker/compose`](https://github.com/docker/compose) directly and skip any process execution/_docker-compose-in-a-container_ scenario.
 The `ComposeStack` API exposes this variant of using `docker compose` in an easy way.
 
-### Basic examples
+### Usage
 
 Use the convenience `NewDockerCompose(...)` constructor which creates a random identifier and takes a variable number
 of stack files:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
This PR adds a stack option to pass a variadic list of io.Reader to the creation of the compose instance, so the user is able to pass a list of file paths (as strings),
or a list of readers containing the bytes to generate the compose files on the fly.

It will use a temporary directory in the O.S. to generate the compose files from the readers, removing them after the compose.Down is called. The tmp dir will be subdir from the current time in nanoseconds.


<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
Support users that generate the compose files from other sources (e.g. downloading it from the internet).


<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes #285

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
