### PR TITLE
Add support for Weaviate v1.25

### DIFF
--- a/modules/weaviate/examples_test.go
+++ b/modules/weaviate/examples_test.go
@@ -111,7 +111,7 @@ func ExampleRunContainer_connectWithClientWithModules() {
 	}
 
 	opts := []testcontainers.ContainerCustomizer{
-		testcontainers.WithImage("semitechnologies/weaviate:1.24.5"),
+		testcontainers.WithImage("semitechnologies/weaviate:1.25.5"),
 		testcontainers.WithEnv(envs),
 	}
 

--- a/modules/weaviate/weaviate.go
+++ b/modules/weaviate/weaviate.go
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	image    = "semitechnologies/weaviate:1.24.6"
+	image    = "semitechnologies/weaviate:1.25.5"
 	httpPort = "8080/tcp"
 	grpcPort = "50051/tcp"
 )
@@ -33,6 +33,7 @@ func RunContainer(ctx context.Context, opts ...testcontainers.ContainerCustomize
 		WaitingFor: wait.ForAll(
 			wait.ForListeningPort(httpPort).WithStartupTimeout(5*time.Second),
 			wait.ForListeningPort(grpcPort).WithStartupTimeout(5*time.Second),
+			wait.ForHTTP("/v1/.well-known/ready").WithPort(httpPort),
 		),
 	}
 

--- a/modules/weaviate/weaviate_test.go
+++ b/modules/weaviate/weaviate_test.go
@@ -19,7 +19,7 @@ import (
 func TestWeaviate(t *testing.T) {
 	ctx := context.Background()
 
-	container, err := weaviate.RunContainer(ctx, testcontainers.WithImage("semitechnologies/weaviate:1.24.5"))
+	container, err := weaviate.RunContainer(ctx, testcontainers.WithImage("semitechnologies/weaviate:1.25.5"))
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
## What does this PR do?

This PR updates Weaviate's default version to latest `v1.25.5` it also adds a wait for http check just to be 100% sure that Weaviate is up and running.

## Why is it important?

Adds support for latest stable Weaviate v1.25 version.

## Related issues

none
