### PR TITLE
fix: missing image build errors

### DIFF
--- a/from_dockerfile_test.go
+++ b/from_dockerfile_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -86,6 +87,28 @@ func TestBuildImageFromDockerfile_NoRepo(t *testing.T) {
 			t.Fatal(err)
 		}
 	})
+}
+
+func TestBuildImageFromDockerfile_BuildError(t *testing.T) {
+	ctx := context.Background()
+	dockerClient, err := NewDockerClientWithOpts(ctx)
+	require.NoError(t, err)
+
+	defer dockerClient.Close()
+
+	req := ContainerRequest{
+		FromDockerfile: FromDockerfile{
+			Dockerfile: "error.Dockerfile",
+			Context:    filepath.Join(".", "testdata"),
+		},
+	}
+	_, err = GenericContainer(ctx, GenericContainerRequest{
+		ProviderType:     providerType,
+		ContainerRequest: req,
+		Started:          true,
+	})
+
+	require.EqualError(t, err, `create container: build image: The command '/bin/sh -c exit 1' returned a non-zero code: 1`)
 }
 
 func TestBuildImageFromDockerfile_NoTag(t *testing.T) {

--- a/generic.go
+++ b/generic.go
@@ -74,7 +74,7 @@ func GenericContainer(ctx context.Context, req GenericContainerRequest) (Contain
 	}
 	if err != nil {
 		// At this point `c` might not be nil. Give the caller an opportunity to call Destroy on the container.
-		return c, fmt.Errorf("%w: failed to create container", err)
+		return c, fmt.Errorf("create container: %w", err)
 	}
 
 	if req.Started && !c.IsRunning() {

--- a/testdata/error.Dockerfile
+++ b/testdata/error.Dockerfile
@@ -1,0 +1,4 @@
+FROM docker.io/alpine
+
+RUN exit 1
+


### PR DESCRIPTION
Ensure build errors are returned to the caller when PrintBuildLog is not set to true.

DisplayJSONMessagesStream and JSONMessage.Display  performs processing of the stream to catch command failures, so needs to always be called.