### PR TITLE
feat(ryuk): allow to configure ryuk timeouts using env variables

### DIFF
--- a/docs/features/configuration.md
+++ b/docs/features/configuration.md
@@ -50,8 +50,8 @@ Please read more about customizing images in the [Image name substitution](image
 1. If your environment already implements automatic cleanup of containers after the execution,
 but does not allow starting privileged containers, you can turn off the Ryuk container by setting
 `TESTCONTAINERS_RYUK_DISABLED` **environment variable** to `true`.
-1. You can specify the connection timeout for Ryuk by setting the `ryuk.connection.timeout` **property**. The default value is 1 minute.
-1. You can specify the reconnection timeout for Ryuk by setting the `ryuk.reconnection.timeout` **property**. The default value is 10 seconds.
+1. You can specify the connection timeout for Ryuk by setting the `TESTCONTAINERS_RYUK_CONNECTION_TIMEOUT` **environment variable**, or the `ryuk.connection.timeout` **property**. The default value is 1 minute.
+1. You can specify the reconnection timeout for Ryuk by setting the `TESTCONTAINERS_RYUK_RECONNECTION_TIMEOUT` **environment variable**, or the `ryuk.reconnection.timeout` **property**. The default value is 10 seconds.
 1. You can configure Ryuk to run in verbose mode by setting any of the `ryuk.verbose` **property** or the `TESTCONTAINERS_RYUK_VERBOSE` **environment variable**. The default value is `false`.
 
 !!!info

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -87,6 +87,16 @@ func read() Config {
 			config.RyukVerbose = ryukVerboseEnv == "true"
 		}
 
+		ryukReconnectionTimeoutEnv := os.Getenv("TESTCONTAINERS_RYUK_RECONNECTION_TIMEOUT")
+		if timeout, err := time.ParseDuration(ryukReconnectionTimeoutEnv); err == nil {
+			config.RyukReconnectionTimeout = timeout
+		}
+
+		ryukConnectionTimeoutEnv := os.Getenv("TESTCONTAINERS_RYUK_CONNECTION_TIMEOUT")
+		if timeout, err := time.ParseDuration(ryukConnectionTimeoutEnv); err == nil {
+			config.RyukConnectionTimeout = timeout
+		}
+
 		return config
 	}
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -23,6 +23,8 @@ func resetTestEnv(t *testing.T) {
 	t.Setenv("TESTCONTAINERS_RYUK_DISABLED", "")
 	t.Setenv("TESTCONTAINERS_RYUK_CONTAINER_PRIVILEGED", "")
 	t.Setenv("TESTCONTAINERS_RYUK_VERBOSE", "")
+	t.Setenv("TESTCONTAINERS_RYUK_RECONNECTION_TIMEOUT", "")
+	t.Setenv("TESTCONTAINERS_RYUK_CONNECTION_TIMEOUT", "")
 }
 
 func TestReadConfig(t *testing.T) {
@@ -74,14 +76,18 @@ func TestReadTCConfig(t *testing.T) {
 		t.Setenv("TESTCONTAINERS_RYUK_DISABLED", "true")
 		t.Setenv("TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX", defaultHubPrefix)
 		t.Setenv("TESTCONTAINERS_RYUK_CONTAINER_PRIVILEGED", "true")
+		t.Setenv("TESTCONTAINERS_RYUK_RECONNECTION_TIMEOUT", "13s")
+		t.Setenv("TESTCONTAINERS_RYUK_CONNECTION_TIMEOUT", "12s")
 
 		config := read()
 
 		expected := Config{
-			HubImageNamePrefix: defaultHubPrefix,
-			RyukDisabled:       true,
-			RyukPrivileged:     true,
-			Host:               "", // docker socket is empty at the properties file
+			HubImageNamePrefix:      defaultHubPrefix,
+			RyukDisabled:            true,
+			RyukPrivileged:          true,
+			Host:                    "", // docker socket is empty at the properties file
+			RyukReconnectionTimeout: 13 * time.Second,
+			RyukConnectionTimeout:   12 * time.Second,
 		}
 
 		assert.Equal(t, expected, config)
@@ -119,13 +125,17 @@ func TestReadTCConfig(t *testing.T) {
 		t.Setenv("TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX", defaultHubPrefix)
 		t.Setenv("TESTCONTAINERS_RYUK_CONTAINER_PRIVILEGED", "true")
 		t.Setenv("TESTCONTAINERS_RYUK_VERBOSE", "true")
+		t.Setenv("TESTCONTAINERS_RYUK_RECONNECTION_TIMEOUT", "13s")
+		t.Setenv("TESTCONTAINERS_RYUK_CONNECTION_TIMEOUT", "12s")
 
 		config := read()
 		expected := Config{
-			HubImageNamePrefix: defaultHubPrefix,
-			RyukDisabled:       true,
-			RyukPrivileged:     true,
-			RyukVerbose:        true,
+			HubImageNamePrefix:      defaultHubPrefix,
+			RyukDisabled:            true,
+			RyukPrivileged:          true,
+			RyukVerbose:             true,
+			RyukReconnectionTimeout: 13 * time.Second,
+			RyukConnectionTimeout:   12 * time.Second,
 		}
 
 		assert.Equal(t, expected, config)
@@ -133,10 +143,10 @@ func TestReadTCConfig(t *testing.T) {
 
 	t.Run("HOME contains TC properties file", func(t *testing.T) {
 		defaultRyukConnectionTimeout := 60 * time.Second
-		defaultRyukReonnectionTimeout := 10 * time.Second
+		defaultRyukReconnectionTimeout := 10 * time.Second
 		defaultConfig := Config{
 			RyukConnectionTimeout:   defaultRyukConnectionTimeout,
-			RyukReconnectionTimeout: defaultRyukReonnectionTimeout,
+			RyukReconnectionTimeout: defaultRyukReconnectionTimeout,
 		}
 
 		tests := []struct {
@@ -152,7 +162,7 @@ func TestReadTCConfig(t *testing.T) {
 				Config{
 					Host:                    tcpDockerHost33293,
 					RyukConnectionTimeout:   defaultRyukConnectionTimeout,
-					RyukReconnectionTimeout: defaultRyukReonnectionTimeout,
+					RyukReconnectionTimeout: defaultRyukReconnectionTimeout,
 				},
 			},
 			{
@@ -164,7 +174,7 @@ func TestReadTCConfig(t *testing.T) {
 				Config{
 					Host:                    tcpDockerHost4711,
 					RyukConnectionTimeout:   defaultRyukConnectionTimeout,
-					RyukReconnectionTimeout: defaultRyukReonnectionTimeout,
+					RyukReconnectionTimeout: defaultRyukReconnectionTimeout,
 				},
 			},
 			{
@@ -179,7 +189,7 @@ func TestReadTCConfig(t *testing.T) {
 					Host:                    tcpDockerHost1234,
 					TLSVerify:               1,
 					RyukConnectionTimeout:   defaultRyukConnectionTimeout,
-					RyukReconnectionTimeout: defaultRyukReonnectionTimeout,
+					RyukReconnectionTimeout: defaultRyukReconnectionTimeout,
 				},
 			},
 			{
@@ -188,7 +198,7 @@ func TestReadTCConfig(t *testing.T) {
 				map[string]string{},
 				Config{
 					RyukConnectionTimeout:   defaultRyukConnectionTimeout,
-					RyukReconnectionTimeout: defaultRyukReonnectionTimeout,
+					RyukReconnectionTimeout: defaultRyukReconnectionTimeout,
 				},
 			},
 			{
@@ -200,7 +210,7 @@ func TestReadTCConfig(t *testing.T) {
 				Config{
 					Host:                    tcpDockerHost1234,
 					RyukConnectionTimeout:   defaultRyukConnectionTimeout,
-					RyukReconnectionTimeout: defaultRyukReonnectionTimeout,
+					RyukReconnectionTimeout: defaultRyukReconnectionTimeout,
 				},
 			},
 			{
@@ -210,7 +220,7 @@ func TestReadTCConfig(t *testing.T) {
 				Config{
 					Host:                    tcpDockerHost33293,
 					RyukConnectionTimeout:   defaultRyukConnectionTimeout,
-					RyukReconnectionTimeout: defaultRyukReonnectionTimeout,
+					RyukReconnectionTimeout: defaultRyukReconnectionTimeout,
 				},
 			},
 			{
@@ -230,7 +240,7 @@ func TestReadTCConfig(t *testing.T) {
 					Host:                    tcpDockerHost1234,
 					CertPath:                "/tmp/certs",
 					RyukConnectionTimeout:   defaultRyukConnectionTimeout,
-					RyukReconnectionTimeout: defaultRyukReonnectionTimeout,
+					RyukReconnectionTimeout: defaultRyukReconnectionTimeout,
 				},
 			},
 			{
@@ -240,7 +250,7 @@ func TestReadTCConfig(t *testing.T) {
 				Config{
 					RyukDisabled:            true,
 					RyukConnectionTimeout:   defaultRyukConnectionTimeout,
-					RyukReconnectionTimeout: defaultRyukReonnectionTimeout,
+					RyukReconnectionTimeout: defaultRyukReconnectionTimeout,
 				},
 			},
 			{
@@ -250,7 +260,7 @@ func TestReadTCConfig(t *testing.T) {
 				Config{
 					RyukPrivileged:          true,
 					RyukConnectionTimeout:   defaultRyukConnectionTimeout,
-					RyukReconnectionTimeout: defaultRyukReonnectionTimeout,
+					RyukReconnectionTimeout: defaultRyukReconnectionTimeout,
 				},
 			},
 			{
@@ -264,13 +274,38 @@ func TestReadTCConfig(t *testing.T) {
 				},
 			},
 			{
+				"With Ryuk container timeouts configured using env vars",
+				``,
+				map[string]string{
+					"TESTCONTAINERS_RYUK_RECONNECTION_TIMEOUT": "13s",
+					"TESTCONTAINERS_RYUK_CONNECTION_TIMEOUT": "12s",
+				},
+				Config{
+					RyukReconnectionTimeout: 13 * time.Second,
+					RyukConnectionTimeout:   12 * time.Second,
+				},
+			},
+			{
+				"With Ryuk container timeouts configured using env vars and properties. Env var wins",
+				`ryuk.connection.timeout=22s
+	ryuk.reconnection.timeout=23s`,
+				map[string]string{
+					"TESTCONTAINERS_RYUK_RECONNECTION_TIMEOUT": "13s",
+					"TESTCONTAINERS_RYUK_CONNECTION_TIMEOUT": "12s",
+				},
+				Config{
+					RyukReconnectionTimeout: 13 * time.Second,
+					RyukConnectionTimeout:   12 * time.Second,
+				},
+			},
+			{
 				"With Ryuk verbose configured using properties",
 				`ryuk.verbose=true`,
 				map[string]string{},
 				Config{
 					RyukVerbose:             true,
 					RyukConnectionTimeout:   defaultRyukConnectionTimeout,
-					RyukReconnectionTimeout: defaultRyukReonnectionTimeout,
+					RyukReconnectionTimeout: defaultRyukReconnectionTimeout,
 				},
 			},
 			{
@@ -282,7 +317,7 @@ func TestReadTCConfig(t *testing.T) {
 				Config{
 					RyukDisabled:            true,
 					RyukConnectionTimeout:   defaultRyukConnectionTimeout,
-					RyukReconnectionTimeout: defaultRyukReonnectionTimeout,
+					RyukReconnectionTimeout: defaultRyukReconnectionTimeout,
 				},
 			},
 			{
@@ -294,7 +329,7 @@ func TestReadTCConfig(t *testing.T) {
 				Config{
 					RyukPrivileged:          true,
 					RyukConnectionTimeout:   defaultRyukConnectionTimeout,
-					RyukReconnectionTimeout: defaultRyukReonnectionTimeout,
+					RyukReconnectionTimeout: defaultRyukReconnectionTimeout,
 				},
 			},
 			{
@@ -306,7 +341,7 @@ func TestReadTCConfig(t *testing.T) {
 				Config{
 					RyukDisabled:            true,
 					RyukConnectionTimeout:   defaultRyukConnectionTimeout,
-					RyukReconnectionTimeout: defaultRyukReonnectionTimeout,
+					RyukReconnectionTimeout: defaultRyukReconnectionTimeout,
 				},
 			},
 			{
@@ -318,7 +353,7 @@ func TestReadTCConfig(t *testing.T) {
 				Config{
 					RyukDisabled:            true,
 					RyukConnectionTimeout:   defaultRyukConnectionTimeout,
-					RyukReconnectionTimeout: defaultRyukReonnectionTimeout,
+					RyukReconnectionTimeout: defaultRyukReconnectionTimeout,
 				},
 			},
 			{
@@ -346,7 +381,7 @@ func TestReadTCConfig(t *testing.T) {
 				Config{
 					RyukVerbose:             true,
 					RyukConnectionTimeout:   defaultRyukConnectionTimeout,
-					RyukReconnectionTimeout: defaultRyukReonnectionTimeout,
+					RyukReconnectionTimeout: defaultRyukReconnectionTimeout,
 				},
 			},
 			{
@@ -358,7 +393,7 @@ func TestReadTCConfig(t *testing.T) {
 				Config{
 					RyukVerbose:             true,
 					RyukConnectionTimeout:   defaultRyukConnectionTimeout,
-					RyukReconnectionTimeout: defaultRyukReonnectionTimeout,
+					RyukReconnectionTimeout: defaultRyukReconnectionTimeout,
 				},
 			},
 			{
@@ -386,7 +421,7 @@ func TestReadTCConfig(t *testing.T) {
 				Config{
 					RyukPrivileged:          true,
 					RyukConnectionTimeout:   defaultRyukConnectionTimeout,
-					RyukReconnectionTimeout: defaultRyukReonnectionTimeout,
+					RyukReconnectionTimeout: defaultRyukReconnectionTimeout,
 				},
 			},
 			{
@@ -398,7 +433,7 @@ func TestReadTCConfig(t *testing.T) {
 				Config{
 					RyukPrivileged:          true,
 					RyukConnectionTimeout:   defaultRyukConnectionTimeout,
-					RyukReconnectionTimeout: defaultRyukReonnectionTimeout,
+					RyukReconnectionTimeout: defaultRyukReconnectionTimeout,
 				},
 			},
 			{
@@ -453,7 +488,7 @@ func TestReadTCConfig(t *testing.T) {
 				Config{
 					HubImageNamePrefix:      defaultHubPrefix + "/props/",
 					RyukConnectionTimeout:   defaultRyukConnectionTimeout,
-					RyukReconnectionTimeout: defaultRyukReonnectionTimeout,
+					RyukReconnectionTimeout: defaultRyukReconnectionTimeout,
 				},
 			},
 			{
@@ -465,7 +500,7 @@ func TestReadTCConfig(t *testing.T) {
 				Config{
 					HubImageNamePrefix:      defaultHubPrefix + "/env/",
 					RyukConnectionTimeout:   defaultRyukConnectionTimeout,
-					RyukReconnectionTimeout: defaultRyukReonnectionTimeout,
+					RyukReconnectionTimeout: defaultRyukReconnectionTimeout,
 				},
 			},
 			{
@@ -477,7 +512,7 @@ func TestReadTCConfig(t *testing.T) {
 				Config{
 					HubImageNamePrefix:      defaultHubPrefix + "/env/",
 					RyukConnectionTimeout:   defaultRyukConnectionTimeout,
-					RyukReconnectionTimeout: defaultRyukReonnectionTimeout,
+					RyukReconnectionTimeout: defaultRyukReconnectionTimeout,
 				},
 			},
 		}


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

* Add the possibility to use environment variables to configure ryuk timeouts (reconnection and connection).
* Update unit tests
* Update documentation
* Fix up a minor typo in tests
 
## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->
Default timeout are not suitable in all situations :
* tests taking longer than 10s gets killed before completing (and may make also the following test fail from what I've observed)
* if image building / pulling takes more than 1m to complete, ryuk will timeout and make the test fail.

Configuring these timeouts is currently done via property file which must be located in user home.
This is not very convenient in CI context (need to create proper property file in runner home).
For some common configuration settings, such as TESTCONTAINERS_RYUK_{DISABLE,VERBOSE} it is possible to use env variable which is much more convenient. So we extend this logic to ryuk timeouts.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->

Couldn't find any.

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
