### PR TITLE
feat: expose JSON representation of a container with Inspect

### DIFF
--- a/container.go
+++ b/container.go
@@ -39,6 +39,7 @@ type Container interface {
 	Endpoint(context.Context, string) (string, error)               // get proto://ip:port string for the first exposed port
 	PortEndpoint(context.Context, nat.Port, string) (string, error) // get proto://ip:port string for the given exposed port
 	Host(context.Context) (string, error)                           // get host where the container port is exposed
+	Inspect(context.Context) (*types.ContainerJSON, error)          // get container info
 	MappedPort(context.Context, nat.Port) (nat.Port, error)         // get externally mapped port for a container port
 	Ports(context.Context) (nat.PortMap, error)                     // get all exposed ports
 	SessionID() string                                              // get session id

--- a/container.go
+++ b/container.go
@@ -41,7 +41,7 @@ type Container interface {
 	Host(context.Context) (string, error)                           // get host where the container port is exposed
 	Inspect(context.Context) (*types.ContainerJSON, error)          // get container info
 	MappedPort(context.Context, nat.Port) (nat.Port, error)         // get externally mapped port for a container port
-	Ports(context.Context) (nat.PortMap, error)                     // get all exposed ports
+	Ports(context.Context) (nat.PortMap, error)                     // Deprecated: Use c.Inspect(ctx).NetworkSettings.Ports instead
 	SessionID() string                                              // get session id
 	IsRunning() bool
 	Start(context.Context) error                                    // start the container
@@ -51,7 +51,7 @@ type Container interface {
 	FollowOutput(LogConsumer)                                       // Deprecated: it will be removed in the next major release
 	StartLogProducer(context.Context, ...LogProductionOption) error // Deprecated: Use the ContainerRequest instead
 	StopLogProducer() error                                         // Deprecated: it will be removed in the next major release
-	Name(context.Context) (string, error)                           // get container name
+	Name(context.Context) (string, error)                           // Deprecated: Use c.Inspect(ctx).Name instead
 	State(context.Context) (*types.ContainerState, error)           // returns container's running state
 	Networks(context.Context) ([]string, error)                     // get container networks
 	NetworkAliases(context.Context) (map[string][]string, error)    // get container network aliases for a network

--- a/docker.go
+++ b/docker.go
@@ -114,10 +114,12 @@ func (c *DockerContainer) IsRunning() bool {
 // Endpoint gets proto://host:port string for the first exposed port
 // Will returns just host:port if proto is ""
 func (c *DockerContainer) Endpoint(ctx context.Context, proto string) (string, error) {
-	ports, err := c.Ports(ctx)
+	inspect, err := c.Inspect(ctx)
 	if err != nil {
 		return "", err
 	}
+
+	ports := inspect.NetworkSettings.Ports
 
 	// get first port
 	var firstPort nat.Port
@@ -177,17 +179,15 @@ func (c *DockerContainer) Inspect(ctx context.Context) (*types.ContainerJSON, er
 
 // MappedPort gets externally mapped port for a container port
 func (c *DockerContainer) MappedPort(ctx context.Context, port nat.Port) (nat.Port, error) {
-	inspect, err := c.inspectContainer(ctx)
+	inspect, err := c.Inspect(ctx)
 	if err != nil {
 		return "", err
 	}
 	if inspect.ContainerJSONBase.HostConfig.NetworkMode == "host" {
 		return port, nil
 	}
-	ports, err := c.Ports(ctx)
-	if err != nil {
-		return "", err
-	}
+
+	ports := inspect.NetworkSettings.Ports
 
 	for k, p := range ports {
 		if k.Port() != port.Port() {
@@ -205,9 +205,10 @@ func (c *DockerContainer) MappedPort(ctx context.Context, port nat.Port) (nat.Po
 	return "", errors.New("port not found")
 }
 
+// Deprecated: use c.Inspect(ctx).NetworkSettings.Ports instead.
 // Ports gets the exposed ports for the container.
 func (c *DockerContainer) Ports(ctx context.Context) (nat.PortMap, error) {
-	inspect, err := c.inspectContainer(ctx)
+	inspect, err := c.Inspect(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -319,23 +320,14 @@ func (c *DockerContainer) Terminate(ctx context.Context) error {
 
 // update container raw info
 func (c *DockerContainer) inspectRawContainer(ctx context.Context) (*types.ContainerJSON, error) {
-	inspect, err := c.inspectContainer(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	c.raw = inspect
-	return c.raw, nil
-}
-
-func (c *DockerContainer) inspectContainer(ctx context.Context) (*types.ContainerJSON, error) {
 	defer c.provider.Close()
 	inspect, err := c.provider.client.ContainerInspect(ctx, c.ID)
 	if err != nil {
 		return nil, err
 	}
 
-	return &inspect, nil
+	c.raw = &inspect
+	return c.raw, nil
 }
 
 // Logs will fetch both STDOUT and STDERR from the current container. Returns a
@@ -403,9 +395,10 @@ func (c *DockerContainer) followOutput(consumer LogConsumer) {
 	c.consumers = append(c.consumers, consumer)
 }
 
+// Deprecated: use c.Inspect(ctx).Name instead.
 // Name gets the name of the container.
 func (c *DockerContainer) Name(ctx context.Context) (string, error) {
-	inspect, err := c.inspectContainer(ctx)
+	inspect, err := c.Inspect(ctx)
 	if err != nil {
 		return "", err
 	}
@@ -426,7 +419,7 @@ func (c *DockerContainer) State(ctx context.Context) (*types.ContainerState, err
 
 // Networks gets the names of the networks the container is attached to.
 func (c *DockerContainer) Networks(ctx context.Context) ([]string, error) {
-	inspect, err := c.inspectContainer(ctx)
+	inspect, err := c.Inspect(ctx)
 	if err != nil {
 		return []string{}, err
 	}
@@ -444,7 +437,7 @@ func (c *DockerContainer) Networks(ctx context.Context) ([]string, error) {
 
 // ContainerIP gets the IP address of the primary network within the container.
 func (c *DockerContainer) ContainerIP(ctx context.Context) (string, error) {
-	inspect, err := c.inspectContainer(ctx)
+	inspect, err := c.Inspect(ctx)
 	if err != nil {
 		return "", err
 	}
@@ -467,7 +460,7 @@ func (c *DockerContainer) ContainerIP(ctx context.Context) (string, error) {
 func (c *DockerContainer) ContainerIPs(ctx context.Context) ([]string, error) {
 	ips := make([]string, 0)
 
-	inspect, err := c.inspectContainer(ctx)
+	inspect, err := c.Inspect(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -482,7 +475,7 @@ func (c *DockerContainer) ContainerIPs(ctx context.Context) ([]string, error) {
 
 // NetworkAliases gets the aliases of the container for the networks it is attached to.
 func (c *DockerContainer) NetworkAliases(ctx context.Context) (map[string][]string, error) {
-	inspect, err := c.inspectContainer(ctx)
+	inspect, err := c.Inspect(ctx)
 	if err != nil {
 		return map[string][]string{}, err
 	}

--- a/docker.go
+++ b/docker.go
@@ -407,11 +407,8 @@ func (c *DockerContainer) Name(ctx context.Context) (string, error) {
 
 // State returns container's running state
 func (c *DockerContainer) State(ctx context.Context) (*types.ContainerState, error) {
-	inspect, err := c.inspectRawContainer(ctx)
+	inspect, err := c.Inspect(ctx)
 	if err != nil {
-		if c.raw != nil {
-			return c.raw.State, err
-		}
 		return nil, err
 	}
 	return inspect.State, nil

--- a/docker.go
+++ b/docker.go
@@ -405,10 +405,14 @@ func (c *DockerContainer) Name(ctx context.Context) (string, error) {
 	return inspect.Name, nil
 }
 
-// State returns container's running state
+// State returns container's running state. This method does not use the cache
+// and always fetches the latest state from the Docker daemon.
 func (c *DockerContainer) State(ctx context.Context) (*types.ContainerState, error) {
-	inspect, err := c.Inspect(ctx)
+	inspect, err := c.inspectRawContainer(ctx)
 	if err != nil {
+		if c.raw != nil {
+			return c.raw.State, err
+		}
 		return nil, err
 	}
 	return inspect.State, nil

--- a/docker_test.go
+++ b/docker_test.go
@@ -267,8 +267,8 @@ func TestContainerTerminationResetsState(t *testing.T) {
 	if nginxA.SessionID() != "" {
 		t.Fatal("Internal state must be reset.")
 	}
-	ports, err := nginxA.Ports(ctx)
-	if err == nil || ports != nil {
+	inspect, err := nginxA.Inspect(ctx)
+	if err == nil || inspect != nil {
 		t.Fatal("expected error from container inspect.")
 	}
 }
@@ -539,10 +539,12 @@ func TestContainerCreationWithName(t *testing.T) {
 	require.NoError(t, err)
 	terminateContainerOnEnd(t, ctx, nginxC)
 
-	name, err := nginxC.Name(ctx)
+	inspect, err := nginxC.Inspect(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	name := inspect.Name
 	if name != expectedName {
 		t.Errorf("Expected container name '%s'. Got '%s'.", expectedName, name)
 	}
@@ -2007,9 +2009,12 @@ func TestDockerProviderFindContainerByName(t *testing.T) {
 		Started: true,
 	})
 	require.NoError(t, err)
-	c1Name, err := c1.Name(ctx)
+
+	c1Inspect, err := c1.Inspect(ctx)
 	require.NoError(t, err)
 	terminateContainerOnEnd(t, ctx, c1)
+
+	c1Name := c1Inspect.Name
 
 	c2, err := GenericContainer(ctx, GenericContainerRequest{
 		ProviderType: providerType,
@@ -2059,8 +2064,10 @@ func TestImageBuiltFromDockerfile_KeepBuiltImage(t *testing.T) {
 			require.NoError(t, err, "create container should not fail")
 			defer func() { _ = c.Terminate(context.Background()) }()
 			// Get the image ID.
-			containerName, err := c.Name(ctx)
-			require.NoError(t, err, "get container name should not fail")
+			containerInspect, err := c.Inspect(ctx)
+			require.NoError(t, err, "container inspect should not fail")
+
+			containerName := containerInspect.Name
 			containerDetails, err := cli.ContainerInspect(ctx, containerName)
 			require.NoError(t, err, "inspect container should not fail")
 			containerImage := containerDetails.Image

--- a/docker_test.go
+++ b/docker_test.go
@@ -1320,6 +1320,29 @@ func TestContainerWithCustomHostname(t *testing.T) {
 	}
 }
 
+func TestContainerInspect_RawInspectIsCleanedOnStop(t *testing.T) {
+	container, err := GenericContainer(context.Background(), GenericContainerRequest{
+		ContainerRequest: ContainerRequest{
+			Image: nginxImage,
+		},
+		Started: true,
+	})
+	require.NoError(t, err)
+	terminateContainerOnEnd(t, context.Background(), container)
+
+	inspect, err := container.Inspect(context.Background())
+	require.NoError(t, err)
+
+	assert.NotEmpty(t, inspect.ID)
+
+	container.Stop(context.Background(), nil)
+
+	// type assertion to ensure that the container is a DockerContainer
+	dc := container.(*DockerContainer)
+
+	assert.Nil(t, dc.raw)
+}
+
 func readHostname(tb testing.TB, containerId string) string {
 	containerClient, err := NewDockerClientWithOpts(context.Background())
 	if err != nil {

--- a/docker_test.go
+++ b/docker_test.go
@@ -306,7 +306,7 @@ func TestContainerStateAfterTermination(t *testing.T) {
 		assert.Nil(t, state, "expected nil container inspect.")
 	})
 
-	t.Run("Non-nil State after termination if raw as already set", func(t *testing.T) {
+	t.Run("Nil State after termination if raw as already set", func(t *testing.T) {
 		ctx := context.Background()
 		nginx, err := createContainerFn(ctx)
 		if err != nil {
@@ -327,7 +327,7 @@ func TestContainerStateAfterTermination(t *testing.T) {
 		state, err = nginx.State(ctx)
 		require.Error(t, err, "expected error from container inspect after container termination.")
 
-		assert.NotNil(t, state, "unexpected nil container inspect after container termination.")
+		assert.Nil(t, state, "unexpected nil container inspect after container termination.")
 	})
 }
 

--- a/modules/localstack/localstack_test.go
+++ b/modules/localstack/localstack_test.go
@@ -127,8 +127,10 @@ func TestRunContainer(t *testing.T) {
 			require.NoError(t, err)
 			assert.NotNil(t, container)
 
-			rawPorts, err := container.Ports(ctx)
+			inspect, err := container.Inspect(ctx)
 			require.NoError(t, err)
+
+			rawPorts := inspect.NetworkSettings.Ports
 
 			ports := 0
 			// only one port is exposed among all the ports in the container

--- a/wait/exec_test.go
+++ b/wait/exec_test.go
@@ -62,6 +62,11 @@ func (st mockExecTarget) Host(_ context.Context) (string, error) {
 	return "", errors.New("not implemented")
 }
 
+func (st mockExecTarget) Inspect(ctx context.Context) (*types.ContainerJSON, error) {
+	return nil, errors.New("not implemented")
+}
+
+// Deprecated: use Inspect instead
 func (st mockExecTarget) Ports(ctx context.Context) (nat.PortMap, error) {
 	return nil, errors.New("not implemented")
 }

--- a/wait/exit_test.go
+++ b/wait/exit_test.go
@@ -20,6 +20,11 @@ func (st exitStrategyTarget) Host(ctx context.Context) (string, error) {
 	return "", nil
 }
 
+func (st exitStrategyTarget) Inspect(ctx context.Context) (*types.ContainerJSON, error) {
+	return nil, nil
+}
+
+// Deprecated: use Inspect instead
 func (st exitStrategyTarget) Ports(ctx context.Context) (nat.PortMap, error) {
 	return nil, nil
 }

--- a/wait/health_test.go
+++ b/wait/health_test.go
@@ -21,6 +21,11 @@ func (st healthStrategyTarget) Host(ctx context.Context) (string, error) {
 	return "", nil
 }
 
+func (st healthStrategyTarget) Inspect(ctx context.Context) (*types.ContainerJSON, error) {
+	return nil, nil
+}
+
+// Deprecated: use Inspect instead
 func (st healthStrategyTarget) Ports(ctx context.Context) (nat.PortMap, error) {
 	return nil, nil
 }

--- a/wait/host_port.go
+++ b/wait/host_port.go
@@ -90,10 +90,13 @@ func (hp *HostPortStrategy) WaitUntilReady(ctx context.Context, target StrategyT
 	internalPort := hp.Port
 	if internalPort == "" {
 		var ports nat.PortMap
-		ports, err = target.Ports(ctx)
+		inspect, err := target.Inspect(ctx)
 		if err != nil {
 			return err
 		}
+
+		ports = inspect.NetworkSettings.Ports
+
 		if len(ports) > 0 {
 			for p := range ports {
 				internalPort = p

--- a/wait/host_port_test.go
+++ b/wait/host_port_test.go
@@ -80,12 +80,18 @@ func TestWaitForExposedPortSucceeds(t *testing.T) {
 		HostImpl: func(_ context.Context) (string, error) {
 			return "localhost", nil
 		},
-		PortsImpl: func(_ context.Context) (nat.PortMap, error) {
-			return nat.PortMap{
-				"80": []nat.PortBinding{
-					{
-						HostIP:   "0.0.0.0",
-						HostPort: port.Port(),
+		InspectImpl: func(_ context.Context) (*types.ContainerJSON, error) {
+			return &types.ContainerJSON{
+				NetworkSettings: &types.NetworkSettings{
+					NetworkSettingsBase: types.NetworkSettingsBase{
+						Ports: nat.PortMap{
+							"80": []nat.PortBinding{
+								{
+									HostIP:   "0.0.0.0",
+									HostPort: port.Port(),
+								},
+							},
+						},
 					},
 				},
 			}, nil
@@ -500,12 +506,18 @@ func TestHostPortStrategySucceedsGivenShellIsNotInstalled(t *testing.T) {
 		HostImpl: func(_ context.Context) (string, error) {
 			return "localhost", nil
 		},
-		PortsImpl: func(_ context.Context) (nat.PortMap, error) {
-			return nat.PortMap{
-				"80": []nat.PortBinding{
-					{
-						HostIP:   "0.0.0.0",
-						HostPort: port.Port(),
+		InspectImpl: func(_ context.Context) (*types.ContainerJSON, error) {
+			return &types.ContainerJSON{
+				NetworkSettings: &types.NetworkSettings{
+					NetworkSettingsBase: types.NetworkSettingsBase{
+						Ports: nat.PortMap{
+							"80": []nat.PortBinding{
+								{
+									HostIP:   "0.0.0.0",
+									HostPort: port.Port(),
+								},
+							},
+						},
 					},
 				},
 			}, nil

--- a/wait/http.go
+++ b/wait/http.go
@@ -185,7 +185,12 @@ func (ws *HTTPStrategy) WaitUntilReady(ctx context.Context, target StrategyTarge
 					return err
 				}
 
-				ports, err = target.Ports(ctx)
+				inspect, err := target.Inspect(ctx)
+				if err != nil {
+					return err
+				}
+
+				ports = inspect.NetworkSettings.Ports
 			}
 		}
 

--- a/wait/http_test.go
+++ b/wait/http_test.go
@@ -491,12 +491,18 @@ func TestHttpStrategyFailsWhileGettingPortDueToOOMKilledContainer(t *testing.T) 
 				OOMKilled: true,
 			}, nil
 		},
-		PortsImpl: func(ctx context.Context) (nat.PortMap, error) {
-			return nat.PortMap{
-				"8080/tcp": []nat.PortBinding{
-					{
-						HostIP:   "127.0.0.1",
-						HostPort: "49152",
+		InspectImpl: func(_ context.Context) (*types.ContainerJSON, error) {
+			return &types.ContainerJSON{
+				NetworkSettings: &types.NetworkSettings{
+					NetworkSettingsBase: types.NetworkSettingsBase{
+						Ports: nat.PortMap{
+							"8080/tcp": []nat.PortBinding{
+								{
+									HostIP:   "127.0.0.1",
+									HostPort: "49152",
+								},
+							},
+						},
 					},
 				},
 			}, nil
@@ -539,12 +545,18 @@ func TestHttpStrategyFailsWhileGettingPortDueToExitedContainer(t *testing.T) {
 				ExitCode: 1,
 			}, nil
 		},
-		PortsImpl: func(ctx context.Context) (nat.PortMap, error) {
-			return nat.PortMap{
-				"8080/tcp": []nat.PortBinding{
-					{
-						HostIP:   "127.0.0.1",
-						HostPort: "49152",
+		InspectImpl: func(_ context.Context) (*types.ContainerJSON, error) {
+			return &types.ContainerJSON{
+				NetworkSettings: &types.NetworkSettings{
+					NetworkSettingsBase: types.NetworkSettingsBase{
+						Ports: nat.PortMap{
+							"8080/tcp": []nat.PortBinding{
+								{
+									HostIP:   "127.0.0.1",
+									HostPort: "49152",
+								},
+							},
+						},
 					},
 				},
 			}, nil
@@ -586,12 +598,18 @@ func TestHttpStrategyFailsWhileGettingPortDueToUnexpectedContainerStatus(t *test
 				Status: "dead",
 			}, nil
 		},
-		PortsImpl: func(ctx context.Context) (nat.PortMap, error) {
-			return nat.PortMap{
-				"8080/tcp": []nat.PortBinding{
-					{
-						HostIP:   "127.0.0.1",
-						HostPort: "49152",
+		InspectImpl: func(_ context.Context) (*types.ContainerJSON, error) {
+			return &types.ContainerJSON{
+				NetworkSettings: &types.NetworkSettings{
+					NetworkSettingsBase: types.NetworkSettingsBase{
+						Ports: nat.PortMap{
+							"8080/tcp": []nat.PortBinding{
+								{
+									HostIP:   "127.0.0.1",
+									HostPort: "49152",
+								},
+							},
+						},
 					},
 				},
 			}, nil
@@ -628,12 +646,18 @@ func TestHTTPStrategyFailsWhileRequestSendingDueToOOMKilledContainer(t *testing.
 				OOMKilled: true,
 			}, nil
 		},
-		PortsImpl: func(ctx context.Context) (nat.PortMap, error) {
-			return nat.PortMap{
-				"8080/tcp": []nat.PortBinding{
-					{
-						HostIP:   "127.0.0.1",
-						HostPort: "49152",
+		InspectImpl: func(_ context.Context) (*types.ContainerJSON, error) {
+			return &types.ContainerJSON{
+				NetworkSettings: &types.NetworkSettings{
+					NetworkSettingsBase: types.NetworkSettingsBase{
+						Ports: nat.PortMap{
+							"8080/tcp": []nat.PortBinding{
+								{
+									HostIP:   "127.0.0.1",
+									HostPort: "49152",
+								},
+							},
+						},
 					},
 				},
 			}, nil
@@ -671,12 +695,18 @@ func TestHttpStrategyFailsWhileRequestSendingDueToExitedContainer(t *testing.T) 
 				ExitCode: 1,
 			}, nil
 		},
-		PortsImpl: func(ctx context.Context) (nat.PortMap, error) {
-			return nat.PortMap{
-				"8080/tcp": []nat.PortBinding{
-					{
-						HostIP:   "127.0.0.1",
-						HostPort: "49152",
+		InspectImpl: func(_ context.Context) (*types.ContainerJSON, error) {
+			return &types.ContainerJSON{
+				NetworkSettings: &types.NetworkSettings{
+					NetworkSettingsBase: types.NetworkSettingsBase{
+						Ports: nat.PortMap{
+							"8080/tcp": []nat.PortBinding{
+								{
+									HostIP:   "127.0.0.1",
+									HostPort: "49152",
+								},
+							},
+						},
 					},
 				},
 			}, nil
@@ -713,12 +743,18 @@ func TestHttpStrategyFailsWhileRequestSendingDueToUnexpectedContainerStatus(t *t
 				Status: "dead",
 			}, nil
 		},
-		PortsImpl: func(ctx context.Context) (nat.PortMap, error) {
-			return nat.PortMap{
-				"8080/tcp": []nat.PortBinding{
-					{
-						HostIP:   "127.0.0.1",
-						HostPort: "49152",
+		InspectImpl: func(_ context.Context) (*types.ContainerJSON, error) {
+			return &types.ContainerJSON{
+				NetworkSettings: &types.NetworkSettings{
+					NetworkSettingsBase: types.NetworkSettingsBase{
+						Ports: nat.PortMap{
+							"8080/tcp": []nat.PortBinding{
+								{
+									HostIP:   "127.0.0.1",
+									HostPort: "49152",
+								},
+							},
+						},
 					},
 				},
 			}, nil
@@ -761,8 +797,14 @@ func TestHttpStrategyFailsWhileGettingPortDueToNoExposedPorts(t *testing.T) {
 				Running: true,
 			}, nil
 		},
-		PortsImpl: func(ctx context.Context) (nat.PortMap, error) {
-			return nat.PortMap{}, nil
+		InspectImpl: func(_ context.Context) (*types.ContainerJSON, error) {
+			return &types.ContainerJSON{
+				NetworkSettings: &types.NetworkSettings{
+					NetworkSettingsBase: types.NetworkSettingsBase{
+						Ports: nat.PortMap{},
+					},
+				},
+			}, nil
 		},
 	}
 
@@ -802,12 +844,18 @@ func TestHttpStrategyFailsWhileGettingPortDueToOnlyUDPPorts(t *testing.T) {
 				Status:  "running",
 			}, nil
 		},
-		PortsImpl: func(ctx context.Context) (nat.PortMap, error) {
-			return nat.PortMap{
-				"8080/udp": []nat.PortBinding{
-					{
-						HostIP:   "127.0.0.1",
-						HostPort: "49152",
+		InspectImpl: func(_ context.Context) (*types.ContainerJSON, error) {
+			return &types.ContainerJSON{
+				NetworkSettings: &types.NetworkSettings{
+					NetworkSettingsBase: types.NetworkSettingsBase{
+						Ports: nat.PortMap{
+							"8080/udp": []nat.PortBinding{
+								{
+									HostIP:   "127.0.0.1",
+									HostPort: "49152",
+								},
+							},
+						},
 					},
 				},
 			}, nil
@@ -850,9 +898,15 @@ func TestHttpStrategyFailsWhileGettingPortDueToExposedPortNoBindings(t *testing.
 				Status:  "running",
 			}, nil
 		},
-		PortsImpl: func(ctx context.Context) (nat.PortMap, error) {
-			return nat.PortMap{
-				"8080/tcp": []nat.PortBinding{},
+		InspectImpl: func(_ context.Context) (*types.ContainerJSON, error) {
+			return &types.ContainerJSON{
+				NetworkSettings: &types.NetworkSettings{
+					NetworkSettingsBase: types.NetworkSettingsBase{
+						Ports: nat.PortMap{
+							"8080/tcp": []nat.PortBinding{},
+						},
+					},
+				},
 			}, nil
 		},
 	}

--- a/wait/nop.go
+++ b/wait/nop.go
@@ -51,6 +51,11 @@ func (st NopStrategyTarget) Host(_ context.Context) (string, error) {
 	return "", nil
 }
 
+func (st NopStrategyTarget) Inspect(_ context.Context) (*types.ContainerJSON, error) {
+	return nil, nil
+}
+
+// Deprecated: use Inspect instead
 func (st NopStrategyTarget) Ports(_ context.Context) (nat.PortMap, error) {
 	return nil, nil
 }

--- a/wait/wait.go
+++ b/wait/wait.go
@@ -25,7 +25,8 @@ type StrategyTimeout interface {
 
 type StrategyTarget interface {
 	Host(context.Context) (string, error)
-	Ports(ctx context.Context) (nat.PortMap, error)
+	Inspect(context.Context) (*types.ContainerJSON, error)
+	Ports(ctx context.Context) (nat.PortMap, error) // Deprecated: use Inspect instead
 	MappedPort(context.Context, nat.Port) (nat.Port, error)
 	Logs(context.Context) (io.ReadCloser, error)
 	Exec(context.Context, []string, ...exec.ProcessOption) (int, io.Reader, error)

--- a/wait/wait_test.go
+++ b/wait/wait_test.go
@@ -15,6 +15,7 @@ var ErrPortNotFound = errors.New("port not found")
 
 type MockStrategyTarget struct {
 	HostImpl       func(context.Context) (string, error)
+	InspectImpl    func(context.Context) (*types.ContainerJSON, error)
 	PortsImpl      func(context.Context) (nat.PortMap, error)
 	MappedPortImpl func(context.Context, nat.Port) (nat.Port, error)
 	LogsImpl       func(context.Context) (io.ReadCloser, error)
@@ -26,8 +27,18 @@ func (st MockStrategyTarget) Host(ctx context.Context) (string, error) {
 	return st.HostImpl(ctx)
 }
 
+func (st MockStrategyTarget) Inspect(ctx context.Context) (*types.ContainerJSON, error) {
+	return st.InspectImpl(ctx)
+}
+
+// Deprecated: use Inspect instead
 func (st MockStrategyTarget) Ports(ctx context.Context) (nat.PortMap, error) {
-	return st.PortsImpl(ctx)
+	inspect, err := st.InspectImpl(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return inspect.NetworkSettings.Ports, nil
 }
 
 func (st MockStrategyTarget) MappedPort(ctx context.Context, port nat.Port) (nat.Port, error) {


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
It exposes the existing inspect method to the Container interface. That will allow consumers to get the JSON representation of the container.

This new method will cache the raw JSON, which will be cleaned after stopping/terminating a container. Remember that when a container is stopped, the JSON representation could change.

At the same time, given the Inspect method retrives all the container info, we are deprecating two container methods: Name and Ports, as they are just passing-through ones. Consumers will just call inspect and from there get the container name and the ports. The deprecation paths have been properly set in the method comments, so the IDEs and the linters will complain/warn about them.

#### Deprecation Path
- c.Name(ctx): Use `c.Inspect(ctx).Name` instead
- c.Ports(ctx): Use `c.Inspect(ctx).NetworkSettings.Ports` instead

As `Inspect` returns an error, you must handle it before reading Name or the Ports.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
It will allow consumers to get the JSON representation of the container.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Relates #1989
- Relates #635, as the access to the raw representation has been optimised.

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
