### PR TITLE
fix(influxdb): include more characters in wait for log regex

### DIFF
--- a/modules/influxdb/influxdb.go
+++ b/modules/influxdb/influxdb.go
@@ -69,7 +69,7 @@ func RunContainer(ctx context.Context, opts ...testcontainers.ContainerCustomize
 		if lastIndex := strings.LastIndex(genericContainerReq.Image, ":"); lastIndex != -1 {
 			tag := genericContainerReq.Image[lastIndex+1:]
 			if tag == "latest" || tag[0] == '2' {
-				genericContainerReq.WaitingFor = wait.ForLog(`Listening log_id=[0-9a-zA-Z_]+ service=tcp-listener transport=http`).AsRegexp()
+				genericContainerReq.WaitingFor = wait.ForLog(`Listening log_id=[0-9a-zA-Z_~]+ service=tcp-listener transport=http`).AsRegexp()
 			}
 		} else {
 			genericContainerReq.WaitingFor = wait.ForLog("Listening for signals")

--- a/modules/influxdb/influxdb_test.go
+++ b/modules/influxdb/influxdb_test.go
@@ -41,7 +41,7 @@ func TestV1Container(t *testing.T) {
 func TestV2Container(t *testing.T) {
 	ctx := context.Background()
 	influxDbContainer, err := influxdb.RunContainer(ctx,
-		testcontainers.WithImage("influxdb:latest"),
+		testcontainers.WithImage("influxdb:2.7.5-alpine"),
 		influxdb.WithDatabase("foo"),
 		influxdb.WithUsername("root"),
 		influxdb.WithPassword("password"),


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
It updates the regex for InfluxDB v2, as we found the log output changed its format.

For that we have used a fixed version of the v2 image: `2.7.5-alpine`.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
The CI started to fail for influxdb:latest

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Related issues
<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Discovered while testing #2531 

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
