### PR TITLE
fix: update search bar eval in mkdocs

### DIFF
--- a/docs/theme/partials/header.html
+++ b/docs/theme/partials/header.html
@@ -124,9 +124,10 @@
     {% endif %}
 
     <!-- Button to open search modal -->
-    {% if "search" in config.plugins %}
+    {% if "material/search" in config.plugins %}
       <label class="md-header__button md-icon" for="__search">
-        {% include ".icons/material/magnify.svg" %}
+        {% set icon = config.theme.icon.search or "material/magnify" %}
+        {% include ".icons/" ~ icon ~ ".svg" %}
       </label>
 
       <!-- Search interface -->


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
This PR updates the name of the mkdocs' search plugin, from `search` to `material/search`, in the header.html partial.

Render URL: https://deploy-preview-2547--testcontainers-go.netlify.app/

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
Search bar was not shown.
<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Caused by #2524 because of https://github.com/squidfunk/mkdocs-material/commit/4b51fa21a8e1f585392b70a73c7f4001f872cb84 in https://github.com/squidfunk/mkdocs-material/pull/4628

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
