### PR TITLE
fix: filter context errors from log production

### DIFF
--- a/docker.go
+++ b/docker.go
@@ -814,7 +814,16 @@ func (c *DockerContainer) stopLogProduction() error {
 
 	c.logProductionWaitGroup.Wait()
 
-	return <-c.logProductionError
+	if err := <-c.logProductionError; err != nil {
+		if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
+			// Returning context errors is not useful for the consumer.
+			return nil
+		}
+
+		return err
+	}
+
+	return nil
 }
 
 // GetLogProductionErrorChannel exposes the only way for the consumer


### PR DESCRIPTION
Don't return context errors from log production as it's confusing to callers which cancel, making it harder to understand any actual errors that occurred.