### PR TITLE
feat: Add optional container user namespace for Ryku

### DIFF
--- a/docs/features/configuration.md
+++ b/docs/features/configuration.md
@@ -53,6 +53,7 @@ but does not allow starting privileged containers, you can turn off the Ryuk con
 1. You can specify the connection timeout for Ryuk by setting the `TESTCONTAINERS_RYUK_CONNECTION_TIMEOUT` **environment variable**, or the `ryuk.connection.timeout` **property**. The default value is 1 minute.
 1. You can specify the reconnection timeout for Ryuk by setting the `TESTCONTAINERS_RYUK_RECONNECTION_TIMEOUT` **environment variable**, or the `ryuk.reconnection.timeout` **property**. The default value is 10 seconds.
 1. You can configure Ryuk to run in verbose mode by setting any of the `ryuk.verbose` **property** or the `TESTCONTAINERS_RYUK_VERBOSE` **environment variable**. The default value is `false`.
+1. You can configure which container user namespace to use for the Ryuk container by setting the `TESTCONTAINERS_RYUK_CONTAINER_USER_NAMESPACE` **environment variable**, or the `ryuk.container.user.namespace` **property**.
 
 !!!info
     For more information about Ryuk, see [Garbage Collector](garbage_collector.md).

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -28,6 +28,7 @@ type Config struct {
 	HubImageNamePrefix      string        `properties:"hub.image.name.prefix,default="`
 	RyukDisabled            bool          `properties:"ryuk.disabled,default=false"`
 	RyukPrivileged          bool          `properties:"ryuk.container.privileged,default=false"`
+	RyukUserNamespace       string        `properties:"ryuk.container.user.namespace,default="`
 	RyukReconnectionTimeout time.Duration `properties:"ryuk.reconnection.timeout,default=10s"`
 	RyukConnectionTimeout   time.Duration `properties:"ryuk.connection.timeout,default=1m"`
 	RyukVerbose             bool          `properties:"ryuk.verbose,default=false"`
@@ -71,6 +72,11 @@ func read() Config {
 		ryukPrivilegedEnv := os.Getenv("TESTCONTAINERS_RYUK_CONTAINER_PRIVILEGED")
 		if parseBool(ryukPrivilegedEnv) {
 			config.RyukPrivileged = ryukPrivilegedEnv == "true"
+		}
+
+		ryukUserNamespaceEnv := os.Getenv("TESTCONTAINERS_RYUK_CONTAINER_USER_NAMESPACE")
+		if ryukUserNamespaceEnv != "" {
+			config.RyukUserNamespace = ryukUserNamespaceEnv
 		}
 
 		ryukVerboseEnv := os.Getenv("TESTCONTAINERS_RYUK_VERBOSE")

--- a/reaper.go
+++ b/reaper.go
@@ -252,6 +252,7 @@ func newReaper(ctx context.Context, sessionID string, provider ReaperProvider) (
 		WaitingFor:   wait.ForListeningPort(listeningPort),
 		Name:         reaperContainerNameFromSessionID(sessionID),
 		HostConfigModifier: func(hc *container.HostConfig) {
+			hc.UsernsMode = container.UsernsMode(tcConfig.RyukUserNamespace)
 			hc.AutoRemove = true
 			hc.Binds = []string{dockerHostMount + ":/var/run/docker.sock"}
 			hc.NetworkMode = Bridge


### PR DESCRIPTION
## What does this PR do?

Users can configure which container user namespace to use for the Ryuk container by setting the `TESTCONTAINERS_RYUK_CONTAINER_USER_NAMESPACE` **environment variable**, or the `ryuk.container.user.namespace` **property**.

## Why is it important?

required for the following error.
```
docker: Error response from daemon: privileged mode is incompatible to user namespaces. You must run the container in the host namespace when running privileged mode'
```

## Related issues

Closes #2684

