### PR TITLE
chore: pin vearch version

### DIFF
--- a/docs/modules/vearch.md
+++ b/docs/modules/vearch.md
@@ -38,7 +38,7 @@ When starting the Vearch container, you can pass options in a variadic way to co
 #### Image
 
 If you need to set a different Vearch Docker image, you can use `testcontainers.WithImage` with a valid Docker image
-for Vearch. E.g. `testcontainers.WithImage("vearch/vearch:latest")`.
+for Vearch. E.g. `testcontainers.WithImage("vearch/vearch:3.5.1")`.
 
 {% include "../features/common_functional_options.md" %}
 

--- a/modules/vearch/examples_test.go
+++ b/modules/vearch/examples_test.go
@@ -12,7 +12,7 @@ import (
 func ExampleRunContainer() {
 	ctx := context.Background()
 
-	vearchContainer, err := vearch.RunContainer(ctx, testcontainers.WithImage("vearch/vearch:latest"))
+	vearchContainer, err := vearch.RunContainer(ctx, testcontainers.WithImage("vearch/vearch:3.5.1"))
 	if err != nil {
 		log.Fatalf("failed to start container: %s", err)
 	}

--- a/modules/vearch/vearch.go
+++ b/modules/vearch/vearch.go
@@ -17,7 +17,7 @@ type VearchContainer struct {
 // RunContainer creates an instance of the Vearch container type
 func RunContainer(ctx context.Context, opts ...testcontainers.ContainerCustomizer) (*VearchContainer, error) {
 	req := testcontainers.ContainerRequest{
-		Image:        "vearch/vearch:latest",
+		Image:        "vearch/vearch:3.5.1",
 		ExposedPorts: []string{"8817/tcp", "9001/tcp"},
 		Cmd:          []string{"-conf=/vearch/config.toml", "all"},
 		Privileged:   true,

--- a/modules/vearch/vearch_test.go
+++ b/modules/vearch/vearch_test.go
@@ -12,7 +12,7 @@ import (
 func TestVearch(t *testing.T) {
 	ctx := context.Background()
 
-	container, err := vearch.RunContainer(ctx, testcontainers.WithImage("vearch/vearch:latest"))
+	container, err := vearch.RunContainer(ctx, testcontainers.WithImage("vearch/vearch:3.5.1"))
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
It pins the version of the Vearch module, to avoid using latest.
<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
For some reason I noticed it during the review but did not commented about it. Changing it is important for reproducibility and not receive a wrong version of the module each time it's used.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Caused by #2560

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
