### PR TITLE
Fix issues in BuildImage()

### DIFF
--- a/docker.go
+++ b/docker.go
@@ -890,6 +890,7 @@ func (p *DockerProvider) BuildImage(ctx context.Context, img ImageBuildInfo) (st
 			if err != nil {
 				return types.ImageBuildResponse{}, backoff.Permanent(err)
 			}
+			defer tryClose(buildOptions.Context) // release resources in any case
 
 			resp, err := p.client.ImageBuild(ctx, buildOptions.Context, buildOptions)
 			if err != nil {
@@ -1661,4 +1662,11 @@ func isPermanentClientError(err error) bool {
 		}
 	}
 	return false
+}
+
+func tryClose(r io.Reader) {
+	rc, ok := r.(io.Closer)
+	if ok {
+		_ = rc.Close()
+	}
 }

--- a/docker.go
+++ b/docker.go
@@ -887,13 +887,11 @@ func (p *DockerProvider) BuildImage(ctx context.Context, img ImageBuildInfo) (st
 		return "", err
 	}
 
-	var buildError error
 	var resp types.ImageBuildResponse
 	err = backoff.RetryNotify(
 		func() error {
 			resp, err = p.client.ImageBuild(ctx, buildOptions.Context, buildOptions)
 			if err != nil {
-				buildError = errors.Join(buildError, err)
 				if isPermanentClientError(err) {
 					return backoff.Permanent(err)
 				}
@@ -909,7 +907,7 @@ func (p *DockerProvider) BuildImage(ctx context.Context, img ImageBuildInfo) (st
 		},
 	)
 	if err != nil {
-		return "", errors.Join(buildError, err)
+		return "", err
 	}
 
 	if img.ShouldPrintBuildLog() {

--- a/docker.go
+++ b/docker.go
@@ -910,6 +910,7 @@ func (p *DockerProvider) BuildImage(ctx context.Context, img ImageBuildInfo) (st
 	if err != nil {
 		return "", err
 	}
+	defer resp.Body.Close()
 
 	if img.ShouldPrintBuildLog() {
 		termFd, isTerm := term.GetFdInfo(os.Stderr)
@@ -925,8 +926,6 @@ func (p *DockerProvider) BuildImage(ctx context.Context, img ImageBuildInfo) (st
 	if err != nil {
 		return "", err
 	}
-
-	_ = resp.Body.Close()
 
 	// the first tag is the one we want
 	return buildOptions.Tags[0], nil


### PR DESCRIPTION
## What does this PR do?

Please see individual commits. The most important fixes are to not reuse the `Context` and to close it to release resources.

`BuildOptions()` calls `GetContext()` which calls `archive.TarWithOptions()` which [starts a goroutine](https://github.com/moby/moby/blob/v27.0.3/pkg/archive/archive.go#L850). This goroutine will be stuck until the reader is closed. So, current code leaks goroutines and open files when `BuildImage()` fails.

## Why is it important?

Improves reliability of image building.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- 

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
