### PR TITLE
feat: add custom container registry substitutor

### DIFF
--- a/options.go
+++ b/options.go
@@ -117,6 +117,47 @@ type ImageSubstitutor interface {
 
 // }
 
+// CustomHubSubstitutor represents a way to substitute the hub of an image with a custom one,
+// using provided value with respect to the HubImageNamePrefix configuration value.
+type CustomHubSubstitutor struct {
+	hub string
+}
+
+// NewCustomHubSubstitutor creates a new CustomHubSubstitutor
+func NewCustomHubSubstitutor(hub string) CustomHubSubstitutor {
+	return CustomHubSubstitutor{
+		hub: hub,
+	}
+}
+
+// Description returns the name of the type and a short description of how it modifies the image.
+func (c CustomHubSubstitutor) Description() string {
+	return fmt.Sprintf("CustomHubSubstitutor (replaces hub with %s)", c.hub)
+}
+
+// Substitute replaces the hub of the image with the provided one, with certain conditions:
+//   - if the hub is empty, the image is returned as is.
+//   - if the image already contains a registry, the image is returned as is.
+//   - if the HubImageNamePrefix configuration value is set, the image is returned as is.
+func (c CustomHubSubstitutor) Substitute(image string) (string, error) {
+	registry := core.ExtractRegistry(image, "")
+	cfg := ReadConfig()
+
+	exclusions := []func() bool{
+		func() bool { return c.hub == "" },
+		func() bool { return registry != "" },
+		func() bool { return cfg.Config.HubImageNamePrefix != "" },
+	}
+
+	for _, exclusion := range exclusions {
+		if exclusion() {
+			return image, nil
+		}
+	}
+
+	return fmt.Sprintf("%s/%s", c.hub, image), nil
+}
+
 // prependHubRegistry represents a way to prepend a custom Hub registry to the image name,
 // using the HubImageNamePrefix configuration value
 type prependHubRegistry struct {


### PR DESCRIPTION
# Custom Registry Substitutor

## What does this PR do?
The new substitutor can be used by modules whose images are not placed on `DockerHub` by default. This way, you don't need to manually prefix your image with a custom container registry. Instead, you can configure your registry with a prefix at the configuration level using hub.image.name.prefix.

In a development environment, `hub.image.name.prefix` is commonly empty, so `CustomHubSubstitutor` will add the desired default prefix. However, in a CI environment, the default prefix will not be added, and the config prefix will be used (handled by `prependHubRegistry`).

## Usage
``` golang
func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustomizer) (*KeycloakContainer, error) {
	req := testcontainers.ContainerRequest{
		Image: img,
		Env: map[string]string{
			keycloakAdminUsernameEnv: defaultKeycloakAdminUsername,
			keycloakAdminPasswordEnv: defaultKeycloakAdminPassword,
		},
		ExposedPorts: []string{keycloakPort},
		Cmd:          []string{keycloakStartupCommand},
		ImageSubstitutors: []testcontainers.ImageSubstitutor{
			testcontainers.NewCustomHubSubstitutor("quay.io"),
		},
	}
}
```