### PR TITLE
fix: proper synchronisation for start/stop log production

### DIFF
--- a/docker.go
+++ b/docker.go
@@ -77,11 +77,10 @@ type DockerContainer struct {
 
 	// logProductionWaitGroup is used to signal when the log production has stopped.
 	// This allows stopLogProduction to safely set logProductionStop to nil.
+	// See simplification in https://go.dev/play/p/x0pOElF2Vjf
 	logProductionWaitGroup sync.WaitGroup
 
-	// logProductionMutex protects logProductionStop channel so it can be started again.
-	logProductionMutex sync.Mutex
-	logProductionStop  chan struct{}
+	logProductionStop chan struct{}
 
 	logProductionTimeout *time.Duration
 	logger               Logging
@@ -696,17 +695,8 @@ func (c *DockerContainer) StartLogProducer(ctx context.Context, opts ...LogProdu
 // Use functional option WithLogProductionTimeout() to override default timeout. If it's
 // lower than 5s and greater than 60s it will be set to 5s or 60s respectively.
 func (c *DockerContainer) startLogProduction(ctx context.Context, opts ...LogProductionOption) error {
-	{
-		c.logProductionMutex.Lock()
-		defer c.logProductionMutex.Unlock()
-
-		if c.logProductionStop != nil {
-			return errors.New("log production already started")
-		}
-
-		c.logProductionStop = make(chan struct{})
-		c.logProductionWaitGroup.Add(1)
-	}
+	c.logProductionStop = make(chan struct{})
+	c.logProductionWaitGroup.Add(1)
 
 	for _, opt := range opts {
 		opt(c)
@@ -827,18 +817,11 @@ func (c *DockerContainer) StopLogProducer() error {
 // stopLogProduction will stop the concurrent process that is reading logs
 // and sending them to each added LogConsumer
 func (c *DockerContainer) stopLogProduction() error {
-	// TODO: Remove locking and wait group once StartLogProducer and StopLogProducer
-	// have been removed and hence logging can only be started / stopped once.
-	c.logProductionMutex.Lock()
-	defer c.logProductionMutex.Unlock()
-	if c.logProductionStop != nil {
-		close(c.logProductionStop)
-		c.logProductionWaitGroup.Wait()
-		// Set c.logProductionStop to nil so that it can be started again.
-		c.logProductionStop = nil
-		return <-c.logProductionError
-	}
-	return nil
+	close(c.logProductionStop)
+
+	c.logProductionWaitGroup.Wait()
+
+	return <-c.logProductionError
 }
 
 // GetLogProductionErrorChannel exposes the only way for the consumer

--- a/docker.go
+++ b/docker.go
@@ -817,7 +817,10 @@ func (c *DockerContainer) StopLogProducer() error {
 // stopLogProduction will stop the concurrent process that is reading logs
 // and sending them to each added LogConsumer
 func (c *DockerContainer) stopLogProduction() error {
-	close(c.logProductionStop)
+	// close the channel to signal the log production to stop if it's not already closed
+	if c.logProductionStop != nil {
+		close(c.logProductionStop)
+	}
 
 	c.logProductionWaitGroup.Wait()
 

--- a/docker.go
+++ b/docker.go
@@ -294,10 +294,6 @@ func (c *DockerContainer) Terminate(ctx context.Context) error {
 	default:
 	}
 
-	defer func() {
-		close(c.logProductionStop)
-	}()
-
 	defer c.provider.client.Close()
 
 	errs := []error{


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
This PR simplifies the sync mechanisms for starting and stopping the produciton of logs:

- the wait group controls the goroutine that reads the logs
- the start logs method initialises the logProductionStop channel, as a buffered channel of 1, so that the stop can close it properly
- the start logs method already used the logProductionStop channel to wait for a signal to stop processing logs
- the start logs method always adds 1 to the wait group, as it'll be the goroutine processing the logs
- the stop logs method will wait for all goroutines to finish
- the stop logs method will signal the logProductionStop channel so that the start method can stop

See https://go.dev/play/p/x0pOElF2Vjf, where we have created a simplified scenario for it.

As a consequence, the mutex is not needed anymore, as the synchronisation happens with channels and wait groups.

The test proposed in the issue report has been added to the log consumers tests.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
Lots of spaguetti code for the synchronisation, that has been simplified thanks to going to first principles (see https://go.dev/play/p/x0pOElF2Vjf)

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes #2572

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
