### PR TITLE
test: add retry on system error test

### DIFF
--- a/testdata/retry/Dockerfile
+++ b/testdata/retry/Dockerfile
@@ -1,0 +1,1 @@
+FROM scratch


### PR DESCRIPTION
Add a test to cover the retry on system error test.

Update test to use empty context to prevent knock on failures being logged confusing the output and check the error returned.