### PR TITLE
chore: skip reaper tests if ryuk is disabled

### DIFF
--- a/reaper_test.go
+++ b/reaper_test.go
@@ -309,6 +309,12 @@ func TestContainerTerminationWithoutReaper(t *testing.T) {
 }
 
 func Test_NewReaper(t *testing.T) {
+	config.Reset() // reset the config using the internal method to avoid the sync.Once
+	tcConfig := config.Read()
+	if tcConfig.RyukDisabled {
+		t.Skip("Ryuk is disabled, skipping test")
+	}
+
 	type cases struct {
 		name   string
 		req    ContainerRequest
@@ -588,6 +594,12 @@ func TestReaper_reuseItFromOtherTestProgramUsingDocker(t *testing.T) {
 // already running for the same session id by returning its container instance
 // instead.
 func TestReaper_ReuseRunning(t *testing.T) {
+	config.Reset() // reset the config using the internal method to avoid the sync.Once
+	tcConfig := config.Read()
+	if tcConfig.RyukDisabled {
+		t.Skip("Ryuk is disabled, skipping test")
+	}
+
 	const concurrency = 64
 
 	timeout, cancel := context.WithTimeout(context.Background(), 5*time.Minute)


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
This PR skips two tests for creating the resource reaper, Ryuk, when Ryuk is disabled.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
They are not of interested in that scenario.

It'll also improve the reliability in the CI pipeline, as we have seen some flakiness in these two skipped tests when Ryuk is disabled.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->


<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
