### PR TITLE
chore: print Docker Info labels in banner

### DIFF
--- a/docker_client.go
+++ b/docker_client.go
@@ -57,17 +57,27 @@ func (c *DockerClient) Info(ctx context.Context) (system.Info, error) {
   Server Version: %v
   API Version: %v
   Operating System: %v
-  Total Memory: %v MB
+  Total Memory: %v MB%s
   Testcontainers for Go Version: v%s
   Resolved Docker Host: %s
   Resolved Docker Socket Path: %s
   Test SessionID: %s
   Test ProcessID: %s
 `
+	infoLabels := ""
+	if len(dockerInfo.Labels) > 0 {
+		infoLabels = `
+  Labels:`
+		for _, lb := range dockerInfo.Labels {
+			infoLabels += "\n    " + lb
+		}
+	}
 
 	Logger.Printf(infoMessage, packagePath,
-		dockerInfo.ServerVersion, c.Client.ClientVersion(),
+		dockerInfo.ServerVersion,
+		c.Client.ClientVersion(),
 		dockerInfo.OperatingSystem, dockerInfo.MemTotal/1024/1024,
+		infoLabels,
 		internal.Version,
 		core.ExtractDockerHost(ctx),
 		core.ExtractDockerSocket(ctx),


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
It captures the Docker labels returned by the calls to `docker info`, and adds them to the initial banner:

Sample output:
```
2024/08/05 13:16:51 github.com/testcontainers/testcontainers-go - Connected to docker: 
  Server Version: 26.1.4 (via Testcontainers Desktop 1.15.1)
  API Version: 1.45
  Operating System: Docker Desktop
  Total Memory: 7841 MB
  Labels:
    com.docker.desktop.address=unix:///Users/mdelapenya/Library/Containers/com.docker.docker/Data/docker-cli.sock
  Testcontainers for Go Version: v0.33.0
  Resolved Docker Host: tcp://127.0.0.1:50211
  Resolved Docker Socket Path: /var/run/docker.sock
  Test SessionID: f15d9d974dddf9f2151699b9b87ae005de5b0d208c9911f666e1b821b106c735
  Test ProcessID: 3a9b55d9-47e5-42f7-9940-db2843dfe504
```

If there are no labels, no entry will be added to the banner.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
Display more info about the server

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->


<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


## Follow-ups
Do we want to present an empty list of labels, or simply skip that entry of there are no labels?