### PR TITLE
Increase Wasm memory limits in Redpanda Module

### DIFF
--- a/modules/redpanda/mounts/bootstrap.yaml.tpl
+++ b/modules/redpanda/mounts/bootstrap.yaml.tpl
@@ -17,6 +17,8 @@ kafka_enable_authorization: true
 
 {{- if .EnableWasmTransform }}
 data_transforms_enabled: true
+data_transforms_per_function_memory_limit: 16777216
+data_transforms_per_core_memory_reservation: 33554432
 {{- end }}
 
 {{- if .AutoCreateTopics }}


### PR DESCRIPTION


<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?

Increases the per-core memory reservation and per-function memory limits for Wasm transforms in the Redpanda Module from their respective defaults to something a bit more generous.

Updated:
  - per function memory limit: 2MiB (default) -> 16MiB
  - per core memory reservation: 20MiB (default) -> 32MiB

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?

This is particularly useful in a testing context, as transforms which exceed the per-function limit will simply not run.

Note that these configuration points require a node restart, so making the adjustment via the Admin API is less practical here.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- 

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
