### PR TITLE
fix(redis): port race

### DIFF
--- a/modules/redis/redis.go
+++ b/modules/redis/redis.go
@@ -54,7 +54,7 @@ func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustom
 	req := testcontainers.ContainerRequest{
 		Image:        img,
 		ExposedPorts: []string{"6379/tcp"},
-		WaitingFor:   wait.ForLog("* Ready to accept connections"),
+		WaitingFor:   wait.ForListeningPort("6379/tcp"),
 	}
 
 	genericContainerReq := testcontainers.GenericContainerRequest{


### PR DESCRIPTION
Fix race condition on port availability by switching to port instead of log check.