### PR TITLE
Fix network accessor for port-forwarding feature

### DIFF
--- a/internal/core/network/network.go
+++ b/internal/core/network/network.go
@@ -10,8 +10,24 @@ import (
 	"github.com/testcontainers/testcontainers-go/internal/core"
 )
 
+type filter string
+
+const (
+	idFilter   filter = "id"
+	nameFilter filter = "name"
+)
+
 // Get returns a network by its ID.
 func Get(ctx context.Context, id string) (types.NetworkResource, error) {
+	return get(ctx, idFilter, id)
+}
+
+// GetByName returns a network by its name.
+func GetByName(ctx context.Context, name string) (types.NetworkResource, error) {
+	return get(ctx, nameFilter, name)
+}
+
+func get(ctx context.Context, f filter, value string) (types.NetworkResource, error) {
 	var nw types.NetworkResource // initialize to the zero value
 
 	cli, err := core.NewClient(ctx)
@@ -21,7 +37,7 @@ func Get(ctx context.Context, id string) (types.NetworkResource, error) {
 	defer cli.Close()
 
 	filters := filters.NewArgs()
-	filters.Add("id", id)
+	filters.Add(string(f), value)
 
 	list, err := cli.NetworkList(ctx, types.NetworkListOptions{Filters: filters})
 	if err != nil {
@@ -29,7 +45,7 @@ func Get(ctx context.Context, id string) (types.NetworkResource, error) {
 	}
 
 	if len(list) == 0 {
-		return nw, fmt.Errorf("network %s not found", id)
+		return nw, fmt.Errorf("network %s not found (filtering by %s)", value, f)
 	}
 
 	return list[0], nil

--- a/port_forwarding.go
+++ b/port_forwarding.go
@@ -55,7 +55,7 @@ func exposeHostPorts(ctx context.Context, req *ContainerRequest, p ...int) (Cont
 	opts := []ContainerCustomizer{}
 	if len(req.Networks) > 0 {
 		// get the first network of the container to connect the SSHD container to it.
-		nw, err := network.Get(ctx, sshdFirstNetwork)
+		nw, err := network.GetByName(ctx, sshdFirstNetwork)
 		if err != nil {
 			return sshdConnectHook, fmt.Errorf("failed to get the network: %w", err)
 		}

--- a/port_forwarding_test.go
+++ b/port_forwarding_test.go
@@ -94,8 +94,8 @@ func TestExposeHostPorts(t *testing.T) {
 					}
 				})
 
-				req.Networks = []string{nw.ID}
-				req.NetworkAliases = map[string][]string{nw.ID: {"myalpine"}}
+				req.Networks = []string{nw.Name}
+				req.NetworkAliases = map[string][]string{nw.Name: {"myalpine"}}
 			}
 
 			ctx := context.Background()


### PR DESCRIPTION
## What does this PR do?

This pull-request fixes a bug in the port-fowarding functionality.
There is confusion between the use of the network name and the network identifier.
In order to correct the problem, a new function for selecting the network by name has been added.
