### PR TITLE
chore: remove obsolete compose version

### DIFF
--- a/modules/compose/compose_api_test.go
+++ b/modules/compose/compose_api_test.go
@@ -435,7 +435,7 @@ func TestDockerComposeAPIComplex(t *testing.T) {
 func TestDockerComposeAPIWithStackReader(t *testing.T) {
 	identifier := testNameHash(t.Name())
 
-	composeContent := `version: '3.7'
+	composeContent := `
 services:
   api-nginx:
     image: docker.io/nginx:stable-alpine
@@ -475,7 +475,7 @@ services:
 func TestDockerComposeAPIWithStackReaderAndComposeFile(t *testing.T) {
 	identifier := testNameHash(t.Name())
 	simple, _ := RenderComposeSimple(t)
-	composeContent := `version: '3.7'
+	composeContent := `
 services:
   api-postgres:
     image: docker.io/postgres:14

--- a/modules/compose/testdata/docker-compose-build.yml
+++ b/modules/compose/testdata/docker-compose-build.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   {{ .ServiceType }}-echo:
     build:

--- a/modules/compose/testdata/docker-compose-complex.yml
+++ b/modules/compose/testdata/docker-compose-complex.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   {{ .ServiceType }}-nginx:
     image: docker.io/nginx:stable-alpine

--- a/modules/compose/testdata/docker-compose-container-name.yml
+++ b/modules/compose/testdata/docker-compose-container-name.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   {{ .ServiceType }}-nginx:
     container_name: {{ .ServiceType }}-nginxy

--- a/modules/compose/testdata/docker-compose-no-exposed-ports.yml
+++ b/modules/compose/testdata/docker-compose-no-exposed-ports.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   {{ .ServiceType }}-nginx:
     image: docker.io/nginx:stable-alpine

--- a/modules/compose/testdata/docker-compose-override.yml
+++ b/modules/compose/testdata/docker-compose-override.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   {{ .ServiceType }}-nginx:
     image: docker.io/nginx:stable-alpine

--- a/modules/compose/testdata/docker-compose-postgres.yml
+++ b/modules/compose/testdata/docker-compose-postgres.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   {{ .ServiceType }}-postgres:
     image: docker.io/postgres:14

--- a/modules/compose/testdata/docker-compose-short-lifespan.yml
+++ b/modules/compose/testdata/docker-compose-short-lifespan.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   tzatziki:
     image: docker.io/alpine:latest

--- a/modules/compose/testdata/docker-compose-simple.yml
+++ b/modules/compose/testdata/docker-compose-simple.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   {{ .ServiceType }}-nginx:
     image: docker.io/nginx:stable-alpine

--- a/modules/compose/testdata/docker-compose-volume.yml
+++ b/modules/compose/testdata/docker-compose-volume.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   {{ .ServiceType }}-nginx:
     image: docker.io/nginx:stable-alpine


### PR DESCRIPTION
Remove the obsolete version field from all docker compose files to stop it warning.