### PR TITLE
fix: do not use deprecated method in postgres tests

### DIFF
--- a/modules/postgres/postgres_test.go
+++ b/modules/postgres/postgres_test.go
@@ -401,9 +401,9 @@ func TestSnapshotWithDockerExecFallback(t *testing.T) {
 
 	// postgresWithSQLDriver {
 	// 1. Start the postgres container and run any migrations on it
-	ctr, err := postgres.RunContainer(
+	ctr, err := postgres.Run(
 		ctx,
-		testcontainers.WithImage("docker.io/postgres:16-alpine"),
+		"docker.io/postgres:16-alpine",
 		postgres.WithDatabase(dbname),
 		postgres.WithUsername(user),
 		postgres.WithPassword(password),


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
Uses the new Run method in the Postgres module's tests.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
Remove the deprecation warning in the lint

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Caused by #2610

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
