### PR TITLE
fix!: docker authentication setup

### DIFF
--- a/container_test.go
+++ b/container_test.go
@@ -147,7 +147,7 @@ func Test_BuildImageWithContexts(t *testing.T) {
 	type TestCase struct {
 		Name               string
 		ContextPath        string
-		ContextArchive     func() (io.Reader, error)
+		ContextArchive     func() (io.ReadSeeker, error)
 		ExpectedEchoOutput string
 		Dockerfile         string
 		ExpectedError      string
@@ -157,7 +157,7 @@ func Test_BuildImageWithContexts(t *testing.T) {
 		{
 			Name: "test build from context archive",
 			// fromDockerfileWithContextArchive {
-			ContextArchive: func() (io.Reader, error) {
+			ContextArchive: func() (io.ReadSeeker, error) {
 				var buf bytes.Buffer
 				tarWriter := tar.NewWriter(&buf)
 				files := []struct {
@@ -202,7 +202,7 @@ func Test_BuildImageWithContexts(t *testing.T) {
 		},
 		{
 			Name: "test build from context archive and be able to use files in it",
-			ContextArchive: func() (io.Reader, error) {
+			ContextArchive: func() (io.ReadSeeker, error) {
 				var buf bytes.Buffer
 				tarWriter := tar.NewWriter(&buf)
 				files := []struct {
@@ -255,14 +255,14 @@ func Test_BuildImageWithContexts(t *testing.T) {
 			ContextPath:        "./testdata",
 			Dockerfile:         "echo.Dockerfile",
 			ExpectedEchoOutput: "this is from the echo test Dockerfile",
-			ContextArchive: func() (io.Reader, error) {
+			ContextArchive: func() (io.ReadSeeker, error) {
 				return nil, nil
 			},
 		},
 		{
 			Name:        "it should error if neither a context nor a context archive are specified",
 			ContextPath: "",
-			ContextArchive: func() (io.Reader, error) {
+			ContextArchive: func() (io.ReadSeeker, error) {
 				return nil, nil
 			},
 			ExpectedError: "create container: you must specify either a build context or an image",
@@ -275,9 +275,8 @@ func Test_BuildImageWithContexts(t *testing.T) {
 			t.Parallel()
 			ctx := context.Background()
 			a, err := testCase.ContextArchive()
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
+
 			req := testcontainers.ContainerRequest{
 				FromDockerfile: testcontainers.FromDockerfile{
 					ContextArchive: a,

--- a/docker.go
+++ b/docker.go
@@ -1114,7 +1114,7 @@ func (p *DockerProvider) CreateContainer(ctx context.Context, req ContainerReque
 		// forward the host ports to the container ports.
 		sshdForwardPortsHook, err := exposeHostPorts(ctx, &req, req.HostAccessPorts...)
 		if err != nil {
-			return nil, fmt.Errorf("failed to expose host ports: %w", err)
+			return nil, fmt.Errorf("expose host ports: %w", err)
 		}
 
 		defaultHooks = append(defaultHooks, sshdForwardPortsHook)
@@ -1292,12 +1292,12 @@ func (p *DockerProvider) ReuseOrCreateContainer(ctx context.Context, req Contain
 func (p *DockerProvider) attemptToPullImage(ctx context.Context, tag string, pullOpt image.PullOptions) error {
 	registry, imageAuth, err := DockerImageAuth(ctx, tag)
 	if err != nil {
-		p.Logger.Printf("Failed to get image auth for %s. Setting empty credentials for the image: %s. Error is:%s", registry, tag, err)
+		p.Logger.Printf("Failed to get image auth for %s. Setting empty credentials for the image: %s. Error is: %s", registry, tag, err)
 	} else {
 		// see https://github.com/docker/docs/blob/e8e1204f914767128814dca0ea008644709c117f/engine/api/sdk/examples.md?plain=1#L649-L657
 		encodedJSON, err := json.Marshal(imageAuth)
 		if err != nil {
-			p.Logger.Printf("Failed to marshal image auth. Setting empty credentials for the image: %s. Error is:%s", tag, err)
+			p.Logger.Printf("Failed to marshal image auth. Setting empty credentials for the image: %s. Error is: %s", tag, err)
 		} else {
 			pullOpt.RegistryAuth = base64.URLEncoding.EncodeToString(encodedJSON)
 		}

--- a/internal/core/images.go
+++ b/internal/core/images.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"bufio"
+	"io"
 	"net/url"
 	"os"
 	"regexp"
@@ -25,17 +26,22 @@ const (
 
 var rxURL = regexp.MustCompile(URL)
 
+// ExtractImagesFromDockerfile extracts images from the Dockerfile sourced from dockerfile.
 func ExtractImagesFromDockerfile(dockerfile string, buildArgs map[string]*string) ([]string, error) {
-	var images []string
-
 	file, err := os.Open(dockerfile)
 	if err != nil {
 		return nil, err
 	}
 	defer file.Close()
 
+	return ExtractImagesFromReader(file, buildArgs)
+}
+
+// ExtractImagesFromReader extracts images from the Dockerfile sourced from r.
+func ExtractImagesFromReader(r io.Reader, buildArgs map[string]*string) ([]string, error) {
+	var images []string
 	var lines []string
-	scanner := bufio.NewScanner(file)
+	scanner := bufio.NewScanner(r)
 	for scanner.Scan() {
 		lines = append(lines, scanner.Text())
 	}


### PR DESCRIPTION
Check and return errors in the process of determining authentication configs so that unexpected failures don't occur latter in the process of build an image or creating a container.

BuildOptions will now return an empty result on error instead of an incomplete one, to ensure that consumers don't use partial data.

Fix builds with different config or override environments failing when the authentication configuration changes, which was introduced by #2646.

Report errors from GetRegistryCredentials calls to avoid unexpected failures latter on in the authentication process.

Split out the functionality to read a Dockerfile from an io.Reader into ExtractImagesFromReader, as required when processing from a tar archive.

Deprecated function ContainerRequest.GetAuthConfigs will now panic if an error occurs, so that callers understand that an failure occured.

BREAKING CHANGE Add support for determining the required authentication in when building an image from a `ContextArchive`, this requires `ContextArchive` support `io.Seeker`.