### PR TITLE
chore: use self-hosted worker for Windows tests

### DIFF
--- a/.github/workflows/ci-windows-trigger.yml
+++ b/.github/workflows/ci-windows-trigger.yml
@@ -11,7 +11,7 @@ jobs:
   windows-test-command-trigger:
     permissions:
       pull-requests: write  # for peter-evans/slash-command-dispatch to create PR reaction
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Trigger windows-test command

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -6,10 +6,7 @@ on:
 
 jobs:
   test-windows:
-    # At the moment, we are running a self-hosted runner on Windows 2022.
-    runs-on: [self-hosted, Windows, X64]
-    strategy:
-      fail-fast: false
+    runs-on: [self-hosted, Windows, X64, desktop-windows-intel]
     timeout-minutes: 30
     steps:
       - name: Create pending status


### PR DESCRIPTION
- **chore: use ubuntu latest in the trigger command**
- **chore: narrow down self-hosted labels**

<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
This PR updates the existing trigger-workflow to:

1. use ubuntu-latest as the worker to receive the command and dispatch the build to the self-hosted worker
2. use a more precise set of labels to match the right self-hosted Windows worker, using intel.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
Start testing Docker Desktop on Windows
<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Relates #2449

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
