### PR TITLE
chore: test cleanups

### DIFF
--- a/file_test.go
+++ b/file_test.go
@@ -8,7 +8,6 @@ import (
 	"compress/gzip"
 	"fmt"
 	"io"
-	"log"
 	"os"
 	"path/filepath"
 	"testing"
@@ -91,7 +90,7 @@ func Test_TarDir(t *testing.T) {
 
 			srcFiles, err := os.ReadDir(src)
 			if err != nil {
-				log.Fatal(err)
+				t.Fatal(err)
 			}
 
 			for _, srcFile := range srcFiles {

--- a/modules/dolt/dolt_test.go
+++ b/modules/dolt/dolt_test.go
@@ -84,7 +84,7 @@ func TestDoltWithPublicRemoteCloneUrl(t *testing.T) {
 }
 
 func createTestCredsFile(t *testing.T) string {
-	file, err := os.CreateTemp(os.TempDir(), "prefix")
+	file, err := os.CreateTemp(t.TempDir(), "prefix")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -100,7 +100,6 @@ func TestDoltWithPrivateRemoteCloneUrl(t *testing.T) {
 	ctx := context.Background()
 
 	filename := createTestCredsFile(t)
-	defer os.RemoveAll(filename)
 	_, err := dolt.Run(ctx,
 		"dolthub/dolt-sql-server:1.32.4",
 		dolt.WithDatabase("foo"),

--- a/modules/openldap/openldap_test.go
+++ b/modules/openldap/openldap_test.go
@@ -177,11 +177,10 @@ mail: test.user@example.org
 userPassword: Password1
 `
 
-	f, err := os.CreateTemp("", "test.ldif")
+	f, err := os.CreateTemp(t.TempDir(), "test.ldif")
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer os.Remove(f.Name())
 
 	_, err = f.WriteString(ldif)
 	if err != nil {


### PR DESCRIPTION
## What does this PR do?

Refactor tests by using `t.TempDir` instead of `os.TempDir`, `t.Fatal` instead of `log.Fatal`.

## Why is it important?

This simplifies and unifies tests without harming readability.