### PR TITLE
chore: increase timeout values

### DIFF
--- a/logconsumer_test.go
+++ b/logconsumer_test.go
@@ -276,7 +276,7 @@ func TestContainerLogWithErrClosed(t *testing.T) {
 		if errors.Is(err, context.DeadlineExceeded) {
 			break
 		}
-		time.Sleep(100 * time.Microsecond)
+		time.Sleep(10 * time.Millisecond)
 		t.Log("retrying get endpoint")
 	}
 	if err != nil {

--- a/wait/log_test.go
+++ b/wait/log_test.go
@@ -26,7 +26,7 @@ func TestWaitForLog(t *testing.T) {
 		target := NopStrategyTarget{
 			ReaderCloser: io.NopCloser(bytes.NewReader([]byte("docker"))),
 		}
-		wg := NewLogStrategy("docker").WithStartupTimeout(100 * time.Microsecond)
+		wg := NewLogStrategy("docker").WithStartupTimeout(100 * time.Millisecond)
 		err := wg.WaitUntilReady(context.Background(), target)
 		if err != nil {
 			t.Fatal(err)
@@ -39,7 +39,7 @@ func TestWaitForLog(t *testing.T) {
 		}
 
 		// get all words that start with "ip", end with "m" and has a whitespace before the "ip"
-		wg := NewLogStrategy(`\sip[\w]+m`).WithStartupTimeout(100 * time.Microsecond).AsRegexp()
+		wg := NewLogStrategy(`\sip[\w]+m`).WithStartupTimeout(100 * time.Millisecond).AsRegexp()
 		err := wg.WaitUntilReady(context.Background(), target)
 		if err != nil {
 			t.Fatal(err)
@@ -53,7 +53,7 @@ func TestWaitWithExactNumberOfOccurrences(t *testing.T) {
 			ReaderCloser: io.NopCloser(bytes.NewReader([]byte("kubernetes\r\ndocker\n\rdocker"))),
 		}
 		wg := NewLogStrategy("docker").
-			WithStartupTimeout(100 * time.Microsecond).
+			WithStartupTimeout(100 * time.Millisecond).
 			WithOccurrence(2)
 		err := wg.WaitUntilReady(context.Background(), target)
 		if err != nil {
@@ -69,7 +69,7 @@ func TestWaitWithExactNumberOfOccurrences(t *testing.T) {
 		// get texts from "ip" to the next "m".
 		// there are three occurrences of this pattern in the string:
 		// one "ipsum mauris" and two "ipsum dolor sit am"
-		wg := NewLogStrategy(`ip(.*)m`).WithStartupTimeout(100 * time.Microsecond).AsRegexp().WithOccurrence(3)
+		wg := NewLogStrategy(`ip(.*)m`).WithStartupTimeout(100 * time.Millisecond).AsRegexp().WithOccurrence(3)
 		err := wg.WaitUntilReady(context.Background(), target)
 		if err != nil {
 			t.Fatal(err)
@@ -98,7 +98,7 @@ func TestWaitWithExactNumberOfOccurrencesButItWillNeverHappen(t *testing.T) {
 
 		// get texts from "ip" to the next "m".
 		// there are only three occurrences matching
-		wg := NewLogStrategy(`do(.*)ck.+`).WithStartupTimeout(100 * time.Microsecond).AsRegexp().WithOccurrence(4)
+		wg := NewLogStrategy(`do(.*)ck.+`).WithStartupTimeout(100 * time.Millisecond).AsRegexp().WithOccurrence(4)
 		err := wg.WaitUntilReady(context.Background(), target)
 		if err == nil {
 			t.Fatal("expected error")
@@ -127,7 +127,7 @@ func TestWaitShouldFailWithExactNumberOfOccurrences(t *testing.T) {
 
 		// get "Maecenas".
 		// there are only one occurrence matching
-		wg := NewLogStrategy(`^Mae[\w]?enas\s`).WithStartupTimeout(100 * time.Microsecond).AsRegexp().WithOccurrence(2)
+		wg := NewLogStrategy(`^Mae[\w]?enas\s`).WithStartupTimeout(100 * time.Millisecond).AsRegexp().WithOccurrence(2)
 		err := wg.WaitUntilReady(context.Background(), target)
 		if err == nil {
 			t.Fatal("expected error")


### PR DESCRIPTION
Increase timeout values from microseconds to milliseconds as the former can lead to failures depending on hardware.