### PR TITLE
fix: use new UUID for sshd server password

### DIFF
--- a/port_forwarding.go
+++ b/port_forwarding.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/docker/docker/api/types/container"
+	"github.com/google/uuid"
 	"golang.org/x/crypto/ssh"
 
 	"github.com/testcontainers/testcontainers-go/internal/core/network"
@@ -25,7 +26,7 @@ const (
 )
 
 // sshPassword is a random password generated for the SSHD container.
-var sshPassword = "123456"
+var sshPassword = uuid.NewString()
 
 // exposeHostPorts performs all the necessary steps to expose the host ports to the container, leveraging
 // the SSHD container to create the tunnel, and the container lifecycle hooks to manage the tunnel lifecycle.


### PR DESCRIPTION

<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
This PR is returning back the original value of the password, which was hardcoded for testing locally.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
Use non-deterministic password for the sshd server.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Caused by #2471
- Related to #2514 

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
