### PR TITLE
docs: fix CircleCI docs

### DIFF
--- a/docs/system_requirements/ci/circle_ci.md
+++ b/docs/system_requirements/ci/circle_ci.md
@@ -6,18 +6,59 @@
 Your CircleCI configuration should use a dedicated VM for Testcontainers to work. You can achieve this by specifying the 
 executor type in your `.circleci/config.yml` to be `machine` instead of the default `docker` executor (see [Choosing an Executor Type](https://circleci.com/docs/executor-intro/) for more info).  
 
-Here is a sample CircleCI configuration that does a checkout of a project and runs Maven:
+Here is a sample CircleCI configuration that does a checkout of a project and runs `go test` for a project. Go is installed for the `tests` job using [`gvm`](https://github.com/andrewkroh/gvm), and a workflow matrix has been defined to run the job with different Go versions. Go steps are finally executed from the `go` orb.
 
 ```yml
+version: 2.1
+
+orbs:
+  go: circleci/go@1.11.0
+
+executors:
+ machine_executor_amd64:
+   machine:
+     image: ubuntu-2204:2024.01.2
+   environment:
+     architecture: "amd64"
+     platform: "linux/amd64"
+
 jobs:
-  build:
-    # Check https://circleci.com/docs/executor-intro#linux-vm for more details
-    machine: true
-      image: ubuntu-2204:2023.04.2
+  tests:
+    executor: machine_executor_amd64
+    parameters:
+      go-version:
+        type: string
     steps:
-      # install Go 1.x
-      # checkout the project
-      - run: go test./...
+      - run:
+          name: Install GVM
+          command: |
+            mkdir ~/gvmbin
+            curl -sL -o ~/gvmbin/gvm https://github.com/andrewkroh/gvm/releases/download/v0.5.2/gvm-linux-amd64
+            chmod +x ~/gvmbin/gvm
+            echo 'export PATH=$PATH:~/gvmbin' >> "$BASH_ENV"
+      - run:
+          name: Install Go
+          command: |
+            eval "$(gvm << parameters.go-version >>)"
+            echo 'eval "$(gvm << parameters.go-version >>)"' >> "$BASH_ENV"
+            go version
+      - checkout # checkout source code
+      - go/load-cache # Load cached Go modules.
+      - go/mod-download # Run 'go mod download'.
+      - go/save-cache # Save Go modules to cache.
+      - go/test: # Runs 'go test ./...' but includes extensive parameterization for finer tuning.
+          covermode: atomic
+          failfast: true
+          race: true
+
+workflows:
+  build-and-test:
+    jobs:
+      - tests:
+          matrix:
+            parameters:
+              go-version: ["1.21.7", "1.22.3"]
+
 ```
 
 You can learn more about the best practices of using Testcontainers together with CircleCI in [this article](https://www.atomicjar.com/2022/12/testcontainers-with-circleci/) for Java.


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
This PR adds a better configuration for CircleCI, fixing a typo and providing a way to install different versions of Go in the worker machine.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
The page contained a typo referring Maven instead of Go, and the example was very simple. This config file has been tested in https://github.com/mdelapenya/testcontainers-go-compose
<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Relates https://github.com/mdelapenya/testcontainers-go-compose/pulls/16

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
