### PR TITLE
chore: improve log handling when container is stopping

### DIFF
--- a/docker.go
+++ b/docker.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
+	"net"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -756,8 +757,7 @@ func (c *DockerContainer) startLogProduction(ctx context.Context, opts ...LogPro
 			h := make([]byte, 8)
 			_, err := io.ReadFull(r, h)
 			if err != nil {
-				// proper type matching requires https://go-review.googlesource.com/c/go/+/250357/ (go 1.16)
-				if strings.Contains(err.Error(), "use of closed network connection") {
+				if errors.Is(err, net.ErrClosed) {
 					now := time.Now()
 					since = fmt.Sprintf("%d.%09d", now.Unix(), int64(now.Nanosecond()))
 					goto BEGIN

--- a/docker.go
+++ b/docker.go
@@ -758,6 +758,8 @@ func (c *DockerContainer) startLogProduction(ctx context.Context, opts ...LogPro
 			_, err := io.ReadFull(r, h)
 			if err != nil {
 				switch {
+				case err == io.EOF:
+					// No more logs coming
 				case errors.Is(err, net.ErrClosed):
 					now := time.Now()
 					since = fmt.Sprintf("%d.%09d", now.Unix(), int64(now.Nanosecond()))


### PR DESCRIPTION
## What does this PR do?

I'm getting an error when my container cleanly stops:

> container log error: EOF. Stopping log consumer: Headers out of sync

Please see individual commits. I tried to tidy up a bit, I hope this is fine.

## Why is it important?

The error is a red herring and distracts users of the library.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- 

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
