### PR TITLE
fix: config via environment

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -20,18 +20,71 @@ var (
 
 // testcontainersConfig {
 
-// Config represents the configuration for Testcontainers
+// Config represents the configuration for Testcontainers.
+// User values are read from ~/.testcontainers.properties file which can be overridden
+// using the specified environment variables. For more information, see [Custom Configuration].
+//
+// The Ryuk prefixed fields controls the [Garbage Collector] feature, which ensures that
+// resources are cleaned up after the test execution.
+//
+// [Garbage Collector]: https://golang.testcontainers.org/features/garbage_collector/
+// [Custom Configuration]: https://golang.testcontainers.org/features/configuration/
 type Config struct {
-	Host                    string        `properties:"docker.host,default="`
-	TLSVerify               int           `properties:"docker.tls.verify,default=0"`
-	CertPath                string        `properties:"docker.cert.path,default="`
-	HubImageNamePrefix      string        `properties:"hub.image.name.prefix,default="`
-	RyukDisabled            bool          `properties:"ryuk.disabled,default=false"`
-	RyukPrivileged          bool          `properties:"ryuk.container.privileged,default=false"`
+	// Host is the address of the Docker daemon.
+	//
+	// Environment variable: DOCKER_HOST
+	Host string `properties:"docker.host,default="`
+
+	// TLSVerify is a flag to enable or disable TLS verification when connecting to a Docker daemon.
+	//
+	// Environment variable: DOCKER_TLS_VERIFY
+	TLSVerify int `properties:"docker.tls.verify,default=0"`
+
+	// CertPath is the path to the directory containing the Docker certificates.
+	// This is used when connecting to a Docker daemon over TLS.
+	//
+	// Environment variable: DOCKER_CERT_PATH
+	CertPath string `properties:"docker.cert.path,default="`
+
+	// HubImageNamePrefix is the prefix used for the images pulled from the Docker Hub.
+	// This is useful when running tests in environments with restricted internet access.
+	//
+	// Environment variable: TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX
+	HubImageNamePrefix string `properties:"hub.image.name.prefix,default="`
+
+	// RyukDisabled is a flag to enable or disable the Garbage Collector.
+	// Setting this to true will prevent testcontainers from automatically cleaning up
+	// resources, which is particularly important in tests which timeout as they
+	// don't run test clean up.
+	//
+	// Environment variable: TESTCONTAINERS_RYUK_DISABLED
+	RyukDisabled bool `properties:"ryuk.disabled,default=false"`
+
+	// RyukPrivileged is a flag to enable or disable the privileged mode for the Garbage Collector container.
+	// Setting this to true will run the Garbage Collector container in privileged mode.
+	//
+	// Environment variable: TESTCONTAINERS_RYUK_CONTAINER_PRIVILEGED
+	RyukPrivileged bool `properties:"ryuk.container.privileged,default=false"`
+
+	// RyukReconnectionTimeout is the time to wait before attempting to reconnect to the Garbage Collector container.
+	//
+	// Environment variable: TESTCONTAINERS_RYUK_RECONNECTION_TIMEOUT
 	RyukReconnectionTimeout time.Duration `properties:"ryuk.reconnection.timeout,default=10s"`
-	RyukConnectionTimeout   time.Duration `properties:"ryuk.connection.timeout,default=1m"`
-	RyukVerbose             bool          `properties:"ryuk.verbose,default=false"`
-	TestcontainersHost      string        `properties:"tc.host,default="`
+
+	// RyukConnectionTimeout is the time to wait before timing out when connecting to the Garbage Collector container.
+	//
+	// Environment variable: TESTCONTAINERS_RYUK_CONNECTION_TIMEOUT
+	RyukConnectionTimeout time.Duration `properties:"ryuk.connection.timeout,default=1m"`
+
+	// RyukVerbose is a flag to enable or disable verbose logging for the Garbage Collector.
+	//
+	// Environment variable: TESTCONTAINERS_RYUK_VERBOSE
+	RyukVerbose bool `properties:"ryuk.verbose,default=false"`
+
+	// TestcontainersHost is the address of the Testcontainers host.
+	//
+	// Environment variable: TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE
+	TestcontainersHost string `properties:"tc.host,default="`
 }
 
 // }

--- a/logger.go
+++ b/logger.go
@@ -8,34 +8,20 @@ import (
 	"testing"
 
 	"github.com/docker/docker/client"
-
-	"github.com/testcontainers/testcontainers-go/internal/config"
 )
 
 // Logger is the default log instance
 var Logger Logging = log.New(os.Stderr, "", log.LstdFlags)
 
 func init() {
-	verbose := false
 	for _, arg := range os.Args {
 		if strings.EqualFold(arg, "-test.v=true") || strings.EqualFold(arg, "-v") {
-			verbose = true
-			break
+			return
 		}
 	}
 
-	if !verbose {
-		Logger = &noopLogger{}
-	}
-
-	if config.Read().RyukDisabled {
-		ryukDisabledMessage := `
-**********************************************************************************************
-Ryuk has been disabled for the current execution. This can cause unexpected behavior in your environment.
-More on this: https://golang.testcontainers.org/features/garbage_collector/
-**********************************************************************************************`
-		Logger.Printf(ryukDisabledMessage)
-	}
+	// If we are not running in verbose mode, we configure a noop logger by default.
+	Logger = &noopLogger{}
 }
 
 // Validate our types implement the required interfaces.


### PR DESCRIPTION
Fix the ability to set the configuration of testcontainers using an environment variable set by a caller before the use of testcontainers.

This removes the warning about disabling the reaper which is actually safe when done correctly.

Also optimise verbose check while there.

Fixes: #2701 #2636 #2609