### PR TITLE
fix: incorrect parsing of exposedPorts in readiness check

### DIFF
--- a/lifecycle.go
+++ b/lifecycle.go
@@ -201,23 +201,25 @@ var defaultLogConsumersHook = func(cfg *LogConsumerConfig) ContainerLifecycleHoo
 func checkPortsMapped(exposedAndMappedPorts nat.PortMap, exposedPorts []string) error {
 	portMap, _, err := nat.ParsePortSpecs(exposedPorts)
 	if err != nil {
-		return fmt.Errorf("could not check mapped ports: %w", err)
+		return fmt.Errorf("parse exposed ports: %w", err)
 	}
 
 	for exposedPort := range portMap {
 		// having entries in exposedAndMappedPorts, where the key is the exposed port,
 		// and the value is the mapped port, means that the port has been already mapped.
-		if _, ok := exposedAndMappedPorts[exposedPort]; !ok {
-			// check if the port is mapped with the protocol (default is TCP)
-			if strings.Contains(string(exposedPort), "/") {
-				return fmt.Errorf("port %s is not mapped yet", exposedPort)
-			}
+		if _, ok := exposedAndMappedPorts[exposedPort]; ok {
+			continue
+		}
 
-			// Port didn't have a type, default to tcp and retry.
-			exposedPort = nat.Port(fmt.Sprintf("%s/tcp", string(exposedPort)))
-			if _, ok := exposedAndMappedPorts[exposedPort]; !ok {
-				return fmt.Errorf("port %s is not mapped yet", exposedPort)
-			}
+		// check if the port is mapped with the protocol (default is TCP)
+		if strings.Contains(string(exposedPort), "/") {
+			return fmt.Errorf("port %s is not mapped yet", exposedPort)
+		}
+
+		// Port didn't have a type, default to tcp and retry.
+		exposedPort += "/tcp"
+		if _, ok := exposedAndMappedPorts[exposedPort]; !ok {
+			return fmt.Errorf("port %s is not mapped yet", exposedPort)
 		}
 	}
 

--- a/lifecycle_test.go
+++ b/lifecycle_test.go
@@ -491,6 +491,10 @@ func TestPortMappingCheck(t *testing.T) {
 			exposedAndMappedPorts: makePortMap("1024/tcp", "1025/tcp", "1026/tcp"),
 			exposedPorts:          []string{"1024", "25:1025/tcp", "1026:1026"},
 		},
+		"only-ipv4": {
+			exposedAndMappedPorts: makePortMap("1024/tcp"),
+			exposedPorts:          []string{"0.0.0.0::1024/tcp"},
+		},
 		"no-mapped-ports": {
 			exposedAndMappedPorts: makePortMap(),
 			exposedPorts:          []string{"1024"},

--- a/lifecycle_test.go
+++ b/lifecycle_test.go
@@ -456,6 +456,83 @@ func TestMergePortBindings(t *testing.T) {
 	}
 }
 
+func TestPortMappingCheck(t *testing.T) {
+	makePortMap := func(ports []string) nat.PortMap {
+		out := make(nat.PortMap)
+		for _, port := range ports {
+			// We don't care about the actual binding in this test
+			out[nat.Port(port)] = make([]nat.PortBinding, 0)
+		}
+		return out
+	}
+
+	tests := []struct {
+		name                  string
+		exposedAndMappedPorts nat.PortMap
+		exposedPorts          []string
+		expectError           bool
+	}{
+		{
+			name:                  "No protocol given",
+			exposedAndMappedPorts: makePortMap([]string{"1024/tcp"}),
+			exposedPorts:          []string{"1024"},
+			expectError:           false,
+		},
+		{
+			name:                  "Protocol given",
+			exposedAndMappedPorts: makePortMap([]string{"1024/tcp"}),
+			exposedPorts:          []string{"1024/tcp"},
+			expectError:           false,
+		},
+		{
+			name:                  "Protocol and target port given",
+			exposedAndMappedPorts: makePortMap([]string{"1024/tcp"}),
+			exposedPorts:          []string{"1024:1024/tcp"},
+			expectError:           false,
+		},
+		{
+			name:                  "Only target port given, no protocol",
+			exposedAndMappedPorts: makePortMap([]string{"1024/tcp"}),
+			exposedPorts:          []string{"1024:1024"},
+			expectError:           false,
+		},
+		{
+			name:                  "Multiple ports with different variations",
+			exposedAndMappedPorts: makePortMap([]string{"1024/tcp", "1025/tcp", "1026/tcp"}),
+			exposedPorts:          []string{"1024", "25:1025/tcp", "1026:1026"},
+			expectError:           false,
+		},
+		{
+			name:                  "No ports mapped yet",
+			exposedAndMappedPorts: makePortMap([]string{}),
+			exposedPorts:          []string{"1024"},
+			expectError:           true,
+		},
+		{
+			name:                  "The wrong port has been mapped",
+			exposedAndMappedPorts: makePortMap([]string{"1023/tcp"}),
+			exposedPorts:          []string{"1024"},
+			expectError:           true,
+		},
+		{
+			name:                  "A subset of ports have been mapped",
+			exposedAndMappedPorts: makePortMap([]string{"1024/tcp", "1025/tcp"}),
+			exposedPorts:          []string{"1024", "1025", "1026"},
+			expectError:           true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := checkPortsMapped(tt.exposedAndMappedPorts, tt.exposedPorts)
+			if tt.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
 func TestLifecycleHooks(t *testing.T) {
 	tests := []struct {
 		name  string


### PR DESCRIPTION
## What does this PR do?

If an explicit port mapping is given in the definition of a container (through `exposedPorts`), the default readiness check fails. See the related issue below for an example. This PR fixes the issue by using the `nat.ParsePortSpecs` function instead of the `nat.Port` function when parsing the `exposedPorts`.

## Why is it important?

Anyone who upgrades to v0.32.0 and has a port defined as for example `4443:4443/tcp` will run into the below issue.

## Related issues


- Closes https://github.com/testcontainers/testcontainers-go/issues/2652

## How to test this PR
I still need to add a unit test for this, any advice on how to approach this?
