### PR TITLE
chore: run rootless mode in nighlty builds

### DIFF
--- a/.github/workflows/docker-moby-latest.yml
+++ b/.github/workflows/docker-moby-latest.yml
@@ -7,9 +7,20 @@ on:
 
 jobs:
   test_latest_moby:
+    strategy:
+      matrix:
+        rootless-docker: [true, false]
     name: "Core tests using latest moby/moby"
     runs-on: 'ubuntu-latest'
     steps:
+      - name: Setup rootless Docker
+        if: ${{ matrix.rootless-docker }}
+        uses: ScribeMD/rootless-docker@6bd157a512c2fafa4e0243a8aa87d964eb890886  # v0.2.2
+
+      - name: Remove Docker root socket
+        if: ${{ matrix.rootless-docker }}
+        run: sudo rm -rf /var/run/docker.sock
+
       - name: Check out code into the Go module directory
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
 


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
This PR updates the nightly build that uses the TEST channel of the Docker builds, so that we are able to run the nightly build for rootful and rootless mode.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
We want to detect regressions the soonest.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Relates https://github.com/moby/moby/issues/48064#issuecomment-2194901075

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
