### PR TITLE
chore: remove most uses of  TestcontainersConfig and deprecated TestcontainersConfig fields.

### DIFF
--- a/docker_test.go
+++ b/docker_test.go
@@ -1898,16 +1898,6 @@ func TestGetGatewayIP(t *testing.T) {
 	}
 }
 
-func TestProviderHasConfig(t *testing.T) {
-	provider, err := NewDockerProvider(WithLogger(TestLogger(t)))
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer provider.Close()
-
-	assert.NotNil(t, provider.Config(), "expecting DockerProvider to provide the configuration")
-}
-
 func TestNetworkModeWithContainerReference(t *testing.T) {
 	ctx := context.Background()
 	nginxA, err := GenericContainer(ctx, GenericContainerRequest{

--- a/logconsumer_test.go
+++ b/logconsumer_test.go
@@ -285,14 +285,14 @@ func TestContainerLogWithErrClosed(t *testing.T) {
 
 	opts := []client.Opt{client.WithHost(remoteDocker), client.WithAPIVersionNegotiation()}
 
-	client, err := NewDockerClientWithOpts(ctx, opts...)
+	dockerClient, err := NewDockerClientWithOpts(ctx, opts...)
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer client.Close()
+	defer dockerClient.Close()
 
 	provider := &DockerProvider{
-		client: client,
+		client: dockerClient,
 		config: ReadConfig(),
 		DockerProviderOptions: &DockerProviderOptions{
 			GenericProviderOptions: &GenericProviderOptions{

--- a/logconsumer_test.go
+++ b/logconsumer_test.go
@@ -293,7 +293,7 @@ func TestContainerLogWithErrClosed(t *testing.T) {
 
 	provider := &DockerProvider{
 		client: dockerClient,
-		config: ReadConfig(),
+		config: config.Read(),
 		DockerProviderOptions: &DockerProviderOptions{
 			GenericProviderOptions: &GenericProviderOptions{
 				Logger: TestLogger(t),

--- a/modules/compose/compose.go
+++ b/modules/compose/compose.go
@@ -151,10 +151,8 @@ func NewDockerComposeWith(opts ...ComposeStackOption) (*dockerCompose, error) {
 		return nil, fmt.Errorf("failed to create reaper provider for compose: %w", err)
 	}
 
-	tcConfig := reaperProvider.Config()
-
 	var composeReaper *testcontainers.Reaper
-	if !tcConfig.RyukDisabled {
+	if !reaperProvider.Config().Config.RyukDisabled {
 		// NewReaper is deprecated: we need to find a way to create the reaper for compose
 		// bypassing the deprecation.
 		r, err := testcontainers.NewReaper(context.Background(), testcontainers.SessionID(), reaperProvider, "")

--- a/provider.go
+++ b/provider.go
@@ -144,16 +144,10 @@ func NewDockerProvider(provOpts ...DockerProviderOption) (*DockerProvider, error
 		return nil, err
 	}
 
-	tcConfig := ReadConfig()
-
-	dockerHost := core.ExtractDockerHost(ctx)
-
-	p := &DockerProvider{
+	return &DockerProvider{
 		DockerProviderOptions: o,
-		host:                  dockerHost,
+		host:                  core.ExtractDockerHost(ctx),
 		client:                c,
-		config:                tcConfig,
-	}
-
-	return p, nil
+		config:                ReadConfig(),
+	}, nil
 }

--- a/provider.go
+++ b/provider.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/testcontainers/testcontainers-go/internal/config"
 	"github.com/testcontainers/testcontainers-go/internal/core"
 )
 
@@ -148,6 +149,6 @@ func NewDockerProvider(provOpts ...DockerProviderOption) (*DockerProvider, error
 		DockerProviderOptions: o,
 		host:                  core.ExtractDockerHost(ctx),
 		client:                c,
-		config:                ReadConfig(),
+		config:                config.Read(),
 	}, nil
 }


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

### remove TestProviderHasConfig as it wasn't testing anything

This test was verifying that DockerProvider.Config() returned a
non-nil value, but Config() does not return a pointer, so it
would always pass (even with an empty struct).


### TestContainerLogWithErrClosed: rename variable that shadowed import


### NewDockerProvider: inline intermediate variables

### modules/compose: NewDockerComposeWith: don't use deprecated RyukDisabled

The TestcontainersConfig.RyukDisabled field is deprecated.
NewDockerProvider() uses ReadConfig() internally to load the config,
which always copies its value from config.Config.RyukDisabled field,
which is not deprecated.

This patch removes the extra redirection, and changes the code to
use Config.RyukDisabled instead.


### DockerProvider: don't use legacy TestcontainersConfig internally

All fields in TestcontainersConfig are deprecated, making it a
wrapper around config.Config and DockerProvider internally only
depends on config.Config. All deprecated fields contain a copy
of values available in config.Config.

However, the exported `Config()` has TestcontainersConfig as return type;
filling the deprecated fields is is currently handled by ReadConfig, but
straightforward, so we can inline that code in the `Config()` method.

This patch:

- changes the (non-exported) config field to hold a config.Config (which
  provides all the data used).
- removes internal uses of the `Config()` method; the `Config()` method
  did not provide value for internal use; the `config` field is not mutated
  (so no synchronisation needed for concurrency).
- updates the `Config()` method to handle conversion of the config.Config
  to a `TestcontainersConfig` (effectively inlining a copy of `ReadConfig`)

After this patch, the only remaining use of `ReadConfig` in testcontainers-go
itself is in tests (`TestReadConfig`); as a follow-up, we can consider
deprecating `ReadConfig` and `TestcontainersConfig`, although `DockerProvider`
may need a new `Config()` method with a different signature if its config
must be accessible for others, which would require the `ContainerProvider`
and `ReaperProvider` interfaces to be updated.


## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

Remove uses of deprecated fields to make it easier to spot where it's still used.


## Follow-ups

consider deprecating `ReadConfig` and `TestcontainersConfig`, although `DockerProvider`
may need a new `Config()` method with a different signature if its config
must be accessible for others, which would require the `ContainerProvider`
and `ReaperProvider` interfaces to be updated.

