### PR TITLE
docs: add consistent snippets for network creation

### DIFF
--- a/docs/features/creating_networks.md
+++ b/docs/features/creating_networks.md
@@ -25,6 +25,6 @@ It's important to mention that the name of the network is automatically generate
 ## Usage example
 
 <!--codeinclude-->
-[Creating a network](../../network/network_test.go) inside_block:createNetwork
-[Creating a network with options](../../network/network_test.go) inside_block:newNetworkWithOptions
+[Creating a network](../../network/examples_test.go) inside_block:createNetwork
+[Creating a network with options](../../network/examples_test.go) inside_block:newNetworkWithOptions
 <!--/codeinclude--> 

--- a/network/examples_test.go
+++ b/network/examples_test.go
@@ -1,0 +1,75 @@
+package network_test
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	dockernetwork "github.com/docker/docker/api/types/network"
+	"github.com/testcontainers/testcontainers-go/network"
+)
+
+func ExampleNew() {
+	// createNetwork {
+	ctx := context.Background()
+
+	net, err := network.New(ctx)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	defer func() {
+		if err := net.Remove(ctx); err != nil {
+			log.Fatalf("failed to remove network: %s", err)
+		}
+	}()
+	// }
+
+	fmt.Println(net.ID != "")
+	fmt.Println(net.Driver)
+
+	// Output:
+	// true
+	// bridge
+}
+
+func ExampleNew_withOptions() {
+	// newNetworkWithOptions {
+	ctx := context.Background()
+
+	// dockernetwork is the alias used for github.com/docker/docker/api/types/network
+	ipamConfig := dockernetwork.IPAM{
+		Driver: "default",
+		Config: []dockernetwork.IPAMConfig{
+			{
+				Subnet:  "10.1.1.0/24",
+				Gateway: "10.1.1.254",
+			},
+		},
+		Options: map[string]string{
+			"driver": "host-local",
+		},
+	}
+	net, err := network.New(ctx,
+		network.WithIPAM(&ipamConfig),
+		network.WithAttachable(),
+		network.WithDriver("bridge"),
+	)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	defer func() {
+		if err := net.Remove(ctx); err != nil {
+			log.Fatalf("failed to remove network: %s", err)
+		}
+	}()
+	// }
+
+	fmt.Println(net.ID != "")
+	fmt.Println(net.Driver)
+
+	// Output:
+	// true
+	// bridge
+}

--- a/network/examples_test.go
+++ b/network/examples_test.go
@@ -6,6 +6,7 @@ import (
 	"log"
 
 	dockernetwork "github.com/docker/docker/api/types/network"
+
 	"github.com/testcontainers/testcontainers-go/network"
 )
 

--- a/network/network_test.go
+++ b/network/network_test.go
@@ -66,7 +66,7 @@ func TestNew(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	assert.Equal(t, 1, len(resources))
+	assert.Len(t, resources, 1)
 
 	newNetwork := resources[0]
 

--- a/network/network_test.go
+++ b/network/network_test.go
@@ -2,8 +2,6 @@ package network_test
 
 import (
 	"context"
-	"fmt"
-	"log"
 	"testing"
 	"time"
 
@@ -23,9 +21,7 @@ const (
 	nginxDefaultPort = "80/tcp"
 )
 
-// Create a network.
-func ExampleNew() {
-	// createNetwork {
+func TestNew(t *testing.T) {
 	ctx := context.Background()
 
 	net, err := network.New(ctx,
@@ -35,18 +31,14 @@ func ExampleNew() {
 		network.WithInternal(),
 		network.WithLabels(map[string]string{"this-is-a-test": "value"}),
 	)
-	if err != nil {
-		fmt.Println(err)
-		return
-	}
+	require.NoError(t, err)
 	defer func() {
 		if err := net.Remove(ctx); err != nil {
-			log.Fatalf("failed to remove network: %s", err)
+			t.Fatalf("failed to remove network: %s", err)
 		}
 	}()
 
 	networkName := net.Name
-	// }
 
 	nginxC, _ := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
 		ContainerRequest: testcontainers.ContainerRequest{
@@ -62,49 +54,30 @@ func ExampleNew() {
 	})
 	defer func() {
 		if err := nginxC.Terminate(ctx); err != nil {
-			log.Fatalf("failed to terminate container: %s", err)
+			t.Fatalf("failed to terminate container: %s", err)
 		}
 	}()
 
 	client, err := testcontainers.NewDockerClientWithOpts(context.Background())
-	if err != nil {
-		fmt.Println(err)
-		return
-	}
+	require.NoError(t, err)
 
 	resources, err := client.NetworkList(context.Background(), dockernetwork.ListOptions{
 		Filters: filters.NewArgs(filters.Arg("name", networkName)),
 	})
-	if err != nil {
-		fmt.Println(err)
-		return
-	}
+	require.NoError(t, err)
 
-	fmt.Println(len(resources))
+	assert.Equal(t, 1, len(resources))
 
 	newNetwork := resources[0]
 
 	expectedLabels := testcontainers.GenericLabels()
 	expectedLabels["this-is-a-test"] = "true"
 
-	fmt.Println(newNetwork.Attachable)
-	fmt.Println(newNetwork.Internal)
-	fmt.Println(newNetwork.Labels["this-is-a-test"])
+	assert.True(t, newNetwork.Attachable)
+	assert.True(t, newNetwork.Internal)
+	assert.Equal(t, "value", newNetwork.Labels["this-is-a-test"])
 
-	state, err := nginxC.State(ctx)
-	if err != nil {
-		fmt.Println(err)
-		return
-	}
-
-	fmt.Println(state.Running)
-
-	// Output:
-	// 1
-	// true
-	// true
-	// value
-	// true
+	require.NoError(t, err)
 }
 
 // testNetworkAliases {


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
It separates the tests from the testable examples for the network creation, updating the docs to the new examples.

The new testable examples contain clearer code snippets for creating networks with and without options.

Render URL: https://deploy-preview-2703--testcontainers-go.netlify.app/features/creating_networks/#__tabbed_1_1

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
Try to avoid confusing users reading our docs, as the default snippet used the internal option for creating networks, and this could cause issues when accessing the ports of containers in that internal network.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->


<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


## Follow-ups
Considering deprecating the functional option to make a network internal (which great power...)
