### PR TITLE
feat: support overriding the default recreate options for compose

### DIFF
--- a/docs/features/docker_compose.md
+++ b/docs/features/docker_compose.md
@@ -61,7 +61,9 @@ Use the advanced `NewDockerComposeWith(...)` constructor allowing you to customi
 
 #### Compose Up options
 
-- `RemoveOrphans`: remove orphaned containers after the stack is stopped.
+- `Recreate`: recreate the containers.
+- `RecreateDependencies`: recreate dependent containers.
+- `RemoveOrphans`: remove orphaned containers when the stack is upped.
 - `Wait`: will wait until the containers reached the running|healthy state.
 
 #### Compose Down options
@@ -80,6 +82,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/docker/compose/v2/pkg/api"
 	tc "github.com/testcontainers/testcontainers-go/modules/compose"
 )
 
@@ -95,7 +99,7 @@ func TestSomethingElse(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 
-	require.NoError(t, compose.Up(ctx, tc.Wait(true)), "compose.Up()")
+	require.NoError(t, compose.Up(ctx, tc.WithRecreate(api.RecreateNever), tc.Wait(true)), "compose.Up()")
 
 	// do some testing here
 }

--- a/docs/features/docker_compose.md
+++ b/docs/features/docker_compose.md
@@ -61,8 +61,8 @@ Use the advanced `NewDockerComposeWith(...)` constructor allowing you to customi
 
 #### Compose Up options
 
-- `Recreate`: recreate the containers.
-- `RecreateDependencies`: recreate dependent containers.
+- `Recreate`: recreate the containers. If any other value than `api.RecreateNever`, `api.RecreateForce` or `api.RecreateDiverged` is provided, the default value `api.RecreateForce` will be used.
+- `RecreateDependencies`: recreate dependent containers. If any other value than `api.RecreateNever`, `api.RecreateForce` or `api.RecreateDiverged` is provided, the default value `api.RecreateForce` will be used.
 - `RemoveOrphans`: remove orphaned containers when the stack is upped.
 - `Wait`: will wait until the containers reached the running|healthy state.
 

--- a/modules/compose/compose.go
+++ b/modules/compose/compose.go
@@ -93,10 +93,16 @@ type waitService struct {
 	publishedPort int
 }
 
+// WithRecreate defines the strategy to apply on existing containers. If any other value than
+// api.RecreateNever, api.RecreateForce or api.RecreateDiverged is provided, the default value
+// api.RecreateForce will be used.
 func WithRecreate(recreate string) StackUpOption {
 	return Recreate(recreate)
 }
 
+// WithRecreateDependencies defines the strategy to apply on container dependencies. If any other value than
+// api.RecreateNever, api.RecreateForce or api.RecreateDiverged is provided, the default value
+// api.RecreateForce will be used.
 func WithRecreateDependencies(recreate string) StackUpOption {
 	return RecreateDependencies(recreate)
 }

--- a/modules/compose/compose.go
+++ b/modules/compose/compose.go
@@ -93,6 +93,14 @@ type waitService struct {
 	publishedPort int
 }
 
+func WithRecreate(recreate string) StackUpOption {
+	return Recreate(recreate)
+}
+
+func WithRecreateDependencies(recreate string) StackUpOption {
+	return RecreateDependencies(recreate)
+}
+
 func WithStackFiles(filePaths ...string) ComposeStackOption {
 	return ComposeStackFiles(filePaths)
 }

--- a/modules/compose/compose_api.go
+++ b/modules/compose/compose_api.go
@@ -59,6 +59,20 @@ func (io IgnoreOrphans) applyToStackUp(co *api.CreateOptions, _ *api.StartOption
 	co.IgnoreOrphans = bool(io)
 }
 
+// Recreate will recreate the containers that are already running
+type Recreate string
+
+func (r Recreate) applyToStackUp(o *stackUpOptions) {
+	o.Recreate = string(r)
+}
+
+// RecreateDependencies will recreate the dependencies of the services that are already running
+type RecreateDependencies string
+
+func (r RecreateDependencies) applyToStackUp(o *stackUpOptions) {
+	o.RecreateDependencies = string(r)
+}
+
 // RemoveOrphans will clean up containers that are not declared on the compose model but own the same labels
 type RemoveOrphans bool
 

--- a/modules/compose/compose_api.go
+++ b/modules/compose/compose_api.go
@@ -63,14 +63,23 @@ func (io IgnoreOrphans) applyToStackUp(co *api.CreateOptions, _ *api.StartOption
 type Recreate string
 
 func (r Recreate) applyToStackUp(o *stackUpOptions) {
-	o.Recreate = string(r)
+	o.Recreate = validateRecreate(string(r))
 }
 
 // RecreateDependencies will recreate the dependencies of the services that are already running
 type RecreateDependencies string
 
 func (r RecreateDependencies) applyToStackUp(o *stackUpOptions) {
-	o.RecreateDependencies = string(r)
+	o.RecreateDependencies = validateRecreate(string(r))
+}
+
+func validateRecreate(r string) string {
+	switch r {
+	case api.RecreateDiverged, api.RecreateForce, api.RecreateNever:
+		return r
+	default:
+		return api.RecreateForce
+	}
 }
 
 // RemoveOrphans will clean up containers that are not declared on the compose model but own the same labels

--- a/modules/compose/compose_api_test.go
+++ b/modules/compose/compose_api_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/docker/compose/v2/pkg/api"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/volume"
 	"github.com/google/uuid"
@@ -560,6 +561,22 @@ func TestDockerComposeAPIWithVolume(t *testing.T) {
 	t.Cleanup(cancel)
 
 	err = compose.Up(ctx, Wait(true))
+	require.NoError(t, err, "compose.Up()")
+}
+
+func TestDockerComposeAPIWithRecreate(t *testing.T) {
+	path, _ := RenderComposeComplex(t)
+	compose, err := NewDockerCompose(path)
+	require.NoError(t, err, "NewDockerCompose()")
+
+	t.Cleanup(func() {
+		require.NoError(t, compose.Down(context.Background(), RemoveOrphans(true), RemoveImagesLocal), "compose.Down()")
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	err = compose.Up(ctx, WithRecreate(api.RecreateNever), WithRecreateDependencies(api.RecreateNever), Wait(true))
 	require.NoError(t, err, "compose.Up()")
 }
 


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
It adds two options: `WithRecreate` and `WithRecreateDependencies` that will allow to override the default behaviour of compose, which was set to `api.RecreateDiverged`.

Now it would be possible to set it to `api.RecreateDiverged`, `api.RecreateForce` or `api.RecreateNever`. If any other value is passed, then `Force` will be used.
<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
Support more user customisation of the compose execution.
<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes #1276

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
