### PR TITLE
chore: run make tests in verbose mode

### DIFF
--- a/commons-test.mk
+++ b/commons-test.mk
@@ -37,6 +37,7 @@ test-%: $(GOBIN)/gotestsum
 		--packages="./..." \
 		--junitfile TEST-unit.xml \
 		-- \
+		-v \
 		-coverprofile=coverage.out \
 		-timeout=30m
 


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
It adds the verbose flag to `go test` in the makefile.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
We want verbosity in the CI logs to debug test errors.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->


<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
