### PR TITLE
chore(compose): return error in options

### DIFF
--- a/modules/compose/compose.go
+++ b/modules/compose/compose.go
@@ -35,7 +35,7 @@ type composeStackOptions struct {
 }
 
 type ComposeStackOption interface {
-	applyToComposeStack(o *composeStackOptions)
+	applyToComposeStack(o *composeStackOptions) error
 }
 
 type stackUpOptions struct {
@@ -112,7 +112,6 @@ func WithStackFiles(filePaths ...string) ComposeStackOption {
 }
 
 // WithStackReaders supports reading the compose file/s from a reader.
-// This function will panic if it's no possible to read the content from the reader.
 func WithStackReaders(readers ...io.Reader) ComposeStackOption {
 	return ComposeStackReaders(readers)
 }
@@ -129,7 +128,9 @@ func NewDockerComposeWith(opts ...ComposeStackOption) (*dockerCompose, error) {
 	}
 
 	for i := range opts {
-		opts[i].applyToComposeStack(&composeOptions)
+		if err := opts[i].applyToComposeStack(&composeOptions); err != nil {
+			return nil, err
+		}
 	}
 
 	if len(composeOptions.Paths) < 1 {

--- a/modules/compose/compose_api.go
+++ b/modules/compose/compose_api.go
@@ -120,7 +120,7 @@ func (ri RemoveImages) applyToStackDown(o *stackDownOptions) {
 
 type ComposeStackReaders []io.Reader
 
-func (r ComposeStackReaders) applyToComposeStack(o *composeStackOptions) {
+func (r ComposeStackReaders) applyToComposeStack(o *composeStackOptions) error {
 	f := make([]string, len(r))
 	baseName := "docker-compose-%d.yml"
 	for i, reader := range r {
@@ -128,19 +128,19 @@ func (r ComposeStackReaders) applyToComposeStack(o *composeStackOptions) {
 		tmp = filepath.Join(tmp, strconv.FormatInt(time.Now().UnixNano(), 10))
 		err := os.MkdirAll(tmp, 0755)
 		if err != nil {
-			panic(err)
+			return fmt.Errorf("failed to create temporary directory: %w", err)
 		}
 
 		name := fmt.Sprintf(baseName, i)
 
 		bs, err := io.ReadAll(reader)
 		if err != nil {
-			panic(err)
+			fmt.Errorf("failed to read from reader: %w", err)
 		}
 
 		err = os.WriteFile(filepath.Join(tmp, name), bs, 0644)
 		if err != nil {
-			panic(err)
+			fmt.Errorf("failed to write to temporary file: %w", err)
 		}
 
 		f[i] = filepath.Join(tmp, name)
@@ -150,18 +150,22 @@ func (r ComposeStackReaders) applyToComposeStack(o *composeStackOptions) {
 	}
 
 	o.Paths = f
+
+	return nil
 }
 
 type ComposeStackFiles []string
 
-func (f ComposeStackFiles) applyToComposeStack(o *composeStackOptions) {
+func (f ComposeStackFiles) applyToComposeStack(o *composeStackOptions) error {
 	o.Paths = f
+	return nil
 }
 
 type StackIdentifier string
 
-func (f StackIdentifier) applyToComposeStack(o *composeStackOptions) {
+func (f StackIdentifier) applyToComposeStack(o *composeStackOptions) error {
 	o.Identifier = string(f)
+	return nil
 }
 
 func (f StackIdentifier) String() string {

--- a/modules/compose/compose_local.go
+++ b/modules/compose/compose_local.go
@@ -96,8 +96,9 @@ func (o ComposeLoggerOption) ApplyToLocalCompose(opts *LocalDockerComposeOptions
 	opts.Logger = o.logger
 }
 
-func (o ComposeLoggerOption) applyToComposeStack(opts *composeStackOptions) {
+func (o ComposeLoggerOption) applyToComposeStack(opts *composeStackOptions) error {
 	opts.Logger = o.logger
+	return nil
 }
 
 // Deprecated: it will be removed in the next major release


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
It changes the signature of the private functional types representing the compose configuration functions: now they return error, so no need to panic any more.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
Avoid panics.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Relates #2267

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
