### PR TITLE
fix: prepend substitutors for built images

### DIFF
--- a/container.go
+++ b/container.go
@@ -375,6 +375,20 @@ func (c *ContainerRequest) BuildOptions() (types.ImageBuildOptions, error) {
 
 	// make sure the first tag is the one defined in the ContainerRequest
 	tag := fmt.Sprintf("%s:%s", c.GetRepo(), c.GetTag())
+
+	// apply substitutors to the built image
+	for _, is := range c.ImageSubstitutors {
+		modifiedTag, err := is.Substitute(tag)
+		if err != nil {
+			return buildOptions, fmt.Errorf("failed to substitute image %s with %s: %w", tag, is.Description(), err)
+		}
+
+		if modifiedTag != tag {
+			Logger.Printf("✍🏼 Replacing image with %s. From: %s to %s\n", is.Description(), tag, modifiedTag)
+			tag = modifiedTag
+		}
+	}
+
 	if len(buildOptions.Tags) > 0 {
 		// prepend the tag
 		buildOptions.Tags = append([]string{tag}, buildOptions.Tags...)

--- a/docker.go
+++ b/docker.go
@@ -1023,18 +1023,6 @@ func (p *DockerProvider) CreateContainer(ctx context.Context, req ContainerReque
 	// always append the hub substitutor after the user-defined ones
 	req.ImageSubstitutors = append(req.ImageSubstitutors, newPrependHubRegistry(tcConfig.HubImageNamePrefix))
 
-	for _, is := range req.ImageSubstitutors {
-		modifiedTag, err := is.Substitute(imageName)
-		if err != nil {
-			return nil, fmt.Errorf("failed to substitute image %s with %s: %w", imageName, is.Description(), err)
-		}
-
-		if modifiedTag != imageName {
-			p.Logger.Printf("✍🏼 Replacing image with %s. From: %s to %s\n", is.Description(), imageName, modifiedTag)
-			imageName = modifiedTag
-		}
-	}
-
 	var platform *specs.Platform
 
 	if req.ShouldBuildImage() {
@@ -1043,6 +1031,18 @@ func (p *DockerProvider) CreateContainer(ctx context.Context, req ContainerReque
 			return nil, err
 		}
 	} else {
+		for _, is := range req.ImageSubstitutors {
+			modifiedTag, err := is.Substitute(imageName)
+			if err != nil {
+				return nil, fmt.Errorf("failed to substitute image %s with %s: %w", imageName, is.Description(), err)
+			}
+
+			if modifiedTag != imageName {
+				Logger.Printf("✍🏼 Replacing image with %s. From: %s to %s\n", is.Description(), imageName, modifiedTag)
+				imageName = modifiedTag
+			}
+		}
+
 		if req.ImagePlatform != "" {
 			p, err := platforms.Parse(req.ImagePlatform)
 			if err != nil {


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
This PR considers the case where an image can be built from a Dockerfile and receives Image substitutors, applying them to build the complete image name after the build.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
Built images did not receive the image substitutors
<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes #2554

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
