### PR TITLE
chore(wait): log test timeout

### DIFF
--- a/wait/log_test.go
+++ b/wait/log_test.go
@@ -8,7 +8,10 @@ import (
 	"time"
 
 	"github.com/docker/docker/api/types"
+	"github.com/stretchr/testify/require"
 )
+
+const logTimeout = time.Second
 
 const loremIpsum = `Lorem ipsum dolor sit amet,
 consectetur adipiscing elit.
@@ -28,9 +31,7 @@ func TestWaitForLog(t *testing.T) {
 		}
 		wg := NewLogStrategy("docker").WithStartupTimeout(100 * time.Microsecond)
 		err := wg.WaitUntilReady(context.Background(), target)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 	})
 
 	t.Run("no regexp", func(t *testing.T) {
@@ -41,9 +42,7 @@ func TestWaitForLog(t *testing.T) {
 		// get all words that start with "ip", end with "m" and has a whitespace before the "ip"
 		wg := NewLogStrategy(`\sip[\w]+m`).WithStartupTimeout(100 * time.Microsecond).AsRegexp()
 		err := wg.WaitUntilReady(context.Background(), target)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 	})
 }
 
@@ -56,9 +55,7 @@ func TestWaitWithExactNumberOfOccurrences(t *testing.T) {
 			WithStartupTimeout(100 * time.Microsecond).
 			WithOccurrence(2)
 		err := wg.WaitUntilReady(context.Background(), target)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 	})
 
 	t.Run("as regexp", func(t *testing.T) {
@@ -71,9 +68,7 @@ func TestWaitWithExactNumberOfOccurrences(t *testing.T) {
 		// one "ipsum mauris" and two "ipsum dolor sit am"
 		wg := NewLogStrategy(`ip(.*)m`).WithStartupTimeout(100 * time.Microsecond).AsRegexp().WithOccurrence(3)
 		err := wg.WaitUntilReady(context.Background(), target)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 	})
 }
 
@@ -83,12 +78,10 @@ func TestWaitWithExactNumberOfOccurrencesButItWillNeverHappen(t *testing.T) {
 			ReaderCloser: io.NopCloser(bytes.NewReader([]byte("kubernetes\r\ndocker"))),
 		}
 		wg := NewLogStrategy("containerd").
-			WithStartupTimeout(100 * time.Microsecond).
+			WithStartupTimeout(logTimeout).
 			WithOccurrence(2)
 		err := wg.WaitUntilReady(context.Background(), target)
-		if err == nil {
-			t.Fatal("expected error")
-		}
+		require.Error(t, err)
 	})
 
 	t.Run("as regexp", func(t *testing.T) {
@@ -100,9 +93,7 @@ func TestWaitWithExactNumberOfOccurrencesButItWillNeverHappen(t *testing.T) {
 		// there are only three occurrences matching
 		wg := NewLogStrategy(`do(.*)ck.+`).WithStartupTimeout(100 * time.Microsecond).AsRegexp().WithOccurrence(4)
 		err := wg.WaitUntilReady(context.Background(), target)
-		if err == nil {
-			t.Fatal("expected error")
-		}
+		require.Error(t, err)
 	})
 }
 
@@ -112,12 +103,10 @@ func TestWaitShouldFailWithExactNumberOfOccurrences(t *testing.T) {
 			ReaderCloser: io.NopCloser(bytes.NewReader([]byte("kubernetes\r\ndocker"))),
 		}
 		wg := NewLogStrategy("docker").
-			WithStartupTimeout(100 * time.Microsecond).
+			WithStartupTimeout(logTimeout).
 			WithOccurrence(2)
 		err := wg.WaitUntilReady(context.Background(), target)
-		if err == nil {
-			t.Fatal("expected error")
-		}
+		require.Error(t, err)
 	})
 
 	t.Run("as regexp", func(t *testing.T) {
@@ -129,9 +118,7 @@ func TestWaitShouldFailWithExactNumberOfOccurrences(t *testing.T) {
 		// there are only one occurrence matching
 		wg := NewLogStrategy(`^Mae[\w]?enas\s`).WithStartupTimeout(100 * time.Microsecond).AsRegexp().WithOccurrence(2)
 		err := wg.WaitUntilReady(context.Background(), target)
-		if err == nil {
-			t.Fatal("expected error")
-		}
+		require.Error(t, err)
 	})
 }
 
@@ -148,37 +135,19 @@ func TestWaitForLogFailsDueToOOMKilledContainer(t *testing.T) {
 	}
 
 	t.Run("no regexp", func(t *testing.T) {
-		wg := ForLog("docker").
-			WithStartupTimeout(100 * time.Microsecond)
+		wg := ForLog("docker").WithStartupTimeout(logTimeout)
 
-		{
-			err := wg.WaitUntilReady(context.Background(), target)
-			if err == nil {
-				t.Fatal("no error")
-			}
-
-			expected := "container crashed with out-of-memory (OOMKilled)"
-			if err.Error() != expected {
-				t.Fatalf("expected %q, got %q", expected, err.Error())
-			}
-		}
+		err := wg.WaitUntilReady(context.Background(), target)
+		expected := "container crashed with out-of-memory (OOMKilled)"
+		require.EqualError(t, err, expected)
 	})
 
 	t.Run("as regexp", func(t *testing.T) {
-		wg := ForLog("docker").
-			WithStartupTimeout(100 * time.Microsecond).AsRegexp()
+		wg := ForLog("docker").WithStartupTimeout(logTimeout).AsRegexp()
 
-		{
-			err := wg.WaitUntilReady(context.Background(), target)
-			if err == nil {
-				t.Fatal("no error")
-			}
-
-			expected := "container crashed with out-of-memory (OOMKilled)"
-			if err.Error() != expected {
-				t.Fatalf("expected %q, got %q", expected, err.Error())
-			}
-		}
+		err := wg.WaitUntilReady(context.Background(), target)
+		expected := "container crashed with out-of-memory (OOMKilled)"
+		require.EqualError(t, err, expected)
 	})
 }
 
@@ -196,37 +165,19 @@ func TestWaitForLogFailsDueToExitedContainer(t *testing.T) {
 	}
 
 	t.Run("no regexp", func(t *testing.T) {
-		wg := ForLog("docker").
-			WithStartupTimeout(100 * time.Microsecond)
+		wg := ForLog("docker").WithStartupTimeout(logTimeout)
 
-		{
-			err := wg.WaitUntilReady(context.Background(), target)
-			if err == nil {
-				t.Fatal("no error")
-			}
-
-			expected := "container exited with code 1"
-			if err.Error() != expected {
-				t.Fatalf("expected %q, got %q", expected, err.Error())
-			}
-		}
+		err := wg.WaitUntilReady(context.Background(), target)
+		expected := "container exited with code 1"
+		require.EqualError(t, err, expected)
 	})
 
 	t.Run("as regexp", func(t *testing.T) {
-		wg := ForLog("docker").
-			WithStartupTimeout(100 * time.Microsecond).AsRegexp()
+		wg := ForLog("docker").WithStartupTimeout(logTimeout).AsRegexp()
 
-		{
-			err := wg.WaitUntilReady(context.Background(), target)
-			if err == nil {
-				t.Fatal("no error")
-			}
-
-			expected := "container exited with code 1"
-			if err.Error() != expected {
-				t.Fatalf("expected %q, got %q", expected, err.Error())
-			}
-		}
+		err := wg.WaitUntilReady(context.Background(), target)
+		expected := "container exited with code 1"
+		require.EqualError(t, err, expected)
 	})
 }
 
@@ -243,36 +194,18 @@ func TestWaitForLogFailsDueToUnexpectedContainerStatus(t *testing.T) {
 	}
 
 	t.Run("no regexp", func(t *testing.T) {
-		wg := ForLog("docker").
-			WithStartupTimeout(100 * time.Microsecond)
+		wg := ForLog("docker").WithStartupTimeout(logTimeout)
 
-		{
-			err := wg.WaitUntilReady(context.Background(), target)
-			if err == nil {
-				t.Fatal("no error")
-			}
-
-			expected := "unexpected container status \"dead\""
-			if err.Error() != expected {
-				t.Fatalf("expected %q, got %q", expected, err.Error())
-			}
-		}
+		err := wg.WaitUntilReady(context.Background(), target)
+		expected := "unexpected container status \"dead\""
+		require.EqualError(t, err, expected)
 	})
 
 	t.Run("as regexp", func(t *testing.T) {
-		wg := ForLog("docker").
-			WithStartupTimeout(100 * time.Microsecond).AsRegexp()
+		wg := ForLog("docker").WithStartupTimeout(logTimeout).AsRegexp()
 
-		{
-			err := wg.WaitUntilReady(context.Background(), target)
-			if err == nil {
-				t.Fatal("no error")
-			}
-
-			expected := "unexpected container status \"dead\""
-			if err.Error() != expected {
-				t.Fatalf("expected %q, got %q", expected, err.Error())
-			}
-		}
+		err := wg.WaitUntilReady(context.Background(), target)
+		expected := "unexpected container status \"dead\""
+		require.EqualError(t, err, expected)
 	})
 }


### PR DESCRIPTION
Increase the log test timeout to avoid random test failures on slow machines.

Convert to require to make tests easier to read / understand.