### PR TITLE
docs(compose): Fix typo docker compose docs

### DIFF
--- a/docs/features/docker_compose.md
+++ b/docs/features/docker_compose.md
@@ -173,7 +173,7 @@ further information.
 
 ## Usage of the `docker compose` binary
 
-_Node:_ this API is deprecated and superseded by `ComposeStack` which takes advantage of `compose` v2 being
+_Note:_ this API is deprecated and superseded by `ComposeStack` which takes advantage of `compose` v2 being
 implemented in Go as well by directly using the upstream project.
 
 You can override Testcontainers' default behaviour and make it use a


### PR DESCRIPTION
## What does this PR do?

This fixes a typo in the docker compose docs for this repo

## Why is it important?

This helps readers to understand the documentation

## Related issues