### PR TITLE
docs: fix broken doc tags

### DIFF
--- a/modules/vearch/examples_test.go
+++ b/modules/vearch/examples_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func ExampleRun() {
+	// runVearchContainer {
 	ctx := context.Background()
 
 	vearchContainer, err := vearch.Run(ctx, "vearch/vearch:3.5.1")

--- a/wait/exec_test.go
+++ b/wait/exec_test.go
@@ -209,5 +209,4 @@ func TestExecStrategyWaitUntilReady_CustomResponseMatcher(t *testing.T) {
 			t.Fatalf("failed to terminate container: %s", err)
 		}
 	})
-	// }
 }


### PR DESCRIPTION
A missing block start in vearch for runVearchContainer.

Remove duplicate block end in exec test.