### PR TITLE
fix(reaper): refactor to allow retries and fix races

### DIFF
--- a/container.go
+++ b/container.go
@@ -37,17 +37,17 @@ type DeprecatedContainer interface {
 
 // Container allows getting info about and controlling a single container instance
 type Container interface {
-	GetContainerID() string                                         // get the container id from the provider
-	Endpoint(context.Context, string) (string, error)               // get proto://ip:port string for the lowest exposed port
-	PortEndpoint(context.Context, nat.Port, string) (string, error) // get proto://ip:port string for the given exposed port
-	Host(context.Context) (string, error)                           // get host where the container port is exposed
-	Inspect(context.Context) (*types.ContainerJSON, error)          // get container info
-	MappedPort(context.Context, nat.Port) (nat.Port, error)         // get externally mapped port for a container port
-	Ports(context.Context) (nat.PortMap, error)                     // Deprecated: Use c.Inspect(ctx).NetworkSettings.Ports instead
-	SessionID() string                                              // get session id
-	IsRunning() bool                                                // IsRunning returns true if the container is running, false otherwise.
-	Start(context.Context) error                                    // start the container
-	Stop(context.Context, *time.Duration) error                     // stop the container
+	GetContainerID() string                                                        // get the container id from the provider
+	Endpoint(context.Context, string) (string, error)                              // get proto://ip:port string for the lowest exposed port
+	PortEndpoint(ctx context.Context, port nat.Port, proto string) (string, error) // get proto://ip:port string for the given exposed port
+	Host(context.Context) (string, error)                                          // get host where the container port is exposed
+	Inspect(context.Context) (*types.ContainerJSON, error)                         // get container info
+	MappedPort(context.Context, nat.Port) (nat.Port, error)                        // get externally mapped port for a container port
+	Ports(context.Context) (nat.PortMap, error)                                    // Deprecated: Use c.Inspect(ctx).NetworkSettings.Ports instead
+	SessionID() string                                                             // get session id
+	IsRunning() bool                                                               // IsRunning returns true if the container is running, false otherwise.
+	Start(context.Context) error                                                   // start the container
+	Stop(context.Context, *time.Duration) error                                    // stop the container
 
 	// Terminate stops and removes the container and its image if it was built and not flagged as kept.
 	Terminate(ctx context.Context) error

--- a/docker_mounts.go
+++ b/docker_mounts.go
@@ -126,9 +126,7 @@ func mapToDockerMounts(containerMounts ContainerMounts) []mount.Mount {
 					Labels: make(map[string]string),
 				}
 			}
-			for k, v := range GenericLabels() {
-				containerMount.VolumeOptions.Labels[k] = v
-			}
+			AddGenericLabels(containerMount.VolumeOptions.Labels)
 		}
 
 		mounts = append(mounts, containerMount)

--- a/generic.go
+++ b/generic.go
@@ -101,7 +101,17 @@ type GenericProvider interface {
 	ImageProvider
 }
 
-// GenericLabels returns a map of labels that can be used to identify containers created by this library
+// GenericLabels returns a map of labels that can be used to identify resources
+// created by this library. This includes the standard LabelSessionID if the
+// reaper is enabled, otherwise this is excluded to prevent resources being
+// incorrectly reaped.
 func GenericLabels() map[string]string {
 	return core.DefaultLabels(core.SessionID())
+}
+
+// AddGenericLabels adds the generic labels to target.
+func AddGenericLabels(target map[string]string) {
+	for k, v := range GenericLabels() {
+		target[k] = v
+	}
 }

--- a/internal/core/labels.go
+++ b/internal/core/labels.go
@@ -6,23 +6,53 @@ import (
 	"strings"
 
 	"github.com/testcontainers/testcontainers-go/internal"
+	"github.com/testcontainers/testcontainers-go/internal/config"
 )
 
 const (
-	LabelBase      = "org.testcontainers"
-	LabelLang      = LabelBase + ".lang"
-	LabelReaper    = LabelBase + ".reaper"
-	LabelRyuk      = LabelBase + ".ryuk"
+	// LabelBase is the base label for all testcontainers labels.
+	LabelBase = "org.testcontainers"
+
+	// LabelLang specifies the language which created the test container.
+	LabelLang = LabelBase + ".lang"
+
+	// LabelReaper identifies the container as a reaper.
+	LabelReaper = LabelBase + ".reaper"
+
+	// LabelRyuk identifies the container as a ryuk.
+	LabelRyuk = LabelBase + ".ryuk"
+
+	// LabelSessionID specifies the session ID of the container.
 	LabelSessionID = LabelBase + ".sessionId"
-	LabelVersion   = LabelBase + ".version"
+
+	// LabelVersion specifies the version of testcontainers which created the container.
+	LabelVersion = LabelBase + ".version"
+
+	// LabelReap specifies the container should be reaped by the reaper.
+	LabelReap = LabelBase + ".reap"
 )
 
+// DefaultLabels returns the standard set of labels which
+// includes LabelSessionID if the reaper is enabled.
 func DefaultLabels(sessionID string) map[string]string {
-	return map[string]string{
+	labels := map[string]string{
 		LabelBase:      "true",
 		LabelLang:      "go",
-		LabelSessionID: sessionID,
 		LabelVersion:   internal.Version,
+		LabelSessionID: sessionID,
+	}
+
+	if !config.Read().RyukDisabled {
+		labels[LabelReap] = "true"
+	}
+
+	return labels
+}
+
+// AddDefaultLabels adds the default labels for sessionID to target.
+func AddDefaultLabels(sessionID string, target map[string]string) {
+	for k, v := range DefaultLabels(sessionID) {
+		target[k] = v
 	}
 }
 

--- a/lifecycle.go
+++ b/lifecycle.go
@@ -33,7 +33,7 @@ type ContainerRequestHook func(ctx context.Context, req ContainerRequest) error
 // - Terminating
 // - Terminated
 // For that, it will receive a Container, modify it and return an error if needed.
-type ContainerHook func(ctx context.Context, container Container) error
+type ContainerHook func(ctx context.Context, ctr Container) error
 
 // ContainerLifecycleHooks is a struct that contains all the hooks that can be used
 // to modify the container lifecycle. All the container lifecycle hooks except the PreCreates hooks

--- a/modules/compose/compose.go
+++ b/modules/compose/compose.go
@@ -153,23 +153,6 @@ func NewDockerComposeWith(opts ...ComposeStackOption) (*dockerCompose, error) {
 		return nil, fmt.Errorf("initialize docker client: %w", err)
 	}
 
-	reaperProvider, err := testcontainers.NewDockerProvider()
-	if err != nil {
-		return nil, fmt.Errorf("failed to create reaper provider for compose: %w", err)
-	}
-
-	var composeReaper *testcontainers.Reaper
-	if !reaperProvider.Config().Config.RyukDisabled {
-		// NewReaper is deprecated: we need to find a way to create the reaper for compose
-		// bypassing the deprecation.
-		r, err := testcontainers.NewReaper(context.Background(), testcontainers.SessionID(), reaperProvider, "")
-		if err != nil {
-			return nil, fmt.Errorf("failed to create reaper for compose: %w", err)
-		}
-
-		composeReaper = r
-	}
-
 	composeAPI := &dockerCompose{
 		name:             composeOptions.Identifier,
 		configs:          composeOptions.Paths,
@@ -182,7 +165,6 @@ func NewDockerComposeWith(opts ...ComposeStackOption) (*dockerCompose, error) {
 		containers:       make(map[string]*testcontainers.DockerContainer),
 		networks:         make(map[string]*testcontainers.DockerNetwork),
 		sessionID:        testcontainers.SessionID(),
-		reaper:           composeReaper,
 	}
 
 	return composeAPI, nil

--- a/modules/compose/compose_api_test.go
+++ b/modules/compose/compose_api_test.go
@@ -48,8 +48,7 @@ func TestDockerComposeAPIStrategyForInvalidService(t *testing.T) {
 		WaitForService("non-existent-srv-1", wait.NewLogStrategy("started").WithStartupTimeout(10*time.Second).WithOccurrence(1)).
 		Up(ctx, Wait(true))
 	cleanup(t, compose)
-	require.Error(t, err, "Expected error to be thrown because service with wait strategy is not running")
-	require.Equal(t, "no container found for service name non-existent-srv-1", err.Error())
+	require.EqualError(t, err, "wait for services: no container found for service name non-existent-srv-1")
 
 	serviceNames := compose.Services()
 

--- a/reaper_test.go
+++ b/reaper_test.go
@@ -4,14 +4,15 @@ import (
 	"context"
 	"errors"
 	"os"
+	"strconv"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/network"
+	"github.com/docker/docker/errdefs"
 	"github.com/docker/go-connections/nat"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/testcontainers/testcontainers-go/internal/config"
@@ -23,48 +24,29 @@ import (
 const testSessionID = "this-is-a-different-session-id"
 
 type mockReaperProvider struct {
-	req               ContainerRequest
-	hostConfig        *container.HostConfig
-	enpointSettings   map[string]*network.EndpointSettings
-	config            TestcontainersConfig
-	initialReaper     *Reaper
-	initialReaperOnce sync.Once
-	t                 *testing.T
+	req              ContainerRequest
+	hostConfig       *container.HostConfig
+	endpointSettings map[string]*network.EndpointSettings
+	config           TestcontainersConfig
 }
 
-func newMockReaperProvider(t *testing.T) *mockReaperProvider {
+func newMockReaperProvider(cfg config.Config) *mockReaperProvider {
 	m := &mockReaperProvider{
 		config: TestcontainersConfig{
-			Config: config.Config{},
+			Config: cfg,
 		},
-		t:             t,
-		initialReaper: reaperInstance,
-		//nolint:govet
-		initialReaperOnce: reaperOnce,
 	}
-
-	// explicitly reset the reaperInstance to nil to start from a fresh state
-	reaperInstance = nil
-	reaperOnce = sync.Once{}
 
 	return m
 }
 
 var errExpected = errors.New("expected")
 
-func (m *mockReaperProvider) RestoreReaperState() {
-	m.t.Cleanup(func() {
-		reaperInstance = m.initialReaper
-		//nolint:govet
-		reaperOnce = m.initialReaperOnce
-	})
-}
-
 func (m *mockReaperProvider) RunContainer(ctx context.Context, req ContainerRequest) (Container, error) {
 	m.req = req
 
 	m.hostConfig = &container.HostConfig{}
-	m.enpointSettings = map[string]*network.EndpointSettings{}
+	m.endpointSettings = map[string]*network.EndpointSettings{}
 
 	if req.HostConfigModifier == nil {
 		req.HostConfigModifier = defaultHostConfigModifier(req)
@@ -72,7 +54,7 @@ func (m *mockReaperProvider) RunContainer(ctx context.Context, req ContainerRequ
 	req.HostConfigModifier(m.hostConfig)
 
 	if req.EnpointSettingsModifier != nil {
-		req.EnpointSettingsModifier(m.enpointSettings)
+		req.EnpointSettingsModifier(m.endpointSettings)
 	}
 
 	// we're only interested in the request, so instead of mocking the Docker client
@@ -84,8 +66,8 @@ func (m *mockReaperProvider) Config() TestcontainersConfig {
 	return m.config
 }
 
-// createContainerRequest creates the expected request and allows for customization
-func createContainerRequest(customize func(ContainerRequest) ContainerRequest) ContainerRequest {
+// expectedReaperRequest creates the expected reaper container request with the given customizations.
+func expectedReaperRequest(customize ...func(*ContainerRequest)) ContainerRequest {
 	req := ContainerRequest{
 		Image:        config.ReaperDefaultImage,
 		ExposedPorts: []string{"8080/tcp"},
@@ -102,21 +84,26 @@ func createContainerRequest(customize func(ContainerRequest) ContainerRequest) C
 
 	req.Labels[core.LabelReaper] = "true"
 	req.Labels[core.LabelRyuk] = "true"
+	delete(req.Labels, core.LabelReap)
 
-	if customize == nil {
-		return req
+	for _, customize := range customize {
+		customize(&req)
 	}
 
-	return customize(req)
+	return req
 }
 
-func TestContainerStartsWithoutTheReaper(t *testing.T) {
-	config.Reset() // reset the config using the internal method to avoid the sync.Once
-	tcConfig := config.Read()
-	if !tcConfig.RyukDisabled {
-		t.Skip("Ryuk is enabled, skipping test")
-	}
+// reaperDisable disables / enables the reaper for the duration of the test.
+func reaperDisable(t *testing.T, disabled bool) {
+	t.Helper()
 
+	config.Reset()
+	t.Setenv("TESTCONTAINERS_RYUK_DISABLED", strconv.FormatBool(disabled))
+	t.Cleanup(config.Reset)
+}
+
+func testContainerStart(t *testing.T) {
+	t.Helper()
 	ctx := context.Background()
 
 	ctr, err := GenericContainer(ctx, GenericContainerRequest{
@@ -131,59 +118,55 @@ func TestContainerStartsWithoutTheReaper(t *testing.T) {
 	})
 	CleanupContainer(t, ctr)
 	require.NoError(t, err)
-
-	sessionID := core.SessionID()
-
-	reaperContainer, err := lookUpReaperContainer(ctx, sessionID)
-	if err != nil {
-		t.Fatal(err, "expected reaper container not found.")
-	}
-	if reaperContainer != nil {
-		t.Fatal("expected zero reaper running.")
-	}
 }
 
-func TestContainerStartsWithTheReaper(t *testing.T) {
-	config.Reset() // reset the config using the internal method to avoid the sync.Once
-	tcConfig := config.Read()
-	if tcConfig.RyukDisabled {
-		t.Skip("Ryuk is disabled, skipping test")
-	}
+// testReaperRunning validates that a reaper is running.
+func testReaperRunning(t *testing.T) {
+	t.Helper()
 
 	ctx := context.Background()
-
-	c, err := GenericContainer(ctx, GenericContainerRequest{
-		ProviderType: providerType,
-		ContainerRequest: ContainerRequest{
-			Image: nginxAlpineImage,
-			ExposedPorts: []string{
-				nginxDefaultPort,
-			},
-		},
-		Started: true,
-	})
-	CleanupContainer(t, c)
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	sessionID := core.SessionID()
-
-	reaperContainer, err := lookUpReaperContainer(ctx, sessionID)
-	if err != nil {
-		t.Fatal(err, "expected reaper container running.")
-	}
-	if reaperContainer == nil {
-		t.Fatal("expected one reaper to be running.")
-	}
+	reaperContainer, err := spawner.lookupContainer(ctx, sessionID)
+	require.NoError(t, err)
+	require.NotNil(t, reaperContainer)
 }
 
-func TestContainerStopWithReaper(t *testing.T) {
-	config.Reset() // reset the config using the internal method to avoid the sync.Once
-	tcConfig := config.Read()
-	if tcConfig.RyukDisabled {
-		t.Skip("Ryuk is disabled, skipping test")
-	}
+func TestContainer(t *testing.T) {
+	reaperDisable(t, false)
+
+	t.Run("start/reaper-enabled", func(t *testing.T) {
+		testContainerStart(t)
+		testReaperRunning(t)
+	})
+
+	t.Run("stop/reaper-enabled", func(t *testing.T) {
+		testContainerStop(t)
+		testReaperRunning(t)
+	})
+
+	t.Run("terminate/reaper-enabled", func(t *testing.T) {
+		testContainerTerminate(t)
+		testReaperRunning(t)
+	})
+
+	reaperDisable(t, true)
+
+	t.Run("start/reaper-disabled", func(t *testing.T) {
+		testContainerStart(t)
+	})
+
+	t.Run("stop/reaper-disabled", func(t *testing.T) {
+		testContainerStop(t)
+	})
+
+	t.Run("terminate/reaper-disabled", func(t *testing.T) {
+		testContainerTerminate(t)
+	})
+}
+
+// testContainerStop tests stopping a container.
+func testContainerStop(t *testing.T) {
+	t.Helper()
 
 	ctx := context.Background()
 
@@ -201,37 +184,21 @@ func TestContainerStopWithReaper(t *testing.T) {
 	require.NoError(t, err)
 
 	state, err := nginxA.State(ctx)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if state.Running != true {
-		t.Fatal("The container shoud be in running state")
-	}
+	require.NoError(t, err)
+	require.True(t, state.Running)
+
 	stopTimeout := 10 * time.Second
 	err = nginxA.Stop(ctx, &stopTimeout)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	state, err = nginxA.State(ctx)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if state.Running != false {
-		t.Fatal("The container shoud not be running")
-	}
-	if state.Status != "exited" {
-		t.Fatal("The container shoud be in exited state")
-	}
+	require.NoError(t, err)
+	require.False(t, state.Running)
+	require.Equal(t, "exited", state.Status)
 }
 
-func TestContainerTerminationWithReaper(t *testing.T) {
-	config.Reset() // reset the config using the internal method to avoid the sync.Once
-	tcConfig := config.Read()
-	if tcConfig.RyukDisabled {
-		t.Skip("Ryuk is disabled, skipping test")
-	}
-
+// testContainerTerminate tests terminating a container.
+func testContainerTerminate(t *testing.T) {
 	ctx := context.Background()
 
 	nginxA, err := GenericContainer(ctx, GenericContainerRequest{
@@ -258,324 +225,274 @@ func TestContainerTerminationWithReaper(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestContainerTerminationWithoutReaper(t *testing.T) {
-	config.Reset() // reset the config using the internal method to avoid the sync.Once
-	tcConfig := config.Read()
-	if !tcConfig.RyukDisabled {
-		t.Skip("Ryuk is enabled, skipping test")
-	}
+func Test_NewReaper(t *testing.T) {
+	reaperDisable(t, false)
 
 	ctx := context.Background()
 
-	nginxA, err := GenericContainer(ctx, GenericContainerRequest{
-		ProviderType: providerType,
-		ContainerRequest: ContainerRequest{
-			Image: nginxAlpineImage,
-			ExposedPorts: []string{
-				nginxDefaultPort,
+	t.Run("non-privileged", func(t *testing.T) {
+		testNewReaper(ctx, t,
+			config.Config{
+				RyukConnectionTimeout:   time.Minute,
+				RyukReconnectionTimeout: 10 * time.Second,
 			},
-		},
-		Started: true,
+			expectedReaperRequest(),
+		)
 	})
-	CleanupContainer(t, nginxA)
-	if err != nil {
-		t.Fatal(err)
-	}
 
-	state, err := nginxA.State(ctx)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if state.Running != true {
-		t.Fatal("The container shoud be in running state")
-	}
-	err = nginxA.Terminate(ctx)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	_, err = nginxA.State(ctx)
-	if err == nil {
-		t.Fatal("expected error from container inspect.")
-	}
-}
-
-func Test_NewReaper(t *testing.T) {
-	config.Reset() // reset the config using the internal method to avoid the sync.Once
-	tcConfig := config.Read()
-	if tcConfig.RyukDisabled {
-		t.Skip("Ryuk is disabled, skipping test")
-	}
-
-	type cases struct {
-		name   string
-		req    ContainerRequest
-		config TestcontainersConfig
-		ctx    context.Context
-		env    map[string]string
-	}
-
-	tests := []cases{
-		{
-			name: "non-privileged",
-			req:  createContainerRequest(nil),
-			config: TestcontainersConfig{Config: config.Config{
-				RyukConnectionTimeout:   time.Minute,
-				RyukReconnectionTimeout: 10 * time.Second,
-			}},
-		},
-		{
-			name: "privileged",
-			req: createContainerRequest(func(req ContainerRequest) ContainerRequest {
-				req.Privileged = true
-				return req
-			}),
-			config: TestcontainersConfig{Config: config.Config{
+	t.Run("privileged", func(t *testing.T) {
+		testNewReaper(ctx, t,
+			config.Config{
 				RyukPrivileged:          true,
 				RyukConnectionTimeout:   time.Minute,
 				RyukReconnectionTimeout: 10 * time.Second,
-			}},
-		},
-		{
-			name: "configured non-default timeouts",
-			req: createContainerRequest(func(req ContainerRequest) ContainerRequest {
+			},
+			expectedReaperRequest(),
+		)
+	})
+
+	t.Run("custom-timeouts", func(t *testing.T) {
+		testNewReaper(ctx, t,
+			config.Config{
+				RyukPrivileged:          true,
+				RyukConnectionTimeout:   2 * time.Minute,
+				RyukReconnectionTimeout: 20 * time.Second,
+			},
+			expectedReaperRequest(func(req *ContainerRequest) {
 				req.Env = map[string]string{
-					"RYUK_CONNECTION_TIMEOUT":   "1m0s",
-					"RYUK_RECONNECTION_TIMEOUT": "10m0s",
+					"RYUK_CONNECTION_TIMEOUT":   "2m0s",
+					"RYUK_RECONNECTION_TIMEOUT": "20s",
 				}
-				return req
 			}),
-			config: TestcontainersConfig{Config: config.Config{
-				RyukPrivileged:          true,
-				RyukConnectionTimeout:   time.Minute,
-				RyukReconnectionTimeout: 10 * time.Minute,
-			}},
-		},
-		{
-			name: "configured verbose mode",
-			req: createContainerRequest(func(req ContainerRequest) ContainerRequest {
+		)
+	})
+
+	t.Run("verbose", func(t *testing.T) {
+		testNewReaper(ctx, t,
+			config.Config{
+				RyukPrivileged: true,
+				RyukVerbose:    true,
+			},
+			expectedReaperRequest(func(req *ContainerRequest) {
 				req.Env = map[string]string{
 					"RYUK_VERBOSE": "true",
 				}
-				return req
 			}),
-			config: TestcontainersConfig{Config: config.Config{
-				RyukPrivileged: true,
-				RyukVerbose:    true,
-			}},
-		},
-		{
-			name: "docker-host in context",
-			req: createContainerRequest(func(req ContainerRequest) ContainerRequest {
-				req.HostConfigModifier = func(hostConfig *container.HostConfig) {
-					hostConfig.Binds = []string{core.MustExtractDockerSocket(context.Background()) + ":/var/run/docker.sock"}
-				}
-				return req
-			}),
-			config: TestcontainersConfig{Config: config.Config{
+		)
+	})
+
+	t.Run("docker-host", func(t *testing.T) {
+		testNewReaper(context.WithValue(ctx, core.DockerHostContextKey, core.DockerSocketPathWithSchema), t,
+			config.Config{
 				RyukConnectionTimeout:   time.Minute,
 				RyukReconnectionTimeout: 10 * time.Second,
-			}},
-			ctx: context.WithValue(context.TODO(), core.DockerHostContextKey, core.DockerSocketPathWithSchema),
-		},
-		{
-			name: "Reaper including custom Hub prefix",
-			req: createContainerRequest(func(req ContainerRequest) ContainerRequest {
-				req.Image = config.ReaperDefaultImage
-				req.Privileged = true
-				return req
+			},
+			expectedReaperRequest(func(req *ContainerRequest) {
+				req.HostConfigModifier = func(hostConfig *container.HostConfig) {
+					hostConfig.Binds = []string{core.MustExtractDockerSocket(ctx) + ":/var/run/docker.sock"}
+				}
 			}),
-			config: TestcontainersConfig{Config: config.Config{
+		)
+	})
+
+	t.Run("hub-prefix", func(t *testing.T) {
+		testNewReaper(context.WithValue(ctx, core.DockerHostContextKey, core.DockerSocketPathWithSchema), t,
+			config.Config{
 				HubImageNamePrefix:      "registry.mycompany.com/mirror",
 				RyukPrivileged:          true,
 				RyukConnectionTimeout:   time.Minute,
 				RyukReconnectionTimeout: 10 * time.Second,
-			}},
-		},
-		{
-			name: "Reaper including custom Hub prefix as env var",
-			req: createContainerRequest(func(req ContainerRequest) ContainerRequest {
+			},
+			expectedReaperRequest(func(req *ContainerRequest) {
 				req.Image = config.ReaperDefaultImage
 				req.Privileged = true
-				return req
 			}),
-			config: TestcontainersConfig{Config: config.Config{
+		)
+	})
+
+	t.Run("hub-prefix-env", func(t *testing.T) {
+		config.Reset()
+		t.Cleanup(config.Reset)
+
+		t.Setenv("TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX", "registry.mycompany.com/mirror")
+		testNewReaper(context.WithValue(ctx, core.DockerHostContextKey, core.DockerSocketPathWithSchema), t,
+			config.Config{
 				RyukPrivileged:          true,
 				RyukConnectionTimeout:   time.Minute,
 				RyukReconnectionTimeout: 10 * time.Second,
-			}},
-			env: map[string]string{
-				"TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX": "registry.mycompany.com/mirror",
 			},
-		},
+			expectedReaperRequest(func(req *ContainerRequest) {
+				req.Image = config.ReaperDefaultImage
+				req.Privileged = true
+			}),
+		)
+	})
+}
+
+func testNewReaper(ctx context.Context, t *testing.T, cfg config.Config, expected ContainerRequest) {
+	t.Helper()
+
+	if prefix := os.Getenv("TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX"); prefix != "" {
+		cfg.HubImageNamePrefix = prefix
 	}
 
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			if test.env != nil {
-				config.Reset() // reset the config using the internal method to avoid the sync.Once
-				for k, v := range test.env {
-					t.Setenv(k, v)
-				}
-			}
+	provider := newMockReaperProvider(cfg)
 
-			if prefix := os.Getenv("TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX"); prefix != "" {
-				test.config.Config.HubImageNamePrefix = prefix
-			}
+	// We need a new reaperSpawner for each test case to avoid reusing
+	// an existing reaper instance.
+	spawner := &reaperSpawner{}
+	reaper, err := spawner.reaper(ctx, testSessionID, provider)
+	cleanupReaper(t, reaper, spawner)
+	// We should have errored out see mockReaperProvider.RunContainer.
+	require.ErrorIs(t, err, errExpected)
 
-			provider := newMockReaperProvider(t)
-			provider.config = test.config
-			t.Cleanup(provider.RestoreReaperState)
+	require.Equal(t, expected.Image, provider.req.Image, "expected image doesn't match the submitted request")
+	require.Equal(t, expected.ExposedPorts, provider.req.ExposedPorts, "expected exposed ports don't match the submitted request")
+	require.Equal(t, expected.Labels, provider.req.Labels, "expected labels don't match the submitted request")
+	require.Equal(t, expected.Mounts, provider.req.Mounts, "expected mounts don't match the submitted request")
+	require.Equal(t, expected.WaitingFor, provider.req.WaitingFor, "expected waitingFor don't match the submitted request")
+	require.Equal(t, expected.Env, provider.req.Env, "expected env doesn't match the submitted request")
 
-			if test.ctx == nil {
-				test.ctx = context.TODO()
-			}
-
-			_, err := reuseOrCreateReaper(test.ctx, testSessionID, provider)
-			// we should have errored out see mockReaperProvider.RunContainer
-			require.EqualError(t, err, "expected")
-
-			assert.Equal(t, test.req.Image, provider.req.Image, "expected image doesn't match the submitted request")
-			assert.Equal(t, test.req.ExposedPorts, provider.req.ExposedPorts, "expected exposed ports don't match the submitted request")
-			assert.Equal(t, test.req.Labels, provider.req.Labels, "expected labels don't match the submitted request")
-			assert.Equal(t, test.req.Mounts, provider.req.Mounts, "expected mounts don't match the submitted request")
-			assert.Equal(t, test.req.WaitingFor, provider.req.WaitingFor, "expected waitingFor don't match the submitted request")
-			assert.Equal(t, test.req.Env, provider.req.Env, "expected env doesn't match the submitted request")
-
-			// checks for reaper's preCreationCallback fields
-			assert.Equal(t, container.NetworkMode(Bridge), provider.hostConfig.NetworkMode, "expected networkMode doesn't match the submitted request")
-			assert.True(t, provider.hostConfig.AutoRemove, "expected networkMode doesn't match the submitted request")
-		})
-	}
+	// checks for reaper's preCreationCallback fields
+	require.Equal(t, container.NetworkMode(Bridge), provider.hostConfig.NetworkMode, "expected networkMode doesn't match the submitted request")
+	require.True(t, provider.hostConfig.AutoRemove, "expected networkMode doesn't match the submitted request")
 }
 
 func Test_ReaperReusedIfHealthy(t *testing.T) {
-	config.Reset() // reset the config using the internal method to avoid the sync.Once
-	tcConfig := config.Read()
-	if tcConfig.RyukDisabled {
-		t.Skip("Ryuk is disabled, skipping test")
-	}
-
-	testProvider := newMockReaperProvider(t)
-	t.Cleanup(testProvider.RestoreReaperState)
+	reaperDisable(t, false)
 
 	SkipIfProviderIsNotHealthy(t)
 
 	ctx := context.Background()
 	// As other integration tests run with the (shared) Reaper as well, re-use the instance to not interrupt other tests
-	wasReaperRunning := reaperInstance != nil
+	if spawner.instance != nil {
+		t.Cleanup(func() {
+			require.NoError(t, spawner.cleanup())
+		})
+	}
 
-	provider, _ := ProviderDocker.GetProvider()
-	reaper, err := reuseOrCreateReaper(context.WithValue(ctx, core.DockerHostContextKey, provider.(*DockerProvider).host), testSessionID, provider)
+	provider, err := ProviderDocker.GetProvider()
+	require.NoError(t, err)
+
+	reaper, err := spawner.reaper(context.WithValue(ctx, core.DockerHostContextKey, provider.(*DockerProvider).host), testSessionID, provider)
+	cleanupReaper(t, reaper, spawner)
 	require.NoError(t, err, "creating the Reaper should not error")
 
-	reaperReused, err := reuseOrCreateReaper(context.WithValue(ctx, core.DockerHostContextKey, provider.(*DockerProvider).host), testSessionID, provider)
+	reaperReused, err := spawner.reaper(context.WithValue(ctx, core.DockerHostContextKey, provider.(*DockerProvider).host), testSessionID, provider)
+	cleanupReaper(t, reaper, spawner)
 	require.NoError(t, err, "reusing the Reaper should not error")
-	// assert that the internal state of both reaper instances is the same
-	assert.Equal(t, reaper.SessionID, reaperReused.SessionID, "expecting the same SessionID")
-	assert.Equal(t, reaper.Endpoint, reaperReused.Endpoint, "expecting the same reaper endpoint")
-	assert.Equal(t, reaper.Provider, reaperReused.Provider, "expecting the same container provider")
-	assert.Equal(t, reaper.container.GetContainerID(), reaperReused.container.GetContainerID(), "expecting the same container ID")
-	assert.Equal(t, reaper.container.SessionID(), reaperReused.container.SessionID(), "expecting the same session ID")
 
-	terminate, err := reaper.Connect()
-	defer func(term chan bool) {
-		term <- true
-	}(terminate)
+	// Ensure the internal state of both reaper instances is the same
+	require.Equal(t, reaper.SessionID, reaperReused.SessionID, "expecting the same SessionID")
+	require.Equal(t, reaper.Endpoint, reaperReused.Endpoint, "expecting the same reaper endpoint")
+	require.Equal(t, reaper.Provider, reaperReused.Provider, "expecting the same container provider")
+	require.Equal(t, reaper.container.GetContainerID(), reaperReused.container.GetContainerID(), "expecting the same container ID")
+	require.Equal(t, reaper.container.SessionID(), reaperReused.container.SessionID(), "expecting the same session ID")
+
+	termSignal, err := reaper.Connect()
+	cleanupTermSignal(t, termSignal)
 	require.NoError(t, err, "connecting to Reaper should be successful")
-
-	if !wasReaperRunning {
-		CleanupContainer(t, reaper.container)
-	}
 }
 
 func Test_RecreateReaperIfTerminated(t *testing.T) {
-	config.Reset() // reset the config using the internal method to avoid the sync.Once
-	tcConfig := config.Read()
-	if tcConfig.RyukDisabled {
-		t.Skip("Ryuk is disabled, skipping test")
-	}
-
-	mockProvider := newMockReaperProvider(t)
-	t.Cleanup(mockProvider.RestoreReaperState)
+	reaperDisable(t, false)
 
 	SkipIfProviderIsNotHealthy(t)
 
-	provider, _ := ProviderDocker.GetProvider()
+	provider, err := ProviderDocker.GetProvider()
+	require.NoError(t, err)
+
 	ctx := context.Background()
-	reaper, err := reuseOrCreateReaper(context.WithValue(ctx, core.DockerHostContextKey, provider.(*DockerProvider).host), testSessionID, provider)
+	reaper, err := spawner.reaper(context.WithValue(ctx, core.DockerHostContextKey, provider.(*DockerProvider).host), testSessionID, provider)
+	cleanupReaper(t, reaper, spawner)
 	require.NoError(t, err, "creating the Reaper should not error")
 
-	terminate, err := reaper.Connect()
-	require.NoError(t, err, "connecting to Reaper should be successful")
-	terminate <- true
+	termSignal, err := reaper.Connect()
+	if termSignal != nil {
+		termSignal <- true
+	}
+	require.NoError(t, err)
 
-	// Wait for ryuk's default timeout (10s) + 1s to allow for a graceful shutdown/cleanup of the container.
-	time.Sleep(11 * time.Second)
+	// Wait for up to ryuk's default reconnect timeout + 1s to allow for a graceful shutdown/cleanup of the container.
+	timeout := time.NewTimer(time.Second * 11)
+	t.Cleanup(func() {
+		timeout.Stop()
+	})
+	for {
+		state, err := reaper.container.State(ctx)
+		if err != nil {
+			if errdefs.IsNotFound(err) {
+				break
+			}
+			require.NoError(t, err)
+		}
 
-	recreatedReaper, err := reuseOrCreateReaper(context.WithValue(ctx, core.DockerHostContextKey, provider.(*DockerProvider).host), testSessionID, provider)
+		if !state.Running {
+			break
+		}
+
+		select {
+		case <-timeout.C:
+			t.Fatal("reaper container should have been terminated")
+		default:
+		}
+
+		time.Sleep(time.Millisecond * 100)
+	}
+
+	recreatedReaper, err := spawner.reaper(context.WithValue(ctx, core.DockerHostContextKey, provider.(*DockerProvider).host), testSessionID, provider)
+	cleanupReaper(t, recreatedReaper, spawner)
 	require.NoError(t, err, "creating the Reaper should not error")
-	assert.NotEqual(t, reaper.container.GetContainerID(), recreatedReaper.container.GetContainerID(), "expected different container ID")
+	require.NotEqual(t, reaper.container.GetContainerID(), recreatedReaper.container.GetContainerID(), "expected different container ID")
 
-	terminate, err = recreatedReaper.Connect()
-	defer func(term chan bool) {
-		term <- true
-	}(terminate)
+	recreatedTermSignal, err := recreatedReaper.Connect()
+	cleanupTermSignal(t, recreatedTermSignal)
 	require.NoError(t, err, "connecting to Reaper should be successful")
-	CleanupContainer(t, recreatedReaper.container)
 }
 
 func TestReaper_reuseItFromOtherTestProgramUsingDocker(t *testing.T) {
-	config.Reset() // reset the config using the internal method to avoid the sync.Once
-	tcConfig := config.Read()
-	if tcConfig.RyukDisabled {
-		t.Skip("Ryuk is disabled, skipping test")
-	}
+	reaperDisable(t, false)
 
-	mockProvider := &mockReaperProvider{
-		initialReaper: reaperInstance,
-		//nolint:govet
-		initialReaperOnce: reaperOnce,
-		t:                 t,
-	}
-	t.Cleanup(mockProvider.RestoreReaperState)
-
-	// explicitly set the reaperInstance to nil to simulate another test program in the same session accessing the same reaper
-	reaperInstance = nil
-	reaperOnce = sync.Once{}
+	// Explicitly set the reaper instance to nil to simulate another test
+	// program in the same session accessing the same reaper.
+	spawner.instance = nil
 
 	SkipIfProviderIsNotHealthy(t)
 
 	ctx := context.Background()
-	// As other integration tests run with the (shared) Reaper as well, re-use the instance to not interrupt other tests
-	wasReaperRunning := reaperInstance != nil
+	// As other integration tests run with the (shared) Reaper as well,
+	// re-use the instance to not interrupt other tests.
+	if spawner.instance != nil {
+		t.Cleanup(func() {
+			require.NoError(t, spawner.cleanup())
+		})
+	}
 
-	provider, _ := ProviderDocker.GetProvider()
-	reaper, err := reuseOrCreateReaper(context.WithValue(ctx, core.DockerHostContextKey, provider.(*DockerProvider).host), testSessionID, provider)
+	provider, err := ProviderDocker.GetProvider()
+	require.NoError(t, err)
+
+	reaper, err := spawner.reaper(context.WithValue(ctx, core.DockerHostContextKey, provider.(*DockerProvider).host), testSessionID, provider)
+	cleanupReaper(t, reaper, spawner)
 	require.NoError(t, err, "creating the Reaper should not error")
 
-	// explicitly reset the reaperInstance to nil to simulate another test program in the same session accessing the same reaper
-	reaperInstance = nil
-	reaperOnce = sync.Once{}
+	// Explicitly reset the reaper instance to nil to simulate another test
+	// program in the same session accessing the same reaper.
+	spawner.instance = nil
 
-	reaperReused, err := reuseOrCreateReaper(context.WithValue(ctx, core.DockerHostContextKey, provider.(*DockerProvider).host), testSessionID, provider)
+	reaperReused, err := spawner.reaper(context.WithValue(ctx, core.DockerHostContextKey, provider.(*DockerProvider).host), testSessionID, provider)
+	cleanupReaper(t, reaper, spawner)
 	require.NoError(t, err, "reusing the Reaper should not error")
-	// assert that the internal state of both reaper instances is the same
-	assert.Equal(t, reaper.SessionID, reaperReused.SessionID, "expecting the same SessionID")
-	assert.Equal(t, reaper.Endpoint, reaperReused.Endpoint, "expecting the same reaper endpoint")
-	assert.Equal(t, reaper.Provider, reaperReused.Provider, "expecting the same container provider")
-	assert.Equal(t, reaper.container.GetContainerID(), reaperReused.container.GetContainerID(), "expecting the same container ID")
-	assert.Equal(t, reaper.container.SessionID(), reaperReused.container.SessionID(), "expecting the same session ID")
 
-	terminate, err := reaper.Connect()
-	defer func(term chan bool) {
-		term <- true
-	}(terminate)
+	// Ensure that the internal state of both reaper instances is the same.
+	require.Equal(t, reaper.SessionID, reaperReused.SessionID, "expecting the same SessionID")
+	require.Equal(t, reaper.Endpoint, reaperReused.Endpoint, "expecting the same reaper endpoint")
+	require.Equal(t, reaper.Provider, reaperReused.Provider, "expecting the same container provider")
+	require.Equal(t, reaper.container.GetContainerID(), reaperReused.container.GetContainerID(), "expecting the same container ID")
+	require.Equal(t, reaper.container.SessionID(), reaperReused.container.SessionID(), "expecting the same session ID")
+
+	termSignal, err := reaper.Connect()
+	cleanupTermSignal(t, termSignal)
 	require.NoError(t, err, "connecting to Reaper should be successful")
-
-	if !wasReaperRunning {
-		CleanupContainer(t, reaper.container)
-	}
 }
 
 // TestReaper_ReuseRunning tests whether reusing the reaper if using
@@ -586,15 +503,11 @@ func TestReaper_reuseItFromOtherTestProgramUsingDocker(t *testing.T) {
 // already running for the same session id by returning its container instance
 // instead.
 func TestReaper_ReuseRunning(t *testing.T) {
-	config.Reset() // reset the config using the internal method to avoid the sync.Once
-	tcConfig := config.Read()
-	if tcConfig.RyukDisabled {
-		t.Skip("Ryuk is disabled, skipping test")
-	}
+	reaperDisable(t, false)
 
 	const concurrency = 64
 
-	timeout, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	timeout, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
 
 	sessionID := SessionID()
@@ -605,27 +518,54 @@ func TestReaper_ReuseRunning(t *testing.T) {
 	obtainedReaperContainerIDs := make([]string, concurrency)
 	var wg sync.WaitGroup
 	for i := 0; i < concurrency; i++ {
-		i := i
 		wg.Add(1)
-		go func() {
+		go func(i int) {
 			defer wg.Done()
-			reaperContainer, err := lookUpReaperContainer(timeout, sessionID)
-			if err == nil && reaperContainer != nil {
-				// Found.
-				obtainedReaperContainerIDs[i] = reaperContainer.GetContainerID()
-				return
-			}
-			// Not found -> create.
-			createdReaper, err := newReaper(timeout, sessionID, dockerProvider)
-			require.NoError(t, err, "new reaper should not fail")
-			obtainedReaperContainerIDs[i] = createdReaper.container.GetContainerID()
-		}()
+			spawner := &reaperSpawner{}
+			reaper, err := spawner.reaper(timeout, sessionID, dockerProvider)
+			cleanupReaper(t, reaper, spawner)
+			require.NoError(t, err)
+
+			obtainedReaperContainerIDs[i] = reaper.container.GetContainerID()
+		}(i)
 	}
 	wg.Wait()
 
 	// Assure that all calls returned the same container.
 	firstContainerID := obtainedReaperContainerIDs[0]
 	for i, containerID := range obtainedReaperContainerIDs {
-		assert.Equal(t, firstContainerID, containerID, "call %d should have returned same container id", i)
+		require.Equal(t, firstContainerID, containerID, "call %d should have returned same container id", i)
 	}
+}
+
+func TestSpawnerBackoff(t *testing.T) {
+	b := spawner.backoff()
+	for i := 0; i < 100; i++ {
+		require.LessOrEqual(t, b.NextBackOff(), time.Millisecond*250, "backoff should not exceed max interval")
+	}
+}
+
+// cleanupReaper schedules reaper for cleanup if it's not nil.
+func cleanupReaper(t *testing.T, reaper *Reaper, spawner *reaperSpawner) {
+	t.Helper()
+
+	if reaper == nil {
+		return
+	}
+
+	t.Cleanup(func() {
+		reaper.close()
+		require.NoError(t, spawner.cleanup())
+	})
+}
+
+// cleanupTermSignal ensures that termSignal
+func cleanupTermSignal(t *testing.T, termSignal chan bool) {
+	t.Helper()
+
+	t.Cleanup(func() {
+		if termSignal != nil {
+			termSignal <- true
+		}
+	})
 }

--- a/testing.go
+++ b/testing.go
@@ -68,11 +68,11 @@ func (lc *StdoutLogConsumer) Accept(l Log) {
 // container is stopped when the function ends.
 //
 // before any error check. If container is nil, its a no-op.
-func CleanupContainer(tb testing.TB, container Container, options ...TerminateOption) {
+func CleanupContainer(tb testing.TB, ctr Container, options ...TerminateOption) {
 	tb.Helper()
 
 	tb.Cleanup(func() {
-		noErrorOrIgnored(tb, TerminateContainer(container, options...))
+		noErrorOrIgnored(tb, TerminateContainer(ctr, options...))
 	})
 }
 


### PR DESCRIPTION
Refactor how the reaper is created to allow for proper retries of temporary errors such as container not found issues during startup or shutdown races.

This eliminates the use of sync.Once which wasn't solving the problem at hand and replaces it with a singleton spawner with locked access.

Wrap reaper errors so we can determine the cause of failures more easily.

Fix race condition in port wait when loading from container by always waiting for the port first.

Remove unnecessary use of buffering and invalid retry logic in reaper connection handling which could never recover correctly from a partial read.

Move the reaper creation just before connections are established in compose to ensure its still running when the Connect calls are made.

Previously the reaper was requested in NewDockerComposeWith which means it could have already shutdown before connections are made during the later sections of Up if the startup took over 1 minute.

This was causing consistent failures for:
TestDockerComposeAPIWithWaitLogStrategy

Ensure that resource labels are correct so that resources aren't reaped when the reaper is disabled by excluding session id when reaper is disabled.

Error when creating a reaper when the config says it's disabled so that we avoid hard to debug issues because a reaper is running when it shouldn't be.