### PR TITLE
Add support for userns remapping

### DIFF
--- a/docs/features/configuration.md
+++ b/docs/features/configuration.md
@@ -53,6 +53,7 @@ but does not allow starting privileged containers, you can turn off the Ryuk con
 1. You can specify the connection timeout for Ryuk by setting the `TESTCONTAINERS_RYUK_CONNECTION_TIMEOUT` **environment variable**, or the `ryuk.connection.timeout` **property**. The default value is 1 minute.
 1. You can specify the reconnection timeout for Ryuk by setting the `TESTCONTAINERS_RYUK_RECONNECTION_TIMEOUT` **environment variable**, or the `ryuk.reconnection.timeout` **property**. The default value is 10 seconds.
 1. You can configure Ryuk to run in verbose mode by setting any of the `ryuk.verbose` **property** or the `TESTCONTAINERS_RYUK_VERBOSE` **environment variable**. The default value is `false`.
+1. You can configure Ryuk to run in the host userns if you're using the `--userns-remap` feature of the docker daemon by setting either the `TESTCONTAINERS_RYUK_USER_NS` **environment variable** or the `ryuk.userns` **property**. The default value is `false`.
 
 !!!info
     For more information about Ryuk, see [Garbage Collector](garbage_collector.md).

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -31,6 +31,7 @@ type Config struct {
 	RyukReconnectionTimeout time.Duration `properties:"ryuk.reconnection.timeout,default=10s"`
 	RyukConnectionTimeout   time.Duration `properties:"ryuk.connection.timeout,default=1m"`
 	RyukVerbose             bool          `properties:"ryuk.verbose,default=false"`
+	RyukUserNs              bool          `properties:"ryuk.userns,default=false"`
 	TestcontainersHost      string        `properties:"tc.host,default="`
 }
 
@@ -85,6 +86,11 @@ func read() Config {
 		ryukVerboseEnv := os.Getenv("TESTCONTAINERS_RYUK_VERBOSE")
 		if parseBool(ryukVerboseEnv) {
 			config.RyukVerbose = ryukVerboseEnv == "true"
+		}
+
+		ryukUserNsEnv := os.Getenv("TESTCONTAINERS_RYUK_USER_NS")
+		if parseBool(ryukUserNsEnv) {
+			config.RyukUserNs = ryukUserNsEnv == "true"
 		}
 
 		ryukReconnectionTimeoutEnv := os.Getenv("TESTCONTAINERS_RYUK_RECONNECTION_TIMEOUT")

--- a/reaper.go
+++ b/reaper.go
@@ -257,6 +257,10 @@ func newReaper(ctx context.Context, sessionID string, provider ReaperProvider) (
 			hc.AutoRemove = true
 			hc.Binds = []string{dockerHostMount + ":/var/run/docker.sock"}
 			hc.NetworkMode = Bridge
+			// Ryuk mounts the Docker socket so running it within a userns will cause major headaches.
+			if tcConfig.RyukUserNs {
+				hc.UsernsMode = "host"
+			}
 		},
 		Env: map[string]string{},
 	}


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->
This PR adds the configuration values `ryuk.userns` / `TESTCONTAINERS_RYUK_USER_NS`, which will cause the ryuk container to run in the host user namespace instead of the default one. This is required because Ryuk mounts the Docker socket into the container and if this isn't done it will receive a permission denied error when trying to access it.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->
Enable scenarios where the user namespace has been remapped.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
N/A

## How to test this PR

Automatically testing this change is difficult because it requires changing the dockerd configuration.

- Configure the Docker daemon to use `--userns-remap` according to this guide: https://docs.docker.com/engine/security/userns-remap/
- Set `TESTCONTAINERS_RYUK_USER_NS` to `true`
- Run Ryuk

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
