### PR TITLE
chore(deps): bump Ryuk to 0.8.1

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -11,7 +11,7 @@ import (
 	"github.com/magiconair/properties"
 )
 
-const ReaperDefaultImage = "testcontainers/ryuk:0.7.0"
+const ReaperDefaultImage = "testcontainers/ryuk:0.8.1"
 
 var (
 	tcConfig     Config

--- a/scripts/bump-reaper.sh
+++ b/scripts/bump-reaper.sh
@@ -39,7 +39,7 @@ function main() {
 
 # This function reads the reaper.go file and extracts the current version.
 function extractCurrentVersion() {
-  cat "${REAPER_FILE}" | grep 'ReaperDefaultImage = ' | cut -d '=' -f 2 | cut -d '"' -f 1
+  cat "${REAPER_FILE}" | grep 'ReaperDefaultImage = ' | cut -d '=' -f 2
 }
 
 main "$@"


### PR DESCRIPTION
- **fix: update bump-reaper script**
- **chore: bump ryuk to 0.8.1**

<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
This PR bumps Ryuk to the latest release, `0.8.1`, also updating the shell script that performed the bump.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
The bump script was outdated, and the ryuk release contains a potential fix for some other issues (see below)
<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes #2596
- Closes #2477
- Closes #2172
- Relates #2445

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
