### PR TITLE
fix(compose): fix compose destroys right after Up

### DIFF
--- a/modules/compose/compose_api_test.go
+++ b/modules/compose/compose_api_test.go
@@ -717,7 +717,7 @@ func TestDockerComposeUp(t *testing.T) {
 
 	config.Reset() // reset the config using the internal method to avoid the sync.Once
 	tcConfig := config.Read()
-	time.Sleep(tcConfig.RyukConnectionTimeout + 10*time.Second) // wait for the timeout of ryuk + 10 seconds to make sure that ryuk doesn't destory the compose project
+	time.Sleep(tcConfig.RyukConnectionTimeout + 10*time.Second) // wait for the timeout of ryuk + 10 seconds to make sure that ryuk doesn't destroy the compose project
 
 	nginxContainer, err := compose.ServiceContainer(context.Background(), "api-nginx")
 	require.NoError(t, err, "ServiceContainer")


### PR DESCRIPTION
## What does this PR do?

The `NewDockerCompose.Up` sends `termSignal` as soon as the function finishes, this causes the compose project to be destroyed and future usages of it is impossible, this PR only sends `termSignal` when there is any error when invoking `Up` method, otherwise do not send terminal signal.

## Why is it important?

Without this patch, the docker compose API is useless, without this patch it just starts the docker compose project and then immediately destroys it, no container can be used after calling `Up` function.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- 

## How to test this PR

It can be easily reproduced by reverting the fix in the `compose_api.go` and run the `compose_api_test.go`, an error will be thrown:

```
 Container 415c1584-bbc5-4984-95ee-51aac9e7e8a4-api-nginx-1  Healthy
    compose_api_test.go:724: 
                Error Trace:    /Users/kezhenxu94/workspace/testcontainers-go/modules/compose/compose_api_test.go:724
                Error:          Received unexpected error:
                                Error response from daemon: No such container: 03b490452d68941c348d83cb4a8f2f26ad3068c3f45c46f77436cf2430006bd1
                Test:           TestDockerComposeUp
                Messages:       Ports
```

while the container must exist as it is what we aim to start up