### PR TITLE
test(mongodb): fix replica test failures

### DIFF
--- a/modules/mongodb/mongodb.go
+++ b/modules/mongodb/mongodb.go
@@ -92,7 +92,7 @@ func WithReplicaSet(replSetName string) testcontainers.CustomizeRequestOption {
 				func(ctx context.Context, c testcontainers.Container) error {
 					ip, err := c.ContainerIP(ctx)
 					if err != nil {
-						return err
+						return fmt.Errorf("container ip: %w", err)
 					}
 
 					cmd := eval("rs.initiate({ _id: '%s', members: [ { _id: 0, host: '%s:27017' } ] })", replSetName, ip)

--- a/modules/mongodb/mongodb_test.go
+++ b/modules/mongodb/mongodb_test.go
@@ -2,7 +2,6 @@ package mongodb_test
 
 import (
 	"context"
-	"log"
 	"testing"
 
 	"go.mongodb.org/mongo-driver/mongo"
@@ -73,14 +72,17 @@ func TestMongoDB(t *testing.T) {
 				tt.Fatalf("failed to get connection string: %s", err)
 			}
 
-			mongoClient, err := mongo.Connect(ctx, options.Client().ApplyURI(endpoint))
+			// Force direct connection to the container to avoid the replica set
+			// connection string that is returned by the container itself when
+			// using the replica set option.
+			mongoClient, err := mongo.Connect(ctx, options.Client().ApplyURI(endpoint+"/?connect=direct"))
 			if err != nil {
 				tt.Fatalf("failed to connect to MongoDB: %s", err)
 			}
 
 			err = mongoClient.Ping(ctx, nil)
 			if err != nil {
-				log.Fatalf("failed to ping MongoDB: %s", err)
+				tt.Fatalf("failed to ping MongoDB: %s", err)
 			}
 
 			if mongoClient.Database("test").Name() != "test" {


### PR DESCRIPTION
Fix mongodb replica test failures due to client using the internal container addresses when direct connection is not requested.

Fix invalid use of log.Fatal instead of tt.Fatal which was causing failures to not be output correctly due to os.Exit.