### PR TITLE
docs: document the SSHd tunnel

### DIFF
--- a/docs/features/common_functional_options.md
+++ b/docs/features/common_functional_options.md
@@ -25,6 +25,18 @@ If you need to either pass additional environment variables to a container or ov
 postgres, err = postgresModule.RunContainer(ctx, testcontainers.WithEnv(map[string]string{"POSTGRES_INITDB_ARGS": "--no-sync"}))
 ```
 
+#### WithHostPortAccess
+
+- Not available until the next release of testcontainers-go <a href="https://github.com/testcontainers/testcontainers-go"><span class="tc-version">:material-tag: main</span></a>
+
+If you need to access a port that is already running in the host, you can use `testcontainers.WithHostPortAccess` for example:
+
+```golang
+postgres, err = postgresModule.RunContainer(ctx, testcontainers.WithHostPortAccess(8080))
+```
+
+To understand more about this feature, please read the [Exposing host ports to the container](/features/networking/#exposing-host-ports-to-the-container) documentation.
+
 #### WithLogConsumers
 
 - Since testcontainers-go <a href="https://github.com/testcontainers/testcontainers-go/releases/tag/v0.28.0"><span class="tc-version">:material-tag: v0.28.0</span></a>

--- a/options.go
+++ b/options.go
@@ -74,6 +74,17 @@ func WithHostConfigModifier(modifier func(hostConfig *container.HostConfig)) Cus
 	}
 }
 
+// WithHostPortAccess allows to expose the host ports to the container
+func WithHostPortAccess(ports ...int) CustomizeRequestOption {
+	return func(req *GenericContainerRequest) {
+		if req.HostAccessPorts == nil {
+			req.HostAccessPorts = []int{}
+		}
+
+		req.HostAccessPorts = append(req.HostAccessPorts, ports...)
+	}
+}
+
 // WithImage sets the image for a container
 func WithImage(image string) CustomizeRequestOption {
 	return func(req *GenericContainerRequest) {

--- a/options_test.go
+++ b/options_test.go
@@ -210,3 +210,36 @@ func TestWithEnv(t *testing.T) {
 		})
 	}
 }
+
+func TestWithHostPortAccess(t *testing.T) {
+	tests := []struct {
+		name      string
+		req       *testcontainers.GenericContainerRequest
+		hostPorts []int
+		expect    []int
+	}{
+		{
+			name: "add to existing",
+			req: &testcontainers.GenericContainerRequest{
+				ContainerRequest: testcontainers.ContainerRequest{
+					HostAccessPorts: []int{1, 2},
+				},
+			},
+			hostPorts: []int{3, 4},
+			expect:    []int{1, 2, 3, 4},
+		},
+		{
+			name:      "add to nil",
+			req:       &testcontainers.GenericContainerRequest{},
+			hostPorts: []int{3, 4},
+			expect:    []int{3, 4},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			opt := testcontainers.WithHostPortAccess(tc.hostPorts...)
+			opt.Customize(tc.req)
+			require.Equal(t, tc.expect, tc.req.HostAccessPorts)
+		})
+	}
+}

--- a/port_forwarding.go
+++ b/port_forwarding.go
@@ -14,7 +14,9 @@ import (
 )
 
 const (
+	// hubSshdImage {
 	image string = "testcontainers/sshd:1.2.0"
+	// }
 	// HostInternal is the internal hostname used to reach the host from the container,
 	// using the SSHD container as a bridge.
 	HostInternal string = "host.testcontainers.internal"

--- a/port_forwarding_test.go
+++ b/port_forwarding_test.go
@@ -73,11 +73,13 @@ func TestExposeHostPorts(t *testing.T) {
 			}
 
 			req := testcontainers.GenericContainerRequest{
+				// hostAccessPorts {
 				ContainerRequest: testcontainers.ContainerRequest{
 					Image:           "alpine:3.17",
 					HostAccessPorts: freePorts,
 					Cmd:             []string{"top"},
 				},
+				// }
 				Started: true,
 			}
 
@@ -128,11 +130,13 @@ func TestExposeHostPorts(t *testing.T) {
 }
 
 func httpRequest(t *testing.T, c testcontainers.Container, port int) (int, string) {
+	// wgetHostInternal {
 	code, reader, err := c.Exec(
 		context.Background(),
 		[]string{"wget", "-q", "-O", "-", fmt.Sprintf("http://%s:%d", testcontainers.HostInternal, port)},
 		tcexec.Multiplexed(),
 	)
+	// }
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
This PR documents the new feature for exposing host ports to containers. It uses the Java docs as reference, adapting it to the implementation details of the Go version.


<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
Document the new feature.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Completes #2471

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
