### PR TITLE
Docs: Update documentation for TESTCONTAINERS_HOST_OVERRIDE

### DIFF
--- a/docs/system_requirements/ci/dind_patterns.md
+++ b/docs/system_requirements/ci/dind_patterns.md
@@ -35,9 +35,9 @@ Where:
 
 
 !!! warning
-    If you are using Docker Desktop, you need to configure the `TESTCONTAINERS_HOST_OVERRIDE` environment variable to use the special DNS name
+    If you are using Docker Desktop, you need to configure the `TC_HOST` environment variable to use the special DNS name
     `host.docker.internal` for accessing the host from within a container, which is provided by Docker Desktop:
-    `-e TESTCONTAINERS_HOST_OVERRIDE=host.docker.internal`
+    `-e TC_HOST=host.docker.internal`
 
 ### Docker Compose example
 

--- a/docs/system_requirements/ci/gitlab_ci.md
+++ b/docs/system_requirements/ci/gitlab_ci.md
@@ -23,13 +23,13 @@ See below for an example runner configuration:
 ```
 
 !!! warning
-    The environment variable `TESTCONTAINERS_HOST_OVERRIDE` needs to be configured, otherwise, a wrong IP address would be used to resolve the Docker host, which will likely lead to failing tests.
+    The environment variable `TC_HOST` needs to be configured, otherwise, a wrong IP address would be used to resolve the Docker host, which will likely lead to failing tests.
 
 Please also include the following in your GitlabCI pipeline definitions (`.gitlab-ci.yml`) that use Testcontainers:
 
 ```yml
 variables:
-  TESTCONTAINERS_HOST_OVERRIDE: "host.docker.internal"
+  TC_HOST: "host.docker.internal"
 ```
 
 ## Example using DinD (Docker-in-Docker)

--- a/docs/system_requirements/rancher.md
+++ b/docs/system_requirements/rancher.md
@@ -18,7 +18,7 @@ Steps are as follows:
 ```sh
 export DOCKER_HOST=unix://$HOME/.rd/docker.sock
 export TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE=/var/run/docker.sock
-export TESTCONTAINERS_HOST_OVERRIDE=$(rdctl shell ip a show vznat | awk '/inet / {sub("/.*",""); print $2}')
+export TC_HOST=$(rdctl shell ip a show vznat | awk '/inet / {sub("/.*",""); print $2}')
 ```
 
 As always, remember that environment variables are not persisted unless you add them to the relevant file for your default shell e.g. `~/.zshrc`.


### PR DESCRIPTION
## What does this PR do?

I changed the documentation for the `TESTCONTAINERS_HOST_OVERRIDE` environment variable which is not used, instead the `TC_HOST` is used.

## Why is it important?

If someone is following the documentation they will not have the desired results.

## Related issues