### PR TITLE
fix: allow compose files and readers to be used together

### DIFF
--- a/modules/compose/compose_api.go
+++ b/modules/compose/compose_api.go
@@ -22,8 +22,8 @@ import (
 	"github.com/docker/docker/client"
 	"golang.org/x/sync/errgroup"
 
-	testcontainers "github.com/testcontainers/testcontainers-go"
-	wait "github.com/testcontainers/testcontainers-go/wait"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/wait"
 )
 
 type stackUpOptionFunc func(s *stackUpOptions)
@@ -149,7 +149,7 @@ func (r ComposeStackReaders) applyToComposeStack(o *composeStackOptions) error {
 		o.temporaryPaths[f[i]] = true
 	}
 
-	o.Paths = f
+	o.Paths = append(o.Paths, f...)
 
 	return nil
 }
@@ -157,7 +157,7 @@ func (r ComposeStackReaders) applyToComposeStack(o *composeStackOptions) error {
 type ComposeStackFiles []string
 
 func (f ComposeStackFiles) applyToComposeStack(o *composeStackOptions) error {
-	o.Paths = f
+	o.Paths = append(o.Paths, f...)
 	return nil
 }
 


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?

Both `WithStackFiles` and `WithStackReaders` assign to the `Paths` field of the `composeStackOptions` which would result in the last option to overwrite all earlier options. 

The documentation specifies that it's possible to use both files and readers.

This PR aligns the implementation with the documentation by appending to the `Paths` field instead of overwriting it.

## Why is it important?

Align the implementation with what one would expect from the documentation

## How to test this PR

I've included a test that includes both a file and a reader
