### PR TITLE
fix: add import to module generation

### DIFF
--- a/modulegen/_template/module.go.tmpl
+++ b/modulegen/_template/module.go.tmpl
@@ -2,6 +2,7 @@
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/testcontainers/testcontainers-go"
 )

--- a/modulegen/main_test.go
+++ b/modulegen/main_test.go
@@ -423,14 +423,14 @@ func assertModuleContent(t *testing.T, module context.TestcontainersModule, exam
 
 	data := sanitiseContent(content)
 	assert.Equal(t, data[0], "package "+lower)
-	assert.Equal(t, data[8], "// "+containerName+" represents the "+exampleName+" container type used in the module")
-	assert.Equal(t, data[9], "type "+containerName+" struct {")
-	assert.Equal(t, data[13], "// "+entrypoint+" creates an instance of the "+exampleName+" container type")
-	assert.Equal(t, data[14], "func "+entrypoint+"(ctx context.Context, opts ...testcontainers.ContainerCustomizer) (*"+containerName+", error) {")
-	assert.Equal(t, data[16], "\t\tImage: \""+module.Image+"\",")
-	assert.Equal(t, data[25], "\t\tif err := opt.Customize(&genericContainerReq); err != nil {")
-	assert.Equal(t, data[26], "\t\t\treturn nil, fmt.Errorf(\"customize: %w\", err)")
-	assert.Equal(t, data[35], "\treturn &"+containerName+"{Container: container}, nil")
+	assert.Equal(t, data[9], "// "+containerName+" represents the "+exampleName+" container type used in the module")
+	assert.Equal(t, data[10], "type "+containerName+" struct {")
+	assert.Equal(t, data[14], "// "+entrypoint+" creates an instance of the "+exampleName+" container type")
+	assert.Equal(t, data[15], "func "+entrypoint+"(ctx context.Context, opts ...testcontainers.ContainerCustomizer) (*"+containerName+", error) {")
+	assert.Equal(t, data[17], "\t\tImage: \""+module.Image+"\",")
+	assert.Equal(t, data[26], "\t\tif err := opt.Customize(&genericContainerReq); err != nil {")
+	assert.Equal(t, data[27], "\t\t\treturn nil, fmt.Errorf(\"customize: %w\", err)")
+	assert.Equal(t, data[36], "\treturn &"+containerName+"{Container: container}, nil")
 }
 
 // assert content GitHub workflow for the module


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
This PR adds a missing import for "fmt" in the template that generates the module Go file.
<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
The modules are generated, but the process fails because the code does not compile: missing import.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Caused by #2267

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


## Follow-ups
There is no need to create a patch release, as users of the module generation tool will use it from the source code.
