### PR TITLE
fixed documentation on TESTCONTAINERS_HOST_OVERRIDE

### DIFF
--- a/docs/system_requirements/ci/dind_patterns.md
+++ b/docs/system_requirements/ci/dind_patterns.md
@@ -35,9 +35,9 @@ Where:
 
 
 !!! warning
-    If you are using Docker Desktop, you need to configure the `TESTCONTAINERS_HOST_OVERRIDE` environment variable to use the special DNS name
+    If you are using Docker Desktop, you need to configure the `TC_HOST` environment variable to use the special DNS name
     `host.docker.internal` for accessing the host from within a container, which is provided by Docker Desktop:
-    `-e TESTCONTAINERS_HOST_OVERRIDE=host.docker.internal`
+    `-e TC_HOST=host.docker.internal`
 
 ### Docker Compose example
 

--- a/docs/system_requirements/ci/gitlab_ci.md
+++ b/docs/system_requirements/ci/gitlab_ci.md
@@ -23,13 +23,13 @@ See below for an example runner configuration:
 ```
 
 !!! warning
-    The environment variable `TESTCONTAINERS_HOST_OVERRIDE` needs to be configured, otherwise, a wrong IP address would be used to resolve the Docker host, which will likely lead to failing tests.
+    The environment variable `TC_HOST` needs to be configured, otherwise, a wrong IP address would be used to resolve the Docker host, which will likely lead to failing tests.
 
 Please also include the following in your GitlabCI pipeline definitions (`.gitlab-ci.yml`) that use Testcontainers:
 
 ```yml
 variables:
-  TESTCONTAINERS_HOST_OVERRIDE: "host.docker.internal"
+  TC_HOST: "host.docker.internal"
 ```
 
 ## Example using DinD (Docker-in-Docker)

--- a/docs/system_requirements/rancher.md
+++ b/docs/system_requirements/rancher.md
@@ -18,7 +18,7 @@ Steps are as follows:
 ```sh
 export DOCKER_HOST=unix://$HOME/.rd/docker.sock
 export TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE=/var/run/docker.sock
-export TESTCONTAINERS_HOST_OVERRIDE=$(rdctl shell ip a show vznat | awk '/inet / {sub("/.*",""); print $2}')
+export TC_HOST=$(rdctl shell ip a show vznat | awk '/inet / {sub("/.*",""); print $2}')
 ```
 
 As always, remember that environment variables are not persisted unless you add them to the relevant file for your default shell e.g. `~/.zshrc`.


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
Fixed the documentation around overriding the host of the docker daemon where the container port is exposed.
It was wrongfully documented to set `TESTCONTAINERS_HOST_OVERRIDE` environment variable. The correct environment variable is `TC_HOST`.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
Current documentation is wrong as setting`TESTCONTAINERS_HOST_OVERRIDE` does not override the host of the docker daemon where the container port is exposed.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Related issues
- Relates #1373 
- Closes #2209

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- 

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
