### PR TITLE
fix: remove configuration reading from logger initialization

### DIFF
--- a/config.go
+++ b/config.go
@@ -18,6 +18,17 @@ type TestcontainersConfig struct {
 // of the TestcontainersConfig struct
 func ReadConfig() TestcontainersConfig {
 	cfg := config.Read()
+
+	if cfg.RyukDisabled {
+		ryukDisabledMessage := `
+**********************************************************************************************
+Ryuk has been disabled for the current execution. This can cause unexpected behavior in your environment.
+More on this: https://golang.testcontainers.org/features/garbage_collector/
+**********************************************************************************************`
+
+		Logger.Printf(ryukDisabledMessage)
+	}
+
 	return TestcontainersConfig{
 		Host:           cfg.Host,
 		TLSVerify:      cfg.TLSVerify,

--- a/logger.go
+++ b/logger.go
@@ -8,8 +8,6 @@ import (
 	"testing"
 
 	"github.com/docker/docker/client"
-
-	"github.com/testcontainers/testcontainers-go/internal/config"
 )
 
 // Logger is the default log instance
@@ -26,15 +24,6 @@ func init() {
 
 	if !verbose {
 		Logger = &noopLogger{}
-	}
-
-	if config.Read().RyukDisabled {
-		ryukDisabledMessage := `
-**********************************************************************************************
-Ryuk has been disabled for the current execution. This can cause unexpected behavior in your environment.
-More on this: https://golang.testcontainers.org/features/garbage_collector/
-**********************************************************************************************`
-		Logger.Printf(ryukDisabledMessage)
 	}
 }
 


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

- fix: remove configuration reading from logger initialization

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

It removes the reading for the environment variables from the logger initialization, and prints the message in a more appropriate location.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

Due to the addition of a new init function for the logger initialization and Ryuk disable message, the environment variables were reading as an init function side effect. This caused variables set on the code using the package does not read property.

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
