### PR TITLE
bug:Merge custom labels with default

### DIFF
--- a/container.go
+++ b/container.go
@@ -392,7 +392,10 @@ func (c *ContainerRequest) BuildOptions() (types.ImageBuildOptions, error) {
 	}
 
 	if !c.ShouldKeepBuiltImage() {
-		buildOptions.Labels = core.DefaultLabels(core.SessionID())
+		err := core.MergeCustomLabels(buildOptions.Labels, core.DefaultLabels(core.SessionID()))
+		if err != nil {
+			panic(fmt.Errorf("Unable to merge custom labels"))
+		}
 	}
 
 	// Do this as late as possible to ensure we don't leak the context on error/panic.

--- a/container_test.go
+++ b/container_test.go
@@ -522,7 +522,7 @@ func TestLabelsForContainer(t *testing.T) {
 			Labels: map[string]string{customLabel: "test"},
 		},
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	containerJson, err := container.Inspect(ctx)
 	require.NoError(t, err)

--- a/internal/core/labels.go
+++ b/internal/core/labels.go
@@ -1,6 +1,9 @@
 package core
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/testcontainers/testcontainers-go/internal"
 )
 
@@ -13,6 +16,7 @@ const (
 	LabelVersion   = LabelBase + ".version"
 )
 
+// DefaultLabels returns the default map of Labels for a container
 func DefaultLabels(sessionID string) map[string]string {
 	return map[string]string{
 		LabelBase:      "true",
@@ -20,4 +24,21 @@ func DefaultLabels(sessionID string) map[string]string {
 		LabelSessionID: sessionID,
 		LabelVersion:   internal.Version,
 	}
+}
+
+// MergeCustomLabels merges default labels in-place to the custom labels.
+//
+// It is an error to use "org.testcontainers" as a prefix to custom labels.
+func MergeCustomLabels(customLabels map[string]string, defaultLabels map[string]string) error {
+	for customLabelKey := range customLabels {
+		_, present := defaultLabels[customLabelKey]
+		if present || strings.HasPrefix(customLabelKey, LabelBase) {
+			return fmt.Errorf("custom labels cannot begin with %s or already be present", LabelBase)
+		}
+	}
+	for defaultLabel, defaultValue := range defaultLabels {
+		customLabels[defaultLabel] = defaultValue
+	}
+
+	return nil
 }


### PR DESCRIPTION

## What does this PR do?

Fixes custom label merging with the default labels.

## Why is it important?

If users set custom labels via container customizes, they will expect those labels are present in the container inspection

## Related issues


- Closes #2632 



## How to test this PR

Unit tests have been added.

