### PR TITLE
fix(compose): avoid race conditions when caching services

### DIFF
--- a/modules/compose/compose_api.go
+++ b/modules/compose/compose_api.go
@@ -370,6 +370,8 @@ func (d *dockerCompose) Up(ctx context.Context, opts ...StackUpOption) error {
 				}()
 			}
 
+			d.containersLock.Lock()
+			defer d.containersLock.Unlock()
 			d.containers[srv.Name] = dc
 
 			return nil
@@ -398,6 +400,8 @@ func (d *dockerCompose) Up(ctx context.Context, opts ...StackUpOption) error {
 			}
 
 			// cache all the containers on compose.up
+			d.containersLock.Lock()
+			defer d.containersLock.Unlock()
 			d.containers[svc] = target
 
 			return strategy.WaitUntilReady(errGrpCtx, target)


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
This PR uses the existing lock to protect the access to the containers map, which after #2485 caused the race condition.
<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
Prevent race conditions
<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Caused by #2485

## How to test this PR

I discovered this issue while running the compose tests with `-race`.

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
