### PR TITLE
fix(elasticsearch): wait for

### DIFF
--- a/modules/elasticsearch/options.go
+++ b/modules/elasticsearch/options.go
@@ -16,7 +16,6 @@ type Options struct {
 
 func defaultOptions() *Options {
 	return &Options{
-		CACert:   nil,
 		Username: defaultUsername,
 	}
 }


### PR DESCRIPTION
Wait for the HTTP port to be available to prevent random failures when the container isn't fully started and returns 503 errors.