### PR TITLE
feat(redpanda): Add option for arbitrary bootstrap config

### DIFF
--- a/modules/redpanda/examples_test.go
+++ b/modules/redpanda/examples_test.go
@@ -17,6 +17,8 @@ func ExampleRun() {
 		redpanda.WithEnableSASL(),
 		redpanda.WithEnableKafkaAuthorization(),
 		redpanda.WithEnableWasmTransform(),
+		redpanda.WithBootstrapConfig("data_transforms_per_core_memory_reservation", 33554432),
+		redpanda.WithBootstrapConfig("data_transforms_per_function_memory_limit", 16777216),
 		redpanda.WithNewServiceAccount("superuser-1", "test"),
 		redpanda.WithNewServiceAccount("superuser-2", "test"),
 		redpanda.WithNewServiceAccount("no-superuser", "test"),

--- a/modules/redpanda/mounts/bootstrap.yaml.tpl
+++ b/modules/redpanda/mounts/bootstrap.yaml.tpl
@@ -22,3 +22,8 @@ data_transforms_enabled: true
 {{- if .AutoCreateTopics }}
 auto_create_topics_enabled: true
 {{- end }}
+
+{{- range $key, $value := .ExtraBootstrapConfig }}
+{{ $key }}: {{ $value }}
+{{- end }}
+

--- a/modules/redpanda/options.go
+++ b/modules/redpanda/options.go
@@ -43,6 +43,10 @@ type options struct {
 	// Listeners is a list of custom listeners that can be provided to access the
 	// containers form within docker networks
 	Listeners []listener
+
+	// ExtraBootstrapConfig is a map of configs to be interpolated into the
+	// container's bootstrap.yml
+	ExtraBootstrapConfig map[string]any
 }
 
 func defaultOptions() options {
@@ -55,6 +59,7 @@ func defaultOptions() options {
 		AutoCreateTopics:                   false,
 		EnableTLS:                          false,
 		Listeners:                          make([]listener, 0),
+		ExtraBootstrapConfig:               make(map[string]any, 0),
 	}
 }
 
@@ -153,5 +158,15 @@ func WithListener(lis string) Option {
 			Port:                 portInt,
 			AuthenticationMethod: o.KafkaAuthenticationMethod,
 		})
+	}
+}
+
+// WithBootstrapConfig adds an arbitrary config kvp to the Redpanda container.
+// Per the name, this config will be interpolated into the generated bootstrap
+// config file, which is particularly useful for configs requiring a restart
+// when otherwise applied to a running Redpanda instance.
+func WithBootstrapConfig(cfg string, val any) Option {
+	return func(o *options) {
+		o.ExtraBootstrapConfig[cfg] = val
 	}
 }

--- a/modules/redpanda/redpanda.go
+++ b/modules/redpanda/redpanda.go
@@ -281,6 +281,7 @@ func renderBootstrapConfig(settings options) ([]byte, error) {
 		KafkaAPIEnableAuthorization: settings.KafkaEnableAuthorization,
 		AutoCreateTopics:            settings.AutoCreateTopics,
 		EnableWasmTransform:         settings.EnableWasmTransform,
+		ExtraBootstrapConfig:        settings.ExtraBootstrapConfig,
 	}
 
 	tpl, err := template.New("bootstrap.yaml").Parse(bootstrapConfigTpl)
@@ -355,6 +356,7 @@ type redpandaBootstrapConfigTplParams struct {
 	KafkaAPIEnableAuthorization bool
 	AutoCreateTopics            bool
 	EnableWasmTransform         bool
+	ExtraBootstrapConfig        map[string]any
 }
 
 type redpandaConfigTplParams struct {


### PR DESCRIPTION


<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?

WithBootstrapConfig adds an arbitrary config kvp to the Redpanda container. Per the name, this config will be interpolated into the generated bootstrap config file, which is particularly useful for configs requiring a restart when otherwise applied to a running Redpanda instance.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?

Several Redpanda cluster config properties can be updated live but require a node restart to take effect. The simplest way to expose these to testcontainer consumers is to provide generic access prior to container startup.

An example usage case is an integration test for a particularly memory hungry Wasm Data Transform, where tuning the per core and per function memory limits in a flexible, implementation driven way may be the difference between testing or not testing that function.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- 

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
