### PR TITLE
chore(ci): pass docker install type to the nightly build payload

### DIFF
--- a/.github/workflows/docker-moby-latest.yml
+++ b/.github/workflows/docker-moby-latest.yml
@@ -14,6 +14,10 @@ jobs:
     runs-on: 'ubuntu-latest'
     continue-on-error: true
     steps:
+      - name: Set the Docker Install type
+        run: |
+          echo "docker_install_type=${{ matrix.rootless-docker == true && 'Rootless' || 'Rootful' }}" >> "$GITHUB_ENV"
+
       - name: Setup rootless Docker
         if: ${{ matrix.rootless-docker }}
         uses: ScribeMD/rootless-docker@6bd157a512c2fafa4e0243a8aa87d964eb890886  # v0.2.2
@@ -51,6 +55,7 @@ jobs:
           cat <<EOF > ./payload-slack-content.json
           {
               "tc_project": "testcontainers-go",
+              "tc_docker_install_type": "${docker_install_type}",
               "tc_github_action_url": "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/attempts/${GITHUB_RUN_ATTEMPT}",
               "tc_github_action_status": "FAILED",
               "tc_slack_channel_id": "${{ secrets.SLACK_DOCKER_LATEST_CHANNEL_ID }}"

--- a/.github/workflows/docker-moby-latest.yml
+++ b/.github/workflows/docker-moby-latest.yml
@@ -12,6 +12,7 @@ jobs:
         rootless-docker: [true, false]
     name: "Core tests using latest moby/moby"
     runs-on: 'ubuntu-latest'
+    continue-on-error: true
     steps:
       - name: Setup rootless Docker
         if: ${{ matrix.rootless-docker }}


### PR DESCRIPTION
- **chore: continue on error for the nightly build**
- **chore: pass docker install type to the payload**

<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
This PR enrichs the JSON payload we submit to Slack when the test-docker-latest build fails, passing if the docker was installed as rootful or rootless.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
Have a quicker preview of the root cause of the error in the Slack message
<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Continues #2611

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
