### PR TITLE
docs: fix compilation of examples

### DIFF
--- a/docs/features/creating_container.md
+++ b/docs/features/creating_container.md
@@ -159,54 +159,57 @@ import (
 	"log"
 
 	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/wait"
 )
 
 const (
 	reusableContainerName = "my_test_reusable_container"
 )
 
-ctx := context.Background()
+func main() {
+	ctx := context.Background()
 
-n1, err := GenericContainer(ctx, GenericContainerRequest{
-	ContainerRequest: ContainerRequest{
-		Image:        "nginx:1.17.6",
-		ExposedPorts: []string{"80/tcp"},
-		WaitingFor:   wait.ForListeningPort("80/tcp"),
-		Name:         reusableContainerName,
-	},
-	Started: true,
-})
-if err != nil {
-	log.Fatal(err)
+	n1, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
+		ContainerRequest: testcontainers.ContainerRequest{
+			Image:        "nginx:1.17.6",
+			ExposedPorts: []string{"80/tcp"},
+			WaitingFor:   wait.ForListeningPort("80/tcp"),
+			Name:         reusableContainerName,
+		},
+		Started: true,
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer n1.Terminate(ctx)
+
+	copiedFileName := "hello_copy.sh"
+	err = n1.CopyFileToContainer(ctx, "./testdata/hello.sh", "/"+copiedFileName, 700)
+
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	n2, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
+		ContainerRequest: testcontainers.ContainerRequest{
+			Image:        "nginx:1.17.6",
+			ExposedPorts: []string{"80/tcp"},
+			WaitingFor:   wait.ForListeningPort("80/tcp"),
+			Name:         reusableContainerName,
+		},
+		Started: true,
+		Reuse:   true,
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	c, _, err := n2.Exec(ctx, []string{"bash", copiedFileName})
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Println(c)
 }
-defer n1.Terminate(ctx)
-
-copiedFileName := "hello_copy.sh"
-err = n1.CopyFileToContainer(ctx, "./testdata/hello.sh", "/"+copiedFileName, 700)
-
-if err != nil {
-	log.Fatal(err)
-}
-
-n2, err := GenericContainer(ctx, GenericContainerRequest{
-	ContainerRequest: ContainerRequest{
-		Image:        "nginx:1.17.6",
-		ExposedPorts: []string{"80/tcp"},
-		WaitingFor:   wait.ForListeningPort("80/tcp"),
-		Name:         reusableContainerName,
-    },
-	Started: true,
-	Reuse: true,
-})
-if err != nil {
-	log.Fatal(err)
-}
-
-c, _, err := n2.Exec(ctx, []string{"bash", copiedFileName})
-if err != nil {
-	log.Fatal(err)
-}
-fmt.Println(c)
 ```
 
 ## Parallel running

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -20,6 +20,7 @@ go get github.com/testcontainers/testcontainers-go
 ```go
 import (
 	"context"
+	"testing"
 
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/wait"
@@ -37,11 +38,11 @@ func TestWithRedis(t *testing.T) {
 		Started:          true,
 	})
 	if err != nil {
-		log.Fatalf("Could not start redis: %s", err)
+		t.Fatalf("Could not start redis: %s", err)
 	}
 	defer func() {
 		if err := redisC.Terminate(ctx); err != nil {
-			log.Fatalf("Could not stop redis: %s", err)
+			t.Fatalf("Could not stop redis: %s", err)
 		}
 	}()
 }


### PR DESCRIPTION
## What does this PR do?

Fixes the compilation of the code snippet examples "Reusable Container" and "Spin Up Redis".

## Why is it important?

Users reading the documentation should be able to copy and paste the code snippets, and they should work without any modifications.