### PR TITLE
docs: fix deprecation warning for material extensions emoji

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -33,8 +33,8 @@ markdown_extensions:
         permalink: true
     - attr_list
     - pymdownx.emoji:
-        emoji_generator: !!python/name:materialx.emoji.to_svg
-        emoji_index: !!python/name:materialx.emoji.twemoji
+        emoji_generator: !!python/name:material.extensions.emoji.to_svg
+        emoji_index: !!python/name:material.extensions.emoji.twemoji
 nav:
     - Home: index.md
     - Quickstart: quickstart.md


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
It uses the new version of emoji for mkdocs: `material.extensions.emoji.to_svg` and `material.extensions.emoji.twemoji`.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
The previous one is deprecated and will be removed in the next version (obtained from the build logs of `make serve-docs`).

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->


<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
