### PR TITLE
feat: expose functions for resource clean up in tests and examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ TEST-*.xml
 tcvenv
 
 **/go.work
+
+# VS Code settings
+.vscode

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,6 +8,7 @@ linters:
     - nonamedreturns
     - testifylint
     - errcheck
+    - nolintlint
 
 linters-settings:
   errorlint:

--- a/cleanup.go
+++ b/cleanup.go
@@ -1,0 +1,107 @@
+package testcontainers
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"reflect"
+	"time"
+)
+
+// terminateOptions is a type that holds the options for terminating a container.
+type terminateOptions struct {
+	ctx     context.Context
+	timeout *time.Duration
+	volumes []string
+}
+
+// TerminateOption is a type that represents an option for terminating a container.
+type TerminateOption func(*terminateOptions)
+
+// StopContext returns a TerminateOption that sets the context.
+// Default: context.Background().
+func StopContext(ctx context.Context) TerminateOption {
+	return func(c *terminateOptions) {
+		c.ctx = ctx
+	}
+}
+
+// StopTimeout returns a TerminateOption that sets the timeout.
+// Default: See [Container.Stop].
+func StopTimeout(timeout time.Duration) TerminateOption {
+	return func(c *terminateOptions) {
+		c.timeout = &timeout
+	}
+}
+
+// RemoveVolumes returns a TerminateOption that sets additional volumes to remove.
+// This is useful when the container creates named volumes that should be removed
+// which are not removed by default.
+// Default: nil.
+func RemoveVolumes(volumes ...string) TerminateOption {
+	return func(c *terminateOptions) {
+		c.volumes = volumes
+	}
+}
+
+// TerminateContainer calls [Container.Terminate] on the container if it is not nil.
+//
+// This should be called as a defer directly after [GenericContainer](...)
+// or a modules Run(...) to ensure the container is terminated when the
+// function ends.
+func TerminateContainer(container Container, options ...TerminateOption) error {
+	if isNil(container) {
+		return nil
+	}
+
+	c := &terminateOptions{
+		ctx: context.Background(),
+	}
+
+	for _, opt := range options {
+		opt(c)
+	}
+
+	// TODO: Add a timeout when terminate supports it.
+	err := container.Terminate(c.ctx)
+	if !isCleanupSafe(err) {
+		return fmt.Errorf("terminate: %w", err)
+	}
+
+	// Remove additional volumes if any.
+	if len(c.volumes) == 0 {
+		return nil
+	}
+
+	client, err := NewDockerClientWithOpts(c.ctx)
+	if err != nil {
+		return fmt.Errorf("docker client: %w", err)
+	}
+
+	defer client.Close()
+
+	// Best effort to remove all volumes.
+	var errs []error
+	for _, volume := range c.volumes {
+		if errRemove := client.VolumeRemove(c.ctx, volume, true); errRemove != nil {
+			errs = append(errs, fmt.Errorf("volume remove %q: %w", volume, errRemove))
+		}
+	}
+
+	return errors.Join(errs...)
+}
+
+// isNil returns true if val is nil or an nil instance false otherwise.
+func isNil(val any) bool {
+	if val == nil {
+		return true
+	}
+
+	valueOf := reflect.ValueOf(val)
+	switch valueOf.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Map, reflect.Ptr, reflect.UnsafePointer, reflect.Interface, reflect.Slice:
+		return valueOf.IsNil()
+	default:
+		return false
+	}
+}

--- a/container_test.go
+++ b/container_test.go
@@ -290,8 +290,7 @@ func Test_BuildImageWithContexts(t *testing.T) {
 				ContainerRequest: req,
 				Started:          true,
 			})
-
-			defer terminateContainerOnEnd(t, ctx, c)
+			testcontainers.CleanupContainer(t, c)
 
 			if testCase.ExpectedError != "" {
 				require.EqualError(t, err, testCase.ExpectedError)
@@ -317,7 +316,7 @@ func Test_GetLogsFromFailedContainer(t *testing.T) {
 		ContainerRequest: req,
 		Started:          true,
 	})
-	terminateContainerOnEnd(t, ctx, c)
+	testcontainers.CleanupContainer(t, c)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "container exited with code 0")
 
@@ -417,25 +416,21 @@ func TestImageSubstitutors(t *testing.T) {
 				ImageSubstitutors: test.substitutors,
 			}
 
-			container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
+			ctr, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
 				ContainerRequest: req,
 				Started:          true,
 			})
+			testcontainers.CleanupContainer(t, ctr)
 			if test.expectedError != nil {
 				require.ErrorIs(t, err, test.expectedError)
 				return
 			}
 
-			if err != nil {
-				t.Fatal(err)
-			}
-			defer func() {
-				terminateContainerOnEnd(t, ctx, container)
-			}()
+			require.NoError(t, err)
 
 			// enforce the concrete type, as GenericContainer returns an interface,
 			// which will be changed in future implementations of the library
-			dockerContainer := container.(*testcontainers.DockerContainer)
+			dockerContainer := ctr.(*testcontainers.DockerContainer)
 			assert.Equal(t, test.expectedImage, dockerContainer.Image)
 		})
 	}
@@ -455,21 +450,17 @@ func TestShouldStartContainersInParallel(t *testing.T) {
 				ExposedPorts: []string{nginxDefaultPort},
 				WaitingFor:   wait.ForHTTP("/").WithStartupTimeout(10 * time.Second),
 			}
-			container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
+			ctr, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
 				ContainerRequest: req,
 				Started:          true,
 			})
-			if err != nil {
-				t.Fatalf("could not start container: %v", err)
-			}
-			// mappedPort {
-			port, err := container.MappedPort(ctx, nginxDefaultPort)
-			// }
-			if err != nil {
-				t.Fatalf("could not get mapped port: %v", err)
-			}
+			testcontainers.CleanupContainer(t, ctr)
+			require.NoError(t, err)
 
-			terminateContainerOnEnd(t, ctx, container)
+			// mappedPort {
+			port, err := ctr.MappedPort(ctx, nginxDefaultPort)
+			// }
+			require.NoError(t, err)
 
 			t.Logf("Parallel container [iteration_%d] listening on %d\n", i, port.Int())
 		})
@@ -480,28 +471,28 @@ func ExampleGenericContainer_withSubstitutors() {
 	ctx := context.Background()
 
 	// applyImageSubstitutors {
-	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
+	ctr, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
 		ContainerRequest: testcontainers.ContainerRequest{
 			Image:             "alpine:latest",
 			ImageSubstitutors: []testcontainers.ImageSubstitutor{dockerImageSubstitutor{}},
 		},
 		Started: true,
 	})
-	// }
-	if err != nil {
-		log.Fatalf("could not start container: %v", err)
-	}
-
 	defer func() {
-		err := container.Terminate(ctx)
-		if err != nil {
-			log.Fatalf("could not terminate container: %v", err)
+		if err := testcontainers.TerminateContainer(ctr); err != nil {
+			log.Printf("failed to terminate container: %s", err)
 		}
 	}()
 
+	// }
+	if err != nil {
+		log.Printf("could not start container: %v", err)
+		return
+	}
+
 	// enforce the concrete type, as GenericContainer returns an interface,
 	// which will be changed in future implementations of the library
-	dockerContainer := container.(*testcontainers.DockerContainer)
+	dockerContainer := ctr.(*testcontainers.DockerContainer)
 
 	fmt.Println(dockerContainer.Image)
 

--- a/docker_auth_test.go
+++ b/docker_auth_test.go
@@ -164,8 +164,8 @@ func TestBuildContainerFromDockerfile(t *testing.T) {
 	}
 
 	redisC, err := prepareRedisImage(ctx, req)
+	CleanupContainer(t, redisC)
 	require.NoError(t, err)
-	terminateContainerOnEnd(t, ctx, redisC)
 }
 
 // removeImageFromLocalCache removes the image from the local cache
@@ -202,8 +202,7 @@ func TestBuildContainerFromDockerfileWithDockerAuthConfig(t *testing.T) {
 			BuildArgs: map[string]*string{
 				"REGISTRY_HOST": &registryHost,
 			},
-			Repo:          "localhost",
-			PrintBuildLog: true,
+			Repo: "localhost",
 		},
 		AlwaysPullImage: true, // make sure the authentication takes place
 		ExposedPorts:    []string{"6379/tcp"},
@@ -211,7 +210,7 @@ func TestBuildContainerFromDockerfileWithDockerAuthConfig(t *testing.T) {
 	}
 
 	redisC, err := prepareRedisImage(ctx, req)
-	terminateContainerOnEnd(t, ctx, redisC)
+	CleanupContainer(t, redisC)
 	require.NoError(t, err)
 }
 
@@ -237,7 +236,7 @@ func TestBuildContainerFromDockerfileShouldFailWithWrongDockerAuthConfig(t *test
 	}
 
 	redisC, err := prepareRedisImage(ctx, req)
-	terminateContainerOnEnd(t, ctx, redisC)
+	CleanupContainer(t, redisC)
 	require.Error(t, err)
 }
 
@@ -259,7 +258,7 @@ func TestCreateContainerFromPrivateRegistry(t *testing.T) {
 		ContainerRequest: req,
 		Started:          true,
 	})
-	terminateContainerOnEnd(t, ctx, redisContainer)
+	CleanupContainer(t, redisContainer)
 	require.NoError(t, err)
 }
 
@@ -298,6 +297,7 @@ func prepareLocalRegistryWithAuth(t *testing.T) string {
 	}
 
 	registryC, err := GenericContainer(ctx, genContainerReq)
+	CleanupContainer(t, registryC)
 	require.NoError(t, err)
 
 	mappedPort, err := registryC.MappedPort(ctx, "5000/tcp")
@@ -309,9 +309,6 @@ func prepareLocalRegistryWithAuth(t *testing.T) string {
 
 	t.Cleanup(func() {
 		removeImageFromLocalCache(t, addr+"/redis:5.0-alpine")
-	})
-	t.Cleanup(func() {
-		require.NoError(t, registryC.Terminate(context.Background()))
 	})
 
 	_, cancel := context.WithCancel(context.Background())

--- a/docker_exec_test.go
+++ b/docker_exec_test.go
@@ -51,19 +51,18 @@ func TestExecWithOptions(t *testing.T) {
 				Image: nginxAlpineImage,
 			}
 
-			container, err := GenericContainer(ctx, GenericContainerRequest{
+			ctr, err := GenericContainer(ctx, GenericContainerRequest{
 				ContainerRequest: req,
 				Started:          true,
 			})
-
+			CleanupContainer(t, ctr)
 			require.NoError(t, err)
-			terminateContainerOnEnd(t, ctx, container)
 
 			// always append the multiplexed option for having the output
 			// in a readable format
 			tt.opts = append(tt.opts, tcexec.Multiplexed())
 
-			code, reader, err := container.Exec(ctx, tt.cmds, tt.opts...)
+			code, reader, err := ctr.Exec(ctx, tt.cmds, tt.opts...)
 			require.NoError(t, err)
 			require.Zero(t, code)
 			require.NotNil(t, reader)
@@ -84,15 +83,14 @@ func TestExecWithMultiplexedResponse(t *testing.T) {
 		Image: nginxAlpineImage,
 	}
 
-	container, err := GenericContainer(ctx, GenericContainerRequest{
+	ctr, err := GenericContainer(ctx, GenericContainerRequest{
 		ContainerRequest: req,
 		Started:          true,
 	})
-
+	CleanupContainer(t, ctr)
 	require.NoError(t, err)
-	terminateContainerOnEnd(t, ctx, container)
 
-	code, reader, err := container.Exec(ctx, []string{"sh", "-c", "echo stdout; echo stderr >&2"}, tcexec.Multiplexed())
+	code, reader, err := ctr.Exec(ctx, []string{"sh", "-c", "echo stdout; echo stderr >&2"}, tcexec.Multiplexed())
 	require.NoError(t, err)
 	require.Zero(t, code)
 	require.NotNil(t, reader)
@@ -112,15 +110,14 @@ func TestExecWithNonMultiplexedResponse(t *testing.T) {
 		Image: nginxAlpineImage,
 	}
 
-	container, err := GenericContainer(ctx, GenericContainerRequest{
+	ctr, err := GenericContainer(ctx, GenericContainerRequest{
 		ContainerRequest: req,
 		Started:          true,
 	})
-
+	CleanupContainer(t, ctr)
 	require.NoError(t, err)
-	terminateContainerOnEnd(t, ctx, container)
 
-	code, reader, err := container.Exec(ctx, []string{"sh", "-c", "echo stdout; echo stderr >&2"})
+	code, reader, err := ctr.Exec(ctx, []string{"sh", "-c", "echo stdout; echo stderr >&2"})
 	require.NoError(t, err)
 	require.Zero(t, code)
 	require.NotNil(t, reader)

--- a/docker_files_test.go
+++ b/docker_files_test.go
@@ -28,7 +28,7 @@ func TestCopyFileToContainer(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
+	ctr, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
 		ContainerRequest: testcontainers.ContainerRequest{
 			Image: "docker.io/bash",
 			Files: []testcontainers.ContainerFile{
@@ -45,9 +45,8 @@ func TestCopyFileToContainer(t *testing.T) {
 		Started: true,
 	})
 	// }
-
+	testcontainers.CleanupContainer(t, ctr)
 	require.NoError(t, err)
-	require.NoError(t, container.Terminate(ctx))
 }
 
 func TestCopyFileToRunningContainer(t *testing.T) {
@@ -65,7 +64,7 @@ func TestCopyFileToRunningContainer(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
+	ctr, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
 		ContainerRequest: testcontainers.ContainerRequest{
 			Image: "docker.io/bash:5.2.26",
 			Files: []testcontainers.ContainerFile{
@@ -79,20 +78,17 @@ func TestCopyFileToRunningContainer(t *testing.T) {
 		},
 		Started: true,
 	})
-	if err != nil {
-		t.Fatal(err)
-	}
+	testcontainers.CleanupContainer(t, ctr)
+	require.NoError(t, err)
 
-	err = container.CopyFileToContainer(ctx, helloPath, "/scripts/hello.sh", 0o700)
+	err = ctr.CopyFileToContainer(ctx, helloPath, "/scripts/hello.sh", 0o700)
 	// }
 
 	require.NoError(t, err)
 
 	// Give some time to the wait script to catch the hello script being created
-	err = wait.ForLog("done").WithStartupTimeout(2*time.Second).WaitUntilReady(ctx, container)
+	err = wait.ForLog("done").WithStartupTimeout(2*time.Second).WaitUntilReady(ctx, ctr)
 	require.NoError(t, err)
-
-	require.NoError(t, container.Terminate(ctx))
 }
 
 func TestCopyDirectoryToContainer(t *testing.T) {
@@ -106,7 +102,7 @@ func TestCopyDirectoryToContainer(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
+	ctr, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
 		ContainerRequest: testcontainers.ContainerRequest{
 			Image: "docker.io/bash",
 			Files: []testcontainers.ContainerFile{
@@ -125,9 +121,8 @@ func TestCopyDirectoryToContainer(t *testing.T) {
 		Started: true,
 	})
 	// }
-
+	testcontainers.CleanupContainer(t, ctr)
 	require.NoError(t, err)
-	require.NoError(t, container.Terminate(ctx))
 }
 
 func TestCopyDirectoryToRunningContainerAsFile(t *testing.T) {
@@ -144,7 +139,7 @@ func TestCopyDirectoryToRunningContainerAsFile(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
+	ctr, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
 		ContainerRequest: testcontainers.ContainerRequest{
 			Image: "docker.io/bash",
 			Files: []testcontainers.ContainerFile{
@@ -158,25 +153,17 @@ func TestCopyDirectoryToRunningContainerAsFile(t *testing.T) {
 		},
 		Started: true,
 	})
-	if err != nil {
-		t.Fatal(err)
-	}
+	testcontainers.CleanupContainer(t, ctr)
+	require.NoError(t, err)
 
 	// as the container is started, we can create the directory first
-	_, _, err = container.Exec(ctx, []string{"mkdir", "-p", "/scripts"})
-	if err != nil {
-		t.Fatal(err)
-	}
+	_, _, err = ctr.Exec(ctx, []string{"mkdir", "-p", "/scripts"})
+	require.NoError(t, err)
 
 	// because the container path is a directory, it will use the copy dir method as fallback
-	err = container.CopyFileToContainer(ctx, dataDirectory, "/scripts", 0o700)
-	if err != nil {
-		t.Fatal(err)
-	}
-	// }
-
+	err = ctr.CopyFileToContainer(ctx, dataDirectory, "/scripts", 0o700)
 	require.NoError(t, err)
-	require.NoError(t, container.Terminate(ctx))
+	// }
 }
 
 func TestCopyDirectoryToRunningContainerAsDir(t *testing.T) {
@@ -194,7 +181,7 @@ func TestCopyDirectoryToRunningContainerAsDir(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
+	ctr, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
 		ContainerRequest: testcontainers.ContainerRequest{
 			Image: "docker.io/bash",
 			Files: []testcontainers.ContainerFile{
@@ -208,22 +195,14 @@ func TestCopyDirectoryToRunningContainerAsDir(t *testing.T) {
 		},
 		Started: true,
 	})
-	if err != nil {
-		t.Fatal(err)
-	}
+	testcontainers.CleanupContainer(t, ctr)
+	require.NoError(t, err)
 
 	// as the container is started, we can create the directory first
-	_, _, err = container.Exec(ctx, []string{"mkdir", "-p", "/scripts"})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	err = container.CopyDirToContainer(ctx, dataDirectory, "/scripts", 0o700)
-	if err != nil {
-		t.Fatal(err)
-	}
-	// }
-
+	_, _, err = ctr.Exec(ctx, []string{"mkdir", "-p", "/scripts"})
 	require.NoError(t, err)
-	require.NoError(t, container.Terminate(ctx))
+
+	err = ctr.CopyDirToContainer(ctx, dataDirectory, "/scripts", 0o700)
+	require.NoError(t, err)
+	// }
 }

--- a/docker_test.go
+++ b/docker_test.go
@@ -82,8 +82,8 @@ func TestContainerWithHostNetworkOptions(t *testing.T) {
 	}
 
 	nginxC, err := GenericContainer(ctx, gcr)
+	CleanupContainer(t, nginxC)
 	require.NoError(t, err)
-	terminateContainerOnEnd(t, ctx, nginxC)
 
 	// host, err := nginxC.Host(ctx)
 	// if err != nil {
@@ -113,11 +113,10 @@ func TestContainerWithHostNetworkOptions_UseExposePortsFromImageConfigs(t *testi
 	}
 
 	nginxC, err := GenericContainer(ctx, gcr)
+	CleanupContainer(t, nginxC)
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	terminateContainerOnEnd(t, ctx, nginxC)
 
 	endpoint, err := nginxC.Endpoint(ctx, "http")
 	if err != nil {
@@ -158,11 +157,11 @@ func TestContainerWithNetworkModeAndNetworkTogether(t *testing.T) {
 	}
 
 	nginx, err := GenericContainer(ctx, gcr)
+	CleanupContainer(t, nginx)
 	if err != nil {
 		// Error when NetworkMode = host and Network = []string{"bridge"}
 		t.Logf("Can't use Network and NetworkMode together, %s\n", err)
 	}
-	terminateContainerOnEnd(t, ctx, nginx)
 }
 
 func TestContainerWithHostNetwork(t *testing.T) {
@@ -197,9 +196,8 @@ func TestContainerWithHostNetwork(t *testing.T) {
 	}
 
 	nginxC, err := GenericContainer(ctx, gcr)
-
+	CleanupContainer(t, nginxC)
 	require.NoError(t, err)
-	terminateContainerOnEnd(t, ctx, nginxC)
 
 	portEndpoint, err := nginxC.PortEndpoint(ctx, nginxHighPort, "http")
 	if err != nil {
@@ -234,9 +232,8 @@ func TestContainerReturnItsContainerID(t *testing.T) {
 			},
 		},
 	})
-
+	CleanupContainer(t, nginxA)
 	require.NoError(t, err)
-	terminateContainerOnEnd(t, ctx, nginxA)
 
 	if nginxA.GetContainerID() == "" {
 		t.Errorf("expected a containerID but we got an empty string.")
@@ -256,21 +253,16 @@ func TestContainerTerminationResetsState(t *testing.T) {
 		},
 		Started: true,
 	})
-	if err != nil {
-		t.Fatal(err)
-	}
+	CleanupContainer(t, nginxA)
+	require.NoError(t, err)
 
 	err = nginxA.Terminate(ctx)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if nginxA.SessionID() != "" {
-		t.Fatal("Internal state must be reset.")
-	}
+	require.NoError(t, err)
+	require.Empty(t, nginxA.SessionID())
+
 	inspect, err := nginxA.Inspect(ctx)
-	if err == nil || inspect != nil {
-		t.Fatal("expected error from container inspect.")
-	}
+	require.Error(t, err)
+	require.Nil(t, inspect)
 }
 
 func TestContainerStateAfterTermination(t *testing.T) {
@@ -290,15 +282,12 @@ func TestContainerStateAfterTermination(t *testing.T) {
 	t.Run("Nil State after termination", func(t *testing.T) {
 		ctx := context.Background()
 		nginx, err := createContainerFn(ctx)
-		if err != nil {
-			t.Fatal(err)
-		}
+		CleanupContainer(t, nginx)
+		require.NoError(t, err)
 
 		// terminate the container before the raw state is set
 		err = nginx.Terminate(ctx)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
 		state, err := nginx.State(ctx)
 		require.Error(t, err, "expected error from container inspect.")
@@ -309,25 +298,20 @@ func TestContainerStateAfterTermination(t *testing.T) {
 	t.Run("Nil State after termination if raw as already set", func(t *testing.T) {
 		ctx := context.Background()
 		nginx, err := createContainerFn(ctx)
-		if err != nil {
-			t.Fatal(err)
-		}
+		CleanupContainer(t, nginx)
+		require.NoError(t, err)
 
 		state, err := nginx.State(ctx)
 		require.NoError(t, err, "unexpected error from container inspect before container termination.")
-
-		assert.NotNil(t, state, "unexpected nil container inspect before container termination.")
+		require.NotNil(t, state, "unexpected nil container inspect before container termination.")
 
 		// terminate the container before the raw state is set
 		err = nginx.Terminate(ctx)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
 		state, err = nginx.State(ctx)
 		require.Error(t, err, "expected error from container inspect after container termination.")
-
-		assert.Nil(t, state, "unexpected nil container inspect after container termination.")
+		require.Nil(t, state, "unexpected nil container inspect after container termination.")
 	})
 }
 
@@ -350,13 +334,12 @@ func TestContainerTerminationRemovesDockerImage(t *testing.T) {
 			},
 			Started: true,
 		})
-		if err != nil {
-			t.Fatal(err)
-		}
+		CleanupContainer(t, ctr)
+		require.NoError(t, err)
+
 		err = ctr.Terminate(ctx)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+
 		_, _, err = dockerClient.ImageInspectWithRaw(ctx, nginxAlpineImage)
 		if err != nil {
 			t.Fatal("nginx image should not have been removed")
@@ -383,6 +366,7 @@ func TestContainerTerminationRemovesDockerImage(t *testing.T) {
 			ContainerRequest: req,
 			Started:          true,
 		})
+		CleanupContainer(t, ctr)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -418,9 +402,8 @@ func TestTwoContainersExposingTheSamePort(t *testing.T) {
 		},
 		Started: true,
 	})
-
+	CleanupContainer(t, nginxA)
 	require.NoError(t, err)
-	terminateContainerOnEnd(t, ctx, nginxA)
 
 	nginxB, err := GenericContainer(ctx, GenericContainerRequest{
 		ProviderType: providerType,
@@ -433,9 +416,8 @@ func TestTwoContainersExposingTheSamePort(t *testing.T) {
 		},
 		Started: true,
 	})
-
+	CleanupContainer(t, nginxB)
 	require.NoError(t, err)
-	terminateContainerOnEnd(t, ctx, nginxB)
 
 	endpointA, err := nginxA.PortEndpoint(ctx, nginxDefaultPort, "http")
 	require.NoError(t, err)
@@ -480,9 +462,8 @@ func TestContainerCreation(t *testing.T) {
 		},
 		Started: true,
 	})
-
+	CleanupContainer(t, nginxC)
 	require.NoError(t, err)
-	terminateContainerOnEnd(t, ctx, nginxC)
 
 	endpoint, err := nginxC.PortEndpoint(ctx, nginxDefaultPort, "http")
 	require.NoError(t, err)
@@ -536,9 +517,8 @@ func TestContainerCreationWithName(t *testing.T) {
 		},
 		Started: true,
 	})
-
+	CleanupContainer(t, nginxC)
 	require.NoError(t, err)
-	terminateContainerOnEnd(t, ctx, nginxC)
 
 	inspect, err := nginxC.Inspect(ctx)
 	if err != nil {
@@ -597,9 +577,8 @@ func TestContainerCreationAndWaitForListeningPortLongEnough(t *testing.T) {
 		},
 		Started: true,
 	})
-
+	CleanupContainer(t, nginxC)
 	require.NoError(t, err)
-	terminateContainerOnEnd(t, ctx, nginxC)
 
 	origin, err := nginxC.PortEndpoint(ctx, nginxDefaultPort, "http")
 	if err != nil {
@@ -630,8 +609,7 @@ func TestContainerCreationTimesOut(t *testing.T) {
 		},
 		Started: true,
 	})
-
-	terminateContainerOnEnd(t, ctx, nginxC)
+	CleanupContainer(t, nginxC)
 
 	if err == nil {
 		t.Error("Expected timeout")
@@ -652,9 +630,8 @@ func TestContainerRespondsWithHttp200ForIndex(t *testing.T) {
 		},
 		Started: true,
 	})
-
+	CleanupContainer(t, nginxC)
 	require.NoError(t, err)
-	terminateContainerOnEnd(t, ctx, nginxC)
 
 	origin, err := nginxC.PortEndpoint(ctx, nginxDefaultPort, "http")
 	if err != nil {
@@ -685,8 +662,7 @@ func TestContainerCreationTimesOutWithHttp(t *testing.T) {
 		},
 		Started: true,
 	})
-	terminateContainerOnEnd(t, ctx, nginxC)
-
+	CleanupContainer(t, nginxC)
 	if err == nil {
 		t.Error("Expected timeout")
 	}
@@ -708,11 +684,10 @@ func TestContainerCreationWaitsForLogContextTimeout(t *testing.T) {
 		ContainerRequest: req,
 		Started:          true,
 	})
+	CleanupContainer(t, c)
 	if err == nil {
 		t.Error("Expected timeout")
 	}
-
-	terminateContainerOnEnd(t, ctx, c)
 }
 
 func TestContainerCreationWaitsForLog(t *testing.T) {
@@ -731,9 +706,8 @@ func TestContainerCreationWaitsForLog(t *testing.T) {
 		ContainerRequest: req,
 		Started:          true,
 	})
-
+	CleanupContainer(t, mysqlC)
 	require.NoError(t, err)
-	terminateContainerOnEnd(t, ctx, mysqlC)
 }
 
 func Test_BuildContainerFromDockerfileWithBuildArgs(t *testing.T) {
@@ -761,9 +735,8 @@ func Test_BuildContainerFromDockerfileWithBuildArgs(t *testing.T) {
 	}
 
 	c, err := GenericContainer(ctx, genContainerReq)
-
+	CleanupContainer(t, c)
 	require.NoError(t, err)
-	terminateContainerOnEnd(t, ctx, c)
 
 	ep, err := c.Endpoint(ctx, "http")
 	require.NoError(t, err)
@@ -779,13 +752,16 @@ func Test_BuildContainerFromDockerfileWithBuildArgs(t *testing.T) {
 }
 
 func Test_BuildContainerFromDockerfileWithBuildLog(t *testing.T) {
-	rescueStdout := os.Stderr
-	r, w, _ := os.Pipe()
-	os.Stderr = w
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
 
-	t.Log("getting ctx")
+	oldStderr := os.Stderr
+	os.Stderr = w
+	t.Cleanup(func() {
+		os.Stderr = oldStderr
+	})
+
 	ctx := context.Background()
-	t.Log("got ctx, creating container request")
 
 	// fromDockerfile {
 	req := ContainerRequest{
@@ -804,17 +780,19 @@ func Test_BuildContainerFromDockerfileWithBuildLog(t *testing.T) {
 	}
 
 	c, err := GenericContainer(ctx, genContainerReq)
-
+	CleanupContainer(t, c)
 	require.NoError(t, err)
-	terminateContainerOnEnd(t, ctx, c)
 
-	_ = w.Close()
-	out, _ := io.ReadAll(r)
-	os.Stdout = rescueStdout
+	err = w.Close()
+	require.NoError(t, err)
+
+	out, err := io.ReadAll(r)
+	require.NoError(t, err)
+
 	temp := strings.Split(string(out), "\n")
 
 	if !regexp.MustCompile(`^Step\s*1/\d+\s*:\s*FROM docker.io/alpine$`).MatchString(temp[0]) {
-		t.Errorf("Expected stdout firstline to be %s. Got '%s'.", "Step 1/* : FROM docker.io/alpine", temp[0])
+		t.Errorf("Expected stdout first line to be %s. Got '%s'.", "Step 1/* : FROM docker.io/alpine", temp[0])
 	}
 }
 
@@ -837,11 +815,10 @@ func TestContainerCreationWaitsForLogAndPortContextTimeout(t *testing.T) {
 		ContainerRequest: req,
 		Started:          true,
 	})
+	CleanupContainer(t, c)
 	if err == nil {
 		t.Fatal("Expected timeout")
 	}
-
-	terminateContainerOnEnd(t, ctx, c)
 }
 
 func TestContainerCreationWaitingForHostPort(t *testing.T) {
@@ -858,9 +835,8 @@ func TestContainerCreationWaitingForHostPort(t *testing.T) {
 		ContainerRequest: req,
 		Started:          true,
 	})
-
+	CleanupContainer(t, nginx)
 	require.NoError(t, err)
-	terminateContainerOnEnd(t, ctx, nginx)
 }
 
 func TestContainerCreationWaitingForHostPortWithoutBashThrowsAnError(t *testing.T) {
@@ -875,9 +851,8 @@ func TestContainerCreationWaitingForHostPortWithoutBashThrowsAnError(t *testing.
 		ContainerRequest: req,
 		Started:          true,
 	})
-
+	CleanupContainer(t, nginx)
 	require.NoError(t, err)
-	terminateContainerOnEnd(t, ctx, nginx)
 }
 
 func TestCMD(t *testing.T) {
@@ -902,9 +877,8 @@ func TestCMD(t *testing.T) {
 		ContainerRequest: req,
 		Started:          true,
 	})
-
+	CleanupContainer(t, c)
 	require.NoError(t, err)
-	terminateContainerOnEnd(t, ctx, c)
 }
 
 func TestEntrypoint(t *testing.T) {
@@ -929,9 +903,8 @@ func TestEntrypoint(t *testing.T) {
 		ContainerRequest: req,
 		Started:          true,
 	})
-
+	CleanupContainer(t, c)
 	require.NoError(t, err)
-	terminateContainerOnEnd(t, ctx, c)
 }
 
 func TestWorkingDir(t *testing.T) {
@@ -957,9 +930,8 @@ func TestWorkingDir(t *testing.T) {
 		ContainerRequest: req,
 		Started:          true,
 	})
-
+	CleanupContainer(t, c)
 	require.NoError(t, err)
-	terminateContainerOnEnd(t, ctx, c)
 }
 
 func ExampleDockerProvider_CreateContainer() {
@@ -969,19 +941,24 @@ func ExampleDockerProvider_CreateContainer() {
 		ExposedPorts: []string{"80/tcp"},
 		WaitingFor:   wait.ForHTTP("/").WithStartupTimeout(10 * time.Second),
 	}
-	nginxC, _ := GenericContainer(ctx, GenericContainerRequest{
+	nginxC, err := GenericContainer(ctx, GenericContainerRequest{
 		ContainerRequest: req,
 		Started:          true,
 	})
 	defer func() {
-		if err := nginxC.Terminate(ctx); err != nil {
-			log.Fatalf("failed to terminate container: %s", err)
+		if err := TerminateContainer(nginxC); err != nil {
+			log.Printf("failed to terminate container: %s", err)
 		}
 	}()
+	if err != nil {
+		log.Printf("failed to create container: %s", err)
+		return
+	}
 
 	state, err := nginxC.State(ctx)
 	if err != nil {
-		log.Fatalf("failed to get container state: %s", err) // nolint:gocritic
+		log.Printf("failed to get container state: %s", err)
+		return
 	}
 
 	fmt.Println(state.Running)
@@ -997,28 +974,38 @@ func ExampleContainer_Host() {
 		ExposedPorts: []string{"80/tcp"},
 		WaitingFor:   wait.ForHTTP("/").WithStartupTimeout(10 * time.Second),
 	}
-	nginxC, _ := GenericContainer(ctx, GenericContainerRequest{
+	nginxC, err := GenericContainer(ctx, GenericContainerRequest{
 		ContainerRequest: req,
 		Started:          true,
 	})
 	defer func() {
-		if err := nginxC.Terminate(ctx); err != nil {
-			log.Fatalf("failed to terminate container: %s", err)
+		if err := TerminateContainer(nginxC); err != nil {
+			log.Printf("failed to terminate container: %s", err)
 		}
 	}()
+	if err != nil {
+		log.Printf("failed to create container: %s", err)
+		return
+	}
 	// containerHost {
-	ip, _ := nginxC.Host(ctx)
+	ip, err := nginxC.Host(ctx)
+	if err != nil {
+		log.Printf("failed to create container: %s", err)
+		return
+	}
 	// }
-	println(ip)
+	fmt.Println(ip)
 
 	state, err := nginxC.State(ctx)
 	if err != nil {
-		log.Fatalf("failed to get container state: %s", err) // nolint:gocritic
+		log.Printf("failed to get container state: %s", err)
+		return
 	}
 
 	fmt.Println(state.Running)
 
 	// Output:
+	// localhost
 	// true
 }
 
@@ -1029,19 +1016,28 @@ func ExampleContainer_Start() {
 		ExposedPorts: []string{"80/tcp"},
 		WaitingFor:   wait.ForHTTP("/").WithStartupTimeout(10 * time.Second),
 	}
-	nginxC, _ := GenericContainer(ctx, GenericContainerRequest{
+	nginxC, err := GenericContainer(ctx, GenericContainerRequest{
 		ContainerRequest: req,
 	})
 	defer func() {
-		if err := nginxC.Terminate(ctx); err != nil {
-			log.Fatalf("failed to terminate container: %s", err)
+		if err := TerminateContainer(nginxC); err != nil {
+			log.Printf("failed to terminate container: %s", err)
 		}
 	}()
-	_ = nginxC.Start(ctx)
+	if err != nil {
+		log.Printf("failed to create container: %s", err)
+		return
+	}
+
+	if err = nginxC.Start(ctx); err != nil {
+		log.Printf("failed to start container: %s", err)
+		return
+	}
 
 	state, err := nginxC.State(ctx)
 	if err != nil {
-		log.Fatalf("failed to get container state: %s", err) // nolint:gocritic
+		log.Printf("failed to get container state: %s", err)
+		return
 	}
 
 	fmt.Println(state.Running)
@@ -1057,19 +1053,24 @@ func ExampleContainer_Stop() {
 		ExposedPorts: []string{"80/tcp"},
 		WaitingFor:   wait.ForHTTP("/").WithStartupTimeout(10 * time.Second),
 	}
-	nginxC, _ := GenericContainer(ctx, GenericContainerRequest{
+	nginxC, err := GenericContainer(ctx, GenericContainerRequest{
 		ContainerRequest: req,
 	})
 	defer func() {
-		if err := nginxC.Terminate(ctx); err != nil {
-			log.Fatalf("failed to terminate container: %s", err)
+		if err := TerminateContainer(nginxC); err != nil {
+			log.Printf("failed to terminate container: %s", err)
 		}
 	}()
+	if err != nil {
+		log.Printf("failed to create and start container: %s", err)
+		return
+	}
+
 	fmt.Println("Container has been started")
 	timeout := 10 * time.Second
-	err := nginxC.Stop(ctx, &timeout)
-	if err != nil {
-		log.Fatalf("failed to stop container: %s", err) // nolint:gocritic
+	if err = nginxC.Stop(ctx, &timeout); err != nil {
+		log.Printf("failed to terminate container: %s", err)
+		return
 	}
 
 	fmt.Println("Container has been stopped")
@@ -1086,15 +1087,20 @@ func ExampleContainer_MappedPort() {
 		ExposedPorts: []string{"80/tcp"},
 		WaitingFor:   wait.ForHTTP("/").WithStartupTimeout(10 * time.Second),
 	}
-	nginxC, _ := GenericContainer(ctx, GenericContainerRequest{
+	nginxC, err := GenericContainer(ctx, GenericContainerRequest{
 		ContainerRequest: req,
 		Started:          true,
 	})
 	defer func() {
-		if err := nginxC.Terminate(ctx); err != nil {
-			log.Fatalf("failed to terminate container: %s", err)
+		if err := TerminateContainer(nginxC); err != nil {
+			log.Printf("failed to terminate container: %s", err)
 		}
 	}()
+	if err != nil {
+		log.Printf("failed to create and start container: %s", err)
+		return
+	}
+
 	// buildingAddresses {
 	ip, _ := nginxC.Host(ctx)
 	port, _ := nginxC.MappedPort(ctx, "80")
@@ -1103,7 +1109,8 @@ func ExampleContainer_MappedPort() {
 
 	state, err := nginxC.State(ctx)
 	if err != nil {
-		log.Fatalf("failed to get container state: %s", err) // nolint:gocritic
+		log.Printf("failed to get container state: %s", err)
+		return
 	}
 
 	fmt.Println(state.Running)
@@ -1140,9 +1147,8 @@ func TestContainerCreationWithVolumeAndFileWritingToIt(t *testing.T) {
 		},
 		Started: true,
 	})
-
+	CleanupContainer(t, bashC, RemoveVolumes(volumeName))
 	require.NoError(t, err)
-	require.NoError(t, bashC.Terminate(ctx))
 }
 
 func TestContainerWithTmpFs(t *testing.T) {
@@ -1158,9 +1164,8 @@ func TestContainerWithTmpFs(t *testing.T) {
 		ContainerRequest: req,
 		Started:          true,
 	})
-
+	CleanupContainer(t, ctr)
 	require.NoError(t, err)
-	terminateContainerOnEnd(t, ctx, ctr)
 
 	path := "/testtmpfs/test.file"
 
@@ -1204,12 +1209,13 @@ func TestContainerWithTmpFs(t *testing.T) {
 
 func TestContainerNonExistentImage(t *testing.T) {
 	t.Run("if the image not found don't propagate the error", func(t *testing.T) {
-		_, err := GenericContainer(context.Background(), GenericContainerRequest{
+		ctr, err := GenericContainer(context.Background(), GenericContainerRequest{
 			ContainerRequest: ContainerRequest{
 				Image: "postgres:nonexistent-version",
 			},
 			Started: true,
 		})
+		CleanupContainer(t, ctr)
 
 		var nf errdefs.ErrNotFound
 		if !errors.As(err, &nf) {
@@ -1228,11 +1234,10 @@ func TestContainerNonExistentImage(t *testing.T) {
 			},
 			Started: true,
 		})
+		CleanupContainer(t, c)
 		if !errors.Is(err, ctx.Err()) {
 			t.Fatalf("err should be a ctx cancelled error %v", err)
 		}
-
-		terminateContainerOnEnd(t, context.Background(), c) // use non-cancelled context
 	})
 }
 
@@ -1253,9 +1258,7 @@ func TestContainerCustomPlatformImage(t *testing.T) {
 			},
 			Started: false,
 		})
-
-		terminateContainerOnEnd(t, ctx, c)
-
+		CleanupContainer(t, c)
 		require.Error(t, err)
 	})
 
@@ -1271,9 +1274,8 @@ func TestContainerCustomPlatformImage(t *testing.T) {
 			},
 			Started: false,
 		})
-
+		CleanupContainer(t, c)
 		require.NoError(t, err)
-		terminateContainerOnEnd(t, ctx, c)
 
 		dockerCli, err := NewDockerClientWithOpts(ctx)
 		require.NoError(t, err)
@@ -1303,9 +1305,8 @@ func TestContainerWithCustomHostname(t *testing.T) {
 		ContainerRequest: req,
 		Started:          true,
 	})
-
+	CleanupContainer(t, ctr)
 	require.NoError(t, err)
-	terminateContainerOnEnd(t, ctx, ctr)
 
 	if actualHostname := readHostname(t, ctr.GetContainerID()); actualHostname != hostname {
 		t.Fatalf("expected hostname %s, got %s", hostname, actualHostname)
@@ -1319,8 +1320,8 @@ func TestContainerInspect_RawInspectIsCleanedOnStop(t *testing.T) {
 		},
 		Started: true,
 	})
+	CleanupContainer(t, ctr)
 	require.NoError(t, err)
-	terminateContainerOnEnd(t, context.Background(), ctr)
 
 	inspect, err := ctr.Inspect(context.Background())
 	require.NoError(t, err)
@@ -1373,9 +1374,8 @@ func TestDockerContainerCopyFileToContainer(t *testing.T) {
 				},
 				Started: true,
 			})
-
+			CleanupContainer(t, nginxC)
 			require.NoError(t, err)
-			terminateContainerOnEnd(t, ctx, nginxC)
 
 			_ = nginxC.CopyFileToContainer(ctx, filepath.Join(".", "testdata", "hello.sh"), tc.copiedFileName, 700)
 			c, _, err := nginxC.Exec(ctx, []string{"bash", tc.copiedFileName})
@@ -1401,11 +1401,10 @@ func TestDockerContainerCopyDirToContainer(t *testing.T) {
 		},
 		Started: true,
 	})
+	CleanupContainer(t, nginxC)
+	require.NoError(t, err)
 
 	p := filepath.Join(".", "testdata", "Dokerfile")
-	require.NoError(t, err)
-	terminateContainerOnEnd(t, ctx, nginxC)
-
 	err = nginxC.CopyDirToContainer(ctx, p, "/tmp/testdata/Dockerfile", 700)
 	require.Error(t, err) // copying a file using the directory method will raise an error
 
@@ -1462,7 +1461,7 @@ func TestDockerCreateContainerWithFiles(t *testing.T) {
 				},
 				Started: false,
 			})
-			terminateContainerOnEnd(t, ctx, nginxC)
+			CleanupContainer(t, nginxC)
 
 			if err != nil {
 				require.Contains(t, err.Error(), tc.errMsg)
@@ -1547,7 +1546,7 @@ func TestDockerCreateContainerWithDirs(t *testing.T) {
 				},
 				Started: false,
 			})
-			terminateContainerOnEnd(t, ctx, nginxC)
+			CleanupContainer(t, nginxC)
 
 			require.Equal(t, (err != nil), tc.hasError)
 			if err == nil {
@@ -1587,9 +1586,8 @@ func TestDockerContainerCopyToContainer(t *testing.T) {
 				},
 				Started: true,
 			})
-
+			CleanupContainer(t, nginxC)
 			require.NoError(t, err)
-			terminateContainerOnEnd(t, ctx, nginxC)
 
 			fileContent, err := os.ReadFile(filepath.Join(".", "testdata", "hello.sh"))
 			if err != nil {
@@ -1626,9 +1624,8 @@ func TestDockerContainerCopyFileFromContainer(t *testing.T) {
 		},
 		Started: true,
 	})
-
+	CleanupContainer(t, nginxC)
 	require.NoError(t, err)
-	terminateContainerOnEnd(t, ctx, nginxC)
 
 	copiedFileName := "hello_copy.sh"
 	_ = nginxC.CopyFileToContainer(ctx, filepath.Join(".", "testdata", "hello.sh"), "/"+copiedFileName, 700)
@@ -1665,9 +1662,8 @@ func TestDockerContainerCopyEmptyFileFromContainer(t *testing.T) {
 		},
 		Started: true,
 	})
-
+	CleanupContainer(t, nginxC)
 	require.NoError(t, err)
-	terminateContainerOnEnd(t, ctx, nginxC)
 
 	copiedFileName := "hello_copy.sh"
 	_ = nginxC.CopyFileToContainer(ctx, filepath.Join(".", "testdata", "empty.sh"), "/"+copiedFileName, 700)
@@ -1729,9 +1725,8 @@ func TestDockerContainerResources(t *testing.T) {
 		},
 		Started: true,
 	})
-
+	CleanupContainer(t, nginxC)
 	require.NoError(t, err)
-	terminateContainerOnEnd(t, ctx, nginxC)
 
 	c, err := NewDockerClientWithOpts(ctx)
 	require.NoError(t, err)
@@ -1766,8 +1761,8 @@ func TestContainerCapAdd(t *testing.T) {
 		},
 		Started: true,
 	})
+	CleanupContainer(t, nginx)
 	require.NoError(t, err)
-	terminateContainerOnEnd(t, ctx, nginx)
 
 	dockerClient, err := NewDockerClientWithOpts(ctx)
 	require.NoError(t, err)
@@ -1799,11 +1794,10 @@ func TestContainerRunningCheckingStatusCode(t *testing.T) {
 		ContainerRequest: req,
 		Started:          true,
 	})
+	CleanupContainer(t, influx)
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	terminateContainerOnEnd(t, ctx, influx)
 }
 
 func TestContainerWithUserID(t *testing.T) {
@@ -1819,9 +1813,8 @@ func TestContainerWithUserID(t *testing.T) {
 		ContainerRequest: req,
 		Started:          true,
 	})
-
+	CleanupContainer(t, ctr)
 	require.NoError(t, err)
-	terminateContainerOnEnd(t, ctx, ctr)
 
 	r, err := ctr.Logs(ctx)
 	if err != nil {
@@ -1848,9 +1841,8 @@ func TestContainerWithNoUserID(t *testing.T) {
 		ContainerRequest: req,
 		Started:          true,
 	})
-
+	CleanupContainer(t, ctr)
 	require.NoError(t, err)
-	terminateContainerOnEnd(t, ctx, ctr)
 
 	r, err := ctr.Logs(ctx)
 	if err != nil {
@@ -1892,9 +1884,8 @@ func TestNetworkModeWithContainerReference(t *testing.T) {
 		},
 		Started: true,
 	})
-
+	CleanupContainer(t, nginxA)
 	require.NoError(t, err)
-	terminateContainerOnEnd(t, ctx, nginxA)
 
 	networkMode := fmt.Sprintf("container:%v", nginxA.GetContainerID())
 	nginxB, err := GenericContainer(ctx, GenericContainerRequest{
@@ -1907,9 +1898,8 @@ func TestNetworkModeWithContainerReference(t *testing.T) {
 		},
 		Started: true,
 	})
-
+	CleanupContainer(t, nginxB)
 	require.NoError(t, err)
-	terminateContainerOnEnd(t, ctx, nginxB)
 }
 
 // creates a temporary dir in which the files will be extracted. Then it will compare the bytes of each file in the source with the bytes from the copied-from-container file
@@ -1957,16 +1947,6 @@ func assertExtractedFiles(t *testing.T, ctx context.Context, container Container
 	}
 }
 
-func terminateContainerOnEnd(tb testing.TB, ctx context.Context, ctr Container) {
-	tb.Helper()
-	if ctr == nil {
-		return
-	}
-	tb.Cleanup(func() {
-		require.NoError(tb, ctr.Terminate(ctx))
-	})
-}
-
 func TestDockerProviderFindContainerByName(t *testing.T) {
 	ctx := context.Background()
 	provider, err := NewDockerProvider(WithLogger(TestLogger(t)))
@@ -1982,11 +1962,12 @@ func TestDockerProviderFindContainerByName(t *testing.T) {
 		},
 		Started: true,
 	})
+	CleanupContainer(t, c1)
 	require.NoError(t, err)
 
 	c1Inspect, err := c1.Inspect(ctx)
 	require.NoError(t, err)
-	terminateContainerOnEnd(t, ctx, c1)
+	CleanupContainer(t, c1)
 
 	c1Name := c1Inspect.Name
 
@@ -1999,8 +1980,8 @@ func TestDockerProviderFindContainerByName(t *testing.T) {
 		},
 		Started: true,
 	})
+	CleanupContainer(t, c2)
 	require.NoError(t, err)
-	terminateContainerOnEnd(t, ctx, c2)
 
 	c, err := provider.findContainerByName(ctx, "test")
 	require.NoError(t, err)
@@ -2035,8 +2016,8 @@ func TestImageBuiltFromDockerfile_KeepBuiltImage(t *testing.T) {
 					},
 				},
 			})
+			CleanupContainer(t, c)
 			require.NoError(t, err, "create container should not fail")
-			defer func() { _ = c.Terminate(context.Background()) }()
 			// Get the image ID.
 			containerInspect, err := c.Inspect(ctx)
 			require.NoError(t, err, "container inspect should not fail")
@@ -2058,7 +2039,7 @@ func TestImageBuiltFromDockerfile_KeepBuiltImage(t *testing.T) {
 			if tt.keepBuiltImage {
 				require.NoError(t, err, "image should still exist")
 			} else {
-				require.Error(t, err, "image should not exist anymore")
+				require.Error(t, err, "image should not exist any more")
 			}
 		})
 	}
@@ -2295,15 +2276,11 @@ func TestCustomPrefixTrailingSlashIsProperlyRemovedIfPresent(t *testing.T) {
 		ContainerRequest: req,
 		Started:          true,
 	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer func() {
-		terminateContainerOnEnd(t, ctx, c)
-	}()
+	CleanupContainer(t, c)
+	require.NoError(t, err)
 
 	// enforce the concrete type, as GenericContainer returns an interface,
 	// which will be changed in future implementations of the library
 	dockerContainer := c.(*DockerContainer)
-	assert.Equal(t, fmt.Sprintf("%s%s", hubPrefixWithTrailingSlash, dockerImage), dockerContainer.Image)
+	require.Equal(t, fmt.Sprintf("%s%s", hubPrefixWithTrailingSlash, dockerImage), dockerContainer.Image)
 }

--- a/docs/features/common_functional_options.md
+++ b/docs/features/common_functional_options.md
@@ -70,7 +70,8 @@ useful context instead of appearing out of band.
 ```golang
 func TestHandler(t *testing.T) {
     logger := TestLogger(t)
-    _, err := postgresModule.Run(ctx, "postgres:15-alpine", testcontainers.WithLogger(logger))
+    ctr, err := postgresModule.Run(ctx, "postgres:15-alpine", testcontainers.WithLogger(logger))
+    CleanupContainer(t, ctr)
     require.NoError(t, err)
     // Do something with container.
 }

--- a/docs/features/creating_container.md
+++ b/docs/features/creating_container.md
@@ -11,7 +11,15 @@ up with Testcontainers and integrate into your tests:
 
 `testcontainers.GenericContainer` defines the container that should be run, similar to the `docker run` command.
 
-The following test creates an NGINX container and validates that it returns 200 for the status code:
+The following test creates an NGINX container on both the `bridge` (docker default
+network) and the `foo` network and validates that it returns 200 for the status code.
+
+It also demonstrates how to use `CleanupContainer` ensures that nginx container
+is removed when the test ends even if the underlying `GenericContainer` errored
+as well as the `CleanupNetwork` which does the same for networks.
+
+The alternatives for these outside of tests as a `defer` are `TerminateContainer`
+and `Network.Remove` which can be seen in the examples.
 
 ```go
 package main
@@ -32,33 +40,38 @@ type nginxContainer struct {
 }
 
 
-func setupNginx(ctx context.Context) (*nginxContainer, error) {
+func setupNginx(ctx context.Context, networkName string) (*nginxContainer, error) {
 	req := testcontainers.ContainerRequest{
 		Image:        "nginx",
 		ExposedPorts: []string{"80/tcp"},
+		Networks:     []string{"bridge", networkName},
 		WaitingFor:   wait.ForHTTP("/"),
 	}
 	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
 		ContainerRequest: req,
 		Started:          true,
 	})
+	var nginxC *nginxContainer
+	if container != nil {
+		nginxC = &nginxContainer{Container: c}
+	}
 	if err != nil {
-		return nil, err
+		return nginxC, err
 	}
 
 	ip, err := container.Host(ctx)
 	if err != nil {
-		return nil, err
+		return nginxC, err
 	}
 
 	mappedPort, err := container.MappedPort(ctx, "80")
 	if err != nil {
-		return nil, err
+		return nginxC, err
 	}
 
-	uri := fmt.Sprintf("http://%s:%s", ip, mappedPort.Port())
+	nginxC.URI = fmt.Sprintf("http://%s:%s", ip, mappedPort.Port())
 
-	return &nginxContainer{Container: container, URI: uri}, nil
+	return nginxC, nil
 }
 
 func TestIntegrationNginxLatestReturn(t *testing.T) {
@@ -68,24 +81,24 @@ func TestIntegrationNginxLatestReturn(t *testing.T) {
 
 	ctx := context.Background()
 
-	nginxC, err := setupNginx(ctx)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// Clean up the container after the test is complete
-	t.Cleanup(func() {
-		if err := nginxC.Terminate(ctx); err != nil {
-			t.Fatalf("failed to terminate container: %s", err)
-		}
+	networkName := "foo"
+	net, err := provider.CreateNetwork(ctx, NetworkRequest{
+		Name: networkName,
 	})
+	require.NoError(t, err)
+	CleanupNetwork(t, net)
+
+	nginxC, err := setupNginx(ctx, networkName)
+	testcontainers.CleanupContainer(t, nginxC)
+	require.NoError(t, err)
 
 	resp, err := http.Get(nginxC.URI)
-	if resp.StatusCode != http.StatusOK {
-		t.Fatalf("Expected status code %d. Got %d.", http.StatusOK, resp.StatusCode)
-	}
+	require.Equal(t, http.StatusOK, resp.StatusCode)
 }
 ```
+
+
+
 
 ### Lifecycle hooks
 
@@ -145,8 +158,8 @@ The aforementioned `GenericContainer` function and the `ContainerRequest` struct
 
 ## Reusable container
 
-With `Reuse` option you can reuse an existing container. Reusing will work only if you pass an 
-existing container name via 'req.Name' field. If the name is not in a list of existing containers, 
+With `Reuse` option you can reuse an existing container. Reusing will work only if you pass an
+existing container name via 'req.Name' field. If the name is not in a list of existing containers,
 the function will create a new generic container. If `Reuse` is true and `Name` is empty, you will get error.
 
 The following test creates an NGINX container, adds a file into it and then reuses the container again for checking the file:
@@ -178,16 +191,22 @@ func main() {
 		},
 		Started: true,
 	})
+	defer func() {
+		if err := testcontainers.TerminateContainer(n1); err != nil {
+			log.Printf("failed to terminate container: %s", err)
+		}
+	}()
 	if err != nil {
-		log.Fatal(err)
+		log.Print(err)
+		return
 	}
-	defer n1.Terminate(ctx)
 
 	copiedFileName := "hello_copy.sh"
 	err = n1.CopyFileToContainer(ctx, "./testdata/hello.sh", "/"+copiedFileName, 700)
 
 	if err != nil {
-		log.Fatal(err)
+		log.Print(err)
+		return
 	}
 
 	n2, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
@@ -200,13 +219,20 @@ func main() {
 		Started: true,
 		Reuse:   true,
 	})
+	defer func() {
+		if err := testcontainers.TerminateContainer(n2); err != nil {
+			log.Printf("failed to terminate container: %s", err)
+		}
+	}()
 	if err != nil {
-		log.Fatal(err)
+		log.Print(err)
+		return
 	}
 
 	c, _, err := n2.Exec(ctx, []string{"bash", copiedFileName})
 	if err != nil {
-		log.Fatal(err)
+		log.Print(err)
+		return
 	}
 	fmt.Println(c)
 }
@@ -256,25 +282,26 @@ func main() {
 	}
 
 	res, err := testcontainers.ParallelContainers(ctx, requests, testcontainers.ParallelContainersOptions{})
+	for _, c := range res {
+		c := c
+		defer func() {
+			if err := testcontainers.TerminateContainer(c); err != nil {
+				log.Printf("failed to terminate container: %s", c)
+			}
+		}()
+	}
+
 	if err != nil {
 		e, ok := err.(testcontainers.ParallelContainersError)
 		if !ok {
-			log.Fatalf("unknown error: %v", err)
+			log.Printf("unknown error: %v", err)
+			return
 		}
 
 		for _, pe := range e.Errors {
 			fmt.Println(pe.Request, pe.Error)
 		}
 		return
-	}
-
-	for _, c := range res {
-		c := c
-		defer func() {
-			if err := c.Terminate(ctx); err != nil {
-				log.Fatalf("failed to terminate container: %s", c)
-			}
-		}()
 	}
 }
 ```

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -9,7 +9,7 @@ Please read the [system requirements](../system_requirements/) page before you s
 
 ## 2. Install _Testcontainers for Go_
 
-We use [gomod](https://blog.golang.org/using-go-modules) and you can get it installed via:
+We use [go mod](https://blog.golang.org/using-go-modules) and you can get it installed via:
 
 ```
 go get github.com/testcontainers/testcontainers-go
@@ -21,6 +21,8 @@ go get github.com/testcontainers/testcontainers-go
 import (
 	"context"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/wait"
@@ -37,14 +39,8 @@ func TestWithRedis(t *testing.T) {
 		ContainerRequest: req,
 		Started:          true,
 	})
-	if err != nil {
-		t.Fatalf("Could not start redis: %s", err)
-	}
-	defer func() {
-		if err := redisC.Terminate(ctx); err != nil {
-			t.Fatalf("Could not stop redis: %s", err)
-		}
-	}()
+	testcontainers.CleanupContainer(t, redisC)
+	require.NoError(t, err)
 }
 ```
 
@@ -75,7 +71,8 @@ start, leaving to you the decision about when to start it.
 
 All the containers must be removed at some point, otherwise they will run until
 the host is overloaded. One of the ways we have to clean up is by deferring the
-terminated function: `defer redisC.Terminate(ctx)`.
+terminated function: `defer testcontainers.TerminateContainer(redisC)` which
+automatically handles nil container so is safe to use even in the error case.
 
 !!!tip
 

--- a/examples/nginx/go.mod
+++ b/examples/nginx/go.mod
@@ -2,7 +2,10 @@ module github.com/testcontainers/testcontainers-go/examples/nginx
 
 go 1.22
 
-require github.com/testcontainers/testcontainers-go v0.33.0
+require (
+	github.com/stretchr/testify v1.9.0
+	github.com/testcontainers/testcontainers-go v0.32.0
+)
 
 replace github.com/testcontainers/testcontainers-go => ../..
 
@@ -15,6 +18,7 @@ require (
 	github.com/containerd/log v0.1.0 // indirect
 	github.com/containerd/platforms v0.2.1 // indirect
 	github.com/cpuguy83/dockercfg v0.3.1 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/distribution/reference v0.6.0 // indirect
 	github.com/docker/docker v27.1.1+incompatible // indirect
 	github.com/docker/go-connections v0.5.0 // indirect
@@ -26,6 +30,7 @@ require (
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/klauspost/compress v1.17.4 // indirect
+	github.com/kr/text v0.2.0 // indirect
 	github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 // indirect
 	github.com/magiconair/properties v1.8.7 // indirect
 	github.com/moby/docker-image-spec v1.3.1 // indirect
@@ -37,6 +42,7 @@ require (
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c // indirect
 	github.com/shirou/gopsutil/v3 v3.23.12 // indirect
 	github.com/shoenig/go-m1cpu v0.1.6 // indirect
@@ -53,4 +59,5 @@ require (
 	golang.org/x/sys v0.21.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20240318140521-94a12d6c2237 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240318140521-94a12d6c2237 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/examples/nginx/go.sum
+++ b/examples/nginx/go.sum
@@ -16,6 +16,7 @@ github.com/containerd/platforms v0.2.1 h1:zvwtM3rz2YHPQsF2CHYM8+KtB5dvhISiXh5ZpS
 github.com/containerd/platforms v0.2.1/go.mod h1:XHCb+2/hzowdiut9rkudds9bE5yJ7npe7dG/wG+uFPw=
 github.com/cpuguy83/dockercfg v0.3.1 h1:/FpZ+JaygUR/lZP2NlFI2DVfrOEMAIKP5wWEJdoYe9E=
 github.com/cpuguy83/dockercfg v0.3.1/go.mod h1:sugsbF4//dDlL/i+S+rtpIWp+5h0BHJHfjj5/jFyUJc=
+github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.18 h1:n56/Zwd5o6whRC5PMGretI4IdRLlmBXYNjScPaBgsbY=
 github.com/creack/pty v1.1.18/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -52,6 +53,10 @@ github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/compress v1.17.4 h1:Ej5ixsIri7BrIjBkRZLTo6ghwrEtHFk7ijlczPW4fZ4=
 github.com/klauspost/compress v1.17.4/go.mod h1:/dCuZOvVtNoHsyb+cuJD3itjs3NbnF6KH9zAO4BDxPM=
+github.com/kr/pretty v0.3.0 h1:WgNl7dwNpEZ6jJ9k1snq4pZsg7DOEN8hP9Xw0Tsjwk0=
+github.com/kr/pretty v0.3.0/go.mod h1:640gp4NfQd8pI5XOwp5fnNeVWj67G7CFk/SaSQn7NBk=
+github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
+github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 h1:6E+4a0GO5zZEnZ81pIr0yLvtUWk2if982qA3F3QD6H4=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0/go.mod h1:zJYVVT2jmtg6P3p1VtQj7WsuWi/y4VnjVBn7F8KPB3I=
 github.com/magiconair/properties v1.8.7 h1:IeQXZAiQcpL9mgcAe1Nu6cX9LLw6ExEHKjN0VQdvPDY=
@@ -78,6 +83,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c h1:ncq/mPwQF4JjgDlrVEn3C11VoGHZN7m8qihwgMEtzYw=
 github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c/go.mod h1:OmDBASR4679mdNQnz2pUhc2G8CO2JrUAVFDRBDP/hJE=
+github.com/rogpeppe/go-internal v1.8.1 h1:geMPLpDpQOgVyCg5z5GoRwLHepNdb71NXb67XFkP+Eg=
+github.com/rogpeppe/go-internal v1.8.1/go.mod h1:JeRgkft04UBgHMgCIwADu4Pn6Mtm5d4nPKWu0nJ5d+o=
 github.com/shirou/gopsutil/v3 v3.23.12 h1:z90NtUkp3bMtmICZKpC4+WaknU1eXtp5vtbQ11DgpE4=
 github.com/shirou/gopsutil/v3 v3.23.12/go.mod h1:1FrWgea594Jp7qmjHUUPlJDTPgcsb9mGnXDxavtikzM=
 github.com/shoenig/go-m1cpu v0.1.6 h1:nxdKQNcEB6vzgA2E2bvzKIYRuNj7XNJ4S/aRSwKzFtM=
@@ -174,6 +181,8 @@ google.golang.org/grpc v1.64.1/go.mod h1:hiQF4LFZelK2WKaP6W0L92zGHtiQdZxk8CrSdvy
 google.golang.org/protobuf v1.33.0 h1:uNO2rsAINq/JlFpSdYEKIZ0uKD/R9cpdv0T+yoGwGmI=
 google.golang.org/protobuf v1.33.0/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/examples/nginx/nginx.go
+++ b/examples/nginx/nginx.go
@@ -24,21 +24,24 @@ func startContainer(ctx context.Context) (*nginxContainer, error) {
 		ContainerRequest: req,
 		Started:          true,
 	})
+	var nginxC *nginxContainer
+	if container != nil {
+		nginxC = &nginxContainer{Container: container}
+	}
 	if err != nil {
-		return nil, err
+		return nginxC, err
 	}
 
 	ip, err := container.Host(ctx)
 	if err != nil {
-		return nil, err
+		return nginxC, err
 	}
 
 	mappedPort, err := container.MappedPort(ctx, "80")
 	if err != nil {
-		return nil, err
+		return nginxC, err
 	}
 
-	uri := fmt.Sprintf("http://%s:%s", ip, mappedPort.Port())
-
-	return &nginxContainer{Container: container, URI: uri}, nil
+	nginxC.URI = fmt.Sprintf("http://%s:%s", ip, mappedPort.Port())
+	return nginxC, nil
 }

--- a/examples/nginx/nginx_test.go
+++ b/examples/nginx/nginx_test.go
@@ -4,6 +4,10 @@ import (
 	"context"
 	"net/http"
 	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/testcontainers/testcontainers-go"
 )
 
 func TestIntegrationNginxLatestReturn(t *testing.T) {
@@ -14,23 +18,10 @@ func TestIntegrationNginxLatestReturn(t *testing.T) {
 	ctx := context.Background()
 
 	nginxC, err := startContainer(ctx)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// Clean up the container after the test is complete
-	t.Cleanup(func() {
-		if err := nginxC.Terminate(ctx); err != nil {
-			t.Fatalf("failed to terminate container: %s", err)
-		}
-	})
+	testcontainers.CleanupContainer(t, nginxC)
+	require.NoError(t, err)
 
 	resp, err := http.Get(nginxC.URI)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if resp.StatusCode != http.StatusOK {
-		t.Fatalf("Expected status code %d. Got %d.", http.StatusOK, resp.StatusCode)
-	}
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
 }

--- a/examples/toxiproxy/go.mod
+++ b/examples/toxiproxy/go.mod
@@ -6,7 +6,8 @@ require (
 	github.com/Shopify/toxiproxy/v2 v2.8.0
 	github.com/go-redis/redis/v8 v8.11.5
 	github.com/google/uuid v1.6.0
-	github.com/testcontainers/testcontainers-go v0.33.0
+	github.com/stretchr/testify v1.9.0
+	github.com/testcontainers/testcontainers-go v0.32.0
 )
 
 require (
@@ -19,6 +20,7 @@ require (
 	github.com/containerd/log v0.1.0 // indirect
 	github.com/containerd/platforms v0.2.1 // indirect
 	github.com/cpuguy83/dockercfg v0.3.1 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	github.com/distribution/reference v0.6.0 // indirect
 	github.com/docker/docker v27.1.1+incompatible // indirect
@@ -30,6 +32,7 @@ require (
 	github.com/go-ole/go-ole v1.2.6 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/klauspost/compress v1.17.4 // indirect
+	github.com/kr/text v0.2.0 // indirect
 	github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 // indirect
 	github.com/magiconair/properties v1.8.7 // indirect
 	github.com/moby/docker-image-spec v1.3.1 // indirect
@@ -41,6 +44,7 @@ require (
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c // indirect
 	github.com/shirou/gopsutil/v3 v3.23.12 // indirect
 	github.com/shoenig/go-m1cpu v0.1.6 // indirect
@@ -57,6 +61,7 @@ require (
 	golang.org/x/sys v0.21.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20240318140521-94a12d6c2237 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240318140521-94a12d6c2237 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
 replace github.com/testcontainers/testcontainers-go => ../..

--- a/examples/toxiproxy/go.sum
+++ b/examples/toxiproxy/go.sum
@@ -20,6 +20,7 @@ github.com/containerd/platforms v0.2.1 h1:zvwtM3rz2YHPQsF2CHYM8+KtB5dvhISiXh5ZpS
 github.com/containerd/platforms v0.2.1/go.mod h1:XHCb+2/hzowdiut9rkudds9bE5yJ7npe7dG/wG+uFPw=
 github.com/cpuguy83/dockercfg v0.3.1 h1:/FpZ+JaygUR/lZP2NlFI2DVfrOEMAIKP5wWEJdoYe9E=
 github.com/cpuguy83/dockercfg v0.3.1/go.mod h1:sugsbF4//dDlL/i+S+rtpIWp+5h0BHJHfjj5/jFyUJc=
+github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.18 h1:n56/Zwd5o6whRC5PMGretI4IdRLlmBXYNjScPaBgsbY=
 github.com/creack/pty v1.1.18/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -62,6 +63,10 @@ github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/compress v1.17.4 h1:Ej5ixsIri7BrIjBkRZLTo6ghwrEtHFk7ijlczPW4fZ4=
 github.com/klauspost/compress v1.17.4/go.mod h1:/dCuZOvVtNoHsyb+cuJD3itjs3NbnF6KH9zAO4BDxPM=
+github.com/kr/pretty v0.3.0 h1:WgNl7dwNpEZ6jJ9k1snq4pZsg7DOEN8hP9Xw0Tsjwk0=
+github.com/kr/pretty v0.3.0/go.mod h1:640gp4NfQd8pI5XOwp5fnNeVWj67G7CFk/SaSQn7NBk=
+github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
+github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 h1:6E+4a0GO5zZEnZ81pIr0yLvtUWk2if982qA3F3QD6H4=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0/go.mod h1:zJYVVT2jmtg6P3p1VtQj7WsuWi/y4VnjVBn7F8KPB3I=
 github.com/magiconair/properties v1.8.7 h1:IeQXZAiQcpL9mgcAe1Nu6cX9LLw6ExEHKjN0VQdvPDY=
@@ -94,6 +99,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c h1:ncq/mPwQF4JjgDlrVEn3C11VoGHZN7m8qihwgMEtzYw=
 github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c/go.mod h1:OmDBASR4679mdNQnz2pUhc2G8CO2JrUAVFDRBDP/hJE=
+github.com/rogpeppe/go-internal v1.8.1 h1:geMPLpDpQOgVyCg5z5GoRwLHepNdb71NXb67XFkP+Eg=
+github.com/rogpeppe/go-internal v1.8.1/go.mod h1:JeRgkft04UBgHMgCIwADu4Pn6Mtm5d4nPKWu0nJ5d+o=
 github.com/shirou/gopsutil/v3 v3.23.12 h1:z90NtUkp3bMtmICZKpC4+WaknU1eXtp5vtbQ11DgpE4=
 github.com/shirou/gopsutil/v3 v3.23.12/go.mod h1:1FrWgea594Jp7qmjHUUPlJDTPgcsb9mGnXDxavtikzM=
 github.com/shoenig/go-m1cpu v0.1.6 h1:nxdKQNcEB6vzgA2E2bvzKIYRuNj7XNJ4S/aRSwKzFtM=
@@ -190,6 +197,8 @@ google.golang.org/grpc v1.64.1/go.mod h1:hiQF4LFZelK2WKaP6W0L92zGHtiQdZxk8CrSdvy
 google.golang.org/protobuf v1.33.0 h1:uNO2rsAINq/JlFpSdYEKIZ0uKD/R9cpdv0T+yoGwGmI=
 google.golang.org/protobuf v1.33.0/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkepLTh2hOroT7a+7czfdQ=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=

--- a/examples/toxiproxy/redis.go
+++ b/examples/toxiproxy/redis.go
@@ -27,9 +27,9 @@ func setupRedis(ctx context.Context, network string, networkAlias []string) (*re
 		ContainerRequest: req,
 		Started:          true,
 	})
-	if err != nil {
-		return nil, err
+	var nginxC *redisContainer
+	if container != nil {
+		nginxC = &redisContainer{Container: container}
 	}
-
-	return &redisContainer{Container: container}, nil
+	return nginxC, err
 }

--- a/examples/toxiproxy/toxiproxy.go
+++ b/examples/toxiproxy/toxiproxy.go
@@ -31,21 +31,25 @@ func startContainer(ctx context.Context, network string, networkAlias []string) 
 		ContainerRequest: req,
 		Started:          true,
 	})
+	var toxiC *toxiproxyContainer
+	if container != nil {
+		toxiC = &toxiproxyContainer{Container: container}
+	}
 	if err != nil {
-		return nil, err
+		return toxiC, err
 	}
 
 	mappedPort, err := container.MappedPort(ctx, "8474")
 	if err != nil {
-		return nil, err
+		return toxiC, err
 	}
 
 	hostIP, err := container.Host(ctx)
 	if err != nil {
-		return nil, err
+		return toxiC, err
 	}
 
-	uri := fmt.Sprintf("%s:%s", hostIP, mappedPort.Port())
+	toxiC.URI = fmt.Sprintf("%s:%s", hostIP, mappedPort.Port())
 
-	return &toxiproxyContainer{Container: container, URI: uri}, nil
+	return toxiC, nil
 }

--- a/generic_test.go
+++ b/generic_test.go
@@ -38,7 +38,7 @@ func TestGenericReusableContainer(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.True(t, n1.IsRunning())
-	terminateContainerOnEnd(t, ctx, n1)
+	CleanupContainer(t, n1)
 
 	copiedFileName := "hello_copy.sh"
 	err = n1.CopyFileToContainer(ctx, "./testdata/hello.sh", "/"+copiedFileName, 700)
@@ -123,7 +123,7 @@ func TestGenericContainerShouldReturnRefOnError(t *testing.T) {
 	})
 	require.Error(t, err)
 	require.NotNil(t, c)
-	terminateContainerOnEnd(t, context.Background(), c)
+	CleanupContainer(t, c)
 }
 
 func TestGenericReusableContainerInSubprocess(t *testing.T) {
@@ -160,7 +160,7 @@ func TestGenericReusableContainerInSubprocess(t *testing.T) {
 	nginxC, err := containerFromDockerResponse(context.Background(), ctrs[0])
 	require.NoError(t, err)
 
-	terminateContainerOnEnd(t, context.Background(), nginxC)
+	CleanupContainer(t, nginxC)
 }
 
 func createReuseContainerInSubprocess(t *testing.T) string {

--- a/image_substitutors_test.go
+++ b/image_substitutors_test.go
@@ -149,6 +149,7 @@ func TestSubstituteBuiltImage(t *testing.T) {
 	t.Run("should not use the properties prefix on built images", func(t *testing.T) {
 		config.Reset()
 		c, err := GenericContainer(context.Background(), req)
+		CleanupContainer(t, c)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/image_test.go
+++ b/image_test.go
@@ -25,14 +25,11 @@ func TestImageList(t *testing.T) {
 		Image: "redis:latest",
 	}
 
-	container, err := provider.CreateContainer(context.Background(), req)
+	ctr, err := provider.CreateContainer(context.Background(), req)
+	CleanupContainer(t, ctr)
 	if err != nil {
 		t.Fatalf("creating test container %v", err)
 	}
-
-	defer func() {
-		_ = container.Terminate(context.Background())
-	}()
 
 	images, err := provider.ListImages(context.Background())
 	if err != nil {
@@ -69,14 +66,11 @@ func TestSaveImages(t *testing.T) {
 		Image: "redis:latest",
 	}
 
-	container, err := provider.CreateContainer(context.Background(), req)
+	ctr, err := provider.CreateContainer(context.Background(), req)
+	CleanupContainer(t, ctr)
 	if err != nil {
 		t.Fatalf("creating test container %v", err)
 	}
-
-	defer func() {
-		_ = container.Terminate(context.Background())
-	}()
 
 	output := filepath.Join(t.TempDir(), "images.tar")
 	err = provider.SaveImages(context.Background(), output, req.Image)

--- a/lifecycle.go
+++ b/lifecycle.go
@@ -411,10 +411,10 @@ func (c ContainerLifecycleHooks) Creating(ctx context.Context) func(req Containe
 // containerHookFn is a helper function that will create a function to be returned by all the different
 // container lifecycle hooks. The created function will iterate over all the hooks and call them one by one.
 func containerHookFn(ctx context.Context, containerHook []ContainerHook) func(container Container) error {
-	return func(container Container) error {
+	return func(ctr Container) error {
 		errs := make([]error, len(containerHook))
 		for i, hook := range containerHook {
-			errs[i] = hook(ctx, container)
+			errs[i] = hook(ctx, ctr)
 		}
 
 		return errors.Join(errs...)

--- a/lifecycle_test.go
+++ b/lifecycle_test.go
@@ -210,12 +210,7 @@ func TestPreCreateModifierHook(t *testing.T) {
 			Name: networkName,
 		})
 		require.NoError(t, err)
-		defer func() {
-			err := net.Remove(ctx)
-			if err != nil {
-				t.Logf("failed to remove network %s: %s\n", networkName, err)
-			}
-		}()
+		CleanupNetwork(t, net)
 
 		dockerNetwork, err := provider.GetNetwork(ctx, NetworkRequest{
 			Name: networkName,
@@ -262,12 +257,7 @@ func TestPreCreateModifierHook(t *testing.T) {
 			Name: networkName,
 		})
 		require.NoError(t, err)
-		defer func() {
-			err := net.Remove(ctx)
-			if err != nil {
-				t.Logf("failed to remove network %s: %s\n", networkName, err)
-			}
-		}()
+		CleanupNetwork(t, net)
 
 		dockerNetwork, err := provider.GetNetwork(ctx, NetworkRequest{
 			Name: networkName,
@@ -549,91 +539,91 @@ func TestLifecycleHooks(t *testing.T) {
 					{
 						PreCreates: []ContainerRequestHook{
 							func(ctx context.Context, req ContainerRequest) error {
-								prints = append(prints, fmt.Sprintf("pre-create hook 1: %#v", req))
+								prints = append(prints, "pre-create hook 1")
 								return nil
 							},
 							func(ctx context.Context, req ContainerRequest) error {
-								prints = append(prints, fmt.Sprintf("pre-create hook 2: %#v", req))
+								prints = append(prints, "pre-create hook 2")
 								return nil
 							},
 						},
 						PostCreates: []ContainerHook{
 							func(ctx context.Context, c Container) error {
-								prints = append(prints, fmt.Sprintf("post-create hook 1: %#v", c))
+								prints = append(prints, "post-create hook 1")
 								return nil
 							},
 							func(ctx context.Context, c Container) error {
-								prints = append(prints, fmt.Sprintf("post-create hook 2: %#v", c))
+								prints = append(prints, "post-create hook 2")
 								return nil
 							},
 						},
 						PreStarts: []ContainerHook{
 							func(ctx context.Context, c Container) error {
-								prints = append(prints, fmt.Sprintf("pre-start hook 1: %#v", c))
+								prints = append(prints, "pre-start hook 1")
 								return nil
 							},
 							func(ctx context.Context, c Container) error {
-								prints = append(prints, fmt.Sprintf("pre-start hook 2: %#v", c))
+								prints = append(prints, "pre-start hook 2")
 								return nil
 							},
 						},
 						PostStarts: []ContainerHook{
 							func(ctx context.Context, c Container) error {
-								prints = append(prints, fmt.Sprintf("post-start hook 1: %#v", c))
+								prints = append(prints, "post-start hook 1")
 								return nil
 							},
 							func(ctx context.Context, c Container) error {
-								prints = append(prints, fmt.Sprintf("post-start hook 2: %#v", c))
+								prints = append(prints, "post-start hook 2")
 								return nil
 							},
 						},
 						PostReadies: []ContainerHook{
 							func(ctx context.Context, c Container) error {
-								prints = append(prints, fmt.Sprintf("post-ready hook 1: %#v", c))
+								prints = append(prints, "post-ready hook 1")
 								return nil
 							},
 							func(ctx context.Context, c Container) error {
-								prints = append(prints, fmt.Sprintf("post-ready hook 2: %#v", c))
+								prints = append(prints, "post-ready hook 2")
 								return nil
 							},
 						},
 						PreStops: []ContainerHook{
 							func(ctx context.Context, c Container) error {
-								prints = append(prints, fmt.Sprintf("pre-stop hook 1: %#v", c))
+								prints = append(prints, "pre-stop hook 1")
 								return nil
 							},
 							func(ctx context.Context, c Container) error {
-								prints = append(prints, fmt.Sprintf("pre-stop hook 2: %#v", c))
+								prints = append(prints, "pre-stop hook 2")
 								return nil
 							},
 						},
 						PostStops: []ContainerHook{
 							func(ctx context.Context, c Container) error {
-								prints = append(prints, fmt.Sprintf("post-stop hook 1: %#v", c))
+								prints = append(prints, "post-stop hook 1")
 								return nil
 							},
 							func(ctx context.Context, c Container) error {
-								prints = append(prints, fmt.Sprintf("post-stop hook 2: %#v", c))
+								prints = append(prints, "post-stop hook 2")
 								return nil
 							},
 						},
 						PreTerminates: []ContainerHook{
 							func(ctx context.Context, c Container) error {
-								prints = append(prints, fmt.Sprintf("pre-terminate hook 1: %#v", c))
+								prints = append(prints, "pre-terminate hook 1")
 								return nil
 							},
 							func(ctx context.Context, c Container) error {
-								prints = append(prints, fmt.Sprintf("pre-terminate hook 2: %#v", c))
+								prints = append(prints, "pre-terminate hook 2")
 								return nil
 							},
 						},
 						PostTerminates: []ContainerHook{
 							func(ctx context.Context, c Container) error {
-								prints = append(prints, fmt.Sprintf("post-terminate hook 1: %#v", c))
+								prints = append(prints, "post-terminate hook 1")
 								return nil
 							},
 							func(ctx context.Context, c Container) error {
-								prints = append(prints, fmt.Sprintf("post-terminate hook 2: %#v", c))
+								prints = append(prints, "post-terminate hook 2")
 								return nil
 							},
 						},
@@ -651,6 +641,7 @@ func TestLifecycleHooks(t *testing.T) {
 				Reuse:            tt.reuse,
 				Started:          true,
 			})
+			CleanupContainer(t, c)
 			require.NoError(t, err)
 			require.NotNil(t, c)
 
@@ -664,7 +655,7 @@ func TestLifecycleHooks(t *testing.T) {
 			err = c.Terminate(ctx)
 			require.NoError(t, err)
 
-			lifecycleHooksIsHonouredFn(t, ctx, prints)
+			lifecycleHooksIsHonouredFn(t, prints)
 		})
 	}
 }
@@ -698,6 +689,7 @@ func TestLifecycleHooks_WithDefaultLogger(t *testing.T) {
 		ContainerRequest: req,
 		Started:          true,
 	})
+	CleanupContainer(t, c)
 	require.NoError(t, err)
 	require.NotNil(t, c)
 
@@ -711,7 +703,8 @@ func TestLifecycleHooks_WithDefaultLogger(t *testing.T) {
 	err = c.Terminate(ctx)
 	require.NoError(t, err)
 
-	require.Len(t, dl.data, 12)
+	// Includes two additional entries for stop when terminate is called.
+	require.Len(t, dl.data, 14)
 }
 
 func TestCombineLifecycleHooks(t *testing.T) {
@@ -864,6 +857,7 @@ func TestLifecycleHooks_WithMultipleHooks(t *testing.T) {
 		ContainerRequest: req,
 		Started:          true,
 	})
+	CleanupContainer(t, c)
 	require.NoError(t, err)
 	require.NotNil(t, c)
 
@@ -877,7 +871,8 @@ func TestLifecycleHooks_WithMultipleHooks(t *testing.T) {
 	err = c.Terminate(ctx)
 	require.NoError(t, err)
 
-	require.Len(t, dl.data, 24)
+	// Includes four additional entries for stop (twice) when terminate is called.
+	require.Len(t, dl.data, 28)
 }
 
 type linesTestLogger struct {
@@ -901,19 +896,19 @@ func TestPrintContainerLogsOnError(t *testing.T) {
 		data: []string{},
 	}
 
-	container, err := GenericContainer(ctx, GenericContainerRequest{
+	ctr, err := GenericContainer(ctx, GenericContainerRequest{
 		ProviderType:     providerType,
 		ContainerRequest: req,
 		Logger:           &arrayOfLinesLogger,
 		Started:          true,
 	})
+	CleanupContainer(t, ctr)
 	// it should fail because the waiting for condition is not met
 	if err == nil {
 		t.Fatal(err)
 	}
-	terminateContainerOnEnd(t, ctx, container)
 
-	containerLogs, err := container.Logs(ctx)
+	containerLogs, err := ctr.Logs(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -944,42 +939,40 @@ func TestPrintContainerLogsOnError(t *testing.T) {
 	}
 }
 
-func lifecycleHooksIsHonouredFn(t *testing.T, ctx context.Context, prints []string) {
-	require.Len(t, prints, 24)
+func lifecycleHooksIsHonouredFn(t *testing.T, prints []string) {
+	t.Helper()
 
-	assert.True(t, strings.HasPrefix(prints[0], "pre-create hook 1: "))
-	assert.True(t, strings.HasPrefix(prints[1], "pre-create hook 2: "))
+	expects := []string{
+		"pre-create hook 1",
+		"pre-create hook 2",
+		"post-create hook 1",
+		"post-create hook 2",
+		"pre-start hook 1",
+		"pre-start hook 2",
+		"post-start hook 1",
+		"post-start hook 2",
+		"post-ready hook 1",
+		"post-ready hook 2",
+		"pre-stop hook 1",
+		"pre-stop hook 2",
+		"post-stop hook 1",
+		"post-stop hook 2",
+		"pre-start hook 1",
+		"pre-start hook 2",
+		"post-start hook 1",
+		"post-start hook 2",
+		"post-ready hook 1",
+		"post-ready hook 2",
+		// Terminate currently calls stop to ensure that child containers are stopped.
+		"pre-stop hook 1",
+		"pre-stop hook 2",
+		"post-stop hook 1",
+		"post-stop hook 2",
+		"pre-terminate hook 1",
+		"pre-terminate hook 2",
+		"post-terminate hook 1",
+		"post-terminate hook 2",
+	}
 
-	assert.True(t, strings.HasPrefix(prints[2], "post-create hook 1: "))
-	assert.True(t, strings.HasPrefix(prints[3], "post-create hook 2: "))
-
-	assert.True(t, strings.HasPrefix(prints[4], "pre-start hook 1: "))
-	assert.True(t, strings.HasPrefix(prints[5], "pre-start hook 2: "))
-
-	assert.True(t, strings.HasPrefix(prints[6], "post-start hook 1: "))
-	assert.True(t, strings.HasPrefix(prints[7], "post-start hook 2: "))
-
-	assert.True(t, strings.HasPrefix(prints[8], "post-ready hook 1: "))
-	assert.True(t, strings.HasPrefix(prints[9], "post-ready hook 2: "))
-
-	assert.True(t, strings.HasPrefix(prints[10], "pre-stop hook 1: "))
-	assert.True(t, strings.HasPrefix(prints[11], "pre-stop hook 2: "))
-
-	assert.True(t, strings.HasPrefix(prints[12], "post-stop hook 1: "))
-	assert.True(t, strings.HasPrefix(prints[13], "post-stop hook 2: "))
-
-	assert.True(t, strings.HasPrefix(prints[14], "pre-start hook 1: "))
-	assert.True(t, strings.HasPrefix(prints[15], "pre-start hook 2: "))
-
-	assert.True(t, strings.HasPrefix(prints[16], "post-start hook 1: "))
-	assert.True(t, strings.HasPrefix(prints[17], "post-start hook 2: "))
-
-	assert.True(t, strings.HasPrefix(prints[18], "post-ready hook 1: "))
-	assert.True(t, strings.HasPrefix(prints[19], "post-ready hook 2: "))
-
-	assert.True(t, strings.HasPrefix(prints[20], "pre-terminate hook 1: "))
-	assert.True(t, strings.HasPrefix(prints[21], "pre-terminate hook 2: "))
-
-	assert.True(t, strings.HasPrefix(prints[22], "post-terminate hook 1: "))
-	assert.True(t, strings.HasPrefix(prints[23], "post-terminate hook 2: "))
+	require.Equal(t, expects, prints)
 }

--- a/modulegen/_template/examples_test.go.tmpl
+++ b/modulegen/_template/examples_test.go.tmpl
@@ -13,21 +13,21 @@ func Example{{ $entrypoint }}() {
 	ctx := context.Background()
 
 	{{ $lower }}Container, err := {{ $lower }}.{{ $entrypoint }}(ctx, "{{ $image }}")
-	if err != nil {
-		log.Fatalf("failed to start container: %s", err)
-	}
-
-	// Clean up the container
 	defer func() {
-		if err := {{ $lower }}Container.Terminate(ctx); err != nil {
-			log.Fatalf("failed to terminate container: %s", err) // nolint:gocritic
+		if err := testcontainers.TerminateContainer({{ $lower }}Container); err != nil {
+			log.Printf("failed to terminate container: %s", err)
 		}
 	}()
+	if err != nil {
+		log.Printf("failed to start container: %s", err)
+		return
+	}
 	// }
 
 	state, err := {{ $lower }}Container.State(ctx)
 	if err != nil {
-		log.Fatalf("failed to get container state: %s", err) // nolint:gocritic
+		log.Printf("failed to get container state: %s", err)
+		return
 	}
 
 	fmt.Println(state.Running)

--- a/modulegen/_template/module.go.tmpl
+++ b/modulegen/_template/module.go.tmpl
@@ -30,9 +30,14 @@ func {{ $entrypoint }}(ctx context.Context, img string, opts ...testcontainers.C
 	}
 
 	container, err := testcontainers.GenericContainer(ctx, genericContainerReq)
-	if err != nil {
-		return nil, err
+	var c *{{ $containerName }}
+	if container != nil {
+		c = &{{ $containerName }}{Container: container}
 	}
 
-	return &{{ $containerName }}{Container: container}, nil
+	if err != nil {
+		return c, fmt.Errorf("generic container: %w", err)
+	}
+
+	return c, nil
 }

--- a/modulegen/_template/module_test.go.tmpl
+++ b/modulegen/_template/module_test.go.tmpl
@@ -4,23 +4,17 @@ import (
 	"context"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/testcontainers/testcontainers-go/{{ ParentDir }}/{{ $lower }}"
 )
 
 func Test{{ $title }}(t *testing.T) {
 	ctx := context.Background()
 
-	container, err := {{ $lower }}.{{ $entrypoint }}(ctx, "{{ $image }}")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// Clean up the container after the test is complete
-	t.Cleanup(func() {
-		if err := container.Terminate(ctx); err != nil {
-			t.Fatalf("failed to terminate container: %s", err)
-		}
-	})
+	ctr, err := {{ $lower }}.{{ $entrypoint }}(ctx, "{{ $image }}")
+	testcontainers.CleanupContainer(t, ctr)
+	require.NoError(t, err)
 
 	// perform assertions
 }

--- a/modulegen/main_test.go
+++ b/modulegen/main_test.go
@@ -407,8 +407,8 @@ func assertModuleTestContent(t *testing.T, module context.TestcontainersModule, 
 
 	data := sanitiseContent(content)
 	assert.Equal(t, "package "+module.Lower()+"_test", data[0])
-	assert.Equal(t, "func Test"+module.Title()+"(t *testing.T) {", data[9])
-	assert.Equal(t, "\tcontainer, err := "+module.Lower()+"."+module.Entrypoint()+"(ctx, \""+module.Image+"\")", data[12])
+	assert.Equal(t, "func Test"+module.Title()+"(t *testing.T) {", data[11])
+	assert.Equal(t, "\tctr, err := "+module.Lower()+"."+module.Entrypoint()+"(ctx, \""+module.Image+"\")", data[14])
 }
 
 // assert content module
@@ -422,15 +422,17 @@ func assertModuleContent(t *testing.T, module context.TestcontainersModule, exam
 	entrypoint := module.Entrypoint()
 
 	data := sanitiseContent(content)
-	assert.Equal(t, "package "+lower, data[0])
-	assert.Equal(t, "// "+containerName+" represents the "+exampleName+" container type used in the module", data[9])
-	assert.Equal(t, "type "+containerName+" struct {", data[10])
-	assert.Equal(t, "// "+entrypoint+" creates an instance of the "+exampleName+" container type", data[14])
-	assert.Equal(t, "func "+entrypoint+"(ctx context.Context, img string, opts ...testcontainers.ContainerCustomizer) (*"+containerName+", error) {", data[15])
-	assert.Equal(t, "\t\tImage: img,", data[17])
-	assert.Equal(t, "\t\tif err := opt.Customize(&genericContainerReq); err != nil {", data[26])
-	assert.Equal(t, "\t\t\treturn nil, fmt.Errorf(\"customize: %w\", err)", data[27])
-	assert.Equal(t, "\treturn &"+containerName+"{Container: container}, nil", data[36])
+	require.Equal(t, "package "+lower, data[0])
+	require.Equal(t, "// "+containerName+" represents the "+exampleName+" container type used in the module", data[9])
+	require.Equal(t, "type "+containerName+" struct {", data[10])
+	require.Equal(t, "// "+entrypoint+" creates an instance of the "+exampleName+" container type", data[14])
+	require.Equal(t, "func "+entrypoint+"(ctx context.Context, img string, opts ...testcontainers.ContainerCustomizer) (*"+containerName+", error) {", data[15])
+	require.Equal(t, "\t\tImage: img,", data[17])
+	require.Equal(t, "\t\tif err := opt.Customize(&genericContainerReq); err != nil {", data[26])
+	require.Equal(t, "\t\t\treturn nil, fmt.Errorf(\"customize: %w\", err)", data[27])
+	require.Equal(t, "\tvar c *"+containerName, data[32])
+	require.Equal(t, "\t\tc = &"+containerName+"{Container: container}", data[34])
+	require.Equal(t, "\treturn c, nil", data[41])
 }
 
 // assert content GitHub workflow for the module

--- a/modules/artemis/artemis.go
+++ b/modules/artemis/artemis.go
@@ -109,12 +109,16 @@ func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustom
 	}
 
 	container, err := testcontainers.GenericContainer(ctx, req)
+	var c *Container
+	if container != nil {
+		c = &Container{Container: container}
+	}
 	if err != nil {
-		return nil, err
+		return c, fmt.Errorf("generic container: %w", err)
 	}
 
-	user := req.Env["ARTEMIS_USER"]
-	password := req.Env["ARTEMIS_PASSWORD"]
+	c.user = req.Env["ARTEMIS_USER"]
+	c.password = req.Env["ARTEMIS_PASSWORD"]
 
-	return &Container{Container: container, user: user, password: password}, nil
+	return c, nil
 }

--- a/modules/artemis/artemis_test.go
+++ b/modules/artemis/artemis_test.go
@@ -64,12 +64,12 @@ func TestArtemis(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			container, err := artemis.Run(ctx, "docker.io/apache/activemq-artemis:2.30.0-alpine", test.opts...)
+			ctr, err := artemis.Run(ctx, "docker.io/apache/activemq-artemis:2.30.0-alpine", test.opts...)
+			testcontainers.CleanupContainer(t, ctr)
 			require.NoError(t, err)
-			t.Cleanup(func() { require.NoError(t, container.Terminate(ctx), "failed to terminate container") })
 
 			// consoleURL {
-			u, err := container.ConsoleURL(ctx)
+			u, err := ctr.ConsoleURL(ctx)
 			// }
 			require.NoError(t, err)
 
@@ -79,15 +79,15 @@ func TestArtemis(t *testing.T) {
 			assert.Equal(t, http.StatusOK, res.StatusCode, "failed to access console")
 
 			if test.user != "" {
-				assert.Equal(t, test.user, container.User(), "unexpected user")
+				assert.Equal(t, test.user, ctr.User(), "unexpected user")
 			}
 
 			if test.pass != "" {
-				assert.Equal(t, test.pass, container.Password(), "unexpected password")
+				assert.Equal(t, test.pass, ctr.Password(), "unexpected password")
 			}
 
 			// brokerEndpoint {
-			host, err := container.BrokerEndpoint(ctx)
+			host, err := ctr.BrokerEndpoint(ctx)
 			// }
 			require.NoError(t, err)
 
@@ -116,7 +116,7 @@ func TestArtemis(t *testing.T) {
 			}
 
 			if test.hook != nil {
-				test.hook(t, container)
+				test.hook(t, ctr)
 			}
 		})
 	}

--- a/modules/artemis/examples_test.go
+++ b/modules/artemis/examples_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/go-stomp/stomp/v3"
 
+	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/modules/artemis"
 )
 
@@ -18,19 +19,21 @@ func ExampleRun() {
 		"docker.io/apache/activemq-artemis:2.30.0",
 		artemis.WithCredentials("test", "test"),
 	)
-	if err != nil {
-		log.Fatalf("failed to start container: %s", err)
-	}
 	defer func() {
-		if err := artemisContainer.Terminate(ctx); err != nil {
-			log.Fatalf("failed to terminate container: %s", err)
+		if err := testcontainers.TerminateContainer(artemisContainer); err != nil {
+			log.Printf("failed to terminate container: %s", err)
 		}
 	}()
+	if err != nil {
+		log.Printf("failed to start container: %s", err)
+		return
+	}
 	// }
 
 	state, err := artemisContainer.State(ctx)
 	if err != nil {
-		log.Fatalf("failed to get container state: %s", err) // nolint:gocritic
+		log.Printf("failed to get container state: %s", err)
+		return
 	}
 
 	fmt.Println(state.Running)
@@ -39,7 +42,8 @@ func ExampleRun() {
 	// Get broker endpoint.
 	host, err := artemisContainer.BrokerEndpoint(ctx)
 	if err != nil {
-		log.Fatalf("failed to get broker endpoint: %s", err)
+		log.Printf("failed to get broker endpoint: %s", err)
+		return
 	}
 
 	// containerUser {
@@ -52,11 +56,12 @@ func ExampleRun() {
 	// Connect to Artemis via STOMP.
 	conn, err := stomp.Dial("tcp", host, stomp.ConnOpt.Login(user, pass))
 	if err != nil {
-		log.Fatalf("failed to connect to Artemis: %s", err)
+		log.Printf("failed to connect to Artemis: %s", err)
+		return
 	}
 	defer func() {
 		if err := conn.Disconnect(); err != nil {
-			log.Fatalf("failed to disconnect from Artemis: %s", err)
+			log.Printf("failed to disconnect from Artemis: %s", err)
 		}
 	}()
 	// }

--- a/modules/azurite/azurite.go
+++ b/modules/azurite/azurite.go
@@ -121,9 +121,14 @@ func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustom
 	}
 
 	container, err := testcontainers.GenericContainer(ctx, genericContainerReq)
-	if err != nil {
-		return nil, err
+	var c *AzuriteContainer
+	if container != nil {
+		c = &AzuriteContainer{Container: container, Settings: settings}
 	}
 
-	return &AzuriteContainer{Container: container, Settings: settings}, nil
+	if err != nil {
+		return c, fmt.Errorf("generic container: %w", err)
+	}
+
+	return c, nil
 }

--- a/modules/azurite/azurite_test.go
+++ b/modules/azurite/azurite_test.go
@@ -4,23 +4,18 @@ import (
 	"context"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
+	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/modules/azurite"
 )
 
 func TestAzurite(t *testing.T) {
 	ctx := context.Background()
 
-	container, err := azurite.Run(ctx, "mcr.microsoft.com/azure-storage/azurite:3.23.0")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// Clean up the container after the test is complete
-	t.Cleanup(func() {
-		if err := container.Terminate(ctx); err != nil {
-			t.Fatalf("failed to terminate container: %s", err)
-		}
-	})
+	ctr, err := azurite.Run(ctx, "mcr.microsoft.com/azure-storage/azurite:3.23.0")
+	testcontainers.CleanupContainer(t, ctr)
+	require.NoError(t, err)
 
 	// perform assertions
 }

--- a/modules/azurite/go.mod
+++ b/modules/azurite/go.mod
@@ -8,7 +8,8 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.3.2
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azqueue v1.0.0
 	github.com/docker/go-connections v0.5.0
-	github.com/testcontainers/testcontainers-go v0.33.0
+	github.com/stretchr/testify v1.9.0
+	github.com/testcontainers/testcontainers-go v0.32.0
 )
 
 require (
@@ -21,6 +22,7 @@ require (
 	github.com/containerd/log v0.1.0 // indirect
 	github.com/containerd/platforms v0.2.1 // indirect
 	github.com/cpuguy83/dockercfg v0.3.1 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/distribution/reference v0.6.0 // indirect
 	github.com/docker/docker v27.1.1+incompatible // indirect
 	github.com/docker/go-units v0.5.0 // indirect
@@ -31,6 +33,7 @@ require (
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/klauspost/compress v1.17.4 // indirect
+	github.com/kr/text v0.2.0 // indirect
 	github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 // indirect
 	github.com/magiconair/properties v1.8.7 // indirect
 	github.com/moby/docker-image-spec v1.3.1 // indirect
@@ -42,6 +45,7 @@ require (
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c // indirect
 	github.com/shirou/gopsutil/v3 v3.23.12 // indirect
 	github.com/shoenig/go-m1cpu v0.1.6 // indirect
@@ -59,6 +63,7 @@ require (
 	golang.org/x/text v0.16.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20240318140521-94a12d6c2237 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240318140521-94a12d6c2237 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
 replace github.com/testcontainers/testcontainers-go => ../..

--- a/modules/azurite/go.sum
+++ b/modules/azurite/go.sum
@@ -32,6 +32,7 @@ github.com/containerd/platforms v0.2.1 h1:zvwtM3rz2YHPQsF2CHYM8+KtB5dvhISiXh5ZpS
 github.com/containerd/platforms v0.2.1/go.mod h1:XHCb+2/hzowdiut9rkudds9bE5yJ7npe7dG/wG+uFPw=
 github.com/cpuguy83/dockercfg v0.3.1 h1:/FpZ+JaygUR/lZP2NlFI2DVfrOEMAIKP5wWEJdoYe9E=
 github.com/cpuguy83/dockercfg v0.3.1/go.mod h1:sugsbF4//dDlL/i+S+rtpIWp+5h0BHJHfjj5/jFyUJc=
+github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.18 h1:n56/Zwd5o6whRC5PMGretI4IdRLlmBXYNjScPaBgsbY=
 github.com/creack/pty v1.1.18/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -73,6 +74,10 @@ github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/compress v1.17.4 h1:Ej5ixsIri7BrIjBkRZLTo6ghwrEtHFk7ijlczPW4fZ4=
 github.com/klauspost/compress v1.17.4/go.mod h1:/dCuZOvVtNoHsyb+cuJD3itjs3NbnF6KH9zAO4BDxPM=
+github.com/kr/pretty v0.3.0 h1:WgNl7dwNpEZ6jJ9k1snq4pZsg7DOEN8hP9Xw0Tsjwk0=
+github.com/kr/pretty v0.3.0/go.mod h1:640gp4NfQd8pI5XOwp5fnNeVWj67G7CFk/SaSQn7NBk=
+github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
+github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 h1:6E+4a0GO5zZEnZ81pIr0yLvtUWk2if982qA3F3QD6H4=
@@ -103,6 +108,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c h1:ncq/mPwQF4JjgDlrVEn3C11VoGHZN7m8qihwgMEtzYw=
 github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c/go.mod h1:OmDBASR4679mdNQnz2pUhc2G8CO2JrUAVFDRBDP/hJE=
+github.com/rogpeppe/go-internal v1.8.1 h1:geMPLpDpQOgVyCg5z5GoRwLHepNdb71NXb67XFkP+Eg=
+github.com/rogpeppe/go-internal v1.8.1/go.mod h1:JeRgkft04UBgHMgCIwADu4Pn6Mtm5d4nPKWu0nJ5d+o=
 github.com/shirou/gopsutil/v3 v3.23.12 h1:z90NtUkp3bMtmICZKpC4+WaknU1eXtp5vtbQ11DgpE4=
 github.com/shirou/gopsutil/v3 v3.23.12/go.mod h1:1FrWgea594Jp7qmjHUUPlJDTPgcsb9mGnXDxavtikzM=
 github.com/shoenig/go-m1cpu v0.1.6 h1:nxdKQNcEB6vzgA2E2bvzKIYRuNj7XNJ4S/aRSwKzFtM=
@@ -199,6 +206,8 @@ google.golang.org/grpc v1.64.1/go.mod h1:hiQF4LFZelK2WKaP6W0L92zGHtiQdZxk8CrSdvy
 google.golang.org/protobuf v1.33.0 h1:uNO2rsAINq/JlFpSdYEKIZ0uKD/R9cpdv0T+yoGwGmI=
 google.golang.org/protobuf v1.33.0/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/modules/cassandra/cassandra.go
+++ b/modules/cassandra/cassandra.go
@@ -2,6 +2,7 @@ package cassandra
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"path/filepath"
 	"strings"
@@ -114,9 +115,14 @@ func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustom
 	}
 
 	container, err := testcontainers.GenericContainer(ctx, genericContainerReq)
-	if err != nil {
-		return nil, err
+	var c *CassandraContainer
+	if container != nil {
+		c = &CassandraContainer{Container: container}
 	}
 
-	return &CassandraContainer{Container: container}, nil
+	if err != nil {
+		return c, fmt.Errorf("generic container: %w", err)
+	}
+
+	return c, nil
 }

--- a/modules/cassandra/cassandra_test.go
+++ b/modules/cassandra/cassandra_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/modules/cassandra"
 )
 
@@ -20,26 +21,18 @@ type Test struct {
 func TestCassandra(t *testing.T) {
 	ctx := context.Background()
 
-	container, err := cassandra.Run(ctx, "cassandra:4.1.3")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// Clean up the container after the test is complete
-	t.Cleanup(func() {
-		require.NoError(t, container.Terminate(ctx))
-	})
+	ctr, err := cassandra.Run(ctx, "cassandra:4.1.3")
+	testcontainers.CleanupContainer(t, ctr)
+	require.NoError(t, err)
 
 	// connectionString {
-	connectionHost, err := container.ConnectionHost(ctx)
+	connectionHost, err := ctr.ConnectionHost(ctx)
 	// }
 	require.NoError(t, err)
 
 	cluster := gocql.NewCluster(connectionHost)
 	session, err := cluster.CreateSession()
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	defer session.Close()
 
 	// perform assertions
@@ -60,17 +53,11 @@ func TestCassandra(t *testing.T) {
 func TestCassandraWithConfigFile(t *testing.T) {
 	ctx := context.Background()
 
-	container, err := cassandra.Run(ctx, "cassandra:4.1.3", cassandra.WithConfigFile(filepath.Join("testdata", "config.yaml")))
-	if err != nil {
-		t.Fatal(err)
-	}
+	ctr, err := cassandra.Run(ctx, "cassandra:4.1.3", cassandra.WithConfigFile(filepath.Join("testdata", "config.yaml")))
+	testcontainers.CleanupContainer(t, ctr)
+	require.NoError(t, err)
 
-	// Clean up the container after the test is complete
-	t.Cleanup(func() {
-		require.NoError(t, container.Terminate(ctx))
-	})
-
-	connectionHost, err := container.ConnectionHost(ctx)
+	connectionHost, err := ctr.ConnectionHost(ctx)
 	require.NoError(t, err)
 
 	cluster := gocql.NewCluster(connectionHost)
@@ -91,19 +78,13 @@ func TestCassandraWithInitScripts(t *testing.T) {
 		ctx := context.Background()
 
 		// withInitScripts {
-		container, err := cassandra.Run(ctx, "cassandra:4.1.3", cassandra.WithInitScripts(filepath.Join("testdata", "init.cql")))
+		ctr, err := cassandra.Run(ctx, "cassandra:4.1.3", cassandra.WithInitScripts(filepath.Join("testdata", "init.cql")))
 		// }
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		// Clean up the container after the test is complete
-		t.Cleanup(func() {
-			require.NoError(t, container.Terminate(ctx))
-		})
+		testcontainers.CleanupContainer(t, ctr)
+		require.NoError(t, err)
 
 		// connectionHost {
-		connectionHost, err := container.ConnectionHost(ctx)
+		connectionHost, err := ctr.ConnectionHost(ctx)
 		// }
 		require.NoError(t, err)
 
@@ -123,17 +104,11 @@ func TestCassandraWithInitScripts(t *testing.T) {
 	t.Run("with init bash script", func(t *testing.T) {
 		ctx := context.Background()
 
-		container, err := cassandra.Run(ctx, "cassandra:4.1.3", cassandra.WithInitScripts(filepath.Join("testdata", "init.sh")))
-		if err != nil {
-			t.Fatal(err)
-		}
+		ctr, err := cassandra.Run(ctx, "cassandra:4.1.3", cassandra.WithInitScripts(filepath.Join("testdata", "init.sh")))
+		testcontainers.CleanupContainer(t, ctr)
+		require.NoError(t, err)
 
-		// Clean up the container after the test is complete
-		t.Cleanup(func() {
-			require.NoError(t, container.Terminate(ctx))
-		})
-
-		connectionHost, err := container.ConnectionHost(ctx)
+		connectionHost, err := ctr.ConnectionHost(ctx)
 		require.NoError(t, err)
 
 		cluster := gocql.NewCluster(connectionHost)

--- a/modules/cassandra/examples_test.go
+++ b/modules/cassandra/examples_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/gocql/gocql"
 
+	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/modules/cassandra"
 )
 
@@ -20,41 +21,44 @@ func ExampleRun() {
 		cassandra.WithInitScripts(filepath.Join("testdata", "init.cql")),
 		cassandra.WithConfigFile(filepath.Join("testdata", "config.yaml")),
 	)
-	if err != nil {
-		log.Fatalf("failed to start container: %s", err)
-	}
-
-	// Clean up the container
 	defer func() {
-		if err := cassandraContainer.Terminate(ctx); err != nil {
-			log.Fatalf("failed to terminate container: %s", err)
+		if err := testcontainers.TerminateContainer(cassandraContainer); err != nil {
+			log.Printf("failed to terminate container: %s", err)
 		}
 	}()
+	if err != nil {
+		log.Printf("failed to start container: %s", err)
+		return
+	}
 	// }
 
 	state, err := cassandraContainer.State(ctx)
 	if err != nil {
-		log.Fatalf("failed to get container state: %s", err) // nolint:gocritic
+		log.Printf("failed to get container state: %s", err)
+		return
 	}
 
 	fmt.Println(state.Running)
 
 	connectionHost, err := cassandraContainer.ConnectionHost(ctx)
 	if err != nil {
-		log.Fatalf("failed to get connection host: %s", err)
+		log.Printf("failed to get connection host: %s", err)
+		return
 	}
 
 	cluster := gocql.NewCluster(connectionHost)
 	session, err := cluster.CreateSession()
 	if err != nil {
-		log.Fatalf("failed to create session: %s", err)
+		log.Printf("failed to create session: %s", err)
+		return
 	}
 	defer session.Close()
 
 	var version string
 	err = session.Query("SELECT release_version FROM system.local").Scan(&version)
 	if err != nil {
-		log.Fatalf("failed to query: %s", err)
+		log.Printf("failed to query: %s", err)
+		return
 	}
 
 	fmt.Println(version)

--- a/modules/chroma/chroma.go
+++ b/modules/chroma/chroma.go
@@ -45,11 +45,16 @@ func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustom
 	}
 
 	container, err := testcontainers.GenericContainer(ctx, genericContainerReq)
-	if err != nil {
-		return nil, err
+	var c *ChromaContainer
+	if container != nil {
+		c = &ChromaContainer{Container: container}
 	}
 
-	return &ChromaContainer{Container: container}, nil
+	if err != nil {
+		return c, fmt.Errorf("generic container: %w", err)
+	}
+
+	return c, nil
 }
 
 // RESTEndpoint returns the REST endpoint of the Chroma container

--- a/modules/chroma/chroma_test.go
+++ b/modules/chroma/chroma_test.go
@@ -8,27 +8,20 @@ import (
 	chromago "github.com/amikos-tech/chroma-go"
 	"github.com/stretchr/testify/require"
 
+	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/modules/chroma"
 )
 
 func TestChroma(t *testing.T) {
 	ctx := context.Background()
 
-	container, err := chroma.Run(ctx, "chromadb/chroma:0.4.24")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// Clean up the container after the test is complete
-	t.Cleanup(func() {
-		if err := container.Terminate(ctx); err != nil {
-			t.Fatalf("failed to terminate container: %s", err)
-		}
-	})
+	ctr, err := chroma.Run(ctx, "chromadb/chroma:0.4.24")
+	testcontainers.CleanupContainer(t, ctr)
+	require.NoError(t, err)
 
 	t.Run("REST Endpoint retrieve docs site", func(tt *testing.T) {
 		// restEndpoint {
-		restEndpoint, err := container.RESTEndpoint(ctx)
+		restEndpoint, err := ctr.RESTEndpoint(ctx)
 		// }
 		if err != nil {
 			tt.Fatalf("failed to get REST endpoint: %s", err)
@@ -48,9 +41,9 @@ func TestChroma(t *testing.T) {
 
 	t.Run("GetClient", func(tt *testing.T) {
 		// restEndpoint {
-		endpoint, err := container.RESTEndpoint(context.Background())
+		endpoint, err := ctr.RESTEndpoint(context.Background())
 		if err != nil {
-			tt.Fatalf("failed to get REST endpoint: %s", err) // nolint:gocritic
+			tt.Fatalf("failed to get REST endpoint: %s", err)
 		}
 		chromaClient, err := chromago.NewClient(endpoint)
 		// }

--- a/modules/chroma/examples_test.go
+++ b/modules/chroma/examples_test.go
@@ -17,21 +17,21 @@ func ExampleRun() {
 	ctx := context.Background()
 
 	chromaContainer, err := chroma.Run(ctx, "chromadb/chroma:0.4.24")
-	if err != nil {
-		log.Fatalf("failed to start container: %s", err)
-	}
-
-	// Clean up the container
 	defer func() {
-		if err := chromaContainer.Terminate(ctx); err != nil {
-			log.Fatalf("failed to terminate container: %s", err) // nolint:gocritic
+		if err := testcontainers.TerminateContainer(chromaContainer); err != nil {
+			log.Printf("failed to terminate container: %s", err)
 		}
 	}()
+	if err != nil {
+		log.Printf("failed to start container: %s", err)
+		return
+	}
 	// }
 
 	state, err := chromaContainer.State(ctx)
 	if err != nil {
-		log.Fatalf("failed to get container state: %s", err) // nolint:gocritic
+		log.Printf("failed to get container state: %s", err)
+		return
 	}
 
 	fmt.Println(state.Running)
@@ -45,24 +45,25 @@ func ExampleChromaContainer_connectWithClient() {
 	ctx := context.Background()
 
 	chromaContainer, err := chroma.Run(ctx, "chromadb/chroma:0.4.24")
-	if err != nil {
-		log.Fatalf("failed to start container: %s", err)
-	}
-
-	// Clean up the container
 	defer func() {
-		if err := chromaContainer.Terminate(ctx); err != nil {
-			log.Fatalf("failed to terminate container: %s", err) // nolint:gocritic
+		if err := testcontainers.TerminateContainer(chromaContainer); err != nil {
+			log.Printf("failed to terminate container: %s", err)
 		}
 	}()
+	if err != nil {
+		log.Printf("failed to start container: %s", err)
+		return
+	}
 
 	endpoint, err := chromaContainer.RESTEndpoint(context.Background())
 	if err != nil {
-		log.Fatalf("failed to get REST endpoint: %s", err) // nolint:gocritic
+		log.Printf("failed to get REST endpoint: %s", err)
+		return
 	}
 	chromaClient, err := chromago.NewClient(endpoint)
 	if err != nil {
-		log.Fatalf("failed to get client: %s", err) // nolint:gocritic
+		log.Printf("failed to get client: %s", err)
+		return
 	}
 
 	hbs, errHb := chromaClient.Heartbeat(context.Background())
@@ -82,32 +83,35 @@ func ExampleChromaContainer_collections() {
 	ctx := context.Background()
 
 	chromaContainer, err := chroma.Run(ctx, "chromadb/chroma:0.4.24", testcontainers.WithEnv(map[string]string{"ALLOW_RESET": "true"}))
-	if err != nil {
-		log.Fatalf("failed to start container: %s", err)
-	}
-
 	defer func() {
-		if err := chromaContainer.Terminate(ctx); err != nil {
-			log.Fatalf("failed to terminate container: %s", err) // nolint:gocritic
+		if err := testcontainers.TerminateContainer(chromaContainer); err != nil {
+			log.Printf("failed to terminate container: %s", err)
 		}
 	}()
+	if err != nil {
+		log.Printf("failed to start container: %s", err)
+		return
+	}
 
 	// getClient {
 	// create the client connection and confirm that we can access the server with it
 	endpoint, err := chromaContainer.RESTEndpoint(context.Background())
 	if err != nil {
-		log.Fatalf("failed to get REST endpoint: %s", err) // nolint:gocritic
+		log.Printf("failed to get REST endpoint: %s", err)
+		return
 	}
 	chromaClient, err := chromago.NewClient(endpoint)
 	// }
 	if err != nil {
-		log.Fatalf("failed to get client: %s", err) // nolint:gocritic
+		log.Printf("failed to get client: %s", err)
+		return
 	}
 	// reset {
 	reset, err := chromaClient.Reset(context.Background())
 	// }
 	if err != nil {
-		log.Fatalf("failed to reset: %s", err) // nolint:gocritic
+		log.Printf("failed to reset: %s", err)
+		return
 	}
 	fmt.Printf("Reset successful: %v\n", reset)
 
@@ -116,7 +120,8 @@ func ExampleChromaContainer_collections() {
 	col, err := chromaClient.CreateCollection(context.Background(), "test-collection", map[string]any{}, true, types.NewConsistentHashEmbeddingFunction(), types.L2)
 	// }
 	if err != nil {
-		log.Fatalf("failed to create collection: %s", err) // nolint:gocritic
+		log.Printf("failed to create collection: %s", err)
+		return
 	}
 
 	fmt.Println("Collection created:", col.Name)
@@ -132,7 +137,8 @@ func ExampleChromaContainer_collections() {
 	)
 	// }
 	if err != nil {
-		log.Fatalf("failed to add data to collection: %s", err) // nolint:gocritic
+		log.Printf("failed to add data to collection: %s", err)
+		return
 	}
 
 	fmt.Println(col1.Count(context.Background()))
@@ -147,7 +153,8 @@ func ExampleChromaContainer_collections() {
 	)
 	// }
 	if err != nil {
-		log.Fatalf("failed to query collection: %s", err) // nolint:gocritic
+		log.Printf("failed to query collection: %s", err)
+		return
 	}
 
 	fmt.Printf("Result of query: %v\n", queryResults)
@@ -156,7 +163,8 @@ func ExampleChromaContainer_collections() {
 	cols, err := chromaClient.ListCollections(context.Background())
 	// }
 	if err != nil {
-		log.Fatalf("failed to list collections: %s", err) // nolint:gocritic
+		log.Printf("failed to list collections: %s", err)
+		return
 	}
 
 	fmt.Println(len(cols))
@@ -165,7 +173,8 @@ func ExampleChromaContainer_collections() {
 	_, err = chromaClient.DeleteCollection(context.Background(), "test-collection")
 	// }
 	if err != nil {
-		log.Fatalf("failed to delete collection: %s", err) // nolint:gocritic
+		log.Printf("failed to delete collection: %s", err)
+		return
 	}
 
 	fmt.Println(err)

--- a/modules/clickhouse/clickhouse.go
+++ b/modules/clickhouse/clickhouse.go
@@ -249,13 +249,17 @@ func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustom
 	}
 
 	container, err := testcontainers.GenericContainer(ctx, genericContainerReq)
+	var c *ClickHouseContainer
+	if container != nil {
+		c = &ClickHouseContainer{Container: container}
+	}
 	if err != nil {
-		return nil, err
+		return c, fmt.Errorf("generic container: %w", err)
 	}
 
-	user := req.Env["CLICKHOUSE_USER"]
-	password := req.Env["CLICKHOUSE_PASSWORD"]
-	dbName := req.Env["CLICKHOUSE_DB"]
+	c.User = req.Env["CLICKHOUSE_USER"]
+	c.Password = req.Env["CLICKHOUSE_PASSWORD"]
+	c.DbName = req.Env["CLICKHOUSE_DB"]
 
-	return &ClickHouseContainer{Container: container, DbName: dbName, Password: password, User: user}, nil
+	return c, nil
 }

--- a/modules/clickhouse/examples_test.go
+++ b/modules/clickhouse/examples_test.go
@@ -9,6 +9,7 @@ import (
 
 	ch "github.com/ClickHouse/clickhouse-go/v2"
 
+	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/modules/clickhouse"
 )
 
@@ -28,31 +29,35 @@ func ExampleRun() {
 		clickhouse.WithInitScripts(filepath.Join("testdata", "init-db.sh")),
 		clickhouse.WithConfigFile(filepath.Join("testdata", "config.xml")),
 	)
-	if err != nil {
-		log.Fatalf("failed to start container: %s", err)
-	}
 	defer func() {
-		if err := clickHouseContainer.Terminate(ctx); err != nil {
-			log.Fatalf("failed to terminate container: %s", err)
+		if err := testcontainers.TerminateContainer(clickHouseContainer); err != nil {
+			log.Printf("failed to terminate container: %s", err)
 		}
 	}()
+	if err != nil {
+		log.Printf("failed to start container: %s", err)
+		return
+	}
 	// }
 
 	state, err := clickHouseContainer.State(ctx)
 	if err != nil {
-		log.Fatalf("failed to get container state: %s", err) // nolint:gocritic
+		log.Printf("failed to get container state: %s", err)
+		return
 	}
 
 	fmt.Println(state.Running)
 
 	connectionString, err := clickHouseContainer.ConnectionString(ctx)
 	if err != nil {
-		log.Fatalf("failed to get connection string: %s", err)
+		log.Printf("failed to get connection string: %s", err)
+		return
 	}
 
 	opts, err := ch.ParseDSN(connectionString)
 	if err != nil {
-		log.Fatalf("failed to parse DSN: %s", err)
+		log.Printf("failed to parse DSN: %s", err)
+		return
 	}
 
 	fmt.Println(strings.HasPrefix(opts.ClientInfo.String(), "clickhouse-go/"))

--- a/modules/cockroachdb/cockroachdb.go
+++ b/modules/cockroachdb/cockroachdb.go
@@ -118,10 +118,16 @@ func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustom
 	}
 
 	container, err := testcontainers.GenericContainer(ctx, req)
-	if err != nil {
-		return nil, err
+	var c *CockroachDBContainer
+	if container != nil {
+		c = &CockroachDBContainer{Container: container, opts: o}
 	}
-	return &CockroachDBContainer{Container: container, opts: o}, nil
+
+	if err != nil {
+		return c, fmt.Errorf("generic container: %w", err)
+	}
+
+	return c, nil
 }
 
 type modiferFunc func(*testcontainers.GenericContainerRequest, options) error

--- a/modules/cockroachdb/examples_test.go
+++ b/modules/cockroachdb/examples_test.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"net/url"
 
+	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/modules/cockroachdb"
 )
 
@@ -14,31 +15,33 @@ func ExampleRun() {
 	ctx := context.Background()
 
 	cockroachdbContainer, err := cockroachdb.Run(ctx, "cockroachdb/cockroach:latest-v23.1")
-	if err != nil {
-		log.Fatalf("failed to start container: %s", err)
-	}
-
-	// Clean up the container
 	defer func() {
-		if err := cockroachdbContainer.Terminate(ctx); err != nil {
-			log.Fatalf("failed to terminate container: %s", err)
+		if err := testcontainers.TerminateContainer(cockroachdbContainer); err != nil {
+			log.Printf("failed to terminate container: %s", err)
 		}
 	}()
+	if err != nil {
+		log.Printf("failed to start container: %s", err)
+		return
+	}
 	// }
 
 	state, err := cockroachdbContainer.State(ctx)
 	if err != nil {
-		log.Fatalf("failed to get container state: %s", err) // nolint:gocritic
+		log.Printf("failed to get container state: %s", err)
+		return
 	}
 	fmt.Println(state.Running)
 
 	addr, err := cockroachdbContainer.ConnectionString(ctx)
 	if err != nil {
-		log.Fatalf("failed to get connection string: %s", err)
+		log.Printf("failed to get connection string: %s", err)
+		return
 	}
 	u, err := url.Parse(addr)
 	if err != nil {
-		log.Fatalf("failed to parse connection string: %s", err)
+		log.Printf("failed to parse connection string: %s", err)
+		return
 	}
 	u.Host = fmt.Sprintf("%s:%s", u.Hostname(), "xxx")
 	fmt.Println(u.String())

--- a/modules/compose/compose_api.go
+++ b/modules/compose/compose_api.go
@@ -460,6 +460,10 @@ func (d *dockerCompose) lookupContainer(ctx context.Context, svcName string) (*t
 	}
 
 	containerInstance := containers[0]
+	// TODO: Fix as this is only setting a subset of the fields
+	// and the container is not fully initialized, for example
+	// the isRunning flag is not set.
+	// See: https://github.com/testcontainers/testcontainers-go/issues/2667
 	ctr := &testcontainers.DockerContainer{
 		ID:    containerInstance.ID,
 		Image: containerInstance.Image,

--- a/modules/consul/consul.go
+++ b/modules/consul/consul.go
@@ -94,9 +94,14 @@ func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustom
 	}
 
 	container, err := testcontainers.GenericContainer(ctx, containerReq)
-	if err != nil {
-		return nil, err
+	var c *ConsulContainer
+	if container != nil {
+		c = &ConsulContainer{Container: container}
 	}
 
-	return &ConsulContainer{Container: container}, nil
+	if err != nil {
+		return c, fmt.Errorf("generic container: %w", err)
+	}
+
+	return c, nil
 }

--- a/modules/consul/consul_test.go
+++ b/modules/consul/consul_test.go
@@ -40,12 +40,12 @@ func TestConsul(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			container, err := consul.Run(ctx, "docker.io/hashicorp/consul:1.15", test.opts...)
+			ctr, err := consul.Run(ctx, "docker.io/hashicorp/consul:1.15", test.opts...)
+			testcontainers.CleanupContainer(t, ctr)
 			require.NoError(t, err)
-			t.Cleanup(func() { require.NoError(t, container.Terminate(ctx), "failed to terminate container") })
 
 			// Check if API is up
-			host, err := container.ApiEndpoint(ctx)
+			host, err := ctr.ApiEndpoint(ctx)
 			require.NoError(t, err)
 			assert.NotEmpty(t, len(host))
 

--- a/modules/consul/examples_test.go
+++ b/modules/consul/examples_test.go
@@ -7,6 +7,7 @@ import (
 
 	capi "github.com/hashicorp/consul/api"
 
+	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/modules/consul"
 )
 
@@ -15,21 +16,21 @@ func ExampleRun() {
 	ctx := context.Background()
 
 	consulContainer, err := consul.Run(ctx, "docker.io/hashicorp/consul:1.15")
-	if err != nil {
-		log.Fatalf("failed to start container: %s", err)
-	}
-
-	// Clean up the container
 	defer func() {
-		if err := consulContainer.Terminate(ctx); err != nil {
-			log.Fatalf("failed to terminate container: %s", err)
+		if err := testcontainers.TerminateContainer(consulContainer); err != nil {
+			log.Printf("failed to terminate container: %s", err)
 		}
 	}()
+	if err != nil {
+		log.Printf("failed to start container: %s", err)
+		return
+	}
 	// }
 
 	state, err := consulContainer.State(ctx)
 	if err != nil {
-		log.Fatalf("failed to get container state: %s", err) // nolint:gocritic
+		log.Printf("failed to get container state: %s", err)
+		return
 	}
 
 	fmt.Println(state.Running)
@@ -43,33 +44,35 @@ func ExampleRun_connect() {
 	ctx := context.Background()
 
 	consulContainer, err := consul.Run(ctx, "docker.io/hashicorp/consul:1.15")
-	if err != nil {
-		log.Fatalf("failed to start container: %s", err)
-	}
-
-	// Clean up the container
 	defer func() {
-		if err := consulContainer.Terminate(ctx); err != nil {
-			log.Fatalf("failed to terminate container: %s", err)
+		if err := testcontainers.TerminateContainer(consulContainer); err != nil {
+			log.Printf("failed to terminate container: %s", err)
 		}
 	}()
+	if err != nil {
+		log.Printf("failed to start container: %s", err)
+		return
+	}
 
 	endpoint, err := consulContainer.ApiEndpoint(ctx)
 	if err != nil {
-		log.Fatalf("failed to get endpoint: %s", err) // nolint:gocritic
+		log.Printf("failed to get endpoint: %s", err)
+		return
 	}
 
 	config := capi.DefaultConfig()
 	config.Address = endpoint
 	client, err := capi.NewClient(config)
 	if err != nil {
-		log.Fatalf("failed to connect to Consul: %s", err)
+		log.Printf("failed to connect to Consul: %s", err)
+		return
 	}
 	// }
 
 	node_name, err := client.Agent().NodeName()
 	if err != nil {
-		log.Fatalf("failed to get node name: %s", err) // nolint:gocritic
+		log.Printf("failed to get node name: %s", err)
+		return
 	}
 	fmt.Println(len(node_name) > 0)
 

--- a/modules/couchbase/couchbase.go
+++ b/modules/couchbase/couchbase.go
@@ -113,21 +113,23 @@ func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustom
 	}
 
 	container, err := testcontainers.GenericContainer(ctx, genericContainerReq)
+	var couchbaseContainer *CouchbaseContainer
+	if container != nil {
+		couchbaseContainer = &CouchbaseContainer{container, config}
+	}
 	if err != nil {
-		return nil, err
+		return couchbaseContainer, err
 	}
 
-	couchbaseContainer := CouchbaseContainer{container, config}
-
 	if err = couchbaseContainer.initCluster(ctx); err != nil {
-		return nil, err
+		return couchbaseContainer, fmt.Errorf("init cluster: %w", err)
 	}
 
 	if err = couchbaseContainer.createBuckets(ctx); err != nil {
-		return nil, err
+		return couchbaseContainer, fmt.Errorf("create buckets: %w", err)
 	}
 
-	return &couchbaseContainer, nil
+	return couchbaseContainer, nil
 }
 
 // StartContainer creates an instance of the Couchbase container type

--- a/modules/couchbase/go.mod
+++ b/modules/couchbase/go.mod
@@ -6,7 +6,8 @@ require (
 	github.com/cenkalti/backoff/v4 v4.2.1
 	github.com/couchbase/gocb/v2 v2.7.2
 	github.com/docker/go-connections v0.5.0
-	github.com/testcontainers/testcontainers-go v0.33.0
+	github.com/stretchr/testify v1.9.0
+	github.com/testcontainers/testcontainers-go v0.32.0
 	github.com/tidwall/gjson v1.17.1
 )
 
@@ -22,6 +23,7 @@ require (
 	github.com/couchbase/goprotostellar v1.0.2 // indirect
 	github.com/couchbaselabs/gocbconnstr/v2 v2.0.0-20230515165046-68b522a21131 // indirect
 	github.com/cpuguy83/dockercfg v0.3.1 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/distribution/reference v0.6.0 // indirect
 	github.com/docker/docker v27.1.1+incompatible // indirect
 	github.com/docker/go-units v0.5.0 // indirect
@@ -45,6 +47,7 @@ require (
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c // indirect
 	github.com/shirou/gopsutil/v3 v3.23.12 // indirect
 	github.com/shoenig/go-m1cpu v0.1.6 // indirect
@@ -67,6 +70,7 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240318140521-94a12d6c2237 // indirect
 	google.golang.org/grpc v1.64.1 // indirect
 	google.golang.org/protobuf v1.33.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
 replace github.com/testcontainers/testcontainers-go => ../..

--- a/modules/couchbase/go.sum
+++ b/modules/couchbase/go.sum
@@ -91,8 +91,12 @@ github.com/klauspost/compress v1.17.4 h1:Ej5ixsIri7BrIjBkRZLTo6ghwrEtHFk7ijlczPW
 github.com/klauspost/compress v1.17.4/go.mod h1:/dCuZOvVtNoHsyb+cuJD3itjs3NbnF6KH9zAO4BDxPM=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
+github.com/kr/pretty v0.3.0 h1:WgNl7dwNpEZ6jJ9k1snq4pZsg7DOEN8hP9Xw0Tsjwk0=
+github.com/kr/pretty v0.3.0/go.mod h1:640gp4NfQd8pI5XOwp5fnNeVWj67G7CFk/SaSQn7NBk=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
+github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 h1:6E+4a0GO5zZEnZ81pIr0yLvtUWk2if982qA3F3QD6H4=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0/go.mod h1:zJYVVT2jmtg6P3p1VtQj7WsuWi/y4VnjVBn7F8KPB3I=
 github.com/magiconair/properties v1.8.7 h1:IeQXZAiQcpL9mgcAe1Nu6cX9LLw6ExEHKjN0VQdvPDY=
@@ -122,6 +126,8 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c h1:ncq/mPwQF4JjgDlrVEn3C11VoGHZN7m8qihwgMEtzYw=
 github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c/go.mod h1:OmDBASR4679mdNQnz2pUhc2G8CO2JrUAVFDRBDP/hJE=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
+github.com/rogpeppe/go-internal v1.8.1 h1:geMPLpDpQOgVyCg5z5GoRwLHepNdb71NXb67XFkP+Eg=
+github.com/rogpeppe/go-internal v1.8.1/go.mod h1:JeRgkft04UBgHMgCIwADu4Pn6Mtm5d4nPKWu0nJ5d+o=
 github.com/shirou/gopsutil/v3 v3.23.12 h1:z90NtUkp3bMtmICZKpC4+WaknU1eXtp5vtbQ11DgpE4=
 github.com/shirou/gopsutil/v3 v3.23.12/go.mod h1:1FrWgea594Jp7qmjHUUPlJDTPgcsb9mGnXDxavtikzM=
 github.com/shoenig/go-m1cpu v0.1.6 h1:nxdKQNcEB6vzgA2E2bvzKIYRuNj7XNJ4S/aRSwKzFtM=
@@ -272,6 +278,8 @@ google.golang.org/protobuf v1.33.0 h1:uNO2rsAINq/JlFpSdYEKIZ0uKD/R9cpdv0T+yoGwGm
 google.golang.org/protobuf v1.33.0/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/modules/dolt/dolt_test.go
+++ b/modules/dolt/dolt_test.go
@@ -9,78 +9,64 @@ import (
 
 	// Import mysql into the scope of this package (required)
 	_ "github.com/go-sql-driver/mysql"
+	"github.com/stretchr/testify/require"
 
+	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/modules/dolt"
 )
 
 func TestDolt(t *testing.T) {
 	ctx := context.Background()
 
-	container, err := dolt.Run(ctx, "dolthub/dolt-sql-server:1.32.4")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// Clean up the container after the test is complete
-	t.Cleanup(func() {
-		if err := container.Terminate(ctx); err != nil {
-			t.Fatalf("failed to terminate container: %s", err)
-		}
-	})
+	ctr, err := dolt.Run(ctx, "dolthub/dolt-sql-server:1.32.4")
+	testcontainers.CleanupContainer(t, ctr)
+	require.NoError(t, err)
 
 	// perform assertions
 	// connectionString {
-	connectionString, err := container.ConnectionString(ctx)
+	connectionString, err := ctr.ConnectionString(ctx)
 	// }
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	db, err := sql.Open("mysql", connectionString)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	defer db.Close()
 
-	if err = db.Ping(); err != nil {
-		t.Errorf("error pinging db: %+v\n", err)
-	}
+	err = db.Ping()
+	require.NoError(t, err)
+
 	_, err = db.Exec("CREATE TABLE IF NOT EXISTS a_table ( \n" +
 		" `col_1` VARCHAR(128) NOT NULL, \n" +
 		" `col_2` VARCHAR(128) NOT NULL, \n" +
 		" PRIMARY KEY (`col_1`, `col_2`) \n" +
 		")")
-	if err != nil {
-		t.Errorf("error creating table: %+v\n", err)
-	}
+	require.NoError(t, err)
 }
 
 func TestDoltWithNonRootUserAndEmptyPassword(t *testing.T) {
 	ctx := context.Background()
 
-	_, err := dolt.Run(ctx,
+	ctr, err := dolt.Run(ctx,
 		"dolthub/dolt-sql-server:1.32.4",
 		dolt.WithDatabase("foo"),
 		dolt.WithUsername("test"),
 		dolt.WithPassword(""))
-	if err.Error() != "empty password can be used only with the root user" {
-		t.Fatal(err)
-	}
+	testcontainers.CleanupContainer(t, ctr)
+	require.EqualError(t, err, "empty password can be used only with the root user")
 }
 
 func TestDoltWithPublicRemoteCloneUrl(t *testing.T) {
 	ctx := context.Background()
 
-	_, err := dolt.Run(ctx,
+	ctr, err := dolt.Run(ctx,
 		"dolthub/dolt-sql-server:1.32.4",
 		dolt.WithDatabase("foo"),
 		dolt.WithUsername("test"),
 		dolt.WithPassword("test"),
 		dolt.WithScripts(filepath.Join("testdata", "check_clone_public.sh")),
 		dolt.WithDoltCloneRemoteUrl("fake-remote-url"))
-	if err != nil {
-		t.Fatal(err)
-	}
+	testcontainers.CleanupContainer(t, ctr)
+	require.NoError(t, err)
 }
 
 func createTestCredsFile(t *testing.T) string {
@@ -100,7 +86,7 @@ func TestDoltWithPrivateRemoteCloneUrl(t *testing.T) {
 	ctx := context.Background()
 
 	filename := createTestCredsFile(t)
-	_, err := dolt.Run(ctx,
+	ctr, err := dolt.Run(ctx,
 		"dolthub/dolt-sql-server:1.32.4",
 		dolt.WithDatabase("foo"),
 		dolt.WithUsername("test"),
@@ -109,93 +95,65 @@ func TestDoltWithPrivateRemoteCloneUrl(t *testing.T) {
 		dolt.WithDoltCloneRemoteUrl("fake-remote-url"),
 		dolt.WithDoltCredsPublicKey("fake-public-key"),
 		dolt.WithCredsFile(filename))
-	if err != nil {
-		t.Fatal(err)
-	}
+	testcontainers.CleanupContainer(t, ctr)
+	require.NoError(t, err)
 }
 
 func TestDoltWithRootUserAndEmptyPassword(t *testing.T) {
 	ctx := context.Background()
 
-	container, err := dolt.Run(ctx,
+	ctr, err := dolt.Run(ctx,
 		"dolthub/dolt-sql-server:1.32.4",
 		dolt.WithDatabase("foo"),
 		dolt.WithUsername("root"),
 		dolt.WithPassword(""))
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// Clean up the container after the test is complete
-	t.Cleanup(func() {
-		if err := container.Terminate(ctx); err != nil {
-			t.Fatalf("failed to terminate container: %s", err)
-		}
-	})
+	testcontainers.CleanupContainer(t, ctr)
+	require.NoError(t, err)
 
 	// perform assertions
-	connectionString := container.MustConnectionString(ctx)
+	connectionString := ctr.MustConnectionString(ctx)
 
 	db, err := sql.Open("mysql", connectionString)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	defer db.Close()
 
-	if err = db.Ping(); err != nil {
-		t.Errorf("error pinging db: %+v\n", err)
-	}
+	err = db.Ping()
+	require.NoError(t, err)
+
 	_, err = db.Exec("CREATE TABLE IF NOT EXISTS a_table ( \n" +
 		" `col_1` VARCHAR(128) NOT NULL, \n" +
 		" `col_2` VARCHAR(128) NOT NULL, \n" +
 		" PRIMARY KEY (`col_1`, `col_2`) \n" +
 		")")
-	if err != nil {
-		t.Errorf("error creating table: %+v\n", err)
-	}
+	require.NoError(t, err)
 }
 
 func TestDoltWithScripts(t *testing.T) {
 	ctx := context.Background()
 
-	container, err := dolt.Run(ctx,
+	ctr, err := dolt.Run(ctx,
 		"dolthub/dolt-sql-server:1.32.4",
 		dolt.WithScripts(filepath.Join("testdata", "schema.sql")))
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// Clean up the container after the test is complete
-	t.Cleanup(func() {
-		if err := container.Terminate(ctx); err != nil {
-			t.Fatalf("failed to terminate container: %s", err)
-		}
-	})
+	testcontainers.CleanupContainer(t, ctr)
+	require.NoError(t, err)
 
 	// perform assertions
-	connectionString := container.MustConnectionString(ctx)
+	connectionString := ctr.MustConnectionString(ctx)
 
 	db, err := sql.Open("mysql", connectionString)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	defer db.Close()
 
-	if err = db.Ping(); err != nil {
-		t.Errorf("error pinging db: %+v\n", err)
-	}
+	err = db.Ping()
+	require.NoError(t, err)
+
 	stmt, err := db.Prepare("SELECT name from profile")
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
+
 	defer stmt.Close()
 	row := stmt.QueryRow()
 	var name string
 	err = row.Scan(&name)
-	if err != nil {
-		t.Errorf("error fetching data")
-	}
-	if name != "profile 1" {
-		t.Fatal("The expected record was not found in the database.")
-	}
+	require.NoError(t, err)
+	require.Equal(t, "profile 1", name)
 }

--- a/modules/dolt/examples_test.go
+++ b/modules/dolt/examples_test.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"path/filepath"
 
+	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/modules/dolt"
 )
 
@@ -22,21 +23,21 @@ func ExampleRun() {
 		dolt.WithPassword("password"),
 		dolt.WithScripts(filepath.Join("testdata", "schema.sql")),
 	)
-	if err != nil {
-		log.Fatalf("failed to run dolt container: %s", err) // nolint:gocritic
-	}
-
-	// Clean up the container
 	defer func() {
-		if err := doltContainer.Terminate(ctx); err != nil {
-			log.Fatalf("failed to terminate dolt container: %s", err) // nolint:gocritic
+		if err := testcontainers.TerminateContainer(doltContainer); err != nil {
+			log.Printf("failed to terminate container: %s", err)
 		}
 	}()
+	if err != nil {
+		log.Printf("failed to run dolt container: %s", err)
+		return
+	}
 	// }
 
 	state, err := doltContainer.State(ctx)
 	if err != nil {
-		log.Fatalf("failed to get container state: %s", err) // nolint:gocritic
+		log.Printf("failed to get container state: %s", err)
+		return
 	}
 
 	fmt.Println(state.Running)
@@ -56,37 +57,41 @@ func ExampleRun_connect() {
 		dolt.WithPassword("password"),
 		dolt.WithScripts(filepath.Join("testdata", "schema.sql")),
 	)
-	if err != nil {
-		log.Fatalf("failed to run dolt container: %s", err) // nolint:gocritic
-	}
-
 	defer func() {
-		if err := doltContainer.Terminate(ctx); err != nil {
-			log.Fatalf("failed to terminate dolt container: %s", err) // nolint:gocritic
+		if err := testcontainers.TerminateContainer(doltContainer); err != nil {
+			log.Printf("failed to terminate container: %s", err)
 		}
 	}()
+	if err != nil {
+		log.Printf("failed to run dolt container: %s", err)
+		return
+	}
 
 	connectionString := doltContainer.MustConnectionString(ctx)
 
 	db, err := sql.Open("mysql", connectionString)
 	if err != nil {
-		log.Fatalf("failed to open database connection: %s", err) // nolint:gocritic
+		log.Printf("failed to open database connection: %s", err)
+		return
 	}
 	defer db.Close()
 
 	if err = db.Ping(); err != nil {
-		log.Fatalf("failed to ping database: %s", err) // nolint:gocritic
+		log.Printf("failed to ping database: %s", err)
+		return
 	}
 	stmt, err := db.Prepare("SELECT dolt_version();")
 	if err != nil {
-		log.Fatalf("failed to prepate sql statement: %s", err) // nolint:gocritic
+		log.Printf("failed to prepate sql statement: %s", err)
+		return
 	}
 	defer stmt.Close()
 	row := stmt.QueryRow()
 	version := ""
 	err = row.Scan(&version)
 	if err != nil {
-		log.Fatalf("failed to scan row: %s", err) // nolint:gocritic
+		log.Printf("failed to scan row: %s", err)
+		return
 	}
 
 	fmt.Println(version)

--- a/modules/dolt/go.mod
+++ b/modules/dolt/go.mod
@@ -4,7 +4,8 @@ go 1.22
 
 require (
 	github.com/go-sql-driver/mysql v1.7.1
-	github.com/testcontainers/testcontainers-go v0.33.0
+	github.com/stretchr/testify v1.9.0
+	github.com/testcontainers/testcontainers-go v0.32.0
 )
 
 require (
@@ -16,6 +17,7 @@ require (
 	github.com/containerd/log v0.1.0 // indirect
 	github.com/containerd/platforms v0.2.1 // indirect
 	github.com/cpuguy83/dockercfg v0.3.1 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/distribution/reference v0.6.0 // indirect
 	github.com/docker/docker v27.1.1+incompatible // indirect
 	github.com/docker/go-connections v0.5.0 // indirect
@@ -27,6 +29,7 @@ require (
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/klauspost/compress v1.17.4 // indirect
+	github.com/kr/text v0.2.0 // indirect
 	github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 // indirect
 	github.com/magiconair/properties v1.8.7 // indirect
 	github.com/moby/docker-image-spec v1.3.1 // indirect
@@ -38,6 +41,7 @@ require (
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c // indirect
 	github.com/shirou/gopsutil/v3 v3.23.12 // indirect
 	github.com/shoenig/go-m1cpu v0.1.6 // indirect
@@ -54,6 +58,7 @@ require (
 	golang.org/x/sys v0.21.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20240318140521-94a12d6c2237 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240318140521-94a12d6c2237 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
 replace github.com/testcontainers/testcontainers-go => ../..

--- a/modules/dolt/go.sum
+++ b/modules/dolt/go.sum
@@ -16,6 +16,7 @@ github.com/containerd/platforms v0.2.1 h1:zvwtM3rz2YHPQsF2CHYM8+KtB5dvhISiXh5ZpS
 github.com/containerd/platforms v0.2.1/go.mod h1:XHCb+2/hzowdiut9rkudds9bE5yJ7npe7dG/wG+uFPw=
 github.com/cpuguy83/dockercfg v0.3.1 h1:/FpZ+JaygUR/lZP2NlFI2DVfrOEMAIKP5wWEJdoYe9E=
 github.com/cpuguy83/dockercfg v0.3.1/go.mod h1:sugsbF4//dDlL/i+S+rtpIWp+5h0BHJHfjj5/jFyUJc=
+github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.18 h1:n56/Zwd5o6whRC5PMGretI4IdRLlmBXYNjScPaBgsbY=
 github.com/creack/pty v1.1.18/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -54,6 +55,10 @@ github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/compress v1.17.4 h1:Ej5ixsIri7BrIjBkRZLTo6ghwrEtHFk7ijlczPW4fZ4=
 github.com/klauspost/compress v1.17.4/go.mod h1:/dCuZOvVtNoHsyb+cuJD3itjs3NbnF6KH9zAO4BDxPM=
+github.com/kr/pretty v0.3.0 h1:WgNl7dwNpEZ6jJ9k1snq4pZsg7DOEN8hP9Xw0Tsjwk0=
+github.com/kr/pretty v0.3.0/go.mod h1:640gp4NfQd8pI5XOwp5fnNeVWj67G7CFk/SaSQn7NBk=
+github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
+github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 h1:6E+4a0GO5zZEnZ81pIr0yLvtUWk2if982qA3F3QD6H4=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0/go.mod h1:zJYVVT2jmtg6P3p1VtQj7WsuWi/y4VnjVBn7F8KPB3I=
 github.com/magiconair/properties v1.8.7 h1:IeQXZAiQcpL9mgcAe1Nu6cX9LLw6ExEHKjN0VQdvPDY=
@@ -80,6 +85,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c h1:ncq/mPwQF4JjgDlrVEn3C11VoGHZN7m8qihwgMEtzYw=
 github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c/go.mod h1:OmDBASR4679mdNQnz2pUhc2G8CO2JrUAVFDRBDP/hJE=
+github.com/rogpeppe/go-internal v1.8.1 h1:geMPLpDpQOgVyCg5z5GoRwLHepNdb71NXb67XFkP+Eg=
+github.com/rogpeppe/go-internal v1.8.1/go.mod h1:JeRgkft04UBgHMgCIwADu4Pn6Mtm5d4nPKWu0nJ5d+o=
 github.com/shirou/gopsutil/v3 v3.23.12 h1:z90NtUkp3bMtmICZKpC4+WaknU1eXtp5vtbQ11DgpE4=
 github.com/shirou/gopsutil/v3 v3.23.12/go.mod h1:1FrWgea594Jp7qmjHUUPlJDTPgcsb9mGnXDxavtikzM=
 github.com/shoenig/go-m1cpu v0.1.6 h1:nxdKQNcEB6vzgA2E2bvzKIYRuNj7XNJ4S/aRSwKzFtM=
@@ -176,6 +183,8 @@ google.golang.org/grpc v1.64.1/go.mod h1:hiQF4LFZelK2WKaP6W0L92zGHtiQdZxk8CrSdvy
 google.golang.org/protobuf v1.33.0 h1:uNO2rsAINq/JlFpSdYEKIZ0uKD/R9cpdv0T+yoGwGmI=
 google.golang.org/protobuf v1.33.0/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/modules/elasticsearch/examples_test.go
+++ b/modules/elasticsearch/examples_test.go
@@ -9,6 +9,7 @@ import (
 
 	es "github.com/elastic/go-elasticsearch/v8"
 
+	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/modules/elasticsearch"
 )
 
@@ -16,19 +17,21 @@ func ExampleRun() {
 	// runElasticsearchContainer {
 	ctx := context.Background()
 	elasticsearchContainer, err := elasticsearch.Run(ctx, "docker.elastic.co/elasticsearch/elasticsearch:8.9.0")
-	if err != nil {
-		log.Fatalf("failed to start container: %s", err)
-	}
 	defer func() {
-		if err := elasticsearchContainer.Terminate(ctx); err != nil {
-			log.Fatalf("failed to terminate container: %s", err)
+		if err := testcontainers.TerminateContainer(elasticsearchContainer); err != nil {
+			log.Printf("failed to terminate container: %s", err)
 		}
 	}()
+	if err != nil {
+		log.Printf("failed to start container: %s", err)
+		return
+	}
 	// }
 
 	state, err := elasticsearchContainer.State(ctx)
 	if err != nil {
-		log.Fatalf("failed to get container state: %s", err) // nolint:gocritic
+		log.Printf("failed to get container state: %s", err)
+		return
 	}
 
 	fmt.Println(state.Running)
@@ -45,15 +48,15 @@ func ExampleRun_withUsingPassword() {
 		"docker.elastic.co/elasticsearch/elasticsearch:7.9.2",
 		elasticsearch.WithPassword("foo"),
 	)
-	if err != nil {
-		log.Fatalf("failed to start container: %s", err)
-	}
 	defer func() {
-		err := elasticsearchContainer.Terminate(ctx)
-		if err != nil {
-			log.Fatalf("failed to terminate container: %s", err)
+		if err := testcontainers.TerminateContainer(elasticsearchContainer); err != nil {
+			log.Printf("failed to terminate container: %s", err)
 		}
 	}()
+	if err != nil {
+		log.Printf("failed to start container: %s", err)
+		return
+	}
 	// }
 
 	fmt.Println(strings.HasPrefix(elasticsearchContainer.Settings.Address, "http://"))
@@ -72,15 +75,15 @@ func ExampleRun_connectUsingElasticsearchClient() {
 		"docker.elastic.co/elasticsearch/elasticsearch:8.9.0",
 		elasticsearch.WithPassword("foo"),
 	)
-	if err != nil {
-		log.Fatalf("failed to start container: %s", err)
-	}
 	defer func() {
-		err := elasticsearchContainer.Terminate(ctx)
-		if err != nil {
-			log.Fatalf("failed to terminate container: %s", err)
+		if err := testcontainers.TerminateContainer(elasticsearchContainer); err != nil {
+			log.Printf("failed to terminate container: %s", err)
 		}
 	}()
+	if err != nil {
+		log.Printf("failed to start container: %s", err)
+		return
+	}
 
 	cfg := es.Config{
 		Addresses: []string{
@@ -93,19 +96,22 @@ func ExampleRun_connectUsingElasticsearchClient() {
 
 	esClient, err := es.NewClient(cfg)
 	if err != nil {
-		log.Fatalf("error creating the client: %s", err) // nolint:gocritic
+		log.Printf("error creating the client: %s", err)
+		return
 	}
 
 	resp, err := esClient.Info()
 	if err != nil {
-		log.Fatalf("error getting response: %s", err)
+		log.Printf("error getting response: %s", err)
+		return
 	}
 	defer resp.Body.Close()
 	// }
 
 	var esResp ElasticsearchResponse
 	if err := json.NewDecoder(resp.Body).Decode(&esResp); err != nil {
-		log.Fatalf("error decoding response: %s", err)
+		log.Printf("error decoding response: %s", err)
+		return
 	}
 
 	fmt.Println(esResp.Tagline)

--- a/modules/gcloud/bigquery.go
+++ b/modules/gcloud/bigquery.go
@@ -33,18 +33,5 @@ func RunBigQuery(ctx context.Context, img string, opts ...testcontainers.Contain
 
 	req.Cmd = []string{"--project", settings.ProjectID}
 
-	container, err := testcontainers.GenericContainer(ctx, req)
-	if err != nil {
-		return nil, err
-	}
-
-	bigQueryContainer, err := newGCloudContainer(ctx, 9050, container, settings)
-	if err != nil {
-		return nil, err
-	}
-
-	// always prepend http:// to the URI
-	bigQueryContainer.URI = "http://" + bigQueryContainer.URI
-
-	return bigQueryContainer, nil
+	return newGCloudContainer(ctx, req, 9050, settings, "http://")
 }

--- a/modules/gcloud/bigtable.go
+++ b/modules/gcloud/bigtable.go
@@ -2,7 +2,6 @@ package gcloud
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/wait"
@@ -33,13 +32,8 @@ func RunBigTable(ctx context.Context, img string, opts ...testcontainers.Contain
 	req.Cmd = []string{
 		"/bin/sh",
 		"-c",
-		"gcloud beta emulators bigtable start --host-port 0.0.0.0:9000 " + fmt.Sprintf("--project=%s", settings.ProjectID),
+		"gcloud beta emulators bigtable start --host-port 0.0.0.0:9000 --project=" + settings.ProjectID,
 	}
 
-	container, err := testcontainers.GenericContainer(ctx, req)
-	if err != nil {
-		return nil, err
-	}
-
-	return newGCloudContainer(ctx, 9000, container, settings)
+	return newGCloudContainer(ctx, req, 9000, settings, "")
 }

--- a/modules/gcloud/datastore.go
+++ b/modules/gcloud/datastore.go
@@ -2,7 +2,6 @@ package gcloud
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/wait"
@@ -33,13 +32,8 @@ func RunDatastore(ctx context.Context, img string, opts ...testcontainers.Contai
 	req.Cmd = []string{
 		"/bin/sh",
 		"-c",
-		"gcloud beta emulators datastore start --host-port 0.0.0.0:8081 " + fmt.Sprintf("--project=%s", settings.ProjectID),
+		"gcloud beta emulators datastore start --host-port 0.0.0.0:8081 --project=" + settings.ProjectID,
 	}
 
-	container, err := testcontainers.GenericContainer(ctx, req)
-	if err != nil {
-		return nil, err
-	}
-
-	return newGCloudContainer(ctx, 8081, container, settings)
+	return newGCloudContainer(ctx, req, 8081, settings, "")
 }

--- a/modules/gcloud/firestore.go
+++ b/modules/gcloud/firestore.go
@@ -2,7 +2,6 @@ package gcloud
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/wait"
@@ -33,13 +32,8 @@ func RunFirestore(ctx context.Context, img string, opts ...testcontainers.Contai
 	req.Cmd = []string{
 		"/bin/sh",
 		"-c",
-		"gcloud beta emulators firestore start --host-port 0.0.0.0:8080 " + fmt.Sprintf("--project=%s", settings.ProjectID),
+		"gcloud beta emulators firestore start --host-port 0.0.0.0:8080 --project=" + settings.ProjectID,
 	}
 
-	container, err := testcontainers.GenericContainer(ctx, req)
-	if err != nil {
-		return nil, err
-	}
-
-	return newGCloudContainer(ctx, 8080, container, settings)
+	return newGCloudContainer(ctx, req, 8080, settings, "")
 }

--- a/modules/gcloud/go.mod
+++ b/modules/gcloud/go.mod
@@ -33,6 +33,7 @@ require (
 	github.com/containerd/log v0.1.0 // indirect
 	github.com/containerd/platforms v0.2.1 // indirect
 	github.com/cpuguy83/dockercfg v0.3.1 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/distribution/reference v0.6.0 // indirect
 	github.com/docker/docker v27.1.1+incompatible // indirect
 	github.com/docker/go-units v0.5.0 // indirect
@@ -68,10 +69,12 @@ require (
 	github.com/opencontainers/image-spec v1.1.0 // indirect
 	github.com/pierrec/lz4/v4 v4.1.18 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c // indirect
 	github.com/shirou/gopsutil/v3 v3.23.12 // indirect
 	github.com/shoenig/go-m1cpu v0.1.6 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect
+	github.com/stretchr/testify v1.9.0 // indirect
 	github.com/tklauser/go-sysconf v0.3.12 // indirect
 	github.com/tklauser/numcpus v0.6.1 // indirect
 	github.com/yusufpapurcu/wmi v1.2.3 // indirect
@@ -97,6 +100,7 @@ require (
 	google.golang.org/genproto/googleapis/api v0.0.0-20240318140521-94a12d6c2237 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240318140521-94a12d6c2237 // indirect
 	google.golang.org/protobuf v1.33.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
 replace github.com/testcontainers/testcontainers-go => ../..

--- a/modules/gcloud/go.sum
+++ b/modules/gcloud/go.sum
@@ -146,6 +146,10 @@ github.com/klauspost/compress v1.17.4 h1:Ej5ixsIri7BrIjBkRZLTo6ghwrEtHFk7ijlczPW
 github.com/klauspost/compress v1.17.4/go.mod h1:/dCuZOvVtNoHsyb+cuJD3itjs3NbnF6KH9zAO4BDxPM=
 github.com/klauspost/cpuid/v2 v2.2.5 h1:0E5MSMDEoAulmXNFquVs//DdoomxaoTY1kUhbc/qbZg=
 github.com/klauspost/cpuid/v2 v2.2.5/go.mod h1:Lcz8mBdAVJIBVzewtcLocK12l3Y+JytZYpaMropDUws=
+github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
+github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
+github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
+github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 h1:6E+4a0GO5zZEnZ81pIr0yLvtUWk2if982qA3F3QD6H4=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0/go.mod h1:zJYVVT2jmtg6P3p1VtQj7WsuWi/y4VnjVBn7F8KPB3I=
 github.com/magiconair/properties v1.8.7 h1:IeQXZAiQcpL9mgcAe1Nu6cX9LLw6ExEHKjN0VQdvPDY=
@@ -180,6 +184,8 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c h1:ncq/mPwQF4JjgDlrVEn3C11VoGHZN7m8qihwgMEtzYw=
 github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c/go.mod h1:OmDBASR4679mdNQnz2pUhc2G8CO2JrUAVFDRBDP/hJE=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
+github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZVejAe8=
+github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
 github.com/shirou/gopsutil/v3 v3.23.12 h1:z90NtUkp3bMtmICZKpC4+WaknU1eXtp5vtbQ11DgpE4=
 github.com/shirou/gopsutil/v3 v3.23.12/go.mod h1:1FrWgea594Jp7qmjHUUPlJDTPgcsb9mGnXDxavtikzM=
 github.com/shoenig/go-m1cpu v0.1.6 h1:nxdKQNcEB6vzgA2E2bvzKIYRuNj7XNJ4S/aRSwKzFtM=
@@ -362,6 +368,8 @@ google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQ
 google.golang.org/protobuf v1.33.0 h1:uNO2rsAINq/JlFpSdYEKIZ0uKD/R9cpdv0T+yoGwGmI=
 google.golang.org/protobuf v1.33.0/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/modules/gcloud/pubsub.go
+++ b/modules/gcloud/pubsub.go
@@ -2,7 +2,6 @@ package gcloud
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/wait"
@@ -33,13 +32,8 @@ func RunPubsub(ctx context.Context, img string, opts ...testcontainers.Container
 	req.Cmd = []string{
 		"/bin/sh",
 		"-c",
-		"gcloud beta emulators pubsub start --host-port 0.0.0.0:8085 " + fmt.Sprintf("--project=%s", settings.ProjectID),
+		"gcloud beta emulators pubsub start --host-port 0.0.0.0:8085 --project=" + settings.ProjectID,
 	}
 
-	container, err := testcontainers.GenericContainer(ctx, req)
-	if err != nil {
-		return nil, err
-	}
-
-	return newGCloudContainer(ctx, 8085, container, settings)
+	return newGCloudContainer(ctx, req, 8085, settings, "")
 }

--- a/modules/gcloud/spanner.go
+++ b/modules/gcloud/spanner.go
@@ -29,10 +29,5 @@ func RunSpanner(ctx context.Context, img string, opts ...testcontainers.Containe
 		return nil, err
 	}
 
-	container, err := testcontainers.GenericContainer(ctx, req)
-	if err != nil {
-		return nil, err
-	}
-
-	return newGCloudContainer(ctx, 9010, container, settings)
+	return newGCloudContainer(ctx, req, 9010, settings, "")
 }

--- a/modules/grafana-lgtm/go.mod
+++ b/modules/grafana-lgtm/go.mod
@@ -4,6 +4,7 @@ go 1.22
 
 require (
 	github.com/docker/go-connections v0.5.0
+	github.com/stretchr/testify v1.9.0
 	github.com/testcontainers/testcontainers-go v0.33.0
 	go.opentelemetry.io/contrib/bridges/otelslog v0.3.0
 	go.opentelemetry.io/contrib/instrumentation/runtime v0.53.0
@@ -18,6 +19,7 @@ require (
 	go.opentelemetry.io/otel/sdk v1.28.0
 	go.opentelemetry.io/otel/sdk/log v0.4.0
 	go.opentelemetry.io/otel/sdk/metric v1.28.0
+	golang.org/x/sync v0.7.0
 )
 
 require (
@@ -31,6 +33,7 @@ require (
 	github.com/containerd/log v0.1.0 // indirect
 	github.com/containerd/platforms v0.2.1 // indirect
 	github.com/cpuguy83/dockercfg v0.3.1 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/distribution/reference v0.6.0 // indirect
 	github.com/docker/docker v27.1.1+incompatible // indirect
 	github.com/docker/go-units v0.5.0 // indirect
@@ -54,6 +57,7 @@ require (
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c // indirect
 	github.com/prometheus/client_golang v1.19.1 // indirect
 	github.com/prometheus/client_model v0.6.1 // indirect
@@ -76,6 +80,7 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240701130421-f6361c86f094 // indirect
 	google.golang.org/grpc v1.64.1 // indirect
 	google.golang.org/protobuf v1.34.2 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
 replace github.com/testcontainers/testcontainers-go => ../..

--- a/modules/grafana-lgtm/go.sum
+++ b/modules/grafana-lgtm/go.sum
@@ -56,6 +56,10 @@ github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/compress v1.17.4 h1:Ej5ixsIri7BrIjBkRZLTo6ghwrEtHFk7ijlczPW4fZ4=
 github.com/klauspost/compress v1.17.4/go.mod h1:/dCuZOvVtNoHsyb+cuJD3itjs3NbnF6KH9zAO4BDxPM=
+github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
+github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
+github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
+github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 h1:6E+4a0GO5zZEnZ81pIr0yLvtUWk2if982qA3F3QD6H4=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0/go.mod h1:zJYVVT2jmtg6P3p1VtQj7WsuWi/y4VnjVBn7F8KPB3I=
 github.com/magiconair/properties v1.8.7 h1:IeQXZAiQcpL9mgcAe1Nu6cX9LLw6ExEHKjN0VQdvPDY=
@@ -92,6 +96,8 @@ github.com/prometheus/common v0.55.0 h1:KEi6DK7lXW/m7Ig5i47x0vRzuBsHuvJdi5ee6Y3G
 github.com/prometheus/common v0.55.0/go.mod h1:2SECS4xJG1kd8XF9IcM1gMX6510RAEL65zxzNImwdc8=
 github.com/prometheus/procfs v0.15.1 h1:YagwOFzUgYfKKHX6Dr+sHT7km/hxC76UB0learggepc=
 github.com/prometheus/procfs v0.15.1/go.mod h1:fB45yRUv8NstnjriLhBQLuOUt+WW4BsoGhij/e3PBqk=
+github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU5NdKM8=
+github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99yedzYV+kq4uf4=
 github.com/shirou/gopsutil/v3 v3.23.12 h1:z90NtUkp3bMtmICZKpC4+WaknU1eXtp5vtbQ11DgpE4=
 github.com/shirou/gopsutil/v3 v3.23.12/go.mod h1:1FrWgea594Jp7qmjHUUPlJDTPgcsb9mGnXDxavtikzM=
 github.com/shoenig/go-m1cpu v0.1.6 h1:nxdKQNcEB6vzgA2E2bvzKIYRuNj7XNJ4S/aRSwKzFtM=
@@ -167,6 +173,8 @@ golang.org/x/net v0.26.0/go.mod h1:5YKkiSynbBIh3p6iOc/vibscux0x38BZDkn8sCUPxHE=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.7.0 h1:YsImfSBoP9QPYL0xyKJPq0gcaJdG3rInoqxTWbfQu9M=
+golang.org/x/sync v0.7.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190916202348-b4ddaad3f8a3/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -204,6 +212,8 @@ google.golang.org/grpc v1.64.1/go.mod h1:hiQF4LFZelK2WKaP6W0L92zGHtiQdZxk8CrSdvy
 google.golang.org/protobuf v1.34.2 h1:6xV6lTsCfpGD21XK49h7MhtcApnLqkfYgPcdHftf6hg=
 google.golang.org/protobuf v1.34.2/go.mod h1:qYOHts0dSfpeUzUFpOMr/WGzszTmLH+DiWniOlNbLDw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/modules/grafana-lgtm/grafana.go
+++ b/modules/grafana-lgtm/grafana.go
@@ -45,7 +45,7 @@ func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustom
 
 	container, err := testcontainers.GenericContainer(ctx, genericContainerReq)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("generic container: %w", err)
 	}
 
 	c := &GrafanaLGTMContainer{Container: container}
@@ -53,7 +53,7 @@ func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustom
 	url, err := c.OtlpHttpEndpoint(ctx)
 	if err != nil {
 		// return the container instance to allow the caller to clean up
-		return c, err
+		return c, fmt.Errorf("otlp http endpoint: %w", err)
 	}
 
 	testcontainers.Logger.Printf("Access to the Grafana dashboard: %s", url)

--- a/modules/inbucket/examples_test.go
+++ b/modules/inbucket/examples_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 
+	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/modules/inbucket"
 )
 
@@ -13,21 +14,21 @@ func ExampleRun() {
 	ctx := context.Background()
 
 	inbucketContainer, err := inbucket.Run(ctx, "inbucket/inbucket:sha-2d409bb")
-	if err != nil {
-		log.Fatalf("failed to start container: %s", err)
-	}
-
-	// Clean up the container
 	defer func() {
-		if err := inbucketContainer.Terminate(ctx); err != nil {
-			log.Fatalf("failed to terminate container: %s", err)
+		if err := testcontainers.TerminateContainer(inbucketContainer); err != nil {
+			log.Printf("failed to terminate container: %s", err)
 		}
 	}()
+	if err != nil {
+		log.Printf("failed to start container: %s", err)
+		return
+	}
 	// }
 
 	state, err := inbucketContainer.State(ctx)
 	if err != nil {
-		log.Fatalf("failed to get container state: %s", err) // nolint:gocritic
+		log.Printf("failed to get container state: %s", err)
+		return
 	}
 
 	fmt.Println(state.Running)

--- a/modules/inbucket/inbucket.go
+++ b/modules/inbucket/inbucket.go
@@ -77,9 +77,14 @@ func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustom
 	}
 
 	container, err := testcontainers.GenericContainer(ctx, genericContainerReq)
-	if err != nil {
-		return nil, err
+	var c *InbucketContainer
+	if container != nil {
+		c = &InbucketContainer{Container: container}
 	}
 
-	return &InbucketContainer{Container: container}, nil
+	if err != nil {
+		return c, fmt.Errorf("generic container: %w", err)
+	}
+
+	return c, nil
 }

--- a/modules/inbucket/inbucket_test.go
+++ b/modules/inbucket/inbucket_test.go
@@ -7,27 +7,24 @@ import (
 
 	"github.com/inbucket/inbucket/pkg/rest/client"
 	"github.com/stretchr/testify/require"
+
+	"github.com/testcontainers/testcontainers-go"
 )
 
 func TestInbucket(t *testing.T) {
 	ctx := context.Background()
 
-	container, err := Run(ctx, "inbucket/inbucket:sha-2d409bb")
+	ctr, err := Run(ctx, "inbucket/inbucket:sha-2d409bb")
+	testcontainers.CleanupContainer(t, ctr)
 	require.NoError(t, err)
 
-	// Clean up the container after the test is complete
-	t.Cleanup(func() {
-		err := container.Terminate(ctx)
-		require.NoError(t, err)
-	})
-
 	// smtpConnection {
-	smtpUrl, err := container.SmtpConnection(ctx)
+	smtpUrl, err := ctr.SmtpConnection(ctx)
 	// }
 	require.NoError(t, err)
 
 	// webInterface {
-	webInterfaceUrl, err := container.WebInterface(ctx)
+	webInterfaceUrl, err := ctr.WebInterface(ctx)
 	// }
 	require.NoError(t, err)
 	restClient, err := client.New(webInterfaceUrl)

--- a/modules/influxdb/examples_test.go
+++ b/modules/influxdb/examples_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 
+	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/modules/influxdb"
 )
 
@@ -18,21 +19,21 @@ func ExampleRun() {
 		influxdb.WithUsername("root"),
 		influxdb.WithPassword("password"),
 	)
-	if err != nil {
-		log.Fatalf("failed to start container: %s", err)
-	}
-
-	// Clean up the container
 	defer func() {
-		if err := influxdbContainer.Terminate(ctx); err != nil {
-			log.Fatalf("failed to terminate container: %s", err)
+		if err := testcontainers.TerminateContainer(influxdbContainer); err != nil {
+			log.Printf("failed to terminate container: %s", err)
 		}
 	}()
+	if err != nil {
+		log.Printf("failed to start container: %s", err)
+		return
+	}
 	// }
 
 	state, err := influxdbContainer.State(ctx)
 	if err != nil {
-		log.Fatalf("failed to get container state: %s", err) // nolint:gocritic
+		log.Printf("failed to get container state: %s", err)
+		return
 	}
 
 	fmt.Println(state.Running)

--- a/modules/influxdb/influxdb.go
+++ b/modules/influxdb/influxdb.go
@@ -80,11 +80,16 @@ func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustom
 	}
 
 	container, err := testcontainers.GenericContainer(ctx, genericContainerReq)
-	if err != nil {
-		return nil, err
+	var c *InfluxDbContainer
+	if container != nil {
+		c = &InfluxDbContainer{Container: container}
 	}
 
-	return &InfluxDbContainer{container}, nil
+	if err != nil {
+		return c, fmt.Errorf("generic container: %w", err)
+	}
+
+	return c, nil
 }
 
 func (c *InfluxDbContainer) MustConnectionUrl(ctx context.Context) string {

--- a/modules/influxdb/influxdb_test.go
+++ b/modules/influxdb/influxdb_test.go
@@ -15,18 +15,11 @@ import (
 	"github.com/testcontainers/testcontainers-go/modules/influxdb"
 )
 
-func containerCleanup(t *testing.T, container testcontainers.Container) {
-	err := container.Terminate(context.Background())
-	require.NoError(t, err, "failed to terminate container")
-}
-
 func TestV1Container(t *testing.T) {
 	ctx := context.Background()
 	influxDbContainer, err := influxdb.Run(ctx, "influxdb:1.8.10")
+	testcontainers.CleanupContainer(t, influxDbContainer)
 	require.NoError(t, err)
-	t.Cleanup(func() {
-		containerCleanup(t, influxDbContainer)
-	})
 
 	state, err := influxDbContainer.State(ctx)
 	require.NoError(t, err)
@@ -44,10 +37,8 @@ func TestV2Container(t *testing.T) {
 		influxdb.WithUsername("root"),
 		influxdb.WithPassword("password"),
 	)
+	testcontainers.CleanupContainer(t, influxDbContainer)
 	require.NoError(t, err)
-	t.Cleanup(func() {
-		containerCleanup(t, influxDbContainer)
-	})
 
 	state, err := influxDbContainer.State(ctx)
 	require.NoError(t, err)
@@ -63,10 +54,8 @@ func TestWithInitDb(t *testing.T) {
 		"influxdb:1.8.10",
 		influxdb.WithInitDb("testdata"),
 	)
+	testcontainers.CleanupContainer(t, influxDbContainer)
 	require.NoError(t, err)
-	t.Cleanup(func() {
-		containerCleanup(t, influxDbContainer)
-	})
 
 	if state, err := influxDbContainer.State(ctx); err != nil || !state.Running {
 		require.NoError(t, err)
@@ -99,10 +88,8 @@ func TestWithConfigFile(t *testing.T) {
 		"influxdb:"+influxVersion,
 		influxdb.WithConfigFile(filepath.Join("testdata", "influxdb.conf")),
 	)
+	testcontainers.CleanupContainer(t, influxDbContainer)
 	require.NoError(t, err)
-	t.Cleanup(func() {
-		containerCleanup(t, influxDbContainer)
-	})
 
 	if state, err := influxDbContainer.State(context.Background()); err != nil || !state.Running {
 		require.NoError(t, err)

--- a/modules/k3s/go.mod
+++ b/modules/k3s/go.mod
@@ -5,7 +5,8 @@ go 1.22
 require (
 	github.com/docker/docker v27.1.1+incompatible
 	github.com/docker/go-connections v0.5.0
-	github.com/testcontainers/testcontainers-go v0.33.0
+	github.com/stretchr/testify v1.9.0
+	github.com/testcontainers/testcontainers-go v0.32.0
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.29.2
 	k8s.io/apimachinery v0.29.2
@@ -56,6 +57,7 @@ require (
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c // indirect
 	github.com/shirou/gopsutil/v3 v3.23.12 // indirect
 	github.com/shoenig/go-m1cpu v0.1.6 // indirect

--- a/modules/k3s/k3s.go
+++ b/modules/k3s/k3s.go
@@ -98,11 +98,16 @@ func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustom
 	}
 
 	container, err := testcontainers.GenericContainer(ctx, genericContainerReq)
-	if err != nil {
-		return nil, err
+	var c *K3sContainer
+	if container != nil {
+		c = &K3sContainer{Container: container}
 	}
 
-	return &K3sContainer{Container: container}, nil
+	if err != nil {
+		return c, fmt.Errorf("generic container: %w", err)
+	}
+
+	return c, nil
 }
 
 func getContainerHost(ctx context.Context, opts ...testcontainers.ContainerCustomizer) (string, error) {

--- a/modules/k3s/k3s_example_test.go
+++ b/modules/k3s/k3s_example_test.go
@@ -9,6 +9,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
 
+	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/modules/k3s"
 )
 
@@ -17,43 +18,47 @@ func ExampleRun() {
 	ctx := context.Background()
 
 	k3sContainer, err := k3s.Run(ctx, "docker.io/rancher/k3s:v1.27.1-k3s1")
-	if err != nil {
-		log.Fatalf("failed to start container: %s", err)
-	}
-
-	// Clean up the container
 	defer func() {
-		if err := k3sContainer.Terminate(ctx); err != nil {
-			log.Fatalf("failed to terminate container: %s", err)
+		if err := testcontainers.TerminateContainer(k3sContainer); err != nil {
+			log.Printf("failed to terminate container: %s", err)
 		}
 	}()
+	if err != nil {
+		log.Printf("failed to start container: %s", err)
+		return
+	}
 	// }
 
 	state, err := k3sContainer.State(ctx)
 	if err != nil {
-		log.Fatalf("failed to get container state: %s", err) // nolint:gocritic
+		log.Printf("failed to get container state: %s", err)
+		return
 	}
 
 	fmt.Println(state.Running)
 
 	kubeConfigYaml, err := k3sContainer.GetKubeConfig(ctx)
 	if err != nil {
-		log.Fatalf("failed to get kubeconfig: %s", err)
+		log.Printf("failed to get kubeconfig: %s", err)
+		return
 	}
 
 	restcfg, err := clientcmd.RESTConfigFromKubeConfig(kubeConfigYaml)
 	if err != nil {
-		log.Fatalf("failed to create rest config: %s", err)
+		log.Printf("failed to create rest config: %s", err)
+		return
 	}
 
 	k8s, err := kubernetes.NewForConfig(restcfg)
 	if err != nil {
-		log.Fatalf("failed to create k8s client: %s", err)
+		log.Printf("failed to create k8s client: %s", err)
+		return
 	}
 
 	nodes, err := k8s.CoreV1().Nodes().List(ctx, v1.ListOptions{})
 	if err != nil {
-		log.Fatalf("failed to list nodes: %s", err)
+		log.Printf("failed to list nodes: %s", err)
+		return
 	}
 
 	fmt.Println(len(nodes.Items))

--- a/modules/k3s/k3s_test.go
+++ b/modules/k3s/k3s_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kwait "k8s.io/apimachinery/pkg/util/wait"
@@ -23,55 +24,33 @@ func Test_LoadImages(t *testing.T) {
 	defer cancel()
 
 	k3sContainer, err := k3s.Run(ctx, "docker.io/rancher/k3s:v1.27.1-k3s1")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// Clean up the container
-	defer func() {
-		if err := k3sContainer.Terminate(ctx); err != nil {
-			t.Fatal(err)
-		}
-	}()
+	testcontainers.CleanupContainer(t, k3sContainer)
+	require.NoError(t, err)
 
 	kubeConfigYaml, err := k3sContainer.GetKubeConfig(ctx)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	restcfg, err := clientcmd.RESTConfigFromKubeConfig(kubeConfigYaml)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	k8s, err := kubernetes.NewForConfig(restcfg)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	provider, err := testcontainers.ProviderDocker.GetProvider()
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	// ensure nginx image is available locally
 	err = provider.PullImage(ctx, "nginx")
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	t.Run("Test load image not available", func(t *testing.T) {
 		err := k3sContainer.LoadImages(ctx, "fake.registry/fake:non-existing")
-		if err == nil {
-			t.Fatal("should had failed")
-		}
+		require.Error(t, err)
 	})
 
 	t.Run("Test load image in cluster", func(t *testing.T) {
 		err := k3sContainer.LoadImages(ctx, "nginx")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
 		pod := &corev1.Pod{
 			TypeMeta: metav1.TypeMeta{
@@ -93,9 +72,7 @@ func Test_LoadImages(t *testing.T) {
 		}
 
 		_, err = k8s.CoreV1().Pods("default").Create(ctx, pod, metav1.CreateOptions{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
 		err = kwait.PollUntilContextCancel(ctx, time.Second, true, func(ctx context.Context) (bool, error) {
 			state, err := getTestPodState(ctx, k8s)
@@ -107,17 +84,11 @@ func Test_LoadImages(t *testing.T) {
 			}
 			return state.Running != nil, nil
 		})
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
 		state, err := getTestPodState(ctx, k8s)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if state.Running == nil {
-			t.Fatalf("Unexpected status %v", state)
-		}
+		require.NoError(t, err)
+		require.NotNil(t, state.Running)
 	})
 }
 
@@ -135,31 +106,17 @@ func Test_APIServerReady(t *testing.T) {
 	ctx := context.Background()
 
 	k3sContainer, err := k3s.Run(ctx, "docker.io/rancher/k3s:v1.27.1-k3s1")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// Clean up the container
-	defer func() {
-		if err := k3sContainer.Terminate(ctx); err != nil {
-			t.Fatal(err)
-		}
-	}()
+	testcontainers.CleanupContainer(t, k3sContainer)
+	require.NoError(t, err)
 
 	kubeConfigYaml, err := k3sContainer.GetKubeConfig(ctx)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	restcfg, err := clientcmd.RESTConfigFromKubeConfig(kubeConfigYaml)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	k8s, err := kubernetes.NewForConfig(restcfg)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	pod := &corev1.Pod{
 		TypeMeta: metav1.TypeMeta{
@@ -180,9 +137,7 @@ func Test_APIServerReady(t *testing.T) {
 	}
 
 	_, err = k8s.CoreV1().Pods("default").Create(context.Background(), pod, metav1.CreateOptions{})
-	if err != nil {
-		t.Fatalf("failed to create pod %v", err)
-	}
+	require.NoError(t, err)
 }
 
 func Test_WithManifestOption(t *testing.T) {
@@ -193,14 +148,6 @@ func Test_WithManifestOption(t *testing.T) {
 		k3s.WithManifest("nginx-manifest.yaml"),
 		testcontainers.WithWaitStrategy(wait.ForExec([]string{"kubectl", "wait", "pod", "nginx", "--for=condition=Ready"})),
 	)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// Clean up the container
-	defer func() {
-		if err := k3sContainer.Terminate(ctx); err != nil {
-			t.Fatal(err)
-		}
-	}()
+	testcontainers.CleanupContainer(t, k3sContainer)
+	require.NoError(t, err)
 }

--- a/modules/k6/examples_test.go
+++ b/modules/k6/examples_test.go
@@ -29,27 +29,29 @@ func ExampleRun() {
 		Started: true,
 	}
 	httpbin, err := testcontainers.GenericContainer(ctx, gcr)
-	if err != nil {
-		log.Fatalf("failed to start container: %s", err)
-	}
-
 	defer func() {
-		if err := httpbin.Terminate(ctx); err != nil {
-			log.Fatalf("failed to terminate container: %s", err)
+		if err := testcontainers.TerminateContainer(httpbin); err != nil {
+			log.Printf("failed to terminate container: %s", err)
 		}
 	}()
+	if err != nil {
+		log.Printf("failed to start container: %s", err)
+		return
+	}
 	// }
 
 	// getHTTPBinIP {
 	httpbinIP, err := httpbin.ContainerIP(ctx)
 	if err != nil {
-		log.Fatalf("failed to get container IP: %s", err) // nolint:gocritic
+		log.Printf("failed to get container IP: %s", err)
+		return
 	}
 	// }
 
 	absPath, err := filepath.Abs(filepath.Join("scripts", "httpbin.js"))
 	if err != nil {
-		log.Fatalf("failed to get absolute path to test script: %s", err)
+		log.Printf("failed to get absolute path to test script: %s", err)
+		return
 	}
 
 	// runK6Container {
@@ -61,21 +63,32 @@ func ExampleRun() {
 		k6.WithTestScript(absPath),
 		k6.SetEnvVar("HTTPBIN", httpbinIP),
 	)
-	if err != nil {
-		log.Fatalf("failed to start container: %s", err)
-	}
-
 	defer func() {
-		if err := k6.Terminate(ctx); err != nil {
-			log.Fatalf("failed to terminate container: %s", err)
+		cacheMount, err := k6.CacheMount(ctx)
+		if err != nil {
+			log.Printf("failed to determine cache mount: %s", err)
+		}
+
+		var options []testcontainers.TerminateOption
+		if cacheMount != "" {
+			options = append(options, testcontainers.RemoveVolumes(cacheMount))
+		}
+
+		if err = testcontainers.TerminateContainer(k6, options...); err != nil {
+			log.Printf("failed to terminate container: %s", err)
 		}
 	}()
+	if err != nil {
+		log.Printf("failed to start container: %s", err)
+		return
+	}
 	//}
 
 	// assert the result of the test
 	state, err := k6.State(ctx)
 	if err != nil {
-		log.Fatalf("failed to get container state: %s", err)
+		log.Printf("failed to get container state: %s", err)
+		return
 	}
 
 	fmt.Println(state.ExitCode)

--- a/modules/k6/go.mod
+++ b/modules/k6/go.mod
@@ -4,7 +4,8 @@ go 1.22
 
 require (
 	github.com/docker/docker v27.1.1+incompatible
-	github.com/testcontainers/testcontainers-go v0.33.0
+	github.com/stretchr/testify v1.9.0
+	github.com/testcontainers/testcontainers-go v0.32.0
 )
 
 require (
@@ -16,6 +17,7 @@ require (
 	github.com/containerd/log v0.1.0 // indirect
 	github.com/containerd/platforms v0.2.1 // indirect
 	github.com/cpuguy83/dockercfg v0.3.1 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/distribution/reference v0.6.0 // indirect
 	github.com/docker/go-connections v0.5.0 // indirect
 	github.com/docker/go-units v0.5.0 // indirect
@@ -26,6 +28,7 @@ require (
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/klauspost/compress v1.17.4 // indirect
+	github.com/kr/text v0.2.0 // indirect
 	github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 // indirect
 	github.com/magiconair/properties v1.8.7 // indirect
 	github.com/moby/docker-image-spec v1.3.1 // indirect
@@ -37,6 +40,7 @@ require (
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c // indirect
 	github.com/shirou/gopsutil/v3 v3.23.12 // indirect
 	github.com/shoenig/go-m1cpu v0.1.6 // indirect
@@ -53,6 +57,7 @@ require (
 	golang.org/x/sys v0.21.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20240318140521-94a12d6c2237 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240318140521-94a12d6c2237 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
 replace github.com/testcontainers/testcontainers-go => ../..

--- a/modules/k6/go.sum
+++ b/modules/k6/go.sum
@@ -16,6 +16,7 @@ github.com/containerd/platforms v0.2.1 h1:zvwtM3rz2YHPQsF2CHYM8+KtB5dvhISiXh5ZpS
 github.com/containerd/platforms v0.2.1/go.mod h1:XHCb+2/hzowdiut9rkudds9bE5yJ7npe7dG/wG+uFPw=
 github.com/cpuguy83/dockercfg v0.3.1 h1:/FpZ+JaygUR/lZP2NlFI2DVfrOEMAIKP5wWEJdoYe9E=
 github.com/cpuguy83/dockercfg v0.3.1/go.mod h1:sugsbF4//dDlL/i+S+rtpIWp+5h0BHJHfjj5/jFyUJc=
+github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.18 h1:n56/Zwd5o6whRC5PMGretI4IdRLlmBXYNjScPaBgsbY=
 github.com/creack/pty v1.1.18/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -52,6 +53,10 @@ github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/compress v1.17.4 h1:Ej5ixsIri7BrIjBkRZLTo6ghwrEtHFk7ijlczPW4fZ4=
 github.com/klauspost/compress v1.17.4/go.mod h1:/dCuZOvVtNoHsyb+cuJD3itjs3NbnF6KH9zAO4BDxPM=
+github.com/kr/pretty v0.3.0 h1:WgNl7dwNpEZ6jJ9k1snq4pZsg7DOEN8hP9Xw0Tsjwk0=
+github.com/kr/pretty v0.3.0/go.mod h1:640gp4NfQd8pI5XOwp5fnNeVWj67G7CFk/SaSQn7NBk=
+github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
+github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 h1:6E+4a0GO5zZEnZ81pIr0yLvtUWk2if982qA3F3QD6H4=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0/go.mod h1:zJYVVT2jmtg6P3p1VtQj7WsuWi/y4VnjVBn7F8KPB3I=
 github.com/magiconair/properties v1.8.7 h1:IeQXZAiQcpL9mgcAe1Nu6cX9LLw6ExEHKjN0VQdvPDY=
@@ -78,6 +83,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c h1:ncq/mPwQF4JjgDlrVEn3C11VoGHZN7m8qihwgMEtzYw=
 github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c/go.mod h1:OmDBASR4679mdNQnz2pUhc2G8CO2JrUAVFDRBDP/hJE=
+github.com/rogpeppe/go-internal v1.8.1 h1:geMPLpDpQOgVyCg5z5GoRwLHepNdb71NXb67XFkP+Eg=
+github.com/rogpeppe/go-internal v1.8.1/go.mod h1:JeRgkft04UBgHMgCIwADu4Pn6Mtm5d4nPKWu0nJ5d+o=
 github.com/shirou/gopsutil/v3 v3.23.12 h1:z90NtUkp3bMtmICZKpC4+WaknU1eXtp5vtbQ11DgpE4=
 github.com/shirou/gopsutil/v3 v3.23.12/go.mod h1:1FrWgea594Jp7qmjHUUPlJDTPgcsb9mGnXDxavtikzM=
 github.com/shoenig/go-m1cpu v0.1.6 h1:nxdKQNcEB6vzgA2E2bvzKIYRuNj7XNJ4S/aRSwKzFtM=
@@ -174,6 +181,8 @@ google.golang.org/grpc v1.64.1/go.mod h1:hiQF4LFZelK2WKaP6W0L92zGHtiQdZxk8CrSdvy
 google.golang.org/protobuf v1.33.0 h1:uNO2rsAINq/JlFpSdYEKIZ0uKD/R9cpdv0T+yoGwGmI=
 google.golang.org/protobuf v1.33.0/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/modules/k6/k6.go
+++ b/modules/k6/k6.go
@@ -17,6 +17,9 @@ import (
 	"github.com/testcontainers/testcontainers-go/wait"
 )
 
+// cacheTarget is the path to the cache volume in the container.
+const cacheTarget = "/cache"
+
 // K6Container represents the K6 container type used in the module
 type K6Container struct {
 	testcontainers.Container
@@ -152,7 +155,7 @@ func WithCache() testcontainers.CustomizeRequestOption {
 				Name:          cacheVol,
 				VolumeOptions: volOptions,
 			},
-			Target: "/cache",
+			Target: cacheTarget,
 		}
 		req.Mounts = append(req.Mounts, mount)
 
@@ -186,9 +189,31 @@ func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustom
 	}
 
 	container, err := testcontainers.GenericContainer(ctx, genericContainerReq)
-	if err != nil {
-		return nil, err
+	var c *K6Container
+	if container != nil {
+		c = &K6Container{Container: container}
 	}
 
-	return &K6Container{Container: container}, nil
+	if err != nil {
+		return c, fmt.Errorf("generic container: %w", err)
+	}
+
+	return c, nil
+}
+
+// CacheMount returns the name of volume used as a cache or an empty string
+// if no cache was found.
+func (k *K6Container) CacheMount(ctx context.Context) (string, error) {
+	inspect, err := k.Inspect(ctx)
+	if err != nil {
+		return "", fmt.Errorf("inspect: %w", err)
+	}
+
+	for _, m := range inspect.Mounts {
+		if m.Type == mount.TypeVolume && m.Destination == cacheTarget {
+			return m.Name, nil
+		}
+	}
+
+	return "", nil
 }

--- a/modules/kafka/examples_test.go
+++ b/modules/kafka/examples_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 
+	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/modules/kafka"
 )
 
@@ -16,21 +17,21 @@ func ExampleRun() {
 		"confluentinc/confluent-local:7.5.0",
 		kafka.WithClusterID("test-cluster"),
 	)
-	if err != nil {
-		log.Fatalf("failed to start container: %s", err)
-	}
-
-	// Clean up the container after
 	defer func() {
-		if err := kafkaContainer.Terminate(ctx); err != nil {
-			log.Fatalf("failed to terminate container: %s", err)
+		if err := testcontainers.TerminateContainer(kafkaContainer); err != nil {
+			log.Printf("failed to terminate container: %s", err)
 		}
 	}()
+	if err != nil {
+		log.Printf("failed to start container: %s", err)
+		return
+	}
 	// }
 
 	state, err := kafkaContainer.State(ctx)
 	if err != nil {
-		log.Fatalf("failed to get container state: %s", err) // nolint:gocritic
+		log.Printf("failed to get container state: %s", err)
+		return
 	}
 
 	fmt.Println(kafkaContainer.ClusterID)

--- a/modules/kafka/go.mod
+++ b/modules/kafka/go.mod
@@ -5,7 +5,8 @@ go 1.22
 require (
 	github.com/IBM/sarama v1.42.1
 	github.com/docker/go-connections v0.5.0
-	github.com/testcontainers/testcontainers-go v0.33.0
+	github.com/stretchr/testify v1.9.0
+	github.com/testcontainers/testcontainers-go v0.32.0
 	golang.org/x/mod v0.16.0
 )
 
@@ -41,6 +42,7 @@ require (
 	github.com/jcmturner/gokrb5/v8 v8.4.4 // indirect
 	github.com/jcmturner/rpc/v2 v2.0.3 // indirect
 	github.com/klauspost/compress v1.17.4 // indirect
+	github.com/kr/text v0.2.0 // indirect
 	github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 // indirect
 	github.com/magiconair/properties v1.8.7 // indirect
 	github.com/moby/docker-image-spec v1.3.1 // indirect
@@ -53,6 +55,7 @@ require (
 	github.com/opencontainers/image-spec v1.1.0 // indirect
 	github.com/pierrec/lz4/v4 v4.1.18 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c // indirect
 	github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475 // indirect
 	github.com/shirou/gopsutil/v3 v3.23.12 // indirect
@@ -71,6 +74,7 @@ require (
 	golang.org/x/sys v0.21.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20240318140521-94a12d6c2237 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240318140521-94a12d6c2237 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
 replace github.com/testcontainers/testcontainers-go => ../..

--- a/modules/kafka/go.sum
+++ b/modules/kafka/go.sum
@@ -18,6 +18,7 @@ github.com/containerd/platforms v0.2.1 h1:zvwtM3rz2YHPQsF2CHYM8+KtB5dvhISiXh5ZpS
 github.com/containerd/platforms v0.2.1/go.mod h1:XHCb+2/hzowdiut9rkudds9bE5yJ7npe7dG/wG+uFPw=
 github.com/cpuguy83/dockercfg v0.3.1 h1:/FpZ+JaygUR/lZP2NlFI2DVfrOEMAIKP5wWEJdoYe9E=
 github.com/cpuguy83/dockercfg v0.3.1/go.mod h1:sugsbF4//dDlL/i+S+rtpIWp+5h0BHJHfjj5/jFyUJc=
+github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.18 h1:n56/Zwd5o6whRC5PMGretI4IdRLlmBXYNjScPaBgsbY=
 github.com/creack/pty v1.1.18/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -86,6 +87,10 @@ github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/compress v1.17.4 h1:Ej5ixsIri7BrIjBkRZLTo6ghwrEtHFk7ijlczPW4fZ4=
 github.com/klauspost/compress v1.17.4/go.mod h1:/dCuZOvVtNoHsyb+cuJD3itjs3NbnF6KH9zAO4BDxPM=
+github.com/kr/pretty v0.3.0 h1:WgNl7dwNpEZ6jJ9k1snq4pZsg7DOEN8hP9Xw0Tsjwk0=
+github.com/kr/pretty v0.3.0/go.mod h1:640gp4NfQd8pI5XOwp5fnNeVWj67G7CFk/SaSQn7NBk=
+github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
+github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 h1:6E+4a0GO5zZEnZ81pIr0yLvtUWk2if982qA3F3QD6H4=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0/go.mod h1:zJYVVT2jmtg6P3p1VtQj7WsuWi/y4VnjVBn7F8KPB3I=
 github.com/magiconair/properties v1.8.7 h1:IeQXZAiQcpL9mgcAe1Nu6cX9LLw6ExEHKjN0VQdvPDY=
@@ -116,6 +121,8 @@ github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c h1:ncq/mPwQF
 github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c/go.mod h1:OmDBASR4679mdNQnz2pUhc2G8CO2JrUAVFDRBDP/hJE=
 github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475 h1:N/ElC8H3+5XpJzTSTfLsJV/mx9Q9g7kxmchpfZyxgzM=
 github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
+github.com/rogpeppe/go-internal v1.8.1 h1:geMPLpDpQOgVyCg5z5GoRwLHepNdb71NXb67XFkP+Eg=
+github.com/rogpeppe/go-internal v1.8.1/go.mod h1:JeRgkft04UBgHMgCIwADu4Pn6Mtm5d4nPKWu0nJ5d+o=
 github.com/shirou/gopsutil/v3 v3.23.12 h1:z90NtUkp3bMtmICZKpC4+WaknU1eXtp5vtbQ11DgpE4=
 github.com/shirou/gopsutil/v3 v3.23.12/go.mod h1:1FrWgea594Jp7qmjHUUPlJDTPgcsb9mGnXDxavtikzM=
 github.com/shoenig/go-m1cpu v0.1.6 h1:nxdKQNcEB6vzgA2E2bvzKIYRuNj7XNJ4S/aRSwKzFtM=
@@ -239,6 +246,8 @@ google.golang.org/grpc v1.64.1/go.mod h1:hiQF4LFZelK2WKaP6W0L92zGHtiQdZxk8CrSdvy
 google.golang.org/protobuf v1.33.0 h1:uNO2rsAINq/JlFpSdYEKIZ0uKD/R9cpdv0T+yoGwGmI=
 google.golang.org/protobuf v1.33.0/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/modules/kafka/kafka.go
+++ b/modules/kafka/kafka.go
@@ -104,16 +104,19 @@ func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustom
 		return nil, err
 	}
 
-	clusterID := genericContainerReq.Env["CLUSTER_ID"]
-
 	configureControllerQuorumVoters(&genericContainerReq)
 
 	container, err := testcontainers.GenericContainer(ctx, genericContainerReq)
-	if err != nil {
-		return nil, err
+	var c *KafkaContainer
+	if container != nil {
+		c = &KafkaContainer{Container: container, ClusterID: genericContainerReq.Env["CLUSTER_ID"]}
 	}
 
-	return &KafkaContainer{Container: container, ClusterID: clusterID}, nil
+	if err != nil {
+		return c, fmt.Errorf("generic container: %w", err)
+	}
+
+	return c, nil
 }
 
 // copyStarterScript copies the starter script into the container.

--- a/modules/kafka/kafka_test.go
+++ b/modules/kafka/kafka_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/IBM/sarama"
+	"github.com/stretchr/testify/require"
 
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/modules/kafka"
@@ -18,16 +19,8 @@ func TestKafka(t *testing.T) {
 	ctx := context.Background()
 
 	kafkaContainer, err := kafka.Run(ctx, "confluentinc/confluent-local:7.5.0", kafka.WithClusterID("kraftCluster"))
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// Clean up the container after the test is complete
-	t.Cleanup(func() {
-		if err := kafkaContainer.Terminate(ctx); err != nil {
-			t.Fatalf("failed to terminate container: %s", err)
-		}
-	})
+	testcontainers.CleanupContainer(t, kafkaContainer)
+	require.NoError(t, err)
 
 	assertAdvertisedListeners(t, kafkaContainer)
 
@@ -38,17 +31,14 @@ func TestKafka(t *testing.T) {
 	// getBrokers {
 	brokers, err := kafkaContainer.Brokers(ctx)
 	// }
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	config := sarama.NewConfig()
 	client, err := sarama.NewConsumerGroup(brokers, "groupName", config)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	consumer, ready, done, cancel := NewTestKafkaConsumer(t)
+	defer cancel()
 	go func() {
 		if err := client.Consume(context.Background(), []string{topic}, consumer); err != nil {
 			cancel()
@@ -64,19 +54,14 @@ func TestKafka(t *testing.T) {
 	config.Producer.Return.Successes = true
 
 	producer, err := sarama.NewSyncProducer(brokers, config)
-	if err != nil {
-		cancel()
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
-	if _, _, err := producer.SendMessage(&sarama.ProducerMessage{
+	_, _, err = producer.SendMessage(&sarama.ProducerMessage{
 		Topic: topic,
 		Key:   sarama.StringEncoder("key"),
 		Value: sarama.StringEncoder("value"),
-	}); err != nil {
-		cancel()
-		t.Fatal(err)
-	}
+	})
+	require.NoError(t, err)
 
 	<-done
 
@@ -91,35 +76,26 @@ func TestKafka(t *testing.T) {
 func TestKafka_invalidVersion(t *testing.T) {
 	ctx := context.Background()
 
-	_, err := kafka.Run(ctx, "confluentinc/confluent-local:6.3.3", kafka.WithClusterID("kraftCluster"))
-	if err == nil {
-		t.Fatal(err)
-	}
+	ctr, err := kafka.Run(ctx, "confluentinc/confluent-local:6.3.3", kafka.WithClusterID("kraftCluster"))
+	testcontainers.CleanupContainer(t, ctr)
+	require.Error(t, err)
 }
 
 // assertAdvertisedListeners checks that the advertised listeners are set correctly:
 // - The BROKER:// protocol is using the hostname of the Kafka container
 func assertAdvertisedListeners(t *testing.T, container testcontainers.Container) {
 	inspect, err := container.Inspect(context.Background())
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	hostname := inspect.Config.Hostname
 
 	code, r, err := container.Exec(context.Background(), []string{"cat", "/usr/sbin/testcontainers_start.sh"})
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
-	if code != 0 {
-		t.Fatalf("expected exit code to be 0, got %d", code)
-	}
+	require.Zero(t, code)
 
 	bs, err := io.ReadAll(r)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	if !strings.Contains(string(bs), "BROKER://"+hostname+":9092") {
 		t.Fatalf("expected advertised listeners to contain %s, got %s", "BROKER://"+hostname+":9092", string(bs))

--- a/modules/localstack/examples_test.go
+++ b/modules/localstack/examples_test.go
@@ -24,21 +24,21 @@ func ExampleRun() {
 	ctx := context.Background()
 
 	localstackContainer, err := localstack.Run(ctx, "localstack/localstack:1.4.0")
-	if err != nil {
-		log.Fatalf("failed to start container: %s", err)
-	}
-
-	// Clean up the container
 	defer func() {
-		if err := localstackContainer.Terminate(ctx); err != nil {
-			log.Fatalf("failed to terminate container: %s", err)
+		if err := testcontainers.TerminateContainer(localstackContainer); err != nil {
+			log.Printf("failed to terminate container: %s", err)
 		}
 	}()
+	if err != nil {
+		log.Printf("failed to start container: %s", err)
+		return
+	}
 	// }
 
 	state, err := localstackContainer.State(ctx)
 	if err != nil {
-		log.Fatalf("failed to get container state: %s", err) // nolint:gocritic
+		log.Printf("failed to get container state: %s", err)
+		return
 	}
 
 	fmt.Println(state.Running)
@@ -53,8 +53,15 @@ func ExampleRun_withNetwork() {
 
 	newNetwork, err := network.New(ctx)
 	if err != nil {
-		log.Fatalf("failed to create network: %s", err)
+		log.Printf("failed to create network: %s", err)
+		return
 	}
+
+	defer func() {
+		if err := newNetwork.Remove(context.Background()); err != nil {
+			log.Printf("failed to remove network: %s", err)
+		}
+	}()
 
 	nwName := newNetwork.Name
 
@@ -64,21 +71,21 @@ func ExampleRun_withNetwork() {
 		testcontainers.WithEnv(map[string]string{"SERVICES": "s3,sqs"}),
 		network.WithNetwork([]string{nwName}, newNetwork),
 	)
+	defer func() {
+		if err := testcontainers.TerminateContainer(localstackContainer); err != nil {
+			log.Printf("failed to terminate container: %s", err)
+		}
+	}()
 	if err != nil {
-		log.Fatalf("failed to start container: %s", err)
+		log.Printf("failed to start container: %s", err)
+		return
 	}
 	// }
 
-	// Clean up the container
-	defer func() {
-		if err := localstackContainer.Terminate(ctx); err != nil {
-			log.Fatalf("failed to terminate container: %s", err)
-		}
-	}()
-
 	networks, err := localstackContainer.Networks(ctx)
 	if err != nil {
-		log.Fatalf("failed to get container networks: %s", err) // nolint:gocritic
+		log.Printf("failed to get container networks: %s", err)
+		return
 	}
 
 	fmt.Println(len(networks))
@@ -90,14 +97,20 @@ func ExampleRun_withNetwork() {
 func ExampleRun_legacyMode() {
 	ctx := context.Background()
 
-	_, err := localstack.Run(
+	ctr, err := localstack.Run(
 		ctx,
 		"localstack/localstack:0.10.0",
 		testcontainers.WithEnv(map[string]string{"SERVICES": "s3,sqs"}),
 		testcontainers.WithWaitStrategy(wait.ForLog("Ready.").WithStartupTimeout(5*time.Minute).WithOccurrence(1)),
 	)
+	defer func() {
+		if err := testcontainers.TerminateContainer(ctr); err != nil {
+			log.Printf("failed to terminate container: %s", err)
+		}
+	}()
 	if err == nil {
-		log.Fatalf("expected an error, got nil")
+		log.Printf("expected an error, got nil")
+		return
 	}
 
 	fmt.Println(err)
@@ -123,7 +136,7 @@ func ExampleRun_usingLambdas() {
 	lambdaName := "localstack-lambda-url-example"
 
 	// withCustomContainerRequest {
-	container, err := localstack.Run(ctx,
+	ctr, err := localstack.Run(ctx,
 		"localstack/localstack:2.3.0",
 		testcontainers.WithEnv(map[string]string{
 			"SERVICES":            "lambda",
@@ -139,17 +152,17 @@ func ExampleRun_usingLambdas() {
 				},
 			},
 		}),
-		// }
 	)
-	if err != nil {
-		log.Fatalf("failed to start container: %s", err)
-	}
+	// }
 	defer func() {
-		err := container.Terminate(ctx)
-		if err != nil {
-			log.Fatalf("failed to terminate container: %s", err)
+		if err := testcontainers.TerminateContainer(ctr); err != nil {
+			log.Printf("failed to terminate container: %s", err)
 		}
 	}()
+	if err != nil {
+		log.Printf("failed to start container: %s", err)
+		return
+	}
 
 	// the three commands below are doing the following:
 	// 1. create a lambda function
@@ -169,9 +182,10 @@ func ExampleRun_usingLambdas() {
 		{"awslocal", "lambda", "wait", "function-active-v2", "--function-name", lambdaName},
 	}
 	for _, cmd := range lambdaCommands {
-		_, _, err := container.Exec(ctx, cmd)
+		_, _, err := ctr.Exec(ctx, cmd)
 		if err != nil {
-			log.Fatalf("failed to execute command %v: %s", cmd, err) // nolint:gocritic
+			log.Printf("failed to execute command %v: %s", cmd, err)
+			return
 		}
 	}
 
@@ -179,15 +193,17 @@ func ExampleRun_usingLambdas() {
 	cmd := []string{
 		"awslocal", "lambda", "list-function-url-configs", "--function-name", lambdaName,
 	}
-	_, reader, err := container.Exec(ctx, cmd, exec.Multiplexed())
+	_, reader, err := ctr.Exec(ctx, cmd, exec.Multiplexed())
 	if err != nil {
-		log.Fatalf("failed to execute command %v: %s", cmd, err)
+		log.Printf("failed to execute command %v: %s", cmd, err)
+		return
 	}
 
 	buf := new(bytes.Buffer)
 	_, err = buf.ReadFrom(reader)
 	if err != nil {
-		log.Fatalf("failed to read from reader: %s", err)
+		log.Printf("failed to read from reader: %s", err)
+		return
 	}
 
 	content := buf.Bytes()
@@ -205,7 +221,8 @@ func ExampleRun_usingLambdas() {
 	v := &FunctionURLConfig{}
 	err = json.Unmarshal(content, v)
 	if err != nil {
-		log.Fatalf("failed to unmarshal content: %s", err)
+		log.Printf("failed to unmarshal content: %s", err)
+		return
 	}
 
 	httpClient := http.Client{
@@ -215,21 +232,24 @@ func ExampleRun_usingLambdas() {
 	functionURL := v.FunctionURLConfigs[0].FunctionURL
 	// replace the port with the one exposed by the container
 
-	mappedPort, err := container.MappedPort(ctx, "4566/tcp")
+	mappedPort, err := ctr.MappedPort(ctx, "4566/tcp")
 	if err != nil {
-		log.Fatalf("failed to get mapped port: %s", err)
+		log.Printf("failed to get mapped port: %s", err)
+		return
 	}
 
 	functionURL = strings.ReplaceAll(functionURL, "4566", mappedPort.Port())
 
 	resp, err := httpClient.Post(functionURL, "application/json", bytes.NewBufferString(`{"num1": "10", "num2": "10"}`))
 	if err != nil {
-		log.Fatalf("failed to send request to lambda function: %s", err)
+		log.Printf("failed to send request to lambda function: %s", err)
+		return
 	}
 
 	jsonResponse, err := io.ReadAll(resp.Body)
 	if err != nil {
-		log.Fatalf("failed to read response body: %s", err)
+		log.Printf("failed to read response body: %s", err)
+		return
 	}
 
 	fmt.Println(string(jsonResponse))

--- a/modules/localstack/localstack.go
+++ b/modules/localstack/localstack.go
@@ -116,13 +116,15 @@ func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustom
 	localStackReq.GenericContainerRequest.Logger.Printf("Setting %s to %s (%s)\n", envVar, req.Env[envVar], hostnameExternalReason)
 
 	container, err := testcontainers.GenericContainer(ctx, localStackReq.GenericContainerRequest)
-	if err != nil {
-		return nil, err
+	var c *LocalStackContainer
+	if container != nil {
+		c = &LocalStackContainer{Container: container}
 	}
 
-	c := &LocalStackContainer{
-		Container: container,
+	if err != nil {
+		return c, fmt.Errorf("generic container: %w", err)
 	}
+
 	return c, nil
 }
 

--- a/modules/localstack/v1/s3_test.go
+++ b/modules/localstack/v1/s3_test.go
@@ -62,10 +62,11 @@ func awsSession(ctx context.Context, l *localstack.LocalStackContainer) (*sessio
 func TestS3(t *testing.T) {
 	ctx := context.Background()
 
-	container, err := localstack.Run(ctx, "localstack/localstack:1.4.0")
+	ctr, err := localstack.Run(ctx, "localstack/localstack:1.4.0")
+	testcontainers.CleanupContainer(t, ctr)
 	require.NoError(t, err)
 
-	session, err := awsSession(ctx, container)
+	session, err := awsSession(ctx, ctr)
 	require.NoError(t, err)
 
 	s3Uploader := s3manager.NewUploader(session)

--- a/modules/localstack/v2/s3_test.go
+++ b/modules/localstack/v2/s3_test.go
@@ -73,10 +73,11 @@ func s3Client(ctx context.Context, l *localstack.LocalStackContainer) (*s3.Clien
 func TestS3(t *testing.T) {
 	ctx := context.Background()
 
-	container, err := localstack.Run(ctx, "localstack/localstack:1.4.0")
+	ctr, err := localstack.Run(ctx, "localstack/localstack:1.4.0")
+	testcontainers.CleanupContainer(t, ctr)
 	require.NoError(t, err)
 
-	s3Client, err := s3Client(ctx, container)
+	s3Client, err := s3Client(ctx, ctr)
 	require.NoError(t, err)
 
 	t.Run("S3 operations", func(t *testing.T) {

--- a/modules/mariadb/examples_test.go
+++ b/modules/mariadb/examples_test.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"path/filepath"
 
+	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/modules/mariadb"
 )
 
@@ -21,21 +22,21 @@ func ExampleRun() {
 		mariadb.WithUsername("root"),
 		mariadb.WithPassword(""),
 	)
-	if err != nil {
-		log.Fatalf("failed to start container: %s", err)
-	}
-
-	// Clean up the container
 	defer func() {
-		if err := mariadbContainer.Terminate(ctx); err != nil {
-			log.Fatalf("failed to terminate container: %s", err)
+		if err := testcontainers.TerminateContainer(mariadbContainer); err != nil {
+			log.Printf("failed to terminate container: %s", err)
 		}
 	}()
+	if err != nil {
+		log.Printf("failed to start container: %s", err)
+		return
+	}
 	// }
 
 	state, err := mariadbContainer.State(ctx)
 	if err != nil {
-		log.Fatalf("failed to get container state: %s", err) // nolint:gocritic
+		log.Printf("failed to get container state: %s", err)
+		return
 	}
 
 	fmt.Println(state.Running)

--- a/modules/mariadb/go.mod
+++ b/modules/mariadb/go.mod
@@ -4,7 +4,8 @@ go 1.22
 
 require (
 	github.com/go-sql-driver/mysql v1.7.1
-	github.com/testcontainers/testcontainers-go v0.33.0
+	github.com/stretchr/testify v1.9.0
+	github.com/testcontainers/testcontainers-go v0.32.0
 )
 
 require (
@@ -16,6 +17,7 @@ require (
 	github.com/containerd/log v0.1.0 // indirect
 	github.com/containerd/platforms v0.2.1 // indirect
 	github.com/cpuguy83/dockercfg v0.3.1 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/distribution/reference v0.6.0 // indirect
 	github.com/docker/docker v27.1.1+incompatible // indirect
 	github.com/docker/go-connections v0.5.0 // indirect
@@ -27,6 +29,7 @@ require (
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/klauspost/compress v1.17.4 // indirect
+	github.com/kr/text v0.2.0 // indirect
 	github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 // indirect
 	github.com/magiconair/properties v1.8.7 // indirect
 	github.com/moby/docker-image-spec v1.3.1 // indirect
@@ -38,6 +41,7 @@ require (
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c // indirect
 	github.com/shirou/gopsutil/v3 v3.23.12 // indirect
 	github.com/shoenig/go-m1cpu v0.1.6 // indirect
@@ -54,6 +58,7 @@ require (
 	golang.org/x/sys v0.21.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20240318140521-94a12d6c2237 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240318140521-94a12d6c2237 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
 replace github.com/testcontainers/testcontainers-go => ../..

--- a/modules/mariadb/go.sum
+++ b/modules/mariadb/go.sum
@@ -16,6 +16,7 @@ github.com/containerd/platforms v0.2.1 h1:zvwtM3rz2YHPQsF2CHYM8+KtB5dvhISiXh5ZpS
 github.com/containerd/platforms v0.2.1/go.mod h1:XHCb+2/hzowdiut9rkudds9bE5yJ7npe7dG/wG+uFPw=
 github.com/cpuguy83/dockercfg v0.3.1 h1:/FpZ+JaygUR/lZP2NlFI2DVfrOEMAIKP5wWEJdoYe9E=
 github.com/cpuguy83/dockercfg v0.3.1/go.mod h1:sugsbF4//dDlL/i+S+rtpIWp+5h0BHJHfjj5/jFyUJc=
+github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.18 h1:n56/Zwd5o6whRC5PMGretI4IdRLlmBXYNjScPaBgsbY=
 github.com/creack/pty v1.1.18/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -54,6 +55,10 @@ github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/compress v1.17.4 h1:Ej5ixsIri7BrIjBkRZLTo6ghwrEtHFk7ijlczPW4fZ4=
 github.com/klauspost/compress v1.17.4/go.mod h1:/dCuZOvVtNoHsyb+cuJD3itjs3NbnF6KH9zAO4BDxPM=
+github.com/kr/pretty v0.3.0 h1:WgNl7dwNpEZ6jJ9k1snq4pZsg7DOEN8hP9Xw0Tsjwk0=
+github.com/kr/pretty v0.3.0/go.mod h1:640gp4NfQd8pI5XOwp5fnNeVWj67G7CFk/SaSQn7NBk=
+github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
+github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 h1:6E+4a0GO5zZEnZ81pIr0yLvtUWk2if982qA3F3QD6H4=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0/go.mod h1:zJYVVT2jmtg6P3p1VtQj7WsuWi/y4VnjVBn7F8KPB3I=
 github.com/magiconair/properties v1.8.7 h1:IeQXZAiQcpL9mgcAe1Nu6cX9LLw6ExEHKjN0VQdvPDY=
@@ -80,6 +85,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c h1:ncq/mPwQF4JjgDlrVEn3C11VoGHZN7m8qihwgMEtzYw=
 github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c/go.mod h1:OmDBASR4679mdNQnz2pUhc2G8CO2JrUAVFDRBDP/hJE=
+github.com/rogpeppe/go-internal v1.8.1 h1:geMPLpDpQOgVyCg5z5GoRwLHepNdb71NXb67XFkP+Eg=
+github.com/rogpeppe/go-internal v1.8.1/go.mod h1:JeRgkft04UBgHMgCIwADu4Pn6Mtm5d4nPKWu0nJ5d+o=
 github.com/shirou/gopsutil/v3 v3.23.12 h1:z90NtUkp3bMtmICZKpC4+WaknU1eXtp5vtbQ11DgpE4=
 github.com/shirou/gopsutil/v3 v3.23.12/go.mod h1:1FrWgea594Jp7qmjHUUPlJDTPgcsb9mGnXDxavtikzM=
 github.com/shoenig/go-m1cpu v0.1.6 h1:nxdKQNcEB6vzgA2E2bvzKIYRuNj7XNJ4S/aRSwKzFtM=
@@ -176,6 +183,8 @@ google.golang.org/grpc v1.64.1/go.mod h1:hiQF4LFZelK2WKaP6W0L92zGHtiQdZxk8CrSdvy
 google.golang.org/protobuf v1.33.0 h1:uNO2rsAINq/JlFpSdYEKIZ0uKD/R9cpdv0T+yoGwGmI=
 google.golang.org/protobuf v1.33.0/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/modules/mariadb/mariadb.go
+++ b/modules/mariadb/mariadb.go
@@ -169,13 +169,21 @@ func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustom
 	}
 
 	container, err := testcontainers.GenericContainer(ctx, genericContainerReq)
-	if err != nil {
-		return nil, err
+	var c *MariaDBContainer
+	if container != nil {
+		c = &MariaDBContainer{
+			Container: container,
+			username:  username,
+			password:  password,
+			database:  req.Env["MARIADB_DATABASE"],
+		}
 	}
 
-	database := req.Env["MARIADB_DATABASE"]
+	if err != nil {
+		return c, fmt.Errorf("generic container: %w", err)
+	}
 
-	return &MariaDBContainer{container, username, password, database}, nil
+	return c, nil
 }
 
 // MustConnectionString panics if the address cannot be determined.

--- a/modules/mariadb/mariadb_test.go
+++ b/modules/mariadb/mariadb_test.go
@@ -8,55 +8,41 @@ import (
 
 	// Import mysql into the scope of this package (required)
 	_ "github.com/go-sql-driver/mysql"
+	"github.com/stretchr/testify/require"
 
+	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/modules/mariadb"
 )
 
 func TestMariaDB(t *testing.T) {
 	ctx := context.Background()
 
-	container, err := mariadb.Run(ctx, "mariadb:11.0.3")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// Clean up the container after the test is complete
-	t.Cleanup(func() {
-		if err := container.Terminate(ctx); err != nil {
-			t.Fatalf("failed to terminate container: %s", err)
-		}
-	})
+	ctr, err := mariadb.Run(ctx, "mariadb:11.0.3")
+	testcontainers.CleanupContainer(t, ctr)
+	require.NoError(t, err)
 
 	// connectionString {
 	// By default, MariaDB transmits data between the server and clients without encrypting it.
-	connectionString, err := container.ConnectionString(ctx, "tls=false")
+	connectionString, err := ctr.ConnectionString(ctx, "tls=false")
 	// }
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
-	mustConnectionString := container.MustConnectionString(ctx, "tls=false")
-	if mustConnectionString != connectionString {
-		t.Errorf("ConnectionString was not equal to MustConnectionString")
-	}
+	mustConnectionString := ctr.MustConnectionString(ctx, "tls=false")
+	require.Equal(t, connectionString, mustConnectionString)
 
 	db, err := sql.Open("mysql", connectionString)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	defer db.Close()
 
-	if err = db.Ping(); err != nil {
-		t.Errorf("error pinging db: %+v\n", err)
-	}
+	err = db.Ping()
+	require.NoError(t, err)
+
 	_, err = db.Exec("CREATE TABLE IF NOT EXISTS a_table ( \n" +
 		" `col_1` VARCHAR(128) NOT NULL, \n" +
 		" `col_2` VARCHAR(128) NOT NULL, \n" +
 		" PRIMARY KEY (`col_1`, `col_2`) \n" +
 		")")
-	if err != nil {
-		t.Errorf("error creating table: %+v\n", err)
-	}
+	require.NoError(t, err)
 }
 
 func TestMariaDBWithNonRootUserAndEmptyPassword(t *testing.T) {
@@ -75,163 +61,105 @@ func TestMariaDBWithNonRootUserAndEmptyPassword(t *testing.T) {
 func TestMariaDBWithRootUserAndEmptyPassword(t *testing.T) {
 	ctx := context.Background()
 
-	container, err := mariadb.Run(ctx,
+	ctr, err := mariadb.Run(ctx,
 		"mariadb:11.0.3",
 		mariadb.WithDatabase("foo"),
 		mariadb.WithUsername("root"),
 		mariadb.WithPassword(""))
-	if err != nil {
-		t.Fatal(err)
-	}
+	testcontainers.CleanupContainer(t, ctr)
+	require.NoError(t, err)
 
-	// Clean up the container after the test is complete
-	t.Cleanup(func() {
-		if err := container.Terminate(ctx); err != nil {
-			t.Fatalf("failed to terminate container: %s", err)
-		}
-	})
-
-	connectionString, err := container.ConnectionString(ctx)
-	if err != nil {
-		t.Fatal(err)
-	}
+	connectionString, err := ctr.ConnectionString(ctx)
+	require.NoError(t, err)
 
 	db, err := sql.Open("mysql", connectionString)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	defer db.Close()
 
-	if err = db.Ping(); err != nil {
-		t.Errorf("error pinging db: %+v\n", err)
-	}
+	err = db.Ping()
+	require.NoError(t, err)
+
 	_, err = db.Exec("CREATE TABLE IF NOT EXISTS a_table ( \n" +
 		" `col_1` VARCHAR(128) NOT NULL, \n" +
 		" `col_2` VARCHAR(128) NOT NULL, \n" +
 		" PRIMARY KEY (`col_1`, `col_2`) \n" +
 		")")
-	if err != nil {
-		t.Errorf("error creating table: %+v\n", err)
-	}
+	require.NoError(t, err)
 }
 
 func TestMariaDBWithMySQLEnvVars(t *testing.T) {
 	ctx := context.Background()
 
-	container, err := mariadb.Run(ctx, "mariadb:10.3.29",
+	ctr, err := mariadb.Run(ctx, "mariadb:10.3.29",
 		mariadb.WithScripts(filepath.Join("testdata", "schema.sql")))
-	if err != nil {
-		t.Fatal(err)
-	}
+	testcontainers.CleanupContainer(t, ctr)
+	require.NoError(t, err)
 
-	t.Cleanup(func() {
-		if err := container.Terminate(ctx); err != nil {
-			t.Fatalf("failed to terminate container: %s", err)
-		}
-	})
-
-	assertDataCanBeFetched(t, ctx, container)
+	assertDataCanBeFetched(t, ctx, ctr)
 }
 
 func TestMariaDBWithConfigFile(t *testing.T) {
 	ctx := context.Background()
 
-	container, err := mariadb.Run(ctx, "mariadb:11.0.3",
+	ctr, err := mariadb.Run(ctx, "mariadb:11.0.3",
 		mariadb.WithConfigFile(filepath.Join("testdata", "my.cnf")))
-	if err != nil {
-		t.Fatal(err)
-	}
+	testcontainers.CleanupContainer(t, ctr)
+	require.NoError(t, err)
 
-	// Clean up the container after the test is complete
-	t.Cleanup(func() {
-		if err := container.Terminate(ctx); err != nil {
-			t.Fatalf("failed to terminate container: %s", err)
-		}
-	})
-
-	connectionString, err := container.ConnectionString(ctx)
-	if err != nil {
-		t.Fatal(err)
-	}
+	connectionString, err := ctr.ConnectionString(ctx)
+	require.NoError(t, err)
 
 	db, err := sql.Open("mysql", connectionString)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	defer db.Close()
 
-	if err = db.Ping(); err != nil {
-		t.Errorf("error pinging db: %+v\n", err)
-	}
+	err = db.Ping()
+	require.NoError(t, err)
 
 	// In MariaDB 10.2.2 and later, the default file format is Barracuda and Antelope is deprecated.
 	// Barracuda is a newer InnoDB file format. It supports the COMPACT, REDUNDANT, DYNAMIC and
 	// COMPRESSED row formats. Tables with large BLOB or TEXT columns in particular could benefit
 	// from the dynamic row format.
 	stmt, err := db.Prepare("SELECT @@GLOBAL.innodb_default_row_format")
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
+
 	defer stmt.Close()
 	row := stmt.QueryRow()
 	innodbFileFormat := ""
 	err = row.Scan(&innodbFileFormat)
-	if err != nil {
-		t.Errorf("error fetching innodb_default_row_format value")
-	}
-	if innodbFileFormat != "dynamic" {
-		t.Fatal("The InnoDB file format has been set by the ini file content")
-	}
+	require.NoError(t, err)
+	require.Equal(t, "dynamic", innodbFileFormat)
 }
 
 func TestMariaDBWithScripts(t *testing.T) {
 	ctx := context.Background()
 
-	container, err := mariadb.Run(ctx,
+	ctr, err := mariadb.Run(ctx,
 		"mariadb:11.0.3",
 		mariadb.WithScripts(filepath.Join("testdata", "schema.sql")))
-	if err != nil {
-		t.Fatal(err)
-	}
+	testcontainers.CleanupContainer(t, ctr)
+	require.NoError(t, err)
 
-	// Clean up the container after the test is complete
-	t.Cleanup(func() {
-		if err := container.Terminate(ctx); err != nil {
-			t.Fatalf("failed to terminate container: %s", err)
-		}
-	})
-
-	assertDataCanBeFetched(t, ctx, container)
+	assertDataCanBeFetched(t, ctx, ctr)
 }
 
 func assertDataCanBeFetched(t *testing.T, ctx context.Context, container *mariadb.MariaDBContainer) {
 	connectionString, err := container.ConnectionString(ctx)
-	if err != nil {
-		t.Fatal(err)
-	}
-
+	require.NoError(t, err)
 	db, err := sql.Open("mysql", connectionString)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	defer db.Close()
 
-	if err = db.Ping(); err != nil {
-		t.Errorf("error pinging db: %+v\n", err)
-	}
+	err = db.Ping()
+	require.NoError(t, err)
 
 	stmt, err := db.Prepare("SELECT name from profile")
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	defer stmt.Close()
+
 	row := stmt.QueryRow()
 	var name string
 	err = row.Scan(&name)
-	if err != nil {
-		t.Errorf("error fetching data")
-	}
-	if name != "profile 1" {
-		t.Fatal("The expected record was not found in the database.")
-	}
+	require.NoError(t, err)
+	require.Equal(t, "profile 1", name)
 }

--- a/modules/milvus/examples_test.go
+++ b/modules/milvus/examples_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/milvus-io/milvus-sdk-go/v2/client"
 	"github.com/milvus-io/milvus-sdk-go/v2/entity"
 
+	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/modules/milvus"
 )
 
@@ -16,21 +17,21 @@ func ExampleRun() {
 	ctx := context.Background()
 
 	milvusContainer, err := milvus.Run(ctx, "milvusdb/milvus:v2.3.9")
-	if err != nil {
-		log.Fatalf("failed to start container: %s", err)
-	}
-
-	// Clean up the container
 	defer func() {
-		if err := milvusContainer.Terminate(ctx); err != nil {
-			log.Fatalf("failed to terminate container: %s", err) // nolint:gocritic
+		if err := testcontainers.TerminateContainer(milvusContainer); err != nil {
+			log.Printf("failed to terminate container: %s", err)
 		}
 	}()
+	if err != nil {
+		log.Printf("failed to start container: %s", err)
+		return
+	}
 	// }
 
 	state, err := milvusContainer.State(ctx)
 	if err != nil {
-		log.Fatalf("failed to get container state: %s", err) // nolint:gocritic
+		log.Printf("failed to get container state: %s", err)
+		return
 	}
 
 	fmt.Println(state.Running)
@@ -44,26 +45,27 @@ func ExampleMilvusContainer_collections() {
 	ctx := context.Background()
 
 	milvusContainer, err := milvus.Run(ctx, "milvusdb/milvus:v2.3.9")
-	if err != nil {
-		log.Fatalf("failed to start container: %s", err)
-	}
-
-	// Clean up the container
 	defer func() {
-		if err := milvusContainer.Terminate(ctx); err != nil {
-			log.Fatalf("failed to terminate container: %s", err) // nolint:gocritic
+		if err := testcontainers.TerminateContainer(milvusContainer); err != nil {
+			log.Printf("failed to terminate container: %s", err)
 		}
 	}()
+	if err != nil {
+		log.Printf("failed to start container: %s", err)
+		return
+	}
 
 	connectionStr, err := milvusContainer.ConnectionString(ctx)
 	if err != nil {
-		log.Fatalf("failed to get connection string: %s", err) // nolint:gocritic
+		log.Printf("failed to get connection string: %s", err)
+		return
 	}
 
 	// Create a client to interact with the Milvus container
 	milvusClient, err := client.NewGrpcClient(context.Background(), connectionStr)
 	if err != nil {
-		log.Fatal("failed to connect to Milvus:", err.Error())
+		log.Print("failed to connect to Milvus:", err.Error())
+		return
 	}
 	defer milvusClient.Close()
 
@@ -101,12 +103,14 @@ func ExampleMilvusContainer_collections() {
 		2, // shardNum
 	)
 	if err != nil {
-		log.Fatalf("failed to create collection: %s", err) // nolint:gocritic
+		log.Printf("failed to create collection: %s", err)
+		return
 	}
 
 	list, err := milvusClient.ListCollections(context.Background())
 	if err != nil {
-		log.Fatalf("failed to list collections: %s", err) // nolint:gocritic
+		log.Printf("failed to list collections: %s", err)
+		return
 	}
 	// }
 

--- a/modules/milvus/milvus.go
+++ b/modules/milvus/milvus.go
@@ -85,11 +85,16 @@ func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustom
 	}
 
 	container, err := testcontainers.GenericContainer(ctx, genericContainerReq)
-	if err != nil {
-		return nil, err
+	var c *MilvusContainer
+	if container != nil {
+		c = &MilvusContainer{Container: container}
 	}
 
-	return &MilvusContainer{Container: container}, nil
+	if err != nil {
+		return c, fmt.Errorf("generic container: %w", err)
+	}
+
+	return c, nil
 }
 
 type embedEtcdConfigTplParams struct {

--- a/modules/milvus/milvus_test.go
+++ b/modules/milvus/milvus_test.go
@@ -7,24 +7,20 @@ import (
 	"github.com/milvus-io/milvus-sdk-go/v2/client"
 	"github.com/stretchr/testify/require"
 
+	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/modules/milvus"
 )
 
 func TestMilvus(t *testing.T) {
 	ctx := context.Background()
 
-	container, err := milvus.Run(ctx, "milvusdb/milvus:v2.3.9")
+	ctr, err := milvus.Run(ctx, "milvusdb/milvus:v2.3.9")
+	testcontainers.CleanupContainer(t, ctr)
 	require.NoError(t, err)
-
-	// Clean up the container after the test is complete
-	t.Cleanup(func() {
-		err = container.Terminate(ctx)
-		require.NoError(t, err)
-	})
 
 	t.Run("Connect to Milvus with gRPC", func(tt *testing.T) {
 		// connectionString {
-		connectionStr, err := container.ConnectionString(ctx)
+		connectionStr, err := ctr.ConnectionString(ctx)
 		// }
 		require.NoError(t, err)
 

--- a/modules/minio/examples_test.go
+++ b/modules/minio/examples_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 
+	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/modules/minio"
 )
 
@@ -13,21 +14,21 @@ func ExampleRun() {
 	ctx := context.Background()
 
 	minioContainer, err := minio.Run(ctx, "minio/minio:RELEASE.2024-01-16T16-07-38Z")
-	if err != nil {
-		log.Fatalf("failed to start container: %s", err)
-	}
-
-	// Clean up the container
 	defer func() {
-		if err := minioContainer.Terminate(ctx); err != nil {
-			log.Fatalf("failed to terminate container: %s", err)
+		if err := testcontainers.TerminateContainer(minioContainer); err != nil {
+			log.Printf("failed to terminate container: %s", err)
 		}
 	}()
+	if err != nil {
+		log.Printf("failed to start container: %s", err)
+		return
+	}
 	// }
 
 	state, err := minioContainer.State(ctx)
 	if err != nil {
-		log.Fatalf("failed to get container state: %s", err) // nolint:gocritic
+		log.Printf("failed to get container state: %s", err)
+		return
 	}
 
 	fmt.Println(state.Running)

--- a/modules/minio/go.mod
+++ b/modules/minio/go.mod
@@ -4,7 +4,8 @@ go 1.22
 
 require (
 	github.com/minio/minio-go/v7 v7.0.68
-	github.com/testcontainers/testcontainers-go v0.33.0
+	github.com/stretchr/testify v1.9.0
+	github.com/testcontainers/testcontainers-go v0.32.0
 )
 
 require (
@@ -16,6 +17,7 @@ require (
 	github.com/containerd/log v0.1.0 // indirect
 	github.com/containerd/platforms v0.2.1 // indirect
 	github.com/cpuguy83/dockercfg v0.3.1 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/distribution/reference v0.6.0 // indirect
 	github.com/docker/docker v27.1.1+incompatible // indirect
 	github.com/docker/go-connections v0.5.0 // indirect
@@ -30,6 +32,7 @@ require (
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/compress v1.17.6 // indirect
 	github.com/klauspost/cpuid/v2 v2.2.6 // indirect
+	github.com/kr/text v0.2.0 // indirect
 	github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 // indirect
 	github.com/magiconair/properties v1.8.7 // indirect
 	github.com/minio/md5-simd v1.1.2 // indirect
@@ -45,6 +48,7 @@ require (
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c // indirect
 	github.com/rs/xid v1.5.0 // indirect
 	github.com/shirou/gopsutil/v3 v3.23.12 // indirect
@@ -64,6 +68,7 @@ require (
 	google.golang.org/genproto/googleapis/api v0.0.0-20240318140521-94a12d6c2237 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240318140521-94a12d6c2237 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
 replace github.com/testcontainers/testcontainers-go => ../..

--- a/modules/minio/go.sum
+++ b/modules/minio/go.sum
@@ -16,6 +16,7 @@ github.com/containerd/platforms v0.2.1 h1:zvwtM3rz2YHPQsF2CHYM8+KtB5dvhISiXh5ZpS
 github.com/containerd/platforms v0.2.1/go.mod h1:XHCb+2/hzowdiut9rkudds9bE5yJ7npe7dG/wG+uFPw=
 github.com/cpuguy83/dockercfg v0.3.1 h1:/FpZ+JaygUR/lZP2NlFI2DVfrOEMAIKP5wWEJdoYe9E=
 github.com/cpuguy83/dockercfg v0.3.1/go.mod h1:sugsbF4//dDlL/i+S+rtpIWp+5h0BHJHfjj5/jFyUJc=
+github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.18 h1:n56/Zwd5o6whRC5PMGretI4IdRLlmBXYNjScPaBgsbY=
 github.com/creack/pty v1.1.18/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -60,6 +61,10 @@ github.com/klauspost/compress v1.17.6/go.mod h1:/dCuZOvVtNoHsyb+cuJD3itjs3NbnF6K
 github.com/klauspost/cpuid/v2 v2.0.1/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=
 github.com/klauspost/cpuid/v2 v2.2.6 h1:ndNyv040zDGIDh8thGkXYjnFtiN02M1PVVF+JE/48xc=
 github.com/klauspost/cpuid/v2 v2.2.6/go.mod h1:Lcz8mBdAVJIBVzewtcLocK12l3Y+JytZYpaMropDUws=
+github.com/kr/pretty v0.3.0 h1:WgNl7dwNpEZ6jJ9k1snq4pZsg7DOEN8hP9Xw0Tsjwk0=
+github.com/kr/pretty v0.3.0/go.mod h1:640gp4NfQd8pI5XOwp5fnNeVWj67G7CFk/SaSQn7NBk=
+github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
+github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 h1:6E+4a0GO5zZEnZ81pIr0yLvtUWk2if982qA3F3QD6H4=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0/go.mod h1:zJYVVT2jmtg6P3p1VtQj7WsuWi/y4VnjVBn7F8KPB3I=
 github.com/magiconair/properties v1.8.7 h1:IeQXZAiQcpL9mgcAe1Nu6cX9LLw6ExEHKjN0VQdvPDY=
@@ -97,6 +102,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c h1:ncq/mPwQF4JjgDlrVEn3C11VoGHZN7m8qihwgMEtzYw=
 github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c/go.mod h1:OmDBASR4679mdNQnz2pUhc2G8CO2JrUAVFDRBDP/hJE=
+github.com/rogpeppe/go-internal v1.8.1 h1:geMPLpDpQOgVyCg5z5GoRwLHepNdb71NXb67XFkP+Eg=
+github.com/rogpeppe/go-internal v1.8.1/go.mod h1:JeRgkft04UBgHMgCIwADu4Pn6Mtm5d4nPKWu0nJ5d+o=
 github.com/rs/xid v1.5.0 h1:mKX4bl4iPYJtEIxp6CYiUuLQ/8DYMoz0PUdtGgMFRVc=
 github.com/rs/xid v1.5.0/go.mod h1:trrq9SKmegXys3aeAKXMUTdJsYXVwGY3RLcfgqegfbg=
 github.com/shirou/gopsutil/v3 v3.23.12 h1:z90NtUkp3bMtmICZKpC4+WaknU1eXtp5vtbQ11DgpE4=
@@ -197,6 +204,8 @@ google.golang.org/grpc v1.64.1/go.mod h1:hiQF4LFZelK2WKaP6W0L92zGHtiQdZxk8CrSdvy
 google.golang.org/protobuf v1.33.0 h1:uNO2rsAINq/JlFpSdYEKIZ0uKD/R9cpdv0T+yoGwGmI=
 google.golang.org/protobuf v1.33.0/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/ini.v1 v1.67.0 h1:Dgnx+6+nfE+IfzjUEISNeydPJh9AXNNsWbGP9KzCsOA=
 gopkg.in/ini.v1 v1.67.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/modules/minio/minio.go
+++ b/modules/minio/minio.go
@@ -93,9 +93,14 @@ func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustom
 	}
 
 	container, err := testcontainers.GenericContainer(ctx, genericContainerReq)
-	if err != nil {
-		return nil, err
+	var c *MinioContainer
+	if container != nil {
+		c = &MinioContainer{Container: container, Username: username, Password: password}
 	}
 
-	return &MinioContainer{Container: container, Username: username, Password: password}, nil
+	if err != nil {
+		return c, fmt.Errorf("generic container: %w", err)
+	}
+
+	return c, nil
 }

--- a/modules/mockserver/examples_test.go
+++ b/modules/mockserver/examples_test.go
@@ -10,6 +10,7 @@ import (
 
 	client "github.com/BraspagDevelopers/mock-server-client"
 
+	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/modules/mockserver"
 )
 
@@ -18,21 +19,21 @@ func ExampleRun() {
 	ctx := context.Background()
 
 	mockserverContainer, err := mockserver.Run(ctx, "mockserver/mockserver:5.15.0")
-	if err != nil {
-		log.Fatalf("failed to start container: %s", err)
-	}
-
-	// Clean up the container
 	defer func() {
-		if err := mockserverContainer.Terminate(ctx); err != nil {
-			log.Fatalf("failed to terminate container: %s", err)
+		if err := testcontainers.TerminateContainer(mockserverContainer); err != nil {
+			log.Printf("failed to terminate container: %s", err)
 		}
 	}()
+	if err != nil {
+		log.Printf("failed to start container: %s", err)
+		return
+	}
 	// }
 
 	state, err := mockserverContainer.State(ctx)
 	if err != nil {
-		log.Fatalf("failed to get container state: %s", err) // nolint:gocritic
+		log.Printf("failed to get container state: %s", err)
+		return
 	}
 
 	fmt.Println(state.Running)
@@ -46,20 +47,20 @@ func ExampleRun_connect() {
 	ctx := context.Background()
 
 	mockserverContainer, err := mockserver.Run(ctx, "mockserver/mockserver:5.15.0")
-	if err != nil {
-		log.Fatalf("failed to start container: %s", err)
-	}
-
-	// Clean up the container
 	defer func() {
-		if err := mockserverContainer.Terminate(ctx); err != nil {
-			log.Fatalf("failed to terminate container: %s", err)
+		if err := testcontainers.TerminateContainer(mockserverContainer); err != nil {
+			log.Printf("failed to terminate container: %s", err)
 		}
 	}()
+	if err != nil {
+		log.Printf("failed to start container: %s", err)
+		return
+	}
 
 	url, err := mockserverContainer.URL(ctx)
 	if err != nil {
-		log.Fatalf("failed to get container URL: %s", err) // nolint:gocritic
+		log.Printf("failed to get container URL: %s", err)
+		return
 	}
 	ms := client.NewClientURL(url)
 	// }
@@ -71,18 +72,21 @@ func ExampleRun_connect() {
 	requestMatcher = requestMatcher.WithJSONFields(map[string]interface{}{"name": "Tools"})
 	err = ms.RegisterExpectation(client.NewExpectation(requestMatcher).WithResponse(client.NewResponseOK().WithJSONBody(map[string]any{"test": "value"})))
 	if err != nil {
-		log.Fatalf("failed to register expectation: %s", err)
+		log.Printf("failed to register expectation: %s", err)
+		return
 	}
 
 	httpClient := &http.Client{}
 	resp, err := httpClient.Post(url+"/api/categories", "application/json", strings.NewReader(`{"name": "Tools"}`))
 	if err != nil {
-		log.Fatalf("failed to send request: %s", err)
+		log.Printf("failed to send request: %s", err)
+		return
 	}
 
 	buf, err := io.ReadAll(resp.Body)
 	if err != nil {
-		log.Fatalf("failed to read response: %s", err)
+		log.Printf("failed to read response: %s", err)
+		return
 	}
 	resp.Body.Close()
 

--- a/modules/mockserver/go.mod
+++ b/modules/mockserver/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/containerd/log v0.1.0 // indirect
 	github.com/containerd/platforms v0.2.1 // indirect
 	github.com/cpuguy83/dockercfg v0.3.1 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/distribution/reference v0.6.0 // indirect
 	github.com/docker/docker v27.1.1+incompatible // indirect
 	github.com/docker/go-connections v0.5.0 // indirect
@@ -28,6 +29,7 @@ require (
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/klauspost/compress v1.17.4 // indirect
+	github.com/kr/text v0.2.0 // indirect
 	github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 // indirect
 	github.com/magiconair/properties v1.8.7 // indirect
 	github.com/moby/docker-image-spec v1.3.1 // indirect
@@ -39,10 +41,12 @@ require (
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c // indirect
 	github.com/shirou/gopsutil/v3 v3.23.12 // indirect
 	github.com/shoenig/go-m1cpu v0.1.6 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect
+	github.com/stretchr/testify v1.9.0 // indirect
 	github.com/tklauser/go-sysconf v0.3.12 // indirect
 	github.com/tklauser/numcpus v0.6.1 // indirect
 	github.com/yusufpapurcu/wmi v1.2.3 // indirect
@@ -55,6 +59,7 @@ require (
 	golang.org/x/sys v0.21.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20240318140521-94a12d6c2237 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240318140521-94a12d6c2237 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
 replace github.com/testcontainers/testcontainers-go => ../..

--- a/modules/mockserver/go.sum
+++ b/modules/mockserver/go.sum
@@ -18,6 +18,7 @@ github.com/containerd/platforms v0.2.1 h1:zvwtM3rz2YHPQsF2CHYM8+KtB5dvhISiXh5ZpS
 github.com/containerd/platforms v0.2.1/go.mod h1:XHCb+2/hzowdiut9rkudds9bE5yJ7npe7dG/wG+uFPw=
 github.com/cpuguy83/dockercfg v0.3.1 h1:/FpZ+JaygUR/lZP2NlFI2DVfrOEMAIKP5wWEJdoYe9E=
 github.com/cpuguy83/dockercfg v0.3.1/go.mod h1:sugsbF4//dDlL/i+S+rtpIWp+5h0BHJHfjj5/jFyUJc=
+github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.18 h1:n56/Zwd5o6whRC5PMGretI4IdRLlmBXYNjScPaBgsbY=
 github.com/creack/pty v1.1.18/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -56,6 +57,10 @@ github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/compress v1.17.4 h1:Ej5ixsIri7BrIjBkRZLTo6ghwrEtHFk7ijlczPW4fZ4=
 github.com/klauspost/compress v1.17.4/go.mod h1:/dCuZOvVtNoHsyb+cuJD3itjs3NbnF6KH9zAO4BDxPM=
+github.com/kr/pretty v0.3.0 h1:WgNl7dwNpEZ6jJ9k1snq4pZsg7DOEN8hP9Xw0Tsjwk0=
+github.com/kr/pretty v0.3.0/go.mod h1:640gp4NfQd8pI5XOwp5fnNeVWj67G7CFk/SaSQn7NBk=
+github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
+github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 h1:6E+4a0GO5zZEnZ81pIr0yLvtUWk2if982qA3F3QD6H4=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0/go.mod h1:zJYVVT2jmtg6P3p1VtQj7WsuWi/y4VnjVBn7F8KPB3I=
 github.com/magiconair/properties v1.8.7 h1:IeQXZAiQcpL9mgcAe1Nu6cX9LLw6ExEHKjN0VQdvPDY=
@@ -82,6 +87,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c h1:ncq/mPwQF4JjgDlrVEn3C11VoGHZN7m8qihwgMEtzYw=
 github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c/go.mod h1:OmDBASR4679mdNQnz2pUhc2G8CO2JrUAVFDRBDP/hJE=
+github.com/rogpeppe/go-internal v1.8.1 h1:geMPLpDpQOgVyCg5z5GoRwLHepNdb71NXb67XFkP+Eg=
+github.com/rogpeppe/go-internal v1.8.1/go.mod h1:JeRgkft04UBgHMgCIwADu4Pn6Mtm5d4nPKWu0nJ5d+o=
 github.com/shirou/gopsutil/v3 v3.23.12 h1:z90NtUkp3bMtmICZKpC4+WaknU1eXtp5vtbQ11DgpE4=
 github.com/shirou/gopsutil/v3 v3.23.12/go.mod h1:1FrWgea594Jp7qmjHUUPlJDTPgcsb9mGnXDxavtikzM=
 github.com/shoenig/go-m1cpu v0.1.6 h1:nxdKQNcEB6vzgA2E2bvzKIYRuNj7XNJ4S/aRSwKzFtM=
@@ -180,6 +187,8 @@ google.golang.org/grpc v1.64.1/go.mod h1:hiQF4LFZelK2WKaP6W0L92zGHtiQdZxk8CrSdvy
 google.golang.org/protobuf v1.33.0 h1:uNO2rsAINq/JlFpSdYEKIZ0uKD/R9cpdv0T+yoGwGmI=
 google.golang.org/protobuf v1.33.0/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/modules/mongodb/go.mod
+++ b/modules/mongodb/go.mod
@@ -3,7 +3,8 @@ module github.com/testcontainers/testcontainers-go/modules/mongodb
 go 1.22
 
 require (
-	github.com/testcontainers/testcontainers-go v0.33.0
+	github.com/stretchr/testify v1.9.0
+	github.com/testcontainers/testcontainers-go v0.32.0
 	go.mongodb.org/mongo-driver v1.13.1
 )
 
@@ -16,6 +17,7 @@ require (
 	github.com/containerd/log v0.1.0 // indirect
 	github.com/containerd/platforms v0.2.1 // indirect
 	github.com/cpuguy83/dockercfg v0.3.1 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/distribution/reference v0.6.0 // indirect
 	github.com/docker/docker v27.1.1+incompatible // indirect
 	github.com/docker/go-connections v0.5.0 // indirect
@@ -28,6 +30,7 @@ require (
 	github.com/golang/snappy v0.0.1 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/klauspost/compress v1.17.4 // indirect
+	github.com/kr/text v0.2.0 // indirect
 	github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 // indirect
 	github.com/magiconair/properties v1.8.7 // indirect
 	github.com/moby/docker-image-spec v1.3.1 // indirect
@@ -40,6 +43,7 @@ require (
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c // indirect
 	github.com/shirou/gopsutil/v3 v3.23.12 // indirect
 	github.com/shoenig/go-m1cpu v0.1.6 // indirect
@@ -62,6 +66,7 @@ require (
 	golang.org/x/text v0.16.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20240318140521-94a12d6c2237 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240318140521-94a12d6c2237 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
 replace github.com/testcontainers/testcontainers-go => ../..

--- a/modules/mongodb/go.sum
+++ b/modules/mongodb/go.sum
@@ -16,6 +16,7 @@ github.com/containerd/platforms v0.2.1 h1:zvwtM3rz2YHPQsF2CHYM8+KtB5dvhISiXh5ZpS
 github.com/containerd/platforms v0.2.1/go.mod h1:XHCb+2/hzowdiut9rkudds9bE5yJ7npe7dG/wG+uFPw=
 github.com/cpuguy83/dockercfg v0.3.1 h1:/FpZ+JaygUR/lZP2NlFI2DVfrOEMAIKP5wWEJdoYe9E=
 github.com/cpuguy83/dockercfg v0.3.1/go.mod h1:sugsbF4//dDlL/i+S+rtpIWp+5h0BHJHfjj5/jFyUJc=
+github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.18 h1:n56/Zwd5o6whRC5PMGretI4IdRLlmBXYNjScPaBgsbY=
 github.com/creack/pty v1.1.18/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -56,6 +57,10 @@ github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+o
 github.com/klauspost/compress v1.13.6/go.mod h1:/3/Vjq9QcHkK5uEr5lBEmyoZ1iFhe47etQ6QUkpK6sk=
 github.com/klauspost/compress v1.17.4 h1:Ej5ixsIri7BrIjBkRZLTo6ghwrEtHFk7ijlczPW4fZ4=
 github.com/klauspost/compress v1.17.4/go.mod h1:/dCuZOvVtNoHsyb+cuJD3itjs3NbnF6KH9zAO4BDxPM=
+github.com/kr/pretty v0.3.0 h1:WgNl7dwNpEZ6jJ9k1snq4pZsg7DOEN8hP9Xw0Tsjwk0=
+github.com/kr/pretty v0.3.0/go.mod h1:640gp4NfQd8pI5XOwp5fnNeVWj67G7CFk/SaSQn7NBk=
+github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
+github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 h1:6E+4a0GO5zZEnZ81pIr0yLvtUWk2if982qA3F3QD6H4=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0/go.mod h1:zJYVVT2jmtg6P3p1VtQj7WsuWi/y4VnjVBn7F8KPB3I=
 github.com/magiconair/properties v1.8.7 h1:IeQXZAiQcpL9mgcAe1Nu6cX9LLw6ExEHKjN0VQdvPDY=
@@ -84,6 +89,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c h1:ncq/mPwQF4JjgDlrVEn3C11VoGHZN7m8qihwgMEtzYw=
 github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c/go.mod h1:OmDBASR4679mdNQnz2pUhc2G8CO2JrUAVFDRBDP/hJE=
+github.com/rogpeppe/go-internal v1.8.1 h1:geMPLpDpQOgVyCg5z5GoRwLHepNdb71NXb67XFkP+Eg=
+github.com/rogpeppe/go-internal v1.8.1/go.mod h1:JeRgkft04UBgHMgCIwADu4Pn6Mtm5d4nPKWu0nJ5d+o=
 github.com/shirou/gopsutil/v3 v3.23.12 h1:z90NtUkp3bMtmICZKpC4+WaknU1eXtp5vtbQ11DgpE4=
 github.com/shirou/gopsutil/v3 v3.23.12/go.mod h1:1FrWgea594Jp7qmjHUUPlJDTPgcsb9mGnXDxavtikzM=
 github.com/shoenig/go-m1cpu v0.1.6 h1:nxdKQNcEB6vzgA2E2bvzKIYRuNj7XNJ4S/aRSwKzFtM=
@@ -212,6 +219,8 @@ google.golang.org/grpc v1.64.1/go.mod h1:hiQF4LFZelK2WKaP6W0L92zGHtiQdZxk8CrSdvy
 google.golang.org/protobuf v1.33.0 h1:uNO2rsAINq/JlFpSdYEKIZ0uKD/R9cpdv0T+yoGwGmI=
 google.golang.org/protobuf v1.33.0/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/modules/mongodb/mongodb.go
+++ b/modules/mongodb/mongodb.go
@@ -50,14 +50,16 @@ func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustom
 	}
 
 	container, err := testcontainers.GenericContainer(ctx, genericContainerReq)
-	if err != nil {
-		return nil, err
+	var c *MongoDBContainer
+	if container != nil {
+		c = &MongoDBContainer{Container: container, username: username, password: password}
 	}
 
-	if username != "" && password != "" {
-		return &MongoDBContainer{Container: container, username: username, password: password}, nil
+	if err != nil {
+		return c, fmt.Errorf("generic container: %w", err)
 	}
-	return &MongoDBContainer{Container: container}, nil
+
+	return c, nil
 }
 
 // WithUsername sets the initial username to be created when the container starts

--- a/modules/mongodb/mongodb_test.go
+++ b/modules/mongodb/mongodb_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
 
@@ -57,37 +58,21 @@ func TestMongoDB(t *testing.T) {
 			ctx := context.Background()
 
 			mongodbContainer, err := mongodb.Run(ctx, tc.img, tc.opts...)
-			if err != nil {
-				tt.Fatalf("failed to start container: %s", err)
-			}
-
-			defer func() {
-				if err := mongodbContainer.Terminate(ctx); err != nil {
-					tt.Fatalf("failed to terminate container: %s", err)
-				}
-			}()
+			testcontainers.CleanupContainer(t, mongodbContainer)
+			require.NoError(tt, err)
 
 			endpoint, err := mongodbContainer.ConnectionString(ctx)
-			if err != nil {
-				tt.Fatalf("failed to get connection string: %s", err)
-			}
+			require.NoError(tt, err)
 
 			// Force direct connection to the container to avoid the replica set
 			// connection string that is returned by the container itself when
 			// using the replica set option.
 			mongoClient, err := mongo.Connect(ctx, options.Client().ApplyURI(endpoint+"/?connect=direct"))
-			if err != nil {
-				tt.Fatalf("failed to connect to MongoDB: %s", err)
-			}
+			require.NoError(tt, err)
 
 			err = mongoClient.Ping(ctx, nil)
-			if err != nil {
-				tt.Fatalf("failed to ping MongoDB: %s", err)
-			}
-
-			if mongoClient.Database("test").Name() != "test" {
-				tt.Fatalf("failed to connect to the correct database")
-			}
+			require.NoError(tt, err)
+			require.Equal(t, "test", mongoClient.Database("test").Name())
 		})
 	}
 }

--- a/modules/mssql/examples_test.go
+++ b/modules/mssql/examples_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 
+	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/modules/mssql"
 )
 
@@ -19,21 +20,21 @@ func ExampleRun() {
 		mssql.WithAcceptEULA(),
 		mssql.WithPassword(password),
 	)
-	if err != nil {
-		log.Fatalf("failed to start container: %s", err)
-	}
-
-	// Clean up the container
 	defer func() {
-		if err := mssqlContainer.Terminate(ctx); err != nil {
-			log.Fatalf("failed to terminate container: %s", err)
+		if err := testcontainers.TerminateContainer(mssqlContainer); err != nil {
+			log.Printf("failed to terminate container: %s", err)
 		}
 	}()
+	if err != nil {
+		log.Printf("failed to start container: %s", err)
+		return
+	}
 	// }
 
 	state, err := mssqlContainer.State(ctx)
 	if err != nil {
-		log.Fatalf("failed to get container state: %s", err) // nolint:gocritic
+		log.Printf("failed to get container state: %s", err)
+		return
 	}
 
 	fmt.Println(state.Running)

--- a/modules/mssql/go.mod
+++ b/modules/mssql/go.mod
@@ -4,7 +4,8 @@ go 1.22
 
 require (
 	github.com/microsoft/go-mssqldb v1.7.0
-	github.com/testcontainers/testcontainers-go v0.33.0
+	github.com/stretchr/testify v1.9.0
+	github.com/testcontainers/testcontainers-go v0.32.0
 )
 
 require (
@@ -16,6 +17,7 @@ require (
 	github.com/containerd/log v0.1.0 // indirect
 	github.com/containerd/platforms v0.2.1 // indirect
 	github.com/cpuguy83/dockercfg v0.3.1 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/distribution/reference v0.6.0 // indirect
 	github.com/docker/docker v27.1.1+incompatible // indirect
 	github.com/docker/go-connections v0.5.0 // indirect
@@ -29,6 +31,7 @@ require (
 	github.com/golang-sql/sqlexp v0.1.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/klauspost/compress v1.17.4 // indirect
+	github.com/kr/text v0.2.0 // indirect
 	github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 // indirect
 	github.com/magiconair/properties v1.8.7 // indirect
 	github.com/moby/docker-image-spec v1.3.1 // indirect
@@ -40,6 +43,7 @@ require (
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c // indirect
 	github.com/shirou/gopsutil/v3 v3.23.12 // indirect
 	github.com/shoenig/go-m1cpu v0.1.6 // indirect
@@ -57,6 +61,7 @@ require (
 	golang.org/x/text v0.16.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20240318140521-94a12d6c2237 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240318140521-94a12d6c2237 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
 replace github.com/testcontainers/testcontainers-go => ../..

--- a/modules/mssql/go.sum
+++ b/modules/mssql/go.sum
@@ -28,6 +28,7 @@ github.com/containerd/platforms v0.2.1 h1:zvwtM3rz2YHPQsF2CHYM8+KtB5dvhISiXh5ZpS
 github.com/containerd/platforms v0.2.1/go.mod h1:XHCb+2/hzowdiut9rkudds9bE5yJ7npe7dG/wG+uFPw=
 github.com/cpuguy83/dockercfg v0.3.1 h1:/FpZ+JaygUR/lZP2NlFI2DVfrOEMAIKP5wWEJdoYe9E=
 github.com/cpuguy83/dockercfg v0.3.1/go.mod h1:sugsbF4//dDlL/i+S+rtpIWp+5h0BHJHfjj5/jFyUJc=
+github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.18 h1:n56/Zwd5o6whRC5PMGretI4IdRLlmBXYNjScPaBgsbY=
 github.com/creack/pty v1.1.18/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -70,6 +71,10 @@ github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/compress v1.17.4 h1:Ej5ixsIri7BrIjBkRZLTo6ghwrEtHFk7ijlczPW4fZ4=
 github.com/klauspost/compress v1.17.4/go.mod h1:/dCuZOvVtNoHsyb+cuJD3itjs3NbnF6KH9zAO4BDxPM=
+github.com/kr/pretty v0.3.0 h1:WgNl7dwNpEZ6jJ9k1snq4pZsg7DOEN8hP9Xw0Tsjwk0=
+github.com/kr/pretty v0.3.0/go.mod h1:640gp4NfQd8pI5XOwp5fnNeVWj67G7CFk/SaSQn7NBk=
+github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
+github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 h1:6E+4a0GO5zZEnZ81pIr0yLvtUWk2if982qA3F3QD6H4=
@@ -102,6 +107,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c h1:ncq/mPwQF4JjgDlrVEn3C11VoGHZN7m8qihwgMEtzYw=
 github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c/go.mod h1:OmDBASR4679mdNQnz2pUhc2G8CO2JrUAVFDRBDP/hJE=
+github.com/rogpeppe/go-internal v1.8.1 h1:geMPLpDpQOgVyCg5z5GoRwLHepNdb71NXb67XFkP+Eg=
+github.com/rogpeppe/go-internal v1.8.1/go.mod h1:JeRgkft04UBgHMgCIwADu4Pn6Mtm5d4nPKWu0nJ5d+o=
 github.com/shirou/gopsutil/v3 v3.23.12 h1:z90NtUkp3bMtmICZKpC4+WaknU1eXtp5vtbQ11DgpE4=
 github.com/shirou/gopsutil/v3 v3.23.12/go.mod h1:1FrWgea594Jp7qmjHUUPlJDTPgcsb9mGnXDxavtikzM=
 github.com/shoenig/go-m1cpu v0.1.6 h1:nxdKQNcEB6vzgA2E2bvzKIYRuNj7XNJ4S/aRSwKzFtM=
@@ -198,6 +205,8 @@ google.golang.org/grpc v1.64.1/go.mod h1:hiQF4LFZelK2WKaP6W0L92zGHtiQdZxk8CrSdvy
 google.golang.org/protobuf v1.33.0 h1:uNO2rsAINq/JlFpSdYEKIZ0uKD/R9cpdv0T+yoGwGmI=
 google.golang.org/protobuf v1.33.0/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/modules/mssql/mssql.go
+++ b/modules/mssql/mssql.go
@@ -70,14 +70,16 @@ func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustom
 	}
 
 	container, err := testcontainers.GenericContainer(ctx, genericContainerReq)
-	if err != nil {
-		return nil, err
+	var c *MSSQLServerContainer
+	if container != nil {
+		c = &MSSQLServerContainer{Container: container, password: req.Env["MSSQL_SA_PASSWORD"], username: defaultUsername}
 	}
 
-	username := defaultUsername
-	password := req.Env["MSSQL_SA_PASSWORD"]
+	if err != nil {
+		return c, fmt.Errorf("generic container: %w", err)
+	}
 
-	return &MSSQLServerContainer{Container: container, password: password, username: username}, nil
+	return c, nil
 }
 
 func (c *MSSQLServerContainer) ConnectionString(ctx context.Context, args ...string) (string, error) {

--- a/modules/mssql/mssql_test.go
+++ b/modules/mssql/mssql_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	_ "github.com/microsoft/go-mssqldb"
+	"github.com/stretchr/testify/require"
 
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/modules/mssql"
@@ -15,63 +16,45 @@ import (
 func TestMSSQLServer(t *testing.T) {
 	ctx := context.Background()
 
-	container, err := mssql.Run(ctx,
+	ctr, err := mssql.Run(ctx,
 		"mcr.microsoft.com/mssql/server:2022-CU10-ubuntu-22.04",
 		mssql.WithAcceptEULA(),
 	)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// Clean up the container after the test is complete
-	t.Cleanup(func() {
-		if err := container.Terminate(ctx); err != nil {
-			t.Fatalf("failed to terminate container: %s", err)
-		}
-	})
+	testcontainers.CleanupContainer(t, ctr)
+	require.NoError(t, err)
 
 	// perform assertions
-	connectionString, err := container.ConnectionString(ctx)
-	if err != nil {
-		t.Fatal(err)
-	}
+	connectionString, err := ctr.ConnectionString(ctx)
+	require.NoError(t, err)
 
 	db, err := sql.Open("sqlserver", connectionString)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	defer db.Close()
 
-	if err = db.Ping(); err != nil {
-		t.Errorf("error pinging db: %+v\n", err)
-	}
+	err = db.Ping()
+	require.NoError(t, err)
 
 	_, err = db.Exec("CREATE TABLE a_table ( " +
 		" [col_1] NVARCHAR(128) NOT NULL, " +
 		" [col_2] NVARCHAR(128) NOT NULL, " +
 		" PRIMARY KEY ([col_1], [col_2]) " +
 		")")
-	if err != nil {
-		t.Errorf("error creating table: %+v\n", err)
-	}
+	require.NoError(t, err)
 }
 
 func TestMSSQLServerWithMissingEulaOption(t *testing.T) {
 	ctx := context.Background()
 
-	container, err := mssql.Run(ctx,
+	ctr, err := mssql.Run(ctx,
 		"mcr.microsoft.com/mssql/server:2022-CU10-ubuntu-22.04",
 		testcontainers.WithWaitStrategy(
 			wait.ForLog("The SQL Server End-User License Agreement (EULA) must be accepted")),
 	)
-	if err != nil {
-		t.Fatalf("Expected a log to confirm missing EULA but got error: %s", err)
-	}
+	testcontainers.CleanupContainer(t, ctr)
+	require.NoError(t, err)
 
-	state, err := container.State(ctx)
-	if err != nil {
-		t.Fatalf("failed to get container state: %s", err)
-	}
+	state, err := ctr.State(ctx)
+	require.NoError(t, err)
 
 	if !state.Running {
 		t.Log("Success: Confirmed proper handling of missing EULA, so container is not running.")
@@ -81,140 +64,89 @@ func TestMSSQLServerWithMissingEulaOption(t *testing.T) {
 func TestMSSQLServerWithConnectionStringParameters(t *testing.T) {
 	ctx := context.Background()
 
-	container, err := mssql.Run(ctx,
+	ctr, err := mssql.Run(ctx,
 		"mcr.microsoft.com/mssql/server:2022-CU10-ubuntu-22.04",
 		mssql.WithAcceptEULA(),
 	)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// Clean up the container after the test is complete
-	t.Cleanup(func() {
-		if err := container.Terminate(ctx); err != nil {
-			t.Fatalf("failed to terminate container: %s", err)
-		}
-	})
+	testcontainers.CleanupContainer(t, ctr)
+	require.NoError(t, err)
 
 	// perform assertions
-	connectionString, err := container.ConnectionString(ctx, "encrypt=false", "TrustServerCertificate=true")
-	if err != nil {
-		t.Fatal(err)
-	}
+	connectionString, err := ctr.ConnectionString(ctx, "encrypt=false", "TrustServerCertificate=true")
+	require.NoError(t, err)
 
 	db, err := sql.Open("sqlserver", connectionString)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
+
 	defer db.Close()
 
-	if err = db.Ping(); err != nil {
-		t.Errorf("error pinging db: %+v\n", err)
-	}
+	err = db.Ping()
+	require.NoError(t, err)
 
 	_, err = db.Exec("CREATE TABLE a_table ( " +
 		" [col_1] NVARCHAR(128) NOT NULL, " +
 		" [col_2] NVARCHAR(128) NOT NULL, " +
 		" PRIMARY KEY ([col_1], [col_2]) " +
 		")")
-	if err != nil {
-		t.Errorf("error creating table: %+v\n", err)
-	}
+	require.NoError(t, err)
 }
 
 func TestMSSQLServerWithCustomStrongPassword(t *testing.T) {
 	ctx := context.Background()
 
-	container, err := mssql.Run(ctx,
+	ctr, err := mssql.Run(ctx,
 		"mcr.microsoft.com/mssql/server:2022-CU10-ubuntu-22.04",
 		mssql.WithAcceptEULA(),
 		mssql.WithPassword("Strong@Passw0rd"),
 	)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// Clean up the container after the test is complete
-	t.Cleanup(func() {
-		if err := container.Terminate(ctx); err != nil {
-			t.Fatalf("failed to terminate container: %s", err)
-		}
-	})
+	testcontainers.CleanupContainer(t, ctr)
+	require.NoError(t, err)
 
 	// perform assertions
-	connectionString, err := container.ConnectionString(ctx)
-	if err != nil {
-		t.Fatal(err)
-	}
+	connectionString, err := ctr.ConnectionString(ctx)
+	require.NoError(t, err)
 
 	db, err := sql.Open("sqlserver", connectionString)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	defer db.Close()
 
-	if err = db.Ping(); err != nil {
-		t.Errorf("error pinging db: %+v\n", err)
-	}
+	err = db.Ping()
+	require.NoError(t, err)
 }
 
 // tests that a weak password is not accepted by the container due to Microsoft's password strength policy
 func TestMSSQLServerWithInvalidPassword(t *testing.T) {
 	ctx := context.Background()
 
-	container, err := mssql.Run(ctx,
+	ctr, err := mssql.Run(ctx,
 		"mcr.microsoft.com/mssql/server:2022-CU10-ubuntu-22.04",
 		testcontainers.WithWaitStrategy(
 			wait.ForLog("Password validation failed")),
 		mssql.WithAcceptEULA(),
 		mssql.WithPassword("weakPassword"),
 	)
-
-	if err == nil {
-		t.Log("Success: Received invalid password validation docker log.")
-	} else {
-		t.Fatalf("Expected a password validation log but got error: %s", err)
-	}
-
-	// Clean up the container after the test is complete
-	t.Cleanup(func() {
-		if err := container.Terminate(ctx); err != nil {
-			t.Fatalf("failed to terminate container: %s", err)
-		}
-	})
+	testcontainers.CleanupContainer(t, ctr)
+	require.NoError(t, err)
 }
 
 func TestMSSQLServerWithAlternativeImage(t *testing.T) {
 	ctx := context.Background()
 
-	container, err := mssql.Run(ctx,
+	ctr, err := mssql.Run(ctx,
 		"mcr.microsoft.com/mssql/server:2022-RTM-GDR1-ubuntu-20.04",
 		mssql.WithAcceptEULA(),
 	)
-	if err != nil {
-		t.Fatalf("Failed to create the container with alternative image: %s", err)
-	}
-
-	// Clean up the container after the test is complete
-	t.Cleanup(func() {
-		if err := container.Terminate(ctx); err != nil {
-			t.Fatalf("failed to terminate container: %s", err)
-		}
-	})
+	testcontainers.CleanupContainer(t, ctr)
+	require.NoError(t, err)
 
 	// perform assertions
-	connectionString, err := container.ConnectionString(ctx)
-	if err != nil {
-		t.Fatal(err)
-	}
+	connectionString, err := ctr.ConnectionString(ctx)
+	require.NoError(t, err)
 
 	db, err := sql.Open("sqlserver", connectionString)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	defer db.Close()
 
-	if err = db.Ping(); err != nil {
-		t.Errorf("error pinging db: %+v\n", err)
-	}
+	err = db.Ping()
+	require.NoError(t, err)
 }

--- a/modules/mysql/go.mod
+++ b/modules/mysql/go.mod
@@ -4,7 +4,8 @@ go 1.22
 
 require (
 	github.com/go-sql-driver/mysql v1.7.1
-	github.com/testcontainers/testcontainers-go v0.33.0
+	github.com/stretchr/testify v1.9.0
+	github.com/testcontainers/testcontainers-go v0.32.0
 
 )
 
@@ -17,6 +18,7 @@ require (
 	github.com/containerd/log v0.1.0 // indirect
 	github.com/containerd/platforms v0.2.1 // indirect
 	github.com/cpuguy83/dockercfg v0.3.1 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/distribution/reference v0.6.0 // indirect
 	github.com/docker/docker v27.1.1+incompatible // indirect
 	github.com/docker/go-connections v0.5.0 // indirect
@@ -28,6 +30,7 @@ require (
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/klauspost/compress v1.17.4 // indirect
+	github.com/kr/text v0.2.0 // indirect
 	github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 // indirect
 	github.com/magiconair/properties v1.8.7 // indirect
 	github.com/moby/docker-image-spec v1.3.1 // indirect
@@ -39,6 +42,7 @@ require (
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c // indirect
 	github.com/shirou/gopsutil/v3 v3.23.12 // indirect
 	github.com/shoenig/go-m1cpu v0.1.6 // indirect
@@ -55,6 +59,7 @@ require (
 	golang.org/x/sys v0.21.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20240318140521-94a12d6c2237 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240318140521-94a12d6c2237 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
 replace github.com/testcontainers/testcontainers-go => ../..

--- a/modules/mysql/go.sum
+++ b/modules/mysql/go.sum
@@ -16,6 +16,7 @@ github.com/containerd/platforms v0.2.1 h1:zvwtM3rz2YHPQsF2CHYM8+KtB5dvhISiXh5ZpS
 github.com/containerd/platforms v0.2.1/go.mod h1:XHCb+2/hzowdiut9rkudds9bE5yJ7npe7dG/wG+uFPw=
 github.com/cpuguy83/dockercfg v0.3.1 h1:/FpZ+JaygUR/lZP2NlFI2DVfrOEMAIKP5wWEJdoYe9E=
 github.com/cpuguy83/dockercfg v0.3.1/go.mod h1:sugsbF4//dDlL/i+S+rtpIWp+5h0BHJHfjj5/jFyUJc=
+github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.18 h1:n56/Zwd5o6whRC5PMGretI4IdRLlmBXYNjScPaBgsbY=
 github.com/creack/pty v1.1.18/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -54,6 +55,10 @@ github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/compress v1.17.4 h1:Ej5ixsIri7BrIjBkRZLTo6ghwrEtHFk7ijlczPW4fZ4=
 github.com/klauspost/compress v1.17.4/go.mod h1:/dCuZOvVtNoHsyb+cuJD3itjs3NbnF6KH9zAO4BDxPM=
+github.com/kr/pretty v0.3.0 h1:WgNl7dwNpEZ6jJ9k1snq4pZsg7DOEN8hP9Xw0Tsjwk0=
+github.com/kr/pretty v0.3.0/go.mod h1:640gp4NfQd8pI5XOwp5fnNeVWj67G7CFk/SaSQn7NBk=
+github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
+github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 h1:6E+4a0GO5zZEnZ81pIr0yLvtUWk2if982qA3F3QD6H4=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0/go.mod h1:zJYVVT2jmtg6P3p1VtQj7WsuWi/y4VnjVBn7F8KPB3I=
 github.com/magiconair/properties v1.8.7 h1:IeQXZAiQcpL9mgcAe1Nu6cX9LLw6ExEHKjN0VQdvPDY=
@@ -80,6 +85,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c h1:ncq/mPwQF4JjgDlrVEn3C11VoGHZN7m8qihwgMEtzYw=
 github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c/go.mod h1:OmDBASR4679mdNQnz2pUhc2G8CO2JrUAVFDRBDP/hJE=
+github.com/rogpeppe/go-internal v1.8.1 h1:geMPLpDpQOgVyCg5z5GoRwLHepNdb71NXb67XFkP+Eg=
+github.com/rogpeppe/go-internal v1.8.1/go.mod h1:JeRgkft04UBgHMgCIwADu4Pn6Mtm5d4nPKWu0nJ5d+o=
 github.com/shirou/gopsutil/v3 v3.23.12 h1:z90NtUkp3bMtmICZKpC4+WaknU1eXtp5vtbQ11DgpE4=
 github.com/shirou/gopsutil/v3 v3.23.12/go.mod h1:1FrWgea594Jp7qmjHUUPlJDTPgcsb9mGnXDxavtikzM=
 github.com/shoenig/go-m1cpu v0.1.6 h1:nxdKQNcEB6vzgA2E2bvzKIYRuNj7XNJ4S/aRSwKzFtM=
@@ -176,6 +183,8 @@ google.golang.org/grpc v1.64.1/go.mod h1:hiQF4LFZelK2WKaP6W0L92zGHtiQdZxk8CrSdvy
 google.golang.org/protobuf v1.33.0 h1:uNO2rsAINq/JlFpSdYEKIZ0uKD/R9cpdv0T+yoGwGmI=
 google.golang.org/protobuf v1.33.0/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/modules/mysql/mysql.go
+++ b/modules/mysql/mysql.go
@@ -86,13 +86,21 @@ func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustom
 	}
 
 	container, err := testcontainers.GenericContainer(ctx, genericContainerReq)
-	if err != nil {
-		return nil, err
+	var c *MySQLContainer
+	if container != nil {
+		c = &MySQLContainer{
+			Container: container,
+			password:  password,
+			username:  username,
+			database:  req.Env["MYSQL_DATABASE"],
+		}
 	}
 
-	database := req.Env["MYSQL_DATABASE"]
+	if err != nil {
+		return c, fmt.Errorf("generic container: %w", err)
+	}
 
-	return &MySQLContainer{container, username, password, database}, nil
+	return c, nil
 }
 
 // MustConnectionString panics if the address cannot be determined.

--- a/modules/mysql/mysql_test.go
+++ b/modules/mysql/mysql_test.go
@@ -8,151 +8,110 @@ import (
 
 	// Import mysql into the scope of this package (required)
 	_ "github.com/go-sql-driver/mysql"
+	"github.com/stretchr/testify/require"
 
+	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/modules/mysql"
 )
 
 func TestMySQL(t *testing.T) {
 	ctx := context.Background()
 
-	container, err := mysql.Run(ctx, "mysql:8.0.36")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// Clean up the container after the test is complete
-	t.Cleanup(func() {
-		if err := container.Terminate(ctx); err != nil {
-			t.Fatalf("failed to terminate container: %s", err)
-		}
-	})
+	ctr, err := mysql.Run(ctx, "mysql:8.0.36")
+	testcontainers.CleanupContainer(t, ctr)
+	require.NoError(t, err)
 
 	// perform assertions
 	// connectionString {
-	connectionString, err := container.ConnectionString(ctx, "tls=skip-verify")
+	connectionString, err := ctr.ConnectionString(ctx, "tls=skip-verify")
 	// }
-	if err != nil {
-		t.Fatal(err)
-	}
-	mustConnectionString := container.MustConnectionString(ctx, "tls=skip-verify")
-	if mustConnectionString != connectionString {
-		t.Errorf("ConnectionString was not equal to MustConnectionString")
-	}
+	require.NoError(t, err)
+
+	mustConnectionString := ctr.MustConnectionString(ctx, "tls=skip-verify")
+	require.Equal(t, connectionString, mustConnectionString)
 
 	db, err := sql.Open("mysql", connectionString)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	defer db.Close()
 
-	if err = db.Ping(); err != nil {
-		t.Errorf("error pinging db: %+v\n", err)
-	}
+	err = db.Ping()
+	require.NoError(t, err)
+
 	_, err = db.Exec("CREATE TABLE IF NOT EXISTS a_table ( \n" +
 		" `col_1` VARCHAR(128) NOT NULL, \n" +
 		" `col_2` VARCHAR(128) NOT NULL, \n" +
 		" PRIMARY KEY (`col_1`, `col_2`) \n" +
 		")")
-	if err != nil {
-		t.Errorf("error creating table: %+v\n", err)
-	}
+	require.NoError(t, err)
 }
 
 func TestMySQLWithNonRootUserAndEmptyPassword(t *testing.T) {
 	ctx := context.Background()
 
-	_, err := mysql.Run(ctx,
+	ctr, err := mysql.Run(ctx,
 		"mysql:8.0.36",
 		mysql.WithDatabase("foo"),
 		mysql.WithUsername("test"),
 		mysql.WithPassword(""))
-	if err.Error() != "empty password can be used only with the root user" {
-		t.Fatal(err)
-	}
+	testcontainers.CleanupContainer(t, ctr)
+	require.EqualError(t, err, "empty password can be used only with the root user")
 }
 
 func TestMySQLWithRootUserAndEmptyPassword(t *testing.T) {
 	ctx := context.Background()
 
-	container, err := mysql.Run(ctx,
+	ctr, err := mysql.Run(ctx,
 		"mysql:8.0.36",
 		mysql.WithDatabase("foo"),
 		mysql.WithUsername("root"),
 		mysql.WithPassword(""))
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// Clean up the container after the test is complete
-	t.Cleanup(func() {
-		if err := container.Terminate(ctx); err != nil {
-			t.Fatalf("failed to terminate container: %s", err)
-		}
-	})
+	testcontainers.CleanupContainer(t, ctr)
+	require.NoError(t, err)
 
 	// perform assertions
-	connectionString, _ := container.ConnectionString(ctx)
+	connectionString, _ := ctr.ConnectionString(ctx)
 
 	db, err := sql.Open("mysql", connectionString)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	defer db.Close()
 
-	if err = db.Ping(); err != nil {
-		t.Errorf("error pinging db: %+v\n", err)
-	}
+	err = db.Ping()
+	require.NoError(t, err)
+
 	_, err = db.Exec("CREATE TABLE IF NOT EXISTS a_table ( \n" +
 		" `col_1` VARCHAR(128) NOT NULL, \n" +
 		" `col_2` VARCHAR(128) NOT NULL, \n" +
 		" PRIMARY KEY (`col_1`, `col_2`) \n" +
 		")")
-	if err != nil {
-		t.Errorf("error creating table: %+v\n", err)
-	}
+	require.NoError(t, err)
 }
 
 func TestMySQLWithScripts(t *testing.T) {
 	ctx := context.Background()
 
-	container, err := mysql.Run(ctx,
+	ctr, err := mysql.Run(ctx,
 		"mysql:8.0.36",
 		mysql.WithScripts(filepath.Join("testdata", "schema.sql")))
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// Clean up the container after the test is complete
-	t.Cleanup(func() {
-		if err := container.Terminate(ctx); err != nil {
-			t.Fatalf("failed to terminate container: %s", err)
-		}
-	})
+	testcontainers.CleanupContainer(t, ctr)
+	require.NoError(t, err)
 
 	// perform assertions
-	connectionString, _ := container.ConnectionString(ctx)
+	connectionString, _ := ctr.ConnectionString(ctx)
 
 	db, err := sql.Open("mysql", connectionString)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	defer db.Close()
 
-	if err = db.Ping(); err != nil {
-		t.Errorf("error pinging db: %+v\n", err)
-	}
+	err = db.Ping()
+	require.NoError(t, err)
+
 	stmt, err := db.Prepare("SELECT name from profile")
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	defer stmt.Close()
+
 	row := stmt.QueryRow()
 	var name string
 	err = row.Scan(&name)
-	if err != nil {
-		t.Errorf("error fetching data")
-	}
-	if name != "profile 1" {
-		t.Fatal("The expected record was not found in the database.")
-	}
+	require.NoError(t, err)
+	require.Equal(t, "profile 1", name)
 }

--- a/modules/nats/examples_test.go
+++ b/modules/nats/examples_test.go
@@ -8,6 +8,7 @@ import (
 
 	natsgo "github.com/nats-io/nats.go"
 
+	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/modules/nats"
 	"github.com/testcontainers/testcontainers-go/network"
 )
@@ -17,21 +18,21 @@ func ExampleRun() {
 	ctx := context.Background()
 
 	natsContainer, err := nats.Run(ctx, "nats:2.9")
-	if err != nil {
-		log.Fatalf("failed to start container: %s", err)
-	}
-
-	// Clean up the container
 	defer func() {
-		if err := natsContainer.Terminate(ctx); err != nil {
-			log.Fatalf("failed to terminate container: %s", err)
+		if err := testcontainers.TerminateContainer(natsContainer); err != nil {
+			log.Printf("failed to terminate container: %s", err)
 		}
 	}()
+	if err != nil {
+		log.Printf("failed to start container: %s", err)
+		return
+	}
 	// }
 
 	state, err := natsContainer.State(ctx)
 	if err != nil {
-		log.Fatalf("failed to get container state: %s", err) // nolint:gocritic
+		log.Printf("failed to get container state: %s", err)
+		return
 	}
 
 	fmt.Println(state.Running)
@@ -44,26 +45,27 @@ func ExampleRun_connectWithCredentials() {
 	// natsConnect {
 	ctx := context.Background()
 
-	container, err := nats.Run(ctx, "nats:2.9", nats.WithUsername("foo"), nats.WithPassword("bar"))
-	if err != nil {
-		log.Fatalf("failed to start container: %s", err)
-	}
-
-	// Clean up the container
+	ctr, err := nats.Run(ctx, "nats:2.9", nats.WithUsername("foo"), nats.WithPassword("bar"))
 	defer func() {
-		if err := container.Terminate(ctx); err != nil {
-			log.Fatalf("failed to terminate container: %s", err)
+		if err := testcontainers.TerminateContainer(ctr); err != nil {
+			log.Printf("failed to terminate container: %s", err)
 		}
 	}()
-
-	uri, err := container.ConnectionString(ctx)
 	if err != nil {
-		log.Fatalf("failed to get connection string: %s", err) // nolint:gocritic
+		log.Printf("failed to start container: %s", err)
+		return
 	}
 
-	nc, err := natsgo.Connect(uri, natsgo.UserInfo(container.User, container.Password))
+	uri, err := ctr.ConnectionString(ctx)
 	if err != nil {
-		log.Fatalf("failed to connect to NATS: %s", err)
+		log.Printf("failed to get connection string: %s", err)
+		return
+	}
+
+	nc, err := natsgo.Connect(uri, natsgo.UserInfo(ctr.User, ctr.Password))
+	if err != nil {
+		log.Printf("failed to connect to NATS: %s", err)
+		return
 	}
 	defer nc.Close()
 	// }
@@ -79,8 +81,15 @@ func ExampleRun_cluster() {
 
 	nwr, err := network.New(ctx)
 	if err != nil {
-		log.Fatalf("failed to create network: %s", err)
+		log.Printf("failed to create network: %s", err)
+		return
 	}
+
+	defer func() {
+		if err := nwr.Remove(context.Background()); err != nil {
+			log.Printf("failed to remove network: %s", err)
+		}
+	}()
 
 	// withArguments {
 	natsContainer1, err := nats.Run(ctx,
@@ -93,15 +102,15 @@ func ExampleRun_cluster() {
 		nats.WithArgument("http_port", "8222"),
 	)
 	// }
-	if err != nil {
-		log.Fatalf("failed to start container: %s", err)
-	}
-	// Clean up the container
 	defer func() {
-		if err := natsContainer1.Terminate(ctx); err != nil {
-			log.Fatalf("failed to terminate container: %s", err)
+		if err := testcontainers.TerminateContainer(natsContainer1); err != nil {
+			log.Printf("failed to terminate container: %s", err)
 		}
 	}()
+	if err != nil {
+		log.Printf("failed to start container: %s", err)
+		return
+	}
 
 	natsContainer2, err := nats.Run(ctx,
 		"nats:2.9",
@@ -112,15 +121,15 @@ func ExampleRun_cluster() {
 		nats.WithArgument("routes", "nats://nats1:6222,nats://nats2:6222,nats://nats3:6222"),
 		nats.WithArgument("http_port", "8222"),
 	)
-	if err != nil {
-		log.Fatalf("failed to start container: %s", err) // nolint:gocritic
-	}
-	// Clean up the container
 	defer func() {
-		if err := natsContainer2.Terminate(ctx); err != nil {
-			log.Fatalf("failed to terminate container: %s", err)
+		if err := testcontainers.TerminateContainer(natsContainer2); err != nil {
+			log.Printf("failed to terminate container: %s", err)
 		}
 	}()
+	if err != nil {
+		log.Printf("failed to start container: %s", err)
+		return
+	}
 
 	natsContainer3, err := nats.Run(ctx,
 		"nats:2.9",
@@ -131,28 +140,34 @@ func ExampleRun_cluster() {
 		nats.WithArgument("routes", "nats://nats1:6222,nats://nats2:6222,nats://nats3:6222"),
 		nats.WithArgument("http_port", "8222"),
 	)
-	if err != nil {
-		log.Fatalf("failed to start container: %s", err) // nolint:gocritic
-	}
 	defer func() {
-		if err := natsContainer3.Terminate(ctx); err != nil {
-			log.Fatalf("failed to terminate container: %s", err)
+		if err := testcontainers.TerminateContainer(natsContainer3); err != nil {
+			log.Printf("failed to terminate container: %s", err)
 		}
 	}()
+	if err != nil {
+		log.Printf("failed to start container: %s", err)
+		return
+	}
 
 	// cluster URL
 	servers := natsContainer1.MustConnectionString(ctx) + "," + natsContainer2.MustConnectionString(ctx) + "," + natsContainer3.MustConnectionString(ctx)
 
 	nc, err := natsgo.Connect(servers, natsgo.MaxReconnects(5), natsgo.ReconnectWait(2*time.Second))
 	if err != nil {
-		log.Fatalf("connecting to nats container failed:\n\t%v\n", err) // nolint:gocritic
+		log.Printf("connecting to nats container failed:\n\t%v\n", err)
+		return
 	}
+
+	// Close connection
+	defer nc.Close()
 
 	{
 		// Simple Publisher
 		err = nc.Publish("foo", []byte("Hello World"))
 		if err != nil {
-			log.Fatalf("failed to publish message: %s", err) // nolint:gocritic
+			log.Printf("failed to publish message: %s", err)
+			return
 		}
 	}
 
@@ -161,13 +176,15 @@ func ExampleRun_cluster() {
 		ch := make(chan *natsgo.Msg, 64)
 		sub, err := nc.ChanSubscribe("channel", ch)
 		if err != nil {
-			log.Fatalf("failed to subscribe to message: %s", err) // nolint:gocritic
+			log.Printf("failed to subscribe to message: %s", err)
+			return
 		}
 
 		// Request
 		err = nc.Publish("channel", []byte("Hello NATS Cluster!"))
 		if err != nil {
-			log.Fatalf("failed to publish message: %s", err) // nolint:gocritic
+			log.Printf("failed to publish message: %s", err)
+			return
 		}
 
 		msg := <-ch
@@ -175,12 +192,14 @@ func ExampleRun_cluster() {
 
 		err = sub.Unsubscribe()
 		if err != nil {
-			log.Fatalf("failed to unsubscribe: %s", err) // nolint:gocritic
+			log.Printf("failed to unsubscribe: %s", err)
+			return
 		}
 
 		err = sub.Drain()
 		if err != nil {
-			log.Fatalf("failed to drain: %s", err) // nolint:gocritic
+			log.Printf("failed to drain: %s", err)
+			return
 		}
 	}
 
@@ -189,29 +208,34 @@ func ExampleRun_cluster() {
 		sub, err := nc.Subscribe("request", func(m *natsgo.Msg) {
 			err1 := m.Respond([]byte("answer is 42"))
 			if err1 != nil {
-				log.Fatalf("failed to respond to message: %s", err1) // nolint:gocritic
+				log.Printf("failed to respond to message: %s", err1)
+				return
 			}
 		})
 		if err != nil {
-			log.Fatalf("failed to subscribe to message: %s", err) // nolint:gocritic
+			log.Printf("failed to subscribe to message: %s", err)
+			return
 		}
 
 		// Request
 		msg, err := nc.Request("request", []byte("what is the answer?"), 1*time.Second)
 		if err != nil {
-			log.Fatalf("failed to send request: %s", err) // nolint:gocritic
+			log.Printf("failed to send request: %s", err)
+			return
 		}
 
 		fmt.Println(string(msg.Data))
 
 		err = sub.Unsubscribe()
 		if err != nil {
-			log.Fatalf("failed to unsubscribe: %s", err) // nolint:gocritic
+			log.Printf("failed to unsubscribe: %s", err)
+			return
 		}
 
 		err = sub.Drain()
 		if err != nil {
-			log.Fatalf("failed to drain: %s", err) // nolint:gocritic
+			log.Printf("failed to drain: %s", err)
+			return
 		}
 	}
 
@@ -219,11 +243,9 @@ func ExampleRun_cluster() {
 	// Close() not needed if this is called.
 	err = nc.Drain()
 	if err != nil {
-		log.Fatalf("failed to drain connection: %s", err) // nolint:gocritic
+		log.Printf("failed to drain connection: %s", err)
+		return
 	}
-
-	// Close connection
-	nc.Close()
 
 	// Output:
 	// Hello NATS Cluster!

--- a/modules/nats/go.mod
+++ b/modules/nats/go.mod
@@ -4,7 +4,8 @@ go 1.22
 
 require (
 	github.com/nats-io/nats.go v1.33.1
-	github.com/testcontainers/testcontainers-go v0.33.0
+	github.com/stretchr/testify v1.9.0
+	github.com/testcontainers/testcontainers-go v0.32.0
 )
 
 require (
@@ -16,6 +17,7 @@ require (
 	github.com/containerd/log v0.1.0 // indirect
 	github.com/containerd/platforms v0.2.1 // indirect
 	github.com/cpuguy83/dockercfg v0.3.1 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/distribution/reference v0.6.0 // indirect
 	github.com/docker/docker v27.1.1+incompatible // indirect
 	github.com/docker/go-connections v0.5.0 // indirect
@@ -27,6 +29,7 @@ require (
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/klauspost/compress v1.17.4 // indirect
+	github.com/kr/text v0.2.0 // indirect
 	github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 // indirect
 	github.com/magiconair/properties v1.8.7 // indirect
 	github.com/moby/docker-image-spec v1.3.1 // indirect
@@ -40,6 +43,7 @@ require (
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c // indirect
 	github.com/shirou/gopsutil/v3 v3.23.12 // indirect
 	github.com/shoenig/go-m1cpu v0.1.6 // indirect
@@ -56,6 +60,7 @@ require (
 	golang.org/x/sys v0.21.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20240318140521-94a12d6c2237 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240318140521-94a12d6c2237 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
 replace github.com/testcontainers/testcontainers-go => ../..

--- a/modules/nats/go.sum
+++ b/modules/nats/go.sum
@@ -16,6 +16,7 @@ github.com/containerd/platforms v0.2.1 h1:zvwtM3rz2YHPQsF2CHYM8+KtB5dvhISiXh5ZpS
 github.com/containerd/platforms v0.2.1/go.mod h1:XHCb+2/hzowdiut9rkudds9bE5yJ7npe7dG/wG+uFPw=
 github.com/cpuguy83/dockercfg v0.3.1 h1:/FpZ+JaygUR/lZP2NlFI2DVfrOEMAIKP5wWEJdoYe9E=
 github.com/cpuguy83/dockercfg v0.3.1/go.mod h1:sugsbF4//dDlL/i+S+rtpIWp+5h0BHJHfjj5/jFyUJc=
+github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.18 h1:n56/Zwd5o6whRC5PMGretI4IdRLlmBXYNjScPaBgsbY=
 github.com/creack/pty v1.1.18/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -52,6 +53,10 @@ github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/compress v1.17.4 h1:Ej5ixsIri7BrIjBkRZLTo6ghwrEtHFk7ijlczPW4fZ4=
 github.com/klauspost/compress v1.17.4/go.mod h1:/dCuZOvVtNoHsyb+cuJD3itjs3NbnF6KH9zAO4BDxPM=
+github.com/kr/pretty v0.3.0 h1:WgNl7dwNpEZ6jJ9k1snq4pZsg7DOEN8hP9Xw0Tsjwk0=
+github.com/kr/pretty v0.3.0/go.mod h1:640gp4NfQd8pI5XOwp5fnNeVWj67G7CFk/SaSQn7NBk=
+github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
+github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 h1:6E+4a0GO5zZEnZ81pIr0yLvtUWk2if982qA3F3QD6H4=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0/go.mod h1:zJYVVT2jmtg6P3p1VtQj7WsuWi/y4VnjVBn7F8KPB3I=
 github.com/magiconair/properties v1.8.7 h1:IeQXZAiQcpL9mgcAe1Nu6cX9LLw6ExEHKjN0VQdvPDY=
@@ -84,6 +89,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c h1:ncq/mPwQF4JjgDlrVEn3C11VoGHZN7m8qihwgMEtzYw=
 github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c/go.mod h1:OmDBASR4679mdNQnz2pUhc2G8CO2JrUAVFDRBDP/hJE=
+github.com/rogpeppe/go-internal v1.8.1 h1:geMPLpDpQOgVyCg5z5GoRwLHepNdb71NXb67XFkP+Eg=
+github.com/rogpeppe/go-internal v1.8.1/go.mod h1:JeRgkft04UBgHMgCIwADu4Pn6Mtm5d4nPKWu0nJ5d+o=
 github.com/shirou/gopsutil/v3 v3.23.12 h1:z90NtUkp3bMtmICZKpC4+WaknU1eXtp5vtbQ11DgpE4=
 github.com/shirou/gopsutil/v3 v3.23.12/go.mod h1:1FrWgea594Jp7qmjHUUPlJDTPgcsb9mGnXDxavtikzM=
 github.com/shoenig/go-m1cpu v0.1.6 h1:nxdKQNcEB6vzgA2E2bvzKIYRuNj7XNJ4S/aRSwKzFtM=
@@ -180,6 +187,8 @@ google.golang.org/grpc v1.64.1/go.mod h1:hiQF4LFZelK2WKaP6W0L92zGHtiQdZxk8CrSdvy
 google.golang.org/protobuf v1.33.0 h1:uNO2rsAINq/JlFpSdYEKIZ0uKD/R9cpdv0T+yoGwGmI=
 google.golang.org/protobuf v1.33.0/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/modules/nats/nats.go
+++ b/modules/nats/nats.go
@@ -59,17 +59,20 @@ func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustom
 	}
 
 	container, err := testcontainers.GenericContainer(ctx, genericContainerReq)
+	var c *NATSContainer
+	if container != nil {
+		c = &NATSContainer{
+			Container: container,
+			User:      settings.CmdArgs["user"],
+			Password:  settings.CmdArgs["pass"],
+		}
+	}
+
 	if err != nil {
-		return nil, err
+		return c, fmt.Errorf("generic container: %w", err)
 	}
 
-	natsContainer := NATSContainer{
-		Container: container,
-		User:      settings.CmdArgs["user"],
-		Password:  settings.CmdArgs["pass"],
-	}
-
-	return &natsContainer, nil
+	return c, nil
 }
 
 func (c *NATSContainer) MustConnectionString(ctx context.Context, args ...string) string {

--- a/modules/nats/nats_test.go
+++ b/modules/nats/nats_test.go
@@ -5,7 +5,9 @@ import (
 	"testing"
 
 	"github.com/nats-io/nats.go"
+	"github.com/stretchr/testify/require"
 
+	"github.com/testcontainers/testcontainers-go"
 	tcnats "github.com/testcontainers/testcontainers-go/modules/nats"
 )
 
@@ -13,67 +15,45 @@ func TestNATS(t *testing.T) {
 	ctx := context.Background()
 
 	//  createNATSContainer {
-	container, err := tcnats.Run(ctx, "nats:2.9")
+	ctr, err := tcnats.Run(ctx, "nats:2.9")
 	//  }
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// Clean up the container after the test is complete
-	t.Cleanup(func() {
-		if err := container.Terminate(ctx); err != nil {
-			t.Fatalf("failed to terminate container: %s", err)
-		}
-	})
+	testcontainers.CleanupContainer(t, ctr)
+	require.NoError(t, err)
 
 	// connectionString {
-	uri, err := container.ConnectionString(ctx)
+	uri, err := ctr.ConnectionString(ctx)
 	// }
-	if err != nil {
-		t.Fatalf("failed to get connection string: %s", err)
-	}
-	mustUri := container.MustConnectionString(ctx)
-	if mustUri != uri {
-		t.Errorf("URI was not equal to MustUri")
-	}
+	require.NoError(t, err)
+
+	mustUri := ctr.MustConnectionString(ctx)
+	require.Equal(t, mustUri, uri)
+
 	// perform assertions
 	nc, err := nats.Connect(uri)
-	if err != nil {
-		t.Fatalf("failed to connect to nats: %s", err)
-	}
+	require.NoError(t, err)
 	defer nc.Close()
 
 	js, err := nc.JetStream()
-	if err != nil {
-		t.Fatalf("failed to create jetstream context: %s", err)
-	}
+	require.NoError(t, err)
 
 	// add stream to nats
-	if _, err = js.AddStream(&nats.StreamConfig{
+	_, err = js.AddStream(&nats.StreamConfig{
 		Name:     "hello",
 		Subjects: []string{"hello"},
-	}); err != nil {
-		t.Fatalf("failed to add stream: %s", err)
-	}
+	})
+	require.NoError(t, err)
 
 	// add subscriber to nats
 	sub, err := js.SubscribeSync("hello", nats.Durable("worker"))
-	if err != nil {
-		t.Fatalf("failed to subscribe to hello: %s", err)
-	}
+	require.NoError(t, err)
 
 	// publish a message to nats
-	if _, err = js.Publish("hello", []byte("hello")); err != nil {
-		t.Fatalf("failed to publish hello: %s", err)
-	}
+	_, err = js.Publish("hello", []byte("hello"))
+	require.NoError(t, err)
 
 	// wait for the message to be received
 	msg, err := sub.NextMsgWithContext(ctx)
-	if err != nil {
-		t.Fatalf("failed to get message: %s", err)
-	}
+	require.NoError(t, err)
 
-	if string(msg.Data) != "hello" {
-		t.Fatalf("expected message to be 'hello', got '%s'", msg.Data)
-	}
+	require.Equal(t, "hello", string(msg.Data))
 }

--- a/modules/neo4j/examples_test.go
+++ b/modules/neo4j/examples_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 
+	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/modules/neo4j"
 )
 
@@ -20,21 +21,21 @@ func ExampleRun() {
 		neo4j.WithLabsPlugin(neo4j.Apoc),
 		neo4j.WithNeo4jSetting("dbms.tx_log.rotation.size", "42M"),
 	)
-	if err != nil {
-		log.Fatalf("failed to start container: %s", err)
-	}
-
-	// Clean up the container
 	defer func() {
-		if err := neo4jContainer.Terminate(ctx); err != nil {
-			log.Fatalf("failed to terminate container: %s", err)
+		if err := testcontainers.TerminateContainer(neo4jContainer); err != nil {
+			log.Printf("failed to terminate container: %s", err)
 		}
 	}()
+	if err != nil {
+		log.Printf("failed to start container: %s", err)
+		return
+	}
 	// }
 
 	state, err := neo4jContainer.State(ctx)
 	if err != nil {
-		log.Fatalf("failed to get container state: %s", err) // nolint:gocritic
+		log.Printf("failed to get container state: %s", err)
+		return
 	}
 
 	fmt.Println(state.Running)

--- a/modules/neo4j/go.mod
+++ b/modules/neo4j/go.mod
@@ -5,7 +5,8 @@ go 1.22
 require (
 	github.com/docker/go-connections v0.5.0
 	github.com/neo4j/neo4j-go-driver/v5 v5.18.0
-	github.com/testcontainers/testcontainers-go v0.33.0
+	github.com/stretchr/testify v1.9.0
+	github.com/testcontainers/testcontainers-go v0.32.0
 )
 
 require (
@@ -17,6 +18,7 @@ require (
 	github.com/containerd/log v0.1.0 // indirect
 	github.com/containerd/platforms v0.2.1 // indirect
 	github.com/cpuguy83/dockercfg v0.3.1 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/distribution/reference v0.6.0 // indirect
 	github.com/docker/docker v27.1.1+incompatible // indirect
 	github.com/docker/go-units v0.5.0 // indirect
@@ -27,6 +29,7 @@ require (
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/klauspost/compress v1.17.4 // indirect
+	github.com/kr/text v0.2.0 // indirect
 	github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 // indirect
 	github.com/magiconair/properties v1.8.7 // indirect
 	github.com/moby/docker-image-spec v1.3.1 // indirect
@@ -38,6 +41,7 @@ require (
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c // indirect
 	github.com/shirou/gopsutil/v3 v3.23.12 // indirect
 	github.com/shoenig/go-m1cpu v0.1.6 // indirect
@@ -54,6 +58,7 @@ require (
 	golang.org/x/sys v0.21.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20240318140521-94a12d6c2237 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240318140521-94a12d6c2237 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
 replace github.com/testcontainers/testcontainers-go => ../..

--- a/modules/neo4j/go.sum
+++ b/modules/neo4j/go.sum
@@ -16,6 +16,7 @@ github.com/containerd/platforms v0.2.1 h1:zvwtM3rz2YHPQsF2CHYM8+KtB5dvhISiXh5ZpS
 github.com/containerd/platforms v0.2.1/go.mod h1:XHCb+2/hzowdiut9rkudds9bE5yJ7npe7dG/wG+uFPw=
 github.com/cpuguy83/dockercfg v0.3.1 h1:/FpZ+JaygUR/lZP2NlFI2DVfrOEMAIKP5wWEJdoYe9E=
 github.com/cpuguy83/dockercfg v0.3.1/go.mod h1:sugsbF4//dDlL/i+S+rtpIWp+5h0BHJHfjj5/jFyUJc=
+github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.18 h1:n56/Zwd5o6whRC5PMGretI4IdRLlmBXYNjScPaBgsbY=
 github.com/creack/pty v1.1.18/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -52,6 +53,10 @@ github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/compress v1.17.4 h1:Ej5ixsIri7BrIjBkRZLTo6ghwrEtHFk7ijlczPW4fZ4=
 github.com/klauspost/compress v1.17.4/go.mod h1:/dCuZOvVtNoHsyb+cuJD3itjs3NbnF6KH9zAO4BDxPM=
+github.com/kr/pretty v0.3.0 h1:WgNl7dwNpEZ6jJ9k1snq4pZsg7DOEN8hP9Xw0Tsjwk0=
+github.com/kr/pretty v0.3.0/go.mod h1:640gp4NfQd8pI5XOwp5fnNeVWj67G7CFk/SaSQn7NBk=
+github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
+github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 h1:6E+4a0GO5zZEnZ81pIr0yLvtUWk2if982qA3F3QD6H4=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0/go.mod h1:zJYVVT2jmtg6P3p1VtQj7WsuWi/y4VnjVBn7F8KPB3I=
 github.com/magiconair/properties v1.8.7 h1:IeQXZAiQcpL9mgcAe1Nu6cX9LLw6ExEHKjN0VQdvPDY=
@@ -80,6 +85,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c h1:ncq/mPwQF4JjgDlrVEn3C11VoGHZN7m8qihwgMEtzYw=
 github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c/go.mod h1:OmDBASR4679mdNQnz2pUhc2G8CO2JrUAVFDRBDP/hJE=
+github.com/rogpeppe/go-internal v1.8.1 h1:geMPLpDpQOgVyCg5z5GoRwLHepNdb71NXb67XFkP+Eg=
+github.com/rogpeppe/go-internal v1.8.1/go.mod h1:JeRgkft04UBgHMgCIwADu4Pn6Mtm5d4nPKWu0nJ5d+o=
 github.com/shirou/gopsutil/v3 v3.23.12 h1:z90NtUkp3bMtmICZKpC4+WaknU1eXtp5vtbQ11DgpE4=
 github.com/shirou/gopsutil/v3 v3.23.12/go.mod h1:1FrWgea594Jp7qmjHUUPlJDTPgcsb9mGnXDxavtikzM=
 github.com/shoenig/go-m1cpu v0.1.6 h1:nxdKQNcEB6vzgA2E2bvzKIYRuNj7XNJ4S/aRSwKzFtM=
@@ -176,6 +183,8 @@ google.golang.org/grpc v1.64.1/go.mod h1:hiQF4LFZelK2WKaP6W0L92zGHtiQdZxk8CrSdvy
 google.golang.org/protobuf v1.33.0 h1:uNO2rsAINq/JlFpSdYEKIZ0uKD/R9cpdv0T+yoGwGmI=
 google.golang.org/protobuf v1.33.0/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/modules/neo4j/neo4j.go
+++ b/modules/neo4j/neo4j.go
@@ -93,11 +93,16 @@ func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustom
 	}
 
 	container, err := testcontainers.GenericContainer(ctx, genericContainerReq)
-	if err != nil {
-		return nil, err
+	var c *Neo4jContainer
+	if container != nil {
+		c = &Neo4jContainer{Container: container}
 	}
 
-	return &Neo4jContainer{Container: container}, nil
+	if err != nil {
+		return c, fmt.Errorf("generic container: %w", err)
+	}
+
+	return c, nil
 }
 
 func isHttpOk() func(status int) bool {

--- a/modules/ollama/examples_test.go
+++ b/modules/ollama/examples_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/tmc/langchaingo/llms"
 	langchainollama "github.com/tmc/langchaingo/llms/ollama"
 
+	"github.com/testcontainers/testcontainers-go"
 	tcollama "github.com/testcontainers/testcontainers-go/modules/ollama"
 )
 
@@ -18,21 +19,21 @@ func ExampleRun() {
 	ctx := context.Background()
 
 	ollamaContainer, err := tcollama.Run(ctx, "ollama/ollama:0.1.25")
-	if err != nil {
-		log.Fatalf("failed to start container: %s", err)
-	}
-
-	// Clean up the container
 	defer func() {
-		if err := ollamaContainer.Terminate(ctx); err != nil {
-			log.Fatalf("failed to terminate container: %s", err) // nolint:gocritic
+		if err := testcontainers.TerminateContainer(ollamaContainer); err != nil {
+			log.Printf("failed to terminate container: %s", err)
 		}
 	}()
+	if err != nil {
+		log.Printf("failed to start container: %s", err)
+		return
+	}
 	// }
 
 	state, err := ollamaContainer.State(ctx)
 	if err != nil {
-		log.Fatalf("failed to get container state: %s", err) // nolint:gocritic
+		log.Printf("failed to get container state: %s", err)
+		return
 	}
 
 	fmt.Println(state.Running)
@@ -46,30 +47,34 @@ func ExampleRun_withModel_llama2_http() {
 	ctx := context.Background()
 
 	ollamaContainer, err := tcollama.Run(ctx, "ollama/ollama:0.1.25")
-	if err != nil {
-		log.Fatalf("failed to start container: %s", err)
-	}
 	defer func() {
-		if err := ollamaContainer.Terminate(ctx); err != nil {
-			log.Fatalf("failed to terminate container: %s", err) // nolint:gocritic
+		if err := testcontainers.TerminateContainer(ollamaContainer); err != nil {
+			log.Printf("failed to terminate container: %s", err)
 		}
 	}()
+	if err != nil {
+		log.Printf("failed to start container: %s", err)
+		return
+	}
 
 	model := "llama2"
 
 	_, _, err = ollamaContainer.Exec(ctx, []string{"ollama", "pull", model})
 	if err != nil {
-		log.Fatalf("failed to pull model %s: %s", model, err) // nolint:gocritic
+		log.Printf("failed to pull model %s: %s", model, err)
+		return
 	}
 
 	_, _, err = ollamaContainer.Exec(ctx, []string{"ollama", "run", model})
 	if err != nil {
-		log.Fatalf("failed to run model %s: %s", model, err) // nolint:gocritic
+		log.Printf("failed to run model %s: %s", model, err)
+		return
 	}
 
 	connectionStr, err := ollamaContainer.ConnectionString(ctx)
 	if err != nil {
-		log.Fatalf("failed to get connection string: %s", err) // nolint:gocritic
+		log.Printf("failed to get connection string: %s", err)
+		return
 	}
 
 	httpClient := &http.Client{}
@@ -82,12 +87,14 @@ func ExampleRun_withModel_llama2_http() {
 
 	req, err := http.NewRequest("POST", fmt.Sprintf("%s/api/generate", connectionStr), strings.NewReader(payload))
 	if err != nil {
-		log.Fatalf("failed to create request: %s", err) // nolint:gocritic
+		log.Printf("failed to create request: %s", err)
+		return
 	}
 
 	resp, err := httpClient.Do(req)
 	if err != nil {
-		log.Fatalf("failed to get response: %s", err) // nolint:gocritic
+		log.Printf("failed to get response: %s", err)
+		return
 	}
 	// }
 
@@ -101,30 +108,34 @@ func ExampleRun_withModel_llama2_langchain() {
 	ctx := context.Background()
 
 	ollamaContainer, err := tcollama.Run(ctx, "ollama/ollama:0.1.25")
-	if err != nil {
-		log.Fatalf("failed to start container: %s", err)
-	}
 	defer func() {
-		if err := ollamaContainer.Terminate(ctx); err != nil {
-			log.Fatalf("failed to terminate container: %s", err) // nolint:gocritic
+		if err := testcontainers.TerminateContainer(ollamaContainer); err != nil {
+			log.Printf("failed to terminate container: %s", err)
 		}
 	}()
+	if err != nil {
+		log.Printf("failed to start container: %s", err)
+		return
+	}
 
 	model := "llama2"
 
 	_, _, err = ollamaContainer.Exec(ctx, []string{"ollama", "pull", model})
 	if err != nil {
-		log.Fatalf("failed to pull model %s: %s", model, err) // nolint:gocritic
+		log.Printf("failed to pull model %s: %s", model, err)
+		return
 	}
 
 	_, _, err = ollamaContainer.Exec(ctx, []string{"ollama", "run", model})
 	if err != nil {
-		log.Fatalf("failed to run model %s: %s", model, err) // nolint:gocritic
+		log.Printf("failed to run model %s: %s", model, err)
+		return
 	}
 
 	connectionStr, err := ollamaContainer.ConnectionString(ctx)
 	if err != nil {
-		log.Fatalf("failed to get connection string: %s", err) // nolint:gocritic
+		log.Printf("failed to get connection string: %s", err)
+		return
 	}
 
 	var llm *langchainollama.LLM
@@ -132,7 +143,8 @@ func ExampleRun_withModel_llama2_langchain() {
 		langchainollama.WithModel(model),
 		langchainollama.WithServerURL(connectionStr),
 	); err != nil {
-		log.Fatalf("failed to create langchain ollama: %s", err) // nolint:gocritic
+		log.Printf("failed to create langchain ollama: %s", err)
+		return
 	}
 
 	completion, err := llm.Call(
@@ -142,7 +154,8 @@ func ExampleRun_withModel_llama2_langchain() {
 		llms.WithTemperature(0.0), // the lower the temperature, the more creative the completion
 	)
 	if err != nil {
-		log.Fatalf("failed to create langchain ollama: %s", err) // nolint:gocritic
+		log.Printf("failed to create langchain ollama: %s", err)
+		return
 	}
 
 	words := []string{

--- a/modules/ollama/go.mod
+++ b/modules/ollama/go.mod
@@ -5,7 +5,8 @@ go 1.22
 require (
 	github.com/docker/docker v27.1.1+incompatible
 	github.com/google/uuid v1.6.0
-	github.com/testcontainers/testcontainers-go v0.33.0
+	github.com/stretchr/testify v1.9.0
+	github.com/testcontainers/testcontainers-go v0.32.0
 	github.com/tmc/langchaingo v0.1.5
 )
 
@@ -18,6 +19,7 @@ require (
 	github.com/containerd/log v0.1.0 // indirect
 	github.com/containerd/platforms v0.2.1 // indirect
 	github.com/cpuguy83/dockercfg v0.3.1 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/distribution/reference v0.6.0 // indirect
 	github.com/dlclark/regexp2 v1.8.1 // indirect
 	github.com/docker/go-connections v0.5.0 // indirect
@@ -40,6 +42,7 @@ require (
 	github.com/opencontainers/image-spec v1.1.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pkoukk/tiktoken-go v0.1.2 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c // indirect
 	github.com/shirou/gopsutil/v3 v3.23.12 // indirect
 	github.com/shoenig/go-m1cpu v0.1.6 // indirect
@@ -56,6 +59,7 @@ require (
 	golang.org/x/sys v0.21.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20240318140521-94a12d6c2237 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240318140521-94a12d6c2237 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
 replace github.com/testcontainers/testcontainers-go => ../..

--- a/modules/ollama/go.sum
+++ b/modules/ollama/go.sum
@@ -54,6 +54,10 @@ github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/compress v1.17.4 h1:Ej5ixsIri7BrIjBkRZLTo6ghwrEtHFk7ijlczPW4fZ4=
 github.com/klauspost/compress v1.17.4/go.mod h1:/dCuZOvVtNoHsyb+cuJD3itjs3NbnF6KH9zAO4BDxPM=
+github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
+github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
+github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
+github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 h1:6E+4a0GO5zZEnZ81pIr0yLvtUWk2if982qA3F3QD6H4=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0/go.mod h1:zJYVVT2jmtg6P3p1VtQj7WsuWi/y4VnjVBn7F8KPB3I=
 github.com/magiconair/properties v1.8.7 h1:IeQXZAiQcpL9mgcAe1Nu6cX9LLw6ExEHKjN0VQdvPDY=
@@ -82,6 +86,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c h1:ncq/mPwQF4JjgDlrVEn3C11VoGHZN7m8qihwgMEtzYw=
 github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c/go.mod h1:OmDBASR4679mdNQnz2pUhc2G8CO2JrUAVFDRBDP/hJE=
+github.com/rogpeppe/go-internal v1.11.0 h1:cWPaGQEPrBb5/AsnsZesgZZ9yb1OQ+GOISoDNXVBh4M=
+github.com/rogpeppe/go-internal v1.11.0/go.mod h1:ddIwULY96R17DhadqLgMfk9H9tvdUzkipdSkR5nkCZA=
 github.com/shirou/gopsutil/v3 v3.23.12 h1:z90NtUkp3bMtmICZKpC4+WaknU1eXtp5vtbQ11DgpE4=
 github.com/shirou/gopsutil/v3 v3.23.12/go.mod h1:1FrWgea594Jp7qmjHUUPlJDTPgcsb9mGnXDxavtikzM=
 github.com/shoenig/go-m1cpu v0.1.6 h1:nxdKQNcEB6vzgA2E2bvzKIYRuNj7XNJ4S/aRSwKzFtM=
@@ -180,6 +186,8 @@ google.golang.org/grpc v1.64.1/go.mod h1:hiQF4LFZelK2WKaP6W0L92zGHtiQdZxk8CrSdvy
 google.golang.org/protobuf v1.33.0 h1:uNO2rsAINq/JlFpSdYEKIZ0uKD/R9cpdv0T+yoGwGmI=
 google.golang.org/protobuf v1.33.0/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/modules/ollama/ollama.go
+++ b/modules/ollama/ollama.go
@@ -101,9 +101,14 @@ func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustom
 	}
 
 	container, err := testcontainers.GenericContainer(ctx, genericContainerReq)
-	if err != nil {
-		return nil, err
+	var c *OllamaContainer
+	if container != nil {
+		c = &OllamaContainer{Container: container}
 	}
 
-	return &OllamaContainer{Container: container}, nil
+	if err != nil {
+		return c, fmt.Errorf("generic container: %w", err)
+	}
+
+	return c, nil
 }

--- a/modules/ollama/ollama_test.go
+++ b/modules/ollama/ollama_test.go
@@ -4,13 +4,14 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"log"
 	"net/http"
 	"strings"
 	"testing"
 
 	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
 
+	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/exec"
 	"github.com/testcontainers/testcontainers-go/modules/ollama"
 )
@@ -18,52 +19,34 @@ import (
 func TestOllama(t *testing.T) {
 	ctx := context.Background()
 
-	container, err := ollama.Run(ctx, "ollama/ollama:0.1.25")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// Clean up the container after the test is complete
-	t.Cleanup(func() {
-		if err := container.Terminate(ctx); err != nil {
-			t.Fatalf("failed to terminate container: %s", err)
-		}
-	})
+	ctr, err := ollama.Run(ctx, "ollama/ollama:0.1.25")
+	testcontainers.CleanupContainer(t, ctr)
+	require.NoError(t, err)
 
 	t.Run("ConnectionString", func(t *testing.T) {
 		// connectionString {
-		connectionStr, err := container.ConnectionString(ctx)
+		connectionStr, err := ctr.ConnectionString(ctx)
 		// }
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
 		httpClient := &http.Client{}
 		resp, err := httpClient.Get(connectionStr)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer resp.Body.Close()
 
-		if resp.StatusCode != http.StatusOK {
-			t.Fatalf("expected status code 200, got %d", resp.StatusCode)
-		}
+		require.Equal(t, http.StatusOK, resp.StatusCode)
 	})
 
 	t.Run("Pull and Run Model", func(t *testing.T) {
 		model := "all-minilm"
 
-		_, _, err = container.Exec(context.Background(), []string{"ollama", "pull", model})
-		if err != nil {
-			log.Fatalf("failed to pull model %s: %s", model, err)
-		}
+		_, _, err = ctr.Exec(context.Background(), []string{"ollama", "pull", model})
+		require.NoError(t, err)
 
-		_, _, err = container.Exec(context.Background(), []string{"ollama", "run", model})
-		if err != nil {
-			log.Fatalf("failed to run model %s: %s", model, err)
-		}
+		_, _, err = ctr.Exec(context.Background(), []string{"ollama", "run", model})
+		require.NoError(t, err)
 
-		assertLoadedModel(t, container)
+		assertLoadedModel(t, ctr)
 	})
 
 	t.Run("Commit to image including model", func(t *testing.T) {
@@ -73,24 +56,16 @@ func TestOllama(t *testing.T) {
 		// Users can change the way this is generated, but it should be unique.
 		targetImage := fmt.Sprintf("%s-%s", ollama.DefaultOllamaImage, strings.ToLower(uuid.New().String()[:4]))
 
-		err := container.Commit(context.Background(), targetImage)
+		err := ctr.Commit(context.Background(), targetImage)
 		// }
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
 		newOllamaContainer, err := ollama.Run(
 			context.Background(),
 			targetImage,
 		)
-		if err != nil {
-			t.Fatal(err)
-		}
-		t.Cleanup(func() {
-			if err := newOllamaContainer.Terminate(context.Background()); err != nil {
-				t.Fatalf("failed to terminate container: %s", err)
-			}
-		})
+		testcontainers.CleanupContainer(t, newOllamaContainer)
+		require.NoError(t, err)
 
 		assertLoadedModel(t, newOllamaContainer)
 	})
@@ -101,30 +76,20 @@ func TestOllama(t *testing.T) {
 // contains the model name.
 func assertLoadedModel(t *testing.T, c *ollama.OllamaContainer) {
 	url, err := c.ConnectionString(context.Background())
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	httpCli := &http.Client{}
 
 	resp, err := httpCli.Get(url + "/api/tags")
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusOK {
-		t.Fatalf("expected status code 200, got %d", resp.StatusCode)
-	}
+	require.Equal(t, http.StatusOK, resp.StatusCode)
 
 	bs, err := io.ReadAll(resp.Body)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
-	if !strings.Contains(string(bs), "all-minilm") {
-		t.Fatalf("expected response to contain all-minilm, got %s", string(bs))
-	}
+	require.Contains(t, string(bs), "all-minilm")
 }
 
 func TestRunContainer_withModel_error(t *testing.T) {
@@ -134,30 +99,21 @@ func TestRunContainer_withModel_error(t *testing.T) {
 		ctx,
 		"ollama/ollama:0.1.25",
 	)
-	if err != nil {
-		t.Fatalf("expected error to be nil, got %s", err)
-	}
+	testcontainers.CleanupContainer(t, ollamaContainer)
+	require.NoError(t, err)
 
 	model := "non-existent"
 
 	_, _, err = ollamaContainer.Exec(ctx, []string{"ollama", "pull", model})
-	if err != nil {
-		log.Fatalf("expected nil error, got %s", err)
-	}
+	require.NoError(t, err)
 
 	// we need to parse the response here to check if the error message is correct
 	_, r, err := ollamaContainer.Exec(ctx, []string{"ollama", "run", model}, exec.Multiplexed())
-	if err != nil {
-		log.Fatalf("expected nil error, got %s", err)
-	}
+	require.NoError(t, err)
 
 	bs, err := io.ReadAll(r)
-	if err != nil {
-		t.Fatalf("failed to run %s model: %s", model, err)
-	}
+	require.NoError(t, err)
 
 	stdOutput := string(bs)
-	if !strings.Contains(stdOutput, "Error: pull model manifest: file does not exist") {
-		t.Fatalf("expected output to contain %q, got %s", "Error: pull model manifest: file does not exist", stdOutput)
-	}
+	require.Contains(t, stdOutput, "Error: pull model manifest: file does not exist")
 }

--- a/modules/openfga/examples_test.go
+++ b/modules/openfga/examples_test.go
@@ -22,21 +22,21 @@ func ExampleRun() {
 	ctx := context.Background()
 
 	openfgaContainer, err := openfga.Run(ctx, "openfga/openfga:v1.5.0")
-	if err != nil {
-		log.Fatalf("failed to start container: %s", err)
-	}
-
-	// Clean up the container
 	defer func() {
-		if err := openfgaContainer.Terminate(ctx); err != nil {
-			log.Fatalf("failed to terminate container: %s", err) // nolint:gocritic
+		if err := testcontainers.TerminateContainer(openfgaContainer); err != nil {
+			log.Printf("failed to terminate container: %s", err)
 		}
 	}()
+	if err != nil {
+		log.Printf("failed to start container: %s", err)
+		return
+	}
 	// }
 
 	state, err := openfgaContainer.State(ctx)
 	if err != nil {
-		log.Fatalf("failed to get container state: %s", err) // nolint:gocritic
+		log.Printf("failed to get container state: %s", err)
+		return
 	}
 
 	fmt.Println(state.Running)
@@ -47,21 +47,21 @@ func ExampleRun() {
 
 func ExampleRun_connectToPlayground() {
 	openfgaContainer, err := openfga.Run(context.Background(), "openfga/openfga:v1.5.0")
-	if err != nil {
-		log.Fatalf("failed to start container: %s", err)
-	}
-
-	// Clean up the container
 	defer func() {
-		if err := openfgaContainer.Terminate(context.Background()); err != nil {
-			log.Fatalf("failed to terminate container: %s", err) // nolint:gocritic
+		if err := testcontainers.TerminateContainer(openfgaContainer); err != nil {
+			log.Printf("failed to terminate container: %s", err)
 		}
 	}()
+	if err != nil {
+		log.Printf("failed to start container: %s", err)
+		return
+	}
 
 	// playgroundEndpoint {
 	playgroundEndpoint, err := openfgaContainer.PlaygroundEndpoint(context.Background())
 	if err != nil {
-		log.Fatalf("failed to get playground endpoint: %s", err) // nolint:gocritic
+		log.Printf("failed to get playground endpoint: %s", err)
+		return
 	}
 	// }
 
@@ -69,7 +69,8 @@ func ExampleRun_connectToPlayground() {
 
 	resp, err := httpClient.Get(playgroundEndpoint)
 	if err != nil {
-		log.Fatalf("failed to get playground endpoint: %s", err) // nolint:gocritic
+		log.Printf("failed to get playground endpoint: %s", err)
+		return
 	}
 
 	fmt.Println(resp.StatusCode)
@@ -80,21 +81,21 @@ func ExampleRun_connectToPlayground() {
 
 func ExampleRun_connectWithSDKClient() {
 	openfgaContainer, err := openfga.Run(context.Background(), "openfga/openfga:v1.5.0")
-	if err != nil {
-		log.Fatalf("failed to start container: %s", err)
-	}
-
-	// Clean up the container
 	defer func() {
-		if err := openfgaContainer.Terminate(context.Background()); err != nil {
-			log.Fatalf("failed to terminate container: %s", err) // nolint:gocritic
+		if err := testcontainers.TerminateContainer(openfgaContainer); err != nil {
+			log.Printf("failed to terminate container: %s", err)
 		}
 	}()
+	if err != nil {
+		log.Printf("failed to start container: %s", err)
+		return
+	}
 
 	// httpEndpoint {
 	httpEndpoint, err := openfgaContainer.HttpEndpoint(context.Background())
 	if err != nil {
-		log.Fatalf("failed to get HTTP endpoint: %s", err) // nolint:gocritic
+		log.Printf("failed to get HTTP endpoint: %s", err)
+		return
 	}
 	// }
 
@@ -103,26 +104,30 @@ func ExampleRun_connectWithSDKClient() {
 		ApiUrl: httpEndpoint, // required
 	})
 	if err != nil {
-		log.Fatalf("failed to create SDK client: %s", err) // nolint:gocritic
+		log.Printf("failed to create SDK client: %s", err)
+		return
 	}
 
 	list, err := fgaClient.ListStores(context.Background()).Execute()
 	if err != nil {
-		log.Fatalf("failed to list stores: %s", err) // nolint:gocritic
+		log.Printf("failed to list stores: %s", err)
+		return
 	}
 
 	fmt.Println(len(list.Stores))
 
 	store, err := fgaClient.CreateStore(context.Background()).Body(client.ClientCreateStoreRequest{Name: "test"}).Execute()
 	if err != nil {
-		log.Fatalf("failed to create store: %s", err) // nolint:gocritic
+		log.Printf("failed to create store: %s", err)
+		return
 	}
 
 	fmt.Println(store.Name)
 
 	list, err = fgaClient.ListStores(context.Background()).Execute()
 	if err != nil {
-		log.Fatalf("failed to list stores: %s", err) // nolint:gocritic
+		log.Printf("failed to list stores: %s", err)
+		return
 	}
 
 	fmt.Println(len(list.Stores))
@@ -145,20 +150,20 @@ func ExampleRun_writeModel() {
 			"OPENFGA_AUTHN_PRESHARED_KEYS": secret,
 		}),
 	)
-	if err != nil {
-		log.Fatalf("failed to start container: %s", err)
-	}
-
-	// Clean up the container
 	defer func() {
-		if err := openfgaContainer.Terminate(context.Background()); err != nil {
-			log.Fatalf("failed to terminate container: %s", err) // nolint:gocritic
+		if err := testcontainers.TerminateContainer(openfgaContainer); err != nil {
+			log.Printf("failed to terminate container: %s", err)
 		}
 	}()
+	if err != nil {
+		log.Printf("failed to start container: %s", err)
+		return
+	}
 
 	httpEndpoint, err := openfgaContainer.HttpEndpoint(context.Background())
 	if err != nil {
-		log.Fatalf("failed to get HTTP endpoint: %s", err) // nolint:gocritic
+		log.Printf("failed to get HTTP endpoint: %s", err)
+		return
 	}
 
 	fgaClient, err := client.NewSdkClient(&client.ClientConfiguration{
@@ -177,28 +182,33 @@ func ExampleRun_writeModel() {
 		StoreId: "11111111111111111111111111",
 	})
 	if err != nil {
-		log.Fatalf("failed to create openfga client: %v", err)
+		log.Printf("failed to create openfga client: %v", err)
+		return
 	}
 
 	f, err := os.Open(filepath.Join("testdata", "authorization_model.json"))
 	if err != nil {
-		log.Fatalf("failed to open file: %v", err)
+		log.Printf("failed to open file: %v", err)
+		return
 	}
 	defer f.Close()
 
 	bs, err := io.ReadAll(f)
 	if err != nil {
-		log.Fatalf("failed to read file: %v", err)
+		log.Printf("failed to read file: %v", err)
+		return
 	}
 
 	var body client.ClientWriteAuthorizationModelRequest
 	if err := json.Unmarshal(bs, &body); err != nil {
-		log.Fatalf("failed to unmarshal json: %v", err)
+		log.Printf("failed to unmarshal json: %v", err)
+		return
 	}
 
 	resp, err := fgaClient.WriteAuthorizationModel(context.Background()).Body(body).Execute()
 	if err != nil {
-		log.Fatalf("failed to write authorization model: %v", err)
+		log.Printf("failed to write authorization model: %v", err)
+		return
 	}
 
 	// }

--- a/modules/openfga/go.mod
+++ b/modules/openfga/go.mod
@@ -4,7 +4,8 @@ go 1.22
 
 require (
 	github.com/openfga/go-sdk v0.3.5
-	github.com/testcontainers/testcontainers-go v0.33.0
+	github.com/stretchr/testify v1.9.0
+	github.com/testcontainers/testcontainers-go v0.32.0
 )
 
 require (
@@ -16,6 +17,7 @@ require (
 	github.com/containerd/log v0.1.0 // indirect
 	github.com/containerd/platforms v0.2.1 // indirect
 	github.com/cpuguy83/dockercfg v0.3.1 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/distribution/reference v0.6.0 // indirect
 	github.com/docker/docker v27.1.1+incompatible // indirect
 	github.com/docker/go-connections v0.5.0 // indirect
@@ -27,6 +29,7 @@ require (
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/klauspost/compress v1.17.4 // indirect
+	github.com/kr/text v0.2.0 // indirect
 	github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 // indirect
 	github.com/magiconair/properties v1.8.7 // indirect
 	github.com/moby/docker-image-spec v1.3.1 // indirect
@@ -38,6 +41,7 @@ require (
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c // indirect
 	github.com/shirou/gopsutil/v3 v3.23.12 // indirect
 	github.com/shoenig/go-m1cpu v0.1.6 // indirect
@@ -55,6 +59,7 @@ require (
 	golang.org/x/sys v0.21.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20240318140521-94a12d6c2237 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240318140521-94a12d6c2237 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
 replace github.com/testcontainers/testcontainers-go => ../..

--- a/modules/openfga/go.sum
+++ b/modules/openfga/go.sum
@@ -16,6 +16,7 @@ github.com/containerd/platforms v0.2.1 h1:zvwtM3rz2YHPQsF2CHYM8+KtB5dvhISiXh5ZpS
 github.com/containerd/platforms v0.2.1/go.mod h1:XHCb+2/hzowdiut9rkudds9bE5yJ7npe7dG/wG+uFPw=
 github.com/cpuguy83/dockercfg v0.3.1 h1:/FpZ+JaygUR/lZP2NlFI2DVfrOEMAIKP5wWEJdoYe9E=
 github.com/cpuguy83/dockercfg v0.3.1/go.mod h1:sugsbF4//dDlL/i+S+rtpIWp+5h0BHJHfjj5/jFyUJc=
+github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.18 h1:n56/Zwd5o6whRC5PMGretI4IdRLlmBXYNjScPaBgsbY=
 github.com/creack/pty v1.1.18/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -54,6 +55,10 @@ github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/compress v1.17.4 h1:Ej5ixsIri7BrIjBkRZLTo6ghwrEtHFk7ijlczPW4fZ4=
 github.com/klauspost/compress v1.17.4/go.mod h1:/dCuZOvVtNoHsyb+cuJD3itjs3NbnF6KH9zAO4BDxPM=
+github.com/kr/pretty v0.3.0 h1:WgNl7dwNpEZ6jJ9k1snq4pZsg7DOEN8hP9Xw0Tsjwk0=
+github.com/kr/pretty v0.3.0/go.mod h1:640gp4NfQd8pI5XOwp5fnNeVWj67G7CFk/SaSQn7NBk=
+github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
+github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 h1:6E+4a0GO5zZEnZ81pIr0yLvtUWk2if982qA3F3QD6H4=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0/go.mod h1:zJYVVT2jmtg6P3p1VtQj7WsuWi/y4VnjVBn7F8KPB3I=
 github.com/magiconair/properties v1.8.7 h1:IeQXZAiQcpL9mgcAe1Nu6cX9LLw6ExEHKjN0VQdvPDY=
@@ -82,6 +87,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c h1:ncq/mPwQF4JjgDlrVEn3C11VoGHZN7m8qihwgMEtzYw=
 github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c/go.mod h1:OmDBASR4679mdNQnz2pUhc2G8CO2JrUAVFDRBDP/hJE=
+github.com/rogpeppe/go-internal v1.8.1 h1:geMPLpDpQOgVyCg5z5GoRwLHepNdb71NXb67XFkP+Eg=
+github.com/rogpeppe/go-internal v1.8.1/go.mod h1:JeRgkft04UBgHMgCIwADu4Pn6Mtm5d4nPKWu0nJ5d+o=
 github.com/shirou/gopsutil/v3 v3.23.12 h1:z90NtUkp3bMtmICZKpC4+WaknU1eXtp5vtbQ11DgpE4=
 github.com/shirou/gopsutil/v3 v3.23.12/go.mod h1:1FrWgea594Jp7qmjHUUPlJDTPgcsb9mGnXDxavtikzM=
 github.com/shoenig/go-m1cpu v0.1.6 h1:nxdKQNcEB6vzgA2E2bvzKIYRuNj7XNJ4S/aRSwKzFtM=
@@ -180,6 +187,8 @@ google.golang.org/grpc v1.64.1/go.mod h1:hiQF4LFZelK2WKaP6W0L92zGHtiQdZxk8CrSdvy
 google.golang.org/protobuf v1.33.0 h1:uNO2rsAINq/JlFpSdYEKIZ0uKD/R9cpdv0T+yoGwGmI=
 google.golang.org/protobuf v1.33.0/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/modules/openfga/openfga.go
+++ b/modules/openfga/openfga.go
@@ -78,9 +78,14 @@ func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustom
 	}
 
 	container, err := testcontainers.GenericContainer(ctx, genericContainerReq)
-	if err != nil {
-		return nil, err
+	var c *OpenFGAContainer
+	if container != nil {
+		c = &OpenFGAContainer{Container: container}
 	}
 
-	return &OpenFGAContainer{Container: container}, nil
+	if err != nil {
+		return c, fmt.Errorf("generic container: %w", err)
+	}
+
+	return c, nil
 }

--- a/modules/openfga/openfga_test.go
+++ b/modules/openfga/openfga_test.go
@@ -4,23 +4,18 @@ import (
 	"context"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
+	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/modules/openfga"
 )
 
 func TestOpenFGA(t *testing.T) {
 	ctx := context.Background()
 
-	container, err := openfga.Run(ctx, "openfga/openfga:v1.5.0")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// Clean up the container after the test is complete
-	t.Cleanup(func() {
-		if err := container.Terminate(ctx); err != nil {
-			t.Fatalf("failed to terminate container: %s", err)
-		}
-	})
+	ctr, err := openfga.Run(ctx, "openfga/openfga:v1.5.0")
+	testcontainers.CleanupContainer(t, ctr)
+	require.NoError(t, err)
 
 	// perform assertions
 }

--- a/modules/openldap/go.mod
+++ b/modules/openldap/go.mod
@@ -4,7 +4,8 @@ go 1.22
 
 require (
 	github.com/go-ldap/ldap/v3 v3.4.6
-	github.com/testcontainers/testcontainers-go v0.33.0
+	github.com/stretchr/testify v1.9.0
+	github.com/testcontainers/testcontainers-go v0.32.0
 )
 
 require (
@@ -17,6 +18,7 @@ require (
 	github.com/containerd/log v0.1.0 // indirect
 	github.com/containerd/platforms v0.2.1 // indirect
 	github.com/cpuguy83/dockercfg v0.3.1 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/distribution/reference v0.6.0 // indirect
 	github.com/docker/docker v27.1.1+incompatible // indirect
 	github.com/docker/go-connections v0.5.0 // indirect
@@ -29,6 +31,7 @@ require (
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/klauspost/compress v1.17.4 // indirect
+	github.com/kr/text v0.2.0 // indirect
 	github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 // indirect
 	github.com/magiconair/properties v1.8.7 // indirect
 	github.com/moby/docker-image-spec v1.3.1 // indirect
@@ -40,6 +43,7 @@ require (
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c // indirect
 	github.com/shirou/gopsutil/v3 v3.23.12 // indirect
 	github.com/shoenig/go-m1cpu v0.1.6 // indirect
@@ -56,6 +60,7 @@ require (
 	golang.org/x/sys v0.21.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20240318140521-94a12d6c2237 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240318140521-94a12d6c2237 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
 replace github.com/testcontainers/testcontainers-go => ../..

--- a/modules/openldap/go.sum
+++ b/modules/openldap/go.sum
@@ -20,6 +20,7 @@ github.com/containerd/platforms v0.2.1 h1:zvwtM3rz2YHPQsF2CHYM8+KtB5dvhISiXh5ZpS
 github.com/containerd/platforms v0.2.1/go.mod h1:XHCb+2/hzowdiut9rkudds9bE5yJ7npe7dG/wG+uFPw=
 github.com/cpuguy83/dockercfg v0.3.1 h1:/FpZ+JaygUR/lZP2NlFI2DVfrOEMAIKP5wWEJdoYe9E=
 github.com/cpuguy83/dockercfg v0.3.1/go.mod h1:sugsbF4//dDlL/i+S+rtpIWp+5h0BHJHfjj5/jFyUJc=
+github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.18 h1:n56/Zwd5o6whRC5PMGretI4IdRLlmBXYNjScPaBgsbY=
 github.com/creack/pty v1.1.18/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -61,6 +62,10 @@ github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/compress v1.17.4 h1:Ej5ixsIri7BrIjBkRZLTo6ghwrEtHFk7ijlczPW4fZ4=
 github.com/klauspost/compress v1.17.4/go.mod h1:/dCuZOvVtNoHsyb+cuJD3itjs3NbnF6KH9zAO4BDxPM=
+github.com/kr/pretty v0.3.0 h1:WgNl7dwNpEZ6jJ9k1snq4pZsg7DOEN8hP9Xw0Tsjwk0=
+github.com/kr/pretty v0.3.0/go.mod h1:640gp4NfQd8pI5XOwp5fnNeVWj67G7CFk/SaSQn7NBk=
+github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
+github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 h1:6E+4a0GO5zZEnZ81pIr0yLvtUWk2if982qA3F3QD6H4=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0/go.mod h1:zJYVVT2jmtg6P3p1VtQj7WsuWi/y4VnjVBn7F8KPB3I=
 github.com/magiconair/properties v1.8.7 h1:IeQXZAiQcpL9mgcAe1Nu6cX9LLw6ExEHKjN0VQdvPDY=
@@ -87,6 +92,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c h1:ncq/mPwQF4JjgDlrVEn3C11VoGHZN7m8qihwgMEtzYw=
 github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c/go.mod h1:OmDBASR4679mdNQnz2pUhc2G8CO2JrUAVFDRBDP/hJE=
+github.com/rogpeppe/go-internal v1.8.1 h1:geMPLpDpQOgVyCg5z5GoRwLHepNdb71NXb67XFkP+Eg=
+github.com/rogpeppe/go-internal v1.8.1/go.mod h1:JeRgkft04UBgHMgCIwADu4Pn6Mtm5d4nPKWu0nJ5d+o=
 github.com/shirou/gopsutil/v3 v3.23.12 h1:z90NtUkp3bMtmICZKpC4+WaknU1eXtp5vtbQ11DgpE4=
 github.com/shirou/gopsutil/v3 v3.23.12/go.mod h1:1FrWgea594Jp7qmjHUUPlJDTPgcsb9mGnXDxavtikzM=
 github.com/shoenig/go-m1cpu v0.1.6 h1:nxdKQNcEB6vzgA2E2bvzKIYRuNj7XNJ4S/aRSwKzFtM=
@@ -211,6 +218,8 @@ google.golang.org/grpc v1.64.1/go.mod h1:hiQF4LFZelK2WKaP6W0L92zGHtiQdZxk8CrSdvy
 google.golang.org/protobuf v1.33.0 h1:uNO2rsAINq/JlFpSdYEKIZ0uKD/R9cpdv0T+yoGwGmI=
 google.golang.org/protobuf v1.33.0/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/modules/openldap/openldap.go
+++ b/modules/openldap/openldap.go
@@ -161,14 +161,19 @@ func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustom
 	}
 
 	container, err := testcontainers.GenericContainer(ctx, genericContainerReq)
-	if err != nil {
-		return nil, err
+	var c *OpenLDAPContainer
+	if container != nil {
+		c = &OpenLDAPContainer{
+			Container:     container,
+			adminUsername: req.Env["LDAP_ADMIN_USERNAME"],
+			adminPassword: req.Env["LDAP_ADMIN_PASSWORD"],
+			rootDn:        req.Env["LDAP_ROOT"],
+		}
 	}
 
-	return &OpenLDAPContainer{
-		Container:     container,
-		adminUsername: req.Env["LDAP_ADMIN_USERNAME"],
-		adminPassword: req.Env["LDAP_ADMIN_PASSWORD"],
-		rootDn:        req.Env["LDAP_ROOT"],
-	}, nil
+	if err != nil {
+		return c, fmt.Errorf("generic container: %w", err)
+	}
+
+	return c, nil
 }

--- a/modules/openldap/openldap_test.go
+++ b/modules/openldap/openldap_test.go
@@ -6,112 +6,70 @@ import (
 	"testing"
 
 	"github.com/go-ldap/ldap/v3"
+	"github.com/stretchr/testify/require"
 
+	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/modules/openldap"
 )
 
 func TestOpenLDAP(t *testing.T) {
 	ctx := context.Background()
 
-	container, err := openldap.Run(ctx, "bitnami/openldap:2.6.6")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// Clean up the container after the test is complete
-	t.Cleanup(func() {
-		if err := container.Terminate(ctx); err != nil {
-			t.Fatalf("failed to terminate container: %s", err)
-		}
-	})
+	ctr, err := openldap.Run(ctx, "bitnami/openldap:2.6.6")
+	testcontainers.CleanupContainer(t, ctr)
+	require.NoError(t, err)
 }
 
 func TestOpenLDAPWithAdminUsernameAndPassword(t *testing.T) {
 	ctx := context.Background()
 
-	container, err := openldap.Run(ctx,
+	ctr, err := openldap.Run(ctx,
 		"bitnami/openldap:2.6.6",
 		openldap.WithAdminUsername("openldap"),
 		openldap.WithAdminPassword("openldap"),
 	)
-	if err != nil {
-		t.Fatal(err)
-	}
+	testcontainers.CleanupContainer(t, ctr)
+	require.NoError(t, err)
 
-	// Clean up the container after the test is complete
-	t.Cleanup(func() {
-		if err := container.Terminate(ctx); err != nil {
-			t.Fatalf("failed to terminate container: %s", err)
-		}
-	})
-
-	connectionString, err := container.ConnectionString(ctx)
-	if err != nil {
-		t.Fatal(err)
-	}
+	connectionString, err := ctr.ConnectionString(ctx)
+	require.NoError(t, err)
 
 	client, err := ldap.DialURL(connectionString)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	defer client.Close()
 
 	// First bind with a read only user
 	err = client.Bind("cn=openldap,dc=example,dc=org", "openldap")
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 }
 
 func TestOpenLDAPWithDifferentRoot(t *testing.T) {
 	ctx := context.Background()
 
-	container, err := openldap.Run(ctx, "bitnami/openldap:2.6.6", openldap.WithRoot("dc=mydomain,dc=com"))
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// Clean up the container after the test is complete
-	t.Cleanup(func() {
-		if err := container.Terminate(ctx); err != nil {
-			t.Fatalf("failed to terminate container: %s", err)
-		}
-	})
+	ctr, err := openldap.Run(ctx, "bitnami/openldap:2.6.6", openldap.WithRoot("dc=mydomain,dc=com"))
+	testcontainers.CleanupContainer(t, ctr)
+	require.NoError(t, err)
 
 	// connectionString {
-	connectionString, err := container.ConnectionString(ctx)
+	connectionString, err := ctr.ConnectionString(ctx)
 	// }
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	client, err := ldap.DialURL(connectionString)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	defer client.Close()
 
 	// First bind with a read only user
 	err = client.Bind("cn=admin,dc=mydomain,dc=com", "adminpassword")
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 }
 
 func TestOpenLDAPLoadLdif(t *testing.T) {
 	ctx := context.Background()
 
-	container, err := openldap.Run(ctx, "bitnami/openldap:2.6.6")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// Clean up the container after the test is complete
-	t.Cleanup(func() {
-		if err := container.Terminate(ctx); err != nil {
-			t.Fatalf("failed to terminate container: %s", err)
-		}
-	})
+	ctr, err := openldap.Run(ctx, "bitnami/openldap:2.6.6")
+	testcontainers.CleanupContainer(t, ctr)
+	require.NoError(t, err)
 
 	// loadLdif {
 	ldif := `
@@ -124,28 +82,20 @@ mail: test.user@example.org
 userPassword: Password1
 `
 
-	err = container.LoadLdif(ctx, []byte(ldif))
+	err = ctr.LoadLdif(ctx, []byte(ldif))
 	// }
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
-	connectionString, err := container.ConnectionString(ctx)
-	if err != nil {
-		t.Fatal(err)
-	}
+	connectionString, err := ctr.ConnectionString(ctx)
+	require.NoError(t, err)
 
 	client, err := ldap.DialURL(connectionString)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	defer client.Close()
 
 	// First bind with a read only user
 	err = client.Bind("cn=admin,dc=example,dc=org", "adminpassword")
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	result, err := client.Search(&ldap.SearchRequest{
 		BaseDN:     "uid=test.user,ou=users,dc=example,dc=org",
@@ -153,16 +103,9 @@ userPassword: Password1
 		Filter:     "(objectClass=*)",
 		Attributes: []string{"dn"},
 	})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if len(result.Entries) != 1 {
-		t.Fatal("Invalid number of entries returned", result.Entries)
-	}
-	if result.Entries[0].DN != "uid=test.user,ou=users,dc=example,dc=org" {
-		t.Fatal("Invalid entry returned", result.Entries[0].DN)
-	}
+	require.NoError(t, err)
+	require.Len(t, result.Entries, 1)
+	require.Equal(t, "uid=test.user,ou=users,dc=example,dc=org", result.Entries[0].DN)
 }
 
 func TestOpenLDAPWithInitialLdif(t *testing.T) {
@@ -178,47 +121,28 @@ userPassword: Password1
 `
 
 	f, err := os.CreateTemp(t.TempDir(), "test.ldif")
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	_, err = f.WriteString(ldif)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
+
 	err = f.Close()
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
-	container, err := openldap.Run(ctx, "bitnami/openldap:2.6.6", openldap.WithInitialLdif(f.Name()))
-	if err != nil {
-		t.Fatal(err)
-	}
+	ctr, err := openldap.Run(ctx, "bitnami/openldap:2.6.6", openldap.WithInitialLdif(f.Name()))
+	testcontainers.CleanupContainer(t, ctr)
+	require.NoError(t, err)
 
-	// Clean up the container after the test is complete
-	t.Cleanup(func() {
-		if err := container.Terminate(ctx); err != nil {
-			t.Fatalf("failed to terminate container: %s", err)
-		}
-	})
-
-	connectionString, err := container.ConnectionString(ctx)
-	if err != nil {
-		t.Fatal(err)
-	}
+	connectionString, err := ctr.ConnectionString(ctx)
+	require.NoError(t, err)
 
 	client, err := ldap.DialURL(connectionString)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	defer client.Close()
 
 	// First bind with a read only user
 	err = client.Bind("cn=admin,dc=example,dc=org", "adminpassword")
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	result, err := client.Search(&ldap.SearchRequest{
 		BaseDN:     "uid=test.user,ou=users,dc=example,dc=org",
@@ -226,14 +150,8 @@ userPassword: Password1
 		Filter:     "(objectClass=*)",
 		Attributes: []string{"dn"},
 	})
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
-	if len(result.Entries) != 1 {
-		t.Fatal("Invalid number of entries returned", result.Entries)
-	}
-	if result.Entries[0].DN != "uid=test.user,ou=users,dc=example,dc=org" {
-		t.Fatal("Invalid entry returned", result.Entries[0].DN)
-	}
+	require.Len(t, result.Entries, 1)
+	require.Equal(t, "uid=test.user,ou=users,dc=example,dc=org", result.Entries[0].DN)
 }

--- a/modules/opensearch/examples_test.go
+++ b/modules/opensearch/examples_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 
+	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/modules/opensearch"
 )
 
@@ -18,21 +19,21 @@ func ExampleRun() {
 		opensearch.WithUsername("new-username"),
 		opensearch.WithPassword("new-password"),
 	)
-	if err != nil {
-		log.Fatalf("failed to start container: %s", err)
-	}
-
-	// Clean up the container
 	defer func() {
-		if err := opensearchContainer.Terminate(ctx); err != nil {
-			log.Fatalf("failed to terminate container: %s", err) // nolint:gocritic
+		if err := testcontainers.TerminateContainer(opensearchContainer); err != nil {
+			log.Printf("failed to terminate container: %s", err)
 		}
 	}()
+	if err != nil {
+		log.Printf("failed to start container: %s", err)
+		return
+	}
 	// }
 
 	state, err := opensearchContainer.State(ctx)
 	if err != nil {
-		log.Fatalf("failed to get container state: %s", err) // nolint:gocritic
+		log.Printf("failed to get container state: %s", err)
+		return
 	}
 
 	fmt.Println(state.Running)

--- a/modules/opensearch/go.mod
+++ b/modules/opensearch/go.mod
@@ -5,7 +5,8 @@ go 1.22
 require (
 	github.com/docker/docker v27.1.1+incompatible
 	github.com/docker/go-units v0.5.0
-	github.com/testcontainers/testcontainers-go v0.33.0
+	github.com/stretchr/testify v1.9.0
+	github.com/testcontainers/testcontainers-go v0.32.0
 )
 
 require (
@@ -17,6 +18,7 @@ require (
 	github.com/containerd/log v0.1.0 // indirect
 	github.com/containerd/platforms v0.2.1 // indirect
 	github.com/cpuguy83/dockercfg v0.3.1 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/distribution/reference v0.6.0 // indirect
 	github.com/docker/go-connections v0.5.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
@@ -26,6 +28,7 @@ require (
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/klauspost/compress v1.17.4 // indirect
+	github.com/kr/text v0.2.0 // indirect
 	github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 // indirect
 	github.com/magiconair/properties v1.8.7 // indirect
 	github.com/moby/docker-image-spec v1.3.1 // indirect
@@ -37,6 +40,7 @@ require (
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c // indirect
 	github.com/shirou/gopsutil/v3 v3.23.12 // indirect
 	github.com/shoenig/go-m1cpu v0.1.6 // indirect
@@ -53,6 +57,7 @@ require (
 	golang.org/x/sys v0.21.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20240318140521-94a12d6c2237 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240318140521-94a12d6c2237 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
 replace github.com/testcontainers/testcontainers-go => ../..

--- a/modules/opensearch/go.sum
+++ b/modules/opensearch/go.sum
@@ -16,6 +16,7 @@ github.com/containerd/platforms v0.2.1 h1:zvwtM3rz2YHPQsF2CHYM8+KtB5dvhISiXh5ZpS
 github.com/containerd/platforms v0.2.1/go.mod h1:XHCb+2/hzowdiut9rkudds9bE5yJ7npe7dG/wG+uFPw=
 github.com/cpuguy83/dockercfg v0.3.1 h1:/FpZ+JaygUR/lZP2NlFI2DVfrOEMAIKP5wWEJdoYe9E=
 github.com/cpuguy83/dockercfg v0.3.1/go.mod h1:sugsbF4//dDlL/i+S+rtpIWp+5h0BHJHfjj5/jFyUJc=
+github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.18 h1:n56/Zwd5o6whRC5PMGretI4IdRLlmBXYNjScPaBgsbY=
 github.com/creack/pty v1.1.18/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -52,6 +53,10 @@ github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/compress v1.17.4 h1:Ej5ixsIri7BrIjBkRZLTo6ghwrEtHFk7ijlczPW4fZ4=
 github.com/klauspost/compress v1.17.4/go.mod h1:/dCuZOvVtNoHsyb+cuJD3itjs3NbnF6KH9zAO4BDxPM=
+github.com/kr/pretty v0.3.0 h1:WgNl7dwNpEZ6jJ9k1snq4pZsg7DOEN8hP9Xw0Tsjwk0=
+github.com/kr/pretty v0.3.0/go.mod h1:640gp4NfQd8pI5XOwp5fnNeVWj67G7CFk/SaSQn7NBk=
+github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
+github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 h1:6E+4a0GO5zZEnZ81pIr0yLvtUWk2if982qA3F3QD6H4=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0/go.mod h1:zJYVVT2jmtg6P3p1VtQj7WsuWi/y4VnjVBn7F8KPB3I=
 github.com/magiconair/properties v1.8.7 h1:IeQXZAiQcpL9mgcAe1Nu6cX9LLw6ExEHKjN0VQdvPDY=
@@ -78,6 +83,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c h1:ncq/mPwQF4JjgDlrVEn3C11VoGHZN7m8qihwgMEtzYw=
 github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c/go.mod h1:OmDBASR4679mdNQnz2pUhc2G8CO2JrUAVFDRBDP/hJE=
+github.com/rogpeppe/go-internal v1.8.1 h1:geMPLpDpQOgVyCg5z5GoRwLHepNdb71NXb67XFkP+Eg=
+github.com/rogpeppe/go-internal v1.8.1/go.mod h1:JeRgkft04UBgHMgCIwADu4Pn6Mtm5d4nPKWu0nJ5d+o=
 github.com/shirou/gopsutil/v3 v3.23.12 h1:z90NtUkp3bMtmICZKpC4+WaknU1eXtp5vtbQ11DgpE4=
 github.com/shirou/gopsutil/v3 v3.23.12/go.mod h1:1FrWgea594Jp7qmjHUUPlJDTPgcsb9mGnXDxavtikzM=
 github.com/shoenig/go-m1cpu v0.1.6 h1:nxdKQNcEB6vzgA2E2bvzKIYRuNj7XNJ4S/aRSwKzFtM=
@@ -174,6 +181,8 @@ google.golang.org/grpc v1.64.1/go.mod h1:hiQF4LFZelK2WKaP6W0L92zGHtiQdZxk8CrSdvy
 google.golang.org/protobuf v1.33.0 h1:uNO2rsAINq/JlFpSdYEKIZ0uKD/R9cpdv0T+yoGwGmI=
 google.golang.org/protobuf v1.33.0/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/modules/opensearch/opensearch.go
+++ b/modules/opensearch/opensearch.go
@@ -118,11 +118,16 @@ func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustom
 		})
 
 	container, err := testcontainers.GenericContainer(ctx, genericContainerReq)
-	if err != nil {
-		return nil, err
+	var c *OpenSearchContainer
+	if container != nil {
+		c = &OpenSearchContainer{Container: container, User: username, Password: password}
 	}
 
-	return &OpenSearchContainer{Container: container, User: username, Password: password}, nil
+	if err != nil {
+		return c, fmt.Errorf("generic container: %w", err)
+	}
+
+	return c, nil
 }
 
 // Address retrieves the address of the OpenSearch container.

--- a/modules/opensearch/opensearch_test.go
+++ b/modules/opensearch/opensearch_test.go
@@ -5,41 +5,30 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
+	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/modules/opensearch"
 )
 
 func TestOpenSearch(t *testing.T) {
 	ctx := context.Background()
 
-	container, err := opensearch.Run(ctx, "opensearchproject/opensearch:2.11.1")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// Clean up the container after the test is complete
-	t.Cleanup(func() {
-		if err := container.Terminate(ctx); err != nil {
-			t.Fatalf("failed to terminate container: %s", err)
-		}
-	})
+	ctr, err := opensearch.Run(ctx, "opensearchproject/opensearch:2.11.1")
+	testcontainers.CleanupContainer(t, ctr)
+	require.NoError(t, err)
 
 	t.Run("Connect to Address", func(t *testing.T) {
-		address, err := container.Address(ctx)
-		if err != nil {
-			t.Fatal(err)
-		}
+		address, err := ctr.Address(ctx)
+		require.NoError(t, err)
 
 		client := &http.Client{}
 
 		req, err := http.NewRequest("GET", address, nil)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
 		resp, err := client.Do(req)
-		if err != nil {
-			t.Fatalf("failed to perform GET request: %s", err)
-		}
+		require.NoError(t, err)
 		defer resp.Body.Close()
 	})
 }

--- a/modules/postgres/examples_test.go
+++ b/modules/postgres/examples_test.go
@@ -32,21 +32,21 @@ func ExampleRun() {
 				WithOccurrence(2).
 				WithStartupTimeout(5*time.Second)),
 	)
-	if err != nil {
-		log.Fatalf("failed to start container: %s", err)
-	}
-
-	// Clean up the container
 	defer func() {
-		if err := postgresContainer.Terminate(ctx); err != nil {
-			log.Fatalf("failed to terminate container: %s", err)
+		if err := testcontainers.TerminateContainer(postgresContainer); err != nil {
+			log.Printf("failed to terminate container: %s", err)
 		}
 	}()
+	if err != nil {
+		log.Printf("failed to start container: %s", err)
+		return
+	}
 	// }
 
 	state, err := postgresContainer.State(ctx)
 	if err != nil {
-		log.Fatalf("failed to get container state: %s", err) // nolint:gocritic
+		log.Printf("failed to get container state: %s", err)
+		return
 	}
 
 	fmt.Println(state.Running)

--- a/modules/postgres/postgres.go
+++ b/modules/postgres/postgres.go
@@ -169,15 +169,22 @@ func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustom
 	}
 
 	container, err := testcontainers.GenericContainer(ctx, genericContainerReq)
-	if err != nil {
-		return nil, err
+	var c *PostgresContainer
+	if container != nil {
+		c = &PostgresContainer{
+			Container:     container,
+			dbName:        req.Env["POSTGRES_DB"],
+			password:      req.Env["POSTGRES_PASSWORD"],
+			user:          req.Env["POSTGRES_USER"],
+			sqlDriverName: settings.SQLDriverName,
+		}
 	}
 
-	user := req.Env["POSTGRES_USER"]
-	password := req.Env["POSTGRES_PASSWORD"]
-	dbName := req.Env["POSTGRES_DB"]
+	if err != nil {
+		return c, fmt.Errorf("generic container: %w", err)
+	}
 
-	return &PostgresContainer{Container: container, dbName: dbName, password: password, user: user, sqlDriverName: settings.SQLDriverName}, nil
+	return c, nil
 }
 
 type snapshotConfig struct {

--- a/modules/postgres/postgres_test.go
+++ b/modules/postgres/postgres_test.go
@@ -3,7 +3,6 @@ package postgres_test
 import (
 	"context"
 	"database/sql"
-	"errors"
 	"fmt"
 	"path/filepath"
 	"testing"
@@ -13,7 +12,6 @@ import (
 	"github.com/jackc/pgx/v5"
 	_ "github.com/jackc/pgx/v5/stdlib"
 	_ "github.com/lib/pq"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/testcontainers/testcontainers-go"
@@ -60,53 +58,45 @@ func TestPostgres(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			container, err := postgres.Run(ctx,
+			ctr, err := postgres.Run(ctx,
 				tt.image,
 				postgres.WithDatabase(dbname),
 				postgres.WithUsername(user),
 				postgres.WithPassword(password),
 				postgres.BasicWaitStrategies(),
 			)
-			if err != nil {
-				t.Fatal(err)
-			}
-
-			// Clean up the container after the test is complete
-			t.Cleanup(func() {
-				if err := container.Terminate(ctx); err != nil {
-					t.Fatalf("failed to terminate container: %s", err)
-				}
-			})
+			testcontainers.CleanupContainer(t, ctr)
+			require.NoError(t, err)
 
 			// connectionString {
 			// explicitly set sslmode=disable because the container is not configured to use TLS
-			connStr, err := container.ConnectionString(ctx, "sslmode=disable", "application_name=test")
+			connStr, err := ctr.ConnectionString(ctx, "sslmode=disable", "application_name=test")
 			// }
 			require.NoError(t, err)
 
-			mustConnStr := container.MustConnectionString(ctx, "sslmode=disable", "application_name=test")
+			mustConnStr := ctr.MustConnectionString(ctx, "sslmode=disable", "application_name=test")
 			if mustConnStr != connStr {
 				t.Errorf("ConnectionString was not equal to MustConnectionString")
 			}
 
 			// Ensure connection string is using generic format
-			id, err := container.MappedPort(ctx, "5432/tcp")
+			id, err := ctr.MappedPort(ctx, "5432/tcp")
 			require.NoError(t, err)
-			assert.Equal(t, fmt.Sprintf("postgres://%s:%s@%s:%s/%s?sslmode=disable&application_name=test", user, password, "localhost", id.Port(), dbname), connStr)
+			require.Equal(t, fmt.Sprintf("postgres://%s:%s@%s:%s/%s?sslmode=disable&application_name=test", user, password, "localhost", id.Port(), dbname), connStr)
 
 			// perform assertions
 			db, err := sql.Open("postgres", connStr)
 			require.NoError(t, err)
-			assert.NotNil(t, db)
+			require.NotNil(t, db)
 			defer db.Close()
 
 			result, err := db.Exec("CREATE TABLE IF NOT EXISTS test (id int, name varchar(255));")
 			require.NoError(t, err)
-			assert.NotNil(t, result)
+			require.NotNil(t, result)
 
 			result, err = db.Exec("INSERT INTO test (id, name) VALUES (1, 'test');")
 			require.NoError(t, err)
-			assert.NotNil(t, result)
+			require.NotNil(t, result)
 		})
 	}
 }
@@ -120,7 +110,7 @@ func TestContainerWithWaitForSQL(t *testing.T) {
 	}
 
 	t.Run("default query", func(t *testing.T) {
-		container, err := postgres.Run(
+		ctr, err := postgres.Run(
 			ctx,
 			"docker.io/postgres:16-alpine",
 			postgres.WithDatabase(dbname),
@@ -128,11 +118,12 @@ func TestContainerWithWaitForSQL(t *testing.T) {
 			postgres.WithPassword(password),
 			testcontainers.WithWaitStrategy(wait.ForSQL(nat.Port(port), "postgres", dbURL)),
 		)
+		testcontainers.CleanupContainer(t, ctr)
 		require.NoError(t, err)
-		require.NotNil(t, container)
+		require.NotNil(t, ctr)
 	})
 	t.Run("custom query", func(t *testing.T) {
-		container, err := postgres.Run(
+		ctr, err := postgres.Run(
 			ctx,
 			"docker.io/postgres:16-alpine",
 			postgres.WithDatabase(dbname),
@@ -140,11 +131,12 @@ func TestContainerWithWaitForSQL(t *testing.T) {
 			postgres.WithPassword(password),
 			testcontainers.WithWaitStrategy(wait.ForSQL(nat.Port(port), "postgres", dbURL).WithStartupTimeout(time.Second*5).WithQuery("SELECT 10")),
 		)
+		testcontainers.CleanupContainer(t, ctr)
 		require.NoError(t, err)
-		require.NotNil(t, container)
+		require.NotNil(t, ctr)
 	})
 	t.Run("custom bad query", func(t *testing.T) {
-		container, err := postgres.Run(
+		ctr, err := postgres.Run(
 			ctx,
 			"docker.io/postgres:16-alpine",
 			postgres.WithDatabase(dbname),
@@ -152,15 +144,15 @@ func TestContainerWithWaitForSQL(t *testing.T) {
 			postgres.WithPassword(password),
 			testcontainers.WithWaitStrategy(wait.ForSQL(nat.Port(port), "postgres", dbURL).WithStartupTimeout(time.Second*5).WithQuery("SELECT 'a' from b")),
 		)
+		testcontainers.CleanupContainer(t, ctr)
 		require.Error(t, err)
-		require.Nil(t, container)
 	})
 }
 
 func TestWithConfigFile(t *testing.T) {
 	ctx := context.Background()
 
-	container, err := postgres.Run(ctx,
+	ctr, err := postgres.Run(ctx,
 		"docker.io/postgres:16-alpine",
 		postgres.WithConfigFile(filepath.Join("testdata", "my-postgres.conf")),
 		postgres.WithDatabase(dbname),
@@ -168,30 +160,23 @@ func TestWithConfigFile(t *testing.T) {
 		postgres.WithPassword(password),
 		postgres.BasicWaitStrategies(),
 	)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	t.Cleanup(func() {
-		if err := container.Terminate(ctx); err != nil {
-			t.Fatalf("failed to terminate container: %s", err)
-		}
-	})
+	testcontainers.CleanupContainer(t, ctr)
+	require.NoError(t, err)
 
 	// explicitly set sslmode=disable because the container is not configured to use TLS
-	connStr, err := container.ConnectionString(ctx, "sslmode=disable")
+	connStr, err := ctr.ConnectionString(ctx, "sslmode=disable")
 	require.NoError(t, err)
 
 	db, err := sql.Open("postgres", connStr)
 	require.NoError(t, err)
-	assert.NotNil(t, db)
+	require.NotNil(t, db)
 	defer db.Close()
 }
 
 func TestWithInitScript(t *testing.T) {
 	ctx := context.Background()
 
-	container, err := postgres.Run(ctx,
+	ctr, err := postgres.Run(ctx,
 		"docker.io/postgres:15.2-alpine",
 		postgres.WithInitScripts(filepath.Join("testdata", "init-user-db.sh")),
 		postgres.WithDatabase(dbname),
@@ -199,37 +184,30 @@ func TestWithInitScript(t *testing.T) {
 		postgres.WithPassword(password),
 		postgres.BasicWaitStrategies(),
 	)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	t.Cleanup(func() {
-		if err := container.Terminate(ctx); err != nil {
-			t.Fatalf("failed to terminate container: %s", err)
-		}
-	})
+	testcontainers.CleanupContainer(t, ctr)
+	require.NoError(t, err)
 
 	// explicitly set sslmode=disable because the container is not configured to use TLS
-	connStr, err := container.ConnectionString(ctx, "sslmode=disable")
+	connStr, err := ctr.ConnectionString(ctx, "sslmode=disable")
 	require.NoError(t, err)
 
 	db, err := sql.Open("postgres", connStr)
 	require.NoError(t, err)
-	assert.NotNil(t, db)
+	require.NotNil(t, db)
 	defer db.Close()
 
 	// database created in init script. See testdata/init-user-db.sh
 	result, err := db.Exec("SELECT * FROM testdb;")
 	require.NoError(t, err)
-	assert.NotNil(t, result)
+	require.NotNil(t, result)
 }
 
 func TestSnapshot(t *testing.T) {
 	// snapshotAndReset {
 	ctx := context.Background()
 
-	// 1. Start the postgres container and run any migrations on it
-	container, err := postgres.Run(
+	// 1. Start the postgres ctr and run any migrations on it
+	ctr, err := postgres.Run(
 		ctx,
 		"docker.io/postgres:16-alpine",
 		postgres.WithDatabase(dbname),
@@ -238,90 +216,58 @@ func TestSnapshot(t *testing.T) {
 		postgres.BasicWaitStrategies(),
 		postgres.WithSQLDriver("pgx"),
 	)
-	if err != nil {
-		t.Fatal(err)
-	}
+	testcontainers.CleanupContainer(t, ctr)
+	require.NoError(t, err)
 
 	// Run any migrations on the database
-	_, _, err = container.Exec(ctx, []string{"psql", "-U", user, "-d", dbname, "-c", "CREATE TABLE users (id SERIAL, name TEXT NOT NULL, age INT NOT NULL)"})
-	if err != nil {
-		t.Fatal(err)
-	}
+	_, _, err = ctr.Exec(ctx, []string{"psql", "-U", user, "-d", dbname, "-c", "CREATE TABLE users (id SERIAL, name TEXT NOT NULL, age INT NOT NULL)"})
+	require.NoError(t, err)
 
 	// 2. Create a snapshot of the database to restore later
-	err = container.Snapshot(ctx, postgres.WithSnapshotName("test-snapshot"))
-	if err != nil {
-		t.Fatal(err)
-	}
+	err = ctr.Snapshot(ctx, postgres.WithSnapshotName("test-snapshot"))
+	require.NoError(t, err)
 
-	// Clean up the container after the test is complete
-	t.Cleanup(func() {
-		if err := container.Terminate(ctx); err != nil {
-			t.Fatalf("failed to terminate container: %s", err)
-		}
-	})
-
-	dbURL, err := container.ConnectionString(ctx)
-	if err != nil {
-		t.Fatal(err)
-	}
+	dbURL, err := ctr.ConnectionString(ctx)
+	require.NoError(t, err)
 
 	t.Run("Test inserting a user", func(t *testing.T) {
 		t.Cleanup(func() {
 			// 3. In each test, reset the DB to its snapshot state.
-			err = container.Restore(ctx)
-			if err != nil {
-				t.Fatal(err)
-			}
+			err = ctr.Restore(ctx)
+			require.NoError(t, err)
 		})
 
 		conn, err := pgx.Connect(context.Background(), dbURL)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer conn.Close(context.Background())
 
 		_, err = conn.Exec(ctx, "INSERT INTO users(name, age) VALUES ($1, $2)", "test", 42)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
 		var name string
 		var age int64
 		err = conn.QueryRow(context.Background(), "SELECT name, age FROM users LIMIT 1").Scan(&name, &age)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
-		if name != "test" {
-			t.Fatalf("Expected %s to equal `test`", name)
-		}
-		if age != 42 {
-			t.Fatalf("Expected %d to equal `42`", age)
-		}
+		require.Equal(t, "test", name)
+		require.EqualValues(t, 42, age)
 	})
 
 	// 4. Run as many tests as you need, they will each get a clean database
 	t.Run("Test querying empty DB", func(t *testing.T) {
 		t.Cleanup(func() {
-			err = container.Restore(ctx)
-			if err != nil {
-				t.Fatal(err)
-			}
+			err = ctr.Restore(ctx)
+			require.NoError(t, err)
 		})
 
 		conn, err := pgx.Connect(context.Background(), dbURL)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer conn.Close(context.Background())
 
 		var name string
 		var age int64
 		err = conn.QueryRow(context.Background(), "SELECT name, age FROM users LIMIT 1").Scan(&name, &age)
-		if !errors.Is(err, pgx.ErrNoRows) {
-			t.Fatalf("Expected error to be a NoRows error, since the DB should be empty on every test. Got %s instead", err)
-		}
+		require.ErrorIs(t, err, pgx.ErrNoRows)
 	})
 	// }
 }
@@ -333,7 +279,7 @@ func TestSnapshotWithOverrides(t *testing.T) {
 	user := "other-user"
 	password := "other-password"
 
-	container, err := postgres.Run(
+	ctr, err := postgres.Run(
 		ctx,
 		"docker.io/postgres:16-alpine",
 		postgres.WithDatabase(dbname),
@@ -341,58 +287,34 @@ func TestSnapshotWithOverrides(t *testing.T) {
 		postgres.WithPassword(password),
 		postgres.BasicWaitStrategies(),
 	)
-	if err != nil {
-		t.Fatal(err)
-	}
+	testcontainers.CleanupContainer(t, ctr)
+	require.NoError(t, err)
 
-	_, _, err = container.Exec(ctx, []string{"psql", "-U", user, "-d", dbname, "-c", "CREATE TABLE users (id SERIAL, name TEXT NOT NULL, age INT NOT NULL)"})
-	if err != nil {
-		t.Fatal(err)
-	}
+	_, _, err = ctr.Exec(ctx, []string{"psql", "-U", user, "-d", dbname, "-c", "CREATE TABLE users (id SERIAL, name TEXT NOT NULL, age INT NOT NULL)"})
+	require.NoError(t, err)
+	err = ctr.Snapshot(ctx, postgres.WithSnapshotName("other-snapshot"))
+	require.NoError(t, err)
 
-	err = container.Snapshot(ctx, postgres.WithSnapshotName("other-snapshot"))
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	t.Cleanup(func() {
-		if err := container.Terminate(ctx); err != nil {
-			t.Fatalf("failed to terminate container: %s", err)
-		}
-	})
-
-	dbURL, err := container.ConnectionString(ctx)
-	if err != nil {
-		t.Fatal(err)
-	}
+	dbURL, err := ctr.ConnectionString(ctx)
+	require.NoError(t, err)
 
 	t.Run("Test that the restore works when not using defaults", func(t *testing.T) {
-		_, _, err = container.Exec(ctx, []string{"psql", "-U", user, "-d", dbname, "-c", "INSERT INTO users(name, age) VALUES ('test', 42)"})
-		if err != nil {
-			t.Fatal(err)
-		}
+		_, _, err = ctr.Exec(ctx, []string{"psql", "-U", user, "-d", dbname, "-c", "INSERT INTO users(name, age) VALUES ('test', 42)"})
+		require.NoError(t, err)
 
 		// Doing the restore before we connect since this resets the pgx connection
-		err = container.Restore(ctx)
-		if err != nil {
-			t.Fatal(err)
-		}
+		err = ctr.Restore(ctx)
+		require.NoError(t, err)
 
 		conn, err := pgx.Connect(context.Background(), dbURL)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer conn.Close(context.Background())
 
 		var count int64
 		err = conn.QueryRow(context.Background(), "SELECT COUNT(1) FROM users").Scan(&count)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
-		if count != 0 {
-			t.Fatalf("Expected %d to equal `0`", count)
-		}
+		require.Zero(t, count)
 	})
 }
 
@@ -413,90 +335,58 @@ func TestSnapshotWithDockerExecFallback(t *testing.T) {
 		postgres.WithSQLDriver("DoesNotExist"),
 	)
 	// }
-	if err != nil {
-		t.Fatal(err)
-	}
+	testcontainers.CleanupContainer(t, ctr)
+	require.NoError(t, err)
 
 	// Run any migrations on the database
 	_, _, err = ctr.Exec(ctx, []string{"psql", "-U", user, "-d", dbname, "-c", "CREATE TABLE users (id SERIAL, name TEXT NOT NULL, age INT NOT NULL)"})
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	// 2. Create a snapshot of the database to restore later
 	err = ctr.Snapshot(ctx, postgres.WithSnapshotName("test-snapshot"))
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// Clean up the container after the test is complete
-	t.Cleanup(func() {
-		if err := ctr.Terminate(ctx); err != nil {
-			t.Fatalf("failed to terminate container: %s", err)
-		}
-	})
+	require.NoError(t, err)
 
 	dbURL, err := ctr.ConnectionString(ctx)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	t.Run("Test inserting a user", func(t *testing.T) {
 		t.Cleanup(func() {
 			// 3. In each test, reset the DB to its snapshot state.
 			err := ctr.Restore(ctx)
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
 		})
 
 		conn, err2 := pgx.Connect(context.Background(), dbURL)
-		if err2 != nil {
-			t.Fatal(err2)
-		}
+		require.NoError(t, err2)
 		defer conn.Close(context.Background())
 
 		_, err2 = conn.Exec(ctx, "INSERT INTO users(name, age) VALUES ($1, $2)", "test", 42)
-		if err2 != nil {
-			t.Fatal(err2)
-		}
+		require.NoError(t, err2)
 
 		var name string
 		var age int64
 		err2 = conn.QueryRow(context.Background(), "SELECT name, age FROM users LIMIT 1").Scan(&name, &age)
-		if err2 != nil {
-			t.Fatal(err2)
-		}
+		require.NoError(t, err2)
 
-		if name != "test" {
-			t.Fatalf("Expected %s to equal `test`", name)
-		}
-		if age != 42 {
-			t.Fatalf("Expected %d to equal `42`", age)
-		}
+		require.Equal(t, "test", name)
+		require.EqualValues(t, 42, age)
 	})
 
 	t.Run("Test querying empty DB", func(t *testing.T) {
 		// 4. Run as many tests as you need, they will each get a clean database
 		t.Cleanup(func() {
 			err := ctr.Restore(ctx)
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
 		})
 
 		conn, err2 := pgx.Connect(context.Background(), dbURL)
-		if err2 != nil {
-			t.Fatal(err2)
-		}
+		require.NoError(t, err2)
 		defer conn.Close(context.Background())
 
 		var name string
 		var age int64
 		err2 = conn.QueryRow(context.Background(), "SELECT name, age FROM users LIMIT 1").Scan(&name, &age)
-		if !errors.Is(err2, pgx.ErrNoRows) {
-			t.Fatalf("Expected error to be a NoRows error, since the DB should be empty on every test. Got %s instead", err2)
-		}
+		require.ErrorIs(t, err2, pgx.ErrNoRows)
 	})
 	// }
 }

--- a/modules/pulsar/examples_test.go
+++ b/modules/pulsar/examples_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 
+	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/modules/pulsar"
 )
 
@@ -13,21 +14,21 @@ func ExampleRun() {
 	ctx := context.Background()
 
 	pulsarContainer, err := pulsar.Run(ctx, "docker.io/apachepulsar/pulsar:2.10.2")
-	if err != nil {
-		log.Fatalf("failed to start container: %s", err)
-	}
-
-	// Clean up the container
 	defer func() {
-		if err := pulsarContainer.Terminate(ctx); err != nil {
-			log.Fatalf("failed to terminate container: %s", err)
+		if err := testcontainers.TerminateContainer(pulsarContainer); err != nil {
+			log.Printf("failed to terminate container: %s", err)
 		}
 	}()
+	if err != nil {
+		log.Printf("failed to start container: %s", err)
+		return
+	}
 	// }
 
 	state, err := pulsarContainer.State(ctx)
 	if err != nil {
-		log.Fatalf("failed to get container state: %s", err) // nolint:gocritic
+		log.Printf("failed to get container state: %s", err)
+		return
 	}
 
 	fmt.Println(state.Running)

--- a/modules/pulsar/pulsar.go
+++ b/modules/pulsar/pulsar.go
@@ -164,14 +164,15 @@ func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustom
 		}
 	}
 
-	c, err := testcontainers.GenericContainer(ctx, genericContainerReq)
+	container, err := testcontainers.GenericContainer(ctx, genericContainerReq)
+	var c *Container
+	if container != nil {
+		c = &Container{Container: container}
+	}
+
 	if err != nil {
-		return nil, err
+		return c, fmt.Errorf("generic container: %w", err)
 	}
 
-	pc := &Container{
-		Container: c,
-	}
-
-	return pc, nil
+	return c, nil
 }

--- a/modules/qdrant/examples_test.go
+++ b/modules/qdrant/examples_test.go
@@ -10,6 +10,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 
+	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/modules/qdrant"
 )
 
@@ -18,21 +19,21 @@ func ExampleRun() {
 	ctx := context.Background()
 
 	qdrantContainer, err := qdrant.Run(ctx, "qdrant/qdrant:v1.7.4")
-	if err != nil {
-		log.Fatalf("failed to start container: %s", err)
-	}
-
-	// Clean up the container
 	defer func() {
-		if err := qdrantContainer.Terminate(ctx); err != nil {
-			log.Fatalf("failed to terminate container: %s", err) // nolint:gocritic
+		if err := testcontainers.TerminateContainer(qdrantContainer); err != nil {
+			log.Printf("failed to terminate container: %s", err)
 		}
 	}()
+	if err != nil {
+		log.Printf("failed to start container: %s", err)
+		return
+	}
 	// }
 
 	state, err := qdrantContainer.State(ctx)
 	if err != nil {
-		log.Fatalf("failed to get container state: %s", err) // nolint:gocritic
+		log.Printf("failed to get container state: %s", err)
+		return
 	}
 
 	fmt.Println(state.Running)
@@ -44,25 +45,27 @@ func ExampleRun() {
 func ExampleRun_createPoints() {
 	// fullExample {
 	qdrantContainer, err := qdrant.Run(context.Background(), "qdrant/qdrant:v1.7.4")
-	if err != nil {
-		log.Fatalf("failed to start container: %s", err)
-	}
-
 	defer func() {
-		if err := qdrantContainer.Terminate(context.Background()); err != nil {
-			log.Fatalf("failed to terminate container: %s", err) // nolint:gocritic
+		if err := testcontainers.TerminateContainer(qdrantContainer); err != nil {
+			log.Printf("failed to terminate container: %s", err)
 		}
 	}()
+	if err != nil {
+		log.Printf("failed to start container: %s", err)
+		return
+	}
 
 	grpcEndpoint, err := qdrantContainer.GRPCEndpoint(context.Background())
 	if err != nil {
-		log.Fatalf("failed to get gRPC endpoint: %s", err) // nolint:gocritic
+		log.Printf("failed to get gRPC endpoint: %s", err)
+		return
 	}
 
 	// Set up a connection to the server.
 	conn, err := grpc.NewClient(grpcEndpoint, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
-		log.Fatalf("did not connect: %v", err)
+		log.Printf("did not connect: %v", err)
+		return
 	}
 	defer conn.Close()
 
@@ -89,7 +92,8 @@ func ExampleRun_createPoints() {
 		},
 	})
 	if err != nil {
-		log.Fatalf("Could not create collection: %v", err)
+		log.Printf("Could not create collection: %v", err)
+		return
 	}
 
 	// 2. Contact the server and print out its response.
@@ -97,7 +101,8 @@ func ExampleRun_createPoints() {
 	defer cancel()
 	r, err := collections_client.List(ctx, &pb.ListCollectionsRequest{})
 	if err != nil {
-		log.Fatalf("could not get collections: %v", err)
+		log.Printf("could not get collections: %v", err)
+		return
 	}
 	fmt.Printf("List of collections: %s\n", r.GetCollections())
 
@@ -113,7 +118,8 @@ func ExampleRun_createPoints() {
 		FieldType:      &fieldIndex1Type,
 	})
 	if err != nil {
-		log.Fatalf("Could not create field index: %v", err)
+		log.Printf("Could not create field index: %v", err)
+		return
 	}
 
 	// 5. Create integer field index
@@ -125,7 +131,8 @@ func ExampleRun_createPoints() {
 		FieldType:      &fieldIndex2Type,
 	})
 	if err != nil {
-		log.Fatalf("Could not create field index: %v", err)
+		log.Printf("Could not create field index: %v", err)
+		return
 	}
 
 	// 6. Upsert points
@@ -258,7 +265,8 @@ func ExampleRun_createPoints() {
 		Points:         upsertPoints,
 	})
 	if err != nil {
-		log.Fatalf("Could not upsert points: %v", err)
+		log.Printf("Could not upsert points: %v", err)
+		return
 	}
 
 	// 7. Retrieve points by ids
@@ -270,7 +278,8 @@ func ExampleRun_createPoints() {
 		},
 	})
 	if err != nil {
-		log.Fatalf("Could not retrieve points: %v", err)
+		log.Printf("Could not retrieve points: %v", err)
+		return
 	}
 
 	fmt.Printf("Retrieved points: %d\n", len(pointsById.GetResult()))
@@ -285,7 +294,8 @@ func ExampleRun_createPoints() {
 		WithPayload: &pb.WithPayloadSelector{SelectorOptions: &pb.WithPayloadSelector_Enable{Enable: true}},
 	})
 	if err != nil {
-		log.Fatalf("Could not search points: %v", err)
+		log.Printf("Could not search points: %v", err)
+		return
 	}
 
 	fmt.Printf("Found points: %d\n", len(unfilteredSearchResult.GetResult()))
@@ -313,7 +323,8 @@ func ExampleRun_createPoints() {
 		},
 	})
 	if err != nil {
-		log.Fatalf("Could not search points: %v", err)
+		log.Printf("Could not search points: %v", err)
+		return
 	}
 	// }
 

--- a/modules/qdrant/go.mod
+++ b/modules/qdrant/go.mod
@@ -4,7 +4,8 @@ go 1.22
 
 require (
 	github.com/qdrant/go-client v1.7.0
-	github.com/testcontainers/testcontainers-go v0.33.0
+	github.com/stretchr/testify v1.9.0
+	github.com/testcontainers/testcontainers-go v0.32.0
 	google.golang.org/grpc v1.64.1
 )
 
@@ -17,6 +18,7 @@ require (
 	github.com/containerd/log v0.1.0 // indirect
 	github.com/containerd/platforms v0.2.1 // indirect
 	github.com/cpuguy83/dockercfg v0.3.1 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/distribution/reference v0.6.0 // indirect
 	github.com/docker/docker v27.1.1+incompatible // indirect
 	github.com/docker/go-connections v0.5.0 // indirect
@@ -28,6 +30,7 @@ require (
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/klauspost/compress v1.17.4 // indirect
+	github.com/kr/text v0.2.0 // indirect
 	github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 // indirect
 	github.com/magiconair/properties v1.8.7 // indirect
 	github.com/moby/docker-image-spec v1.3.1 // indirect
@@ -39,6 +42,7 @@ require (
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c // indirect
 	github.com/shirou/gopsutil/v3 v3.23.12 // indirect
 	github.com/shoenig/go-m1cpu v0.1.6 // indirect
@@ -56,6 +60,7 @@ require (
 	golang.org/x/text v0.16.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240318140521-94a12d6c2237 // indirect
 	google.golang.org/protobuf v1.33.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
 replace github.com/testcontainers/testcontainers-go => ../..

--- a/modules/qdrant/go.sum
+++ b/modules/qdrant/go.sum
@@ -16,6 +16,7 @@ github.com/containerd/platforms v0.2.1 h1:zvwtM3rz2YHPQsF2CHYM8+KtB5dvhISiXh5ZpS
 github.com/containerd/platforms v0.2.1/go.mod h1:XHCb+2/hzowdiut9rkudds9bE5yJ7npe7dG/wG+uFPw=
 github.com/cpuguy83/dockercfg v0.3.1 h1:/FpZ+JaygUR/lZP2NlFI2DVfrOEMAIKP5wWEJdoYe9E=
 github.com/cpuguy83/dockercfg v0.3.1/go.mod h1:sugsbF4//dDlL/i+S+rtpIWp+5h0BHJHfjj5/jFyUJc=
+github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.18 h1:n56/Zwd5o6whRC5PMGretI4IdRLlmBXYNjScPaBgsbY=
 github.com/creack/pty v1.1.18/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -52,6 +53,10 @@ github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/compress v1.17.4 h1:Ej5ixsIri7BrIjBkRZLTo6ghwrEtHFk7ijlczPW4fZ4=
 github.com/klauspost/compress v1.17.4/go.mod h1:/dCuZOvVtNoHsyb+cuJD3itjs3NbnF6KH9zAO4BDxPM=
+github.com/kr/pretty v0.3.0 h1:WgNl7dwNpEZ6jJ9k1snq4pZsg7DOEN8hP9Xw0Tsjwk0=
+github.com/kr/pretty v0.3.0/go.mod h1:640gp4NfQd8pI5XOwp5fnNeVWj67G7CFk/SaSQn7NBk=
+github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
+github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 h1:6E+4a0GO5zZEnZ81pIr0yLvtUWk2if982qA3F3QD6H4=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0/go.mod h1:zJYVVT2jmtg6P3p1VtQj7WsuWi/y4VnjVBn7F8KPB3I=
 github.com/magiconair/properties v1.8.7 h1:IeQXZAiQcpL9mgcAe1Nu6cX9LLw6ExEHKjN0VQdvPDY=
@@ -80,6 +85,8 @@ github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c h1:ncq/mPwQF
 github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c/go.mod h1:OmDBASR4679mdNQnz2pUhc2G8CO2JrUAVFDRBDP/hJE=
 github.com/qdrant/go-client v1.7.0 h1:2TeeWyZAWIup7vvD7Ne6aAvo0H+F5OUb1pB9Z8Y4pFk=
 github.com/qdrant/go-client v1.7.0/go.mod h1:680gkxNAsVtre0Z8hAQmtPzJtz1xFAyCu2TUxULtnoE=
+github.com/rogpeppe/go-internal v1.8.1 h1:geMPLpDpQOgVyCg5z5GoRwLHepNdb71NXb67XFkP+Eg=
+github.com/rogpeppe/go-internal v1.8.1/go.mod h1:JeRgkft04UBgHMgCIwADu4Pn6Mtm5d4nPKWu0nJ5d+o=
 github.com/shirou/gopsutil/v3 v3.23.12 h1:z90NtUkp3bMtmICZKpC4+WaknU1eXtp5vtbQ11DgpE4=
 github.com/shirou/gopsutil/v3 v3.23.12/go.mod h1:1FrWgea594Jp7qmjHUUPlJDTPgcsb9mGnXDxavtikzM=
 github.com/shoenig/go-m1cpu v0.1.6 h1:nxdKQNcEB6vzgA2E2bvzKIYRuNj7XNJ4S/aRSwKzFtM=
@@ -177,6 +184,8 @@ google.golang.org/grpc v1.64.1/go.mod h1:hiQF4LFZelK2WKaP6W0L92zGHtiQdZxk8CrSdvy
 google.golang.org/protobuf v1.33.0 h1:uNO2rsAINq/JlFpSdYEKIZ0uKD/R9cpdv0T+yoGwGmI=
 google.golang.org/protobuf v1.33.0/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/modules/qdrant/qdrant.go
+++ b/modules/qdrant/qdrant.go
@@ -43,11 +43,16 @@ func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustom
 	}
 
 	container, err := testcontainers.GenericContainer(ctx, genericContainerReq)
-	if err != nil {
-		return nil, err
+	var c *QdrantContainer
+	if container != nil {
+		c = &QdrantContainer{Container: container}
 	}
 
-	return &QdrantContainer{Container: container}, nil
+	if err != nil {
+		return c, fmt.Errorf("generic container: %w", err)
+	}
+
+	return c, nil
 }
 
 // RESTEndpoint returns the REST endpoint of the Qdrant container

--- a/modules/qdrant/qdrant_test.go
+++ b/modules/qdrant/qdrant_test.go
@@ -5,79 +5,57 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 
+	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/modules/qdrant"
 )
 
 func TestQdrant(t *testing.T) {
 	ctx := context.Background()
 
-	container, err := qdrant.Run(ctx, "qdrant/qdrant:v1.7.4")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// Clean up the container after the test is complete
-	t.Cleanup(func() {
-		if err := container.Terminate(ctx); err != nil {
-			t.Fatalf("failed to terminate container: %s", err)
-		}
-	})
+	ctr, err := qdrant.Run(ctx, "qdrant/qdrant:v1.7.4")
+	testcontainers.CleanupContainer(t, ctr)
+	require.NoError(t, err)
 
 	t.Run("REST Endpoint", func(tt *testing.T) {
 		// restEndpoint {
-		restEndpoint, err := container.RESTEndpoint(ctx)
+		restEndpoint, err := ctr.RESTEndpoint(ctx)
 		// }
-		if err != nil {
-			tt.Fatalf("failed to get REST endpoint: %s", err)
-		}
+		require.NoError(t, err)
 
 		cli := &http.Client{}
 		resp, err := cli.Get(restEndpoint)
-		if err != nil {
-			tt.Fatalf("failed to perform GET request: %s", err)
-		}
+		require.NoError(t, err)
 		defer resp.Body.Close()
 
-		if resp.StatusCode != http.StatusOK {
-			tt.Fatalf("unexpected status code: %d", resp.StatusCode)
-		}
+		require.Equal(t, http.StatusOK, resp.StatusCode)
 	})
 
 	t.Run("gRPC Endpoint", func(tt *testing.T) {
 		// gRPCEndpoint {
-		grpcEndpoint, err := container.GRPCEndpoint(ctx)
+		grpcEndpoint, err := ctr.GRPCEndpoint(ctx)
 		// }
-		if err != nil {
-			tt.Fatalf("failed to get REST endpoint: %s", err)
-		}
+		require.NoError(t, err)
 
 		conn, err := grpc.NewClient(grpcEndpoint, grpc.WithTransportCredentials(insecure.NewCredentials()))
-		if err != nil {
-			t.Fatalf("did not connect: %v", err)
-		}
+		require.NoError(t, err)
 		defer conn.Close()
 	})
 
 	t.Run("Web UI", func(tt *testing.T) {
 		// webUIEndpoint {
-		webUI, err := container.WebUI(ctx)
+		webUI, err := ctr.WebUI(ctx)
 		// }
-		if err != nil {
-			tt.Fatalf("failed to get REST endpoint: %s", err)
-		}
+		require.NoError(t, err)
 
 		cli := &http.Client{}
 		resp, err := cli.Get(webUI)
-		if err != nil {
-			tt.Fatalf("failed to perform GET request: %s", err)
-		}
+		require.NoError(t, err)
 		defer resp.Body.Close()
 
-		if resp.StatusCode != http.StatusOK {
-			tt.Fatalf("unexpected status code: %d", resp.StatusCode)
-		}
+		require.Equal(t, http.StatusOK, resp.StatusCode)
 	})
 }

--- a/modules/rabbitmq/examples_test.go
+++ b/modules/rabbitmq/examples_test.go
@@ -24,21 +24,21 @@ func ExampleRun() {
 		rabbitmq.WithAdminUsername("admin"),
 		rabbitmq.WithAdminPassword("password"),
 	)
-	if err != nil {
-		log.Fatalf("failed to start container: %s", err)
-	}
-
-	// Clean up the container
 	defer func() {
-		if err := rabbitmqContainer.Terminate(ctx); err != nil {
-			log.Fatalf("failed to terminate container: %s", err)
+		if err := testcontainers.TerminateContainer(rabbitmqContainer); err != nil {
+			log.Printf("failed to terminate container: %s", err)
 		}
 	}()
+	if err != nil {
+		log.Printf("failed to start container: %s", err)
+		return
+	}
 	// }
 
 	state, err := rabbitmqContainer.State(ctx)
 	if err != nil {
-		log.Fatalf("failed to get container state: %s", err) // nolint:gocritic
+		log.Printf("failed to get container state: %s", err)
+		return
 	}
 
 	fmt.Println(state.Running)
@@ -55,28 +55,31 @@ func ExampleRun_connectUsingAmqp() {
 		rabbitmq.WithAdminUsername("admin"),
 		rabbitmq.WithAdminPassword("password"),
 	)
-	if err != nil {
-		log.Fatalf("failed to start container: %s", err)
-	}
 	defer func() {
-		if err := rabbitmqContainer.Terminate(ctx); err != nil {
-			log.Fatalf("failed to terminate container: %s", err)
+		if err := testcontainers.TerminateContainer(rabbitmqContainer); err != nil {
+			log.Printf("failed to terminate container: %s", err)
 		}
 	}()
+	if err != nil {
+		log.Printf("failed to start container: %s", err)
+		return
+	}
 
 	amqpURL, err := rabbitmqContainer.AmqpURL(ctx)
 	if err != nil {
-		log.Fatalf("failed to get AMQP URL: %s", err) // nolint:gocritic
+		log.Printf("failed to get AMQP URL: %s", err)
+		return
 	}
 
 	amqpConnection, err := amqp.Dial(amqpURL)
 	if err != nil {
-		log.Fatalf("failed to connect to RabbitMQ: %s", err) // nolint:gocritic
+		log.Printf("failed to connect to RabbitMQ: %s", err)
+		return
 	}
 	defer func() {
 		err := amqpConnection.Close()
 		if err != nil {
-			log.Fatalf("failed to close connection: %s", err) // nolint:gocritic
+			log.Printf("failed to close connection: %s", err)
 		}
 	}()
 
@@ -93,7 +96,8 @@ func ExampleRun_withSSL() {
 	tmpDir := os.TempDir()
 	certDirs := tmpDir + "/rabbitmq"
 	if err := os.MkdirAll(certDirs, 0o755); err != nil {
-		log.Fatalf("failed to create temporary directory: %s", err)
+		log.Printf("failed to create temporary directory: %s", err)
+		return
 	}
 	defer os.RemoveAll(certDirs)
 
@@ -105,7 +109,8 @@ func ExampleRun_withSSL() {
 		ParentDir: certDirs,
 	})
 	if caCert == nil {
-		log.Fatal("failed to generate CA certificate") // nolint:gocritic
+		log.Print("failed to generate CA certificate")
+		return
 	}
 
 	cert := tlscert.SelfSignedFromRequest(tlscert.Request{
@@ -116,7 +121,8 @@ func ExampleRun_withSSL() {
 		ParentDir: certDirs,
 	})
 	if cert == nil {
-		log.Fatal("failed to generate certificate") // nolint:gocritic
+		log.Print("failed to generate certificate")
+		return
 	}
 
 	sslSettings := rabbitmq.SSLSettings{
@@ -132,20 +138,21 @@ func ExampleRun_withSSL() {
 		"rabbitmq:3.7.25-management-alpine",
 		rabbitmq.WithSSL(sslSettings),
 	)
+	defer func() {
+		if err := testcontainers.TerminateContainer(rabbitmqContainer); err != nil {
+			log.Printf("failed to terminate container: %s", err)
+		}
+	}()
 	if err != nil {
-		log.Fatalf("failed to start container: %s", err) // nolint:gocritic
+		log.Printf("failed to start container: %s", err)
+		return
 	}
 	// }
 
-	defer func() {
-		if err := rabbitmqContainer.Terminate(ctx); err != nil {
-			log.Fatalf("failed to terminate container: %s", err) // nolint:gocritic
-		}
-	}()
-
 	state, err := rabbitmqContainer.State(ctx)
 	if err != nil {
-		log.Fatalf("failed to get container state: %s", err) // nolint:gocritic
+		log.Printf("failed to get container state: %s", err)
+		return
 	}
 
 	fmt.Println(state.Running)
@@ -166,17 +173,22 @@ func ExampleRun_withPlugins() {
 			testcontainers.NewRawCommand([]string{"rabbitmq_random_exchange"}),
 		),
 	)
-	if err != nil {
-		log.Fatalf("failed to start container: %s", err)
-	}
-
 	defer func() {
-		if err := rabbitmqContainer.Terminate(ctx); err != nil {
-			log.Fatalf("failed to terminate container: %s", err)
+		if err := testcontainers.TerminateContainer(rabbitmqContainer); err != nil {
+			log.Printf("failed to terminate container: %s", err)
 		}
 	}()
+	if err != nil {
+		log.Printf("failed to start container: %s", err)
+		return
+	}
 
-	fmt.Println(assertPlugins(rabbitmqContainer, "rabbitmq_shovel", "rabbitmq_random_exchange"))
+	if err = assertPlugins(rabbitmqContainer, "rabbitmq_shovel", "rabbitmq_random_exchange"); err != nil {
+		log.Printf("failed to find plugin: %s", err)
+		return
+	}
+
+	fmt.Println(true)
 
 	// Output:
 	// true
@@ -188,24 +200,26 @@ func ExampleRun_withCustomConfigFile() {
 	rabbitmqContainer, err := rabbitmq.Run(ctx,
 		"rabbitmq:3.7.25-management-alpine",
 	)
-	if err != nil {
-		log.Fatalf("failed to start container: %s", err)
-	}
-
 	defer func() {
-		if err := rabbitmqContainer.Terminate(ctx); err != nil {
-			log.Fatalf("failed to terminate container: %s", err)
+		if err := testcontainers.TerminateContainer(rabbitmqContainer); err != nil {
+			log.Printf("failed to terminate container: %s", err)
 		}
 	}()
+	if err != nil {
+		log.Printf("failed to start container: %s", err)
+		return
+	}
 
 	logs, err := rabbitmqContainer.Logs(ctx)
 	if err != nil {
-		log.Fatalf("failed to get logs: %s", err) // nolint:gocritic
+		log.Printf("failed to get logs: %s", err)
+		return
 	}
 
 	bytes, err := io.ReadAll(logs)
 	if err != nil {
-		log.Fatalf("failed to read logs: %s", err) // nolint:gocritic
+		log.Printf("failed to read logs: %s", err)
+		return
 	}
 
 	fmt.Println(strings.Contains(string(bytes), "config file(s) : /etc/rabbitmq/rabbitmq-testcontainers.conf"))
@@ -214,25 +228,24 @@ func ExampleRun_withCustomConfigFile() {
 	// true
 }
 
-func assertPlugins(container testcontainers.Container, plugins ...string) bool {
+func assertPlugins(container testcontainers.Container, plugins ...string) error {
 	ctx := context.Background()
 
 	for _, plugin := range plugins {
-
 		_, out, err := container.Exec(ctx, []string{"rabbitmq-plugins", "is_enabled", plugin})
 		if err != nil {
-			log.Fatalf("failed to execute command: %s", err)
+			return fmt.Errorf("failed to execute command: %w", err)
 		}
 
 		check, err := io.ReadAll(out)
 		if err != nil {
-			log.Fatalf("failed to read output: %s", err)
+			return fmt.Errorf("failed to read output: %w", err)
 		}
 
 		if !strings.Contains(string(check), plugin+" is enabled") {
-			return false
+			return fmt.Errorf("plugin %q is not enabled", plugin)
 		}
 	}
 
-	return true
+	return nil
 }

--- a/modules/rabbitmq/go.mod
+++ b/modules/rabbitmq/go.mod
@@ -5,15 +5,8 @@ go 1.22
 require (
 	github.com/docker/go-connections v0.5.0
 	github.com/rabbitmq/amqp091-go v1.9.0
-	github.com/testcontainers/testcontainers-go v0.33.0
-)
-
-require (
-	github.com/containerd/platforms v0.2.1 // indirect
-	github.com/moby/docker-image-spec v1.3.1 // indirect
-	golang.org/x/crypto v0.24.0 // indirect
-	golang.org/x/net v0.26.0 // indirect
-	google.golang.org/genproto/googleapis/api v0.0.0-20240318140521-94a12d6c2237 // indirect
+	github.com/stretchr/testify v1.9.0
+	github.com/testcontainers/testcontainers-go v0.32.0
 )
 
 require (
@@ -23,7 +16,9 @@ require (
 	github.com/cenkalti/backoff/v4 v4.2.1 // indirect
 	github.com/containerd/containerd v1.7.18 // indirect
 	github.com/containerd/log v0.1.0 // indirect
+	github.com/containerd/platforms v0.2.1 // indirect
 	github.com/cpuguy83/dockercfg v0.3.1 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/distribution/reference v0.6.0 // indirect
 	github.com/docker/docker v27.1.1+incompatible // indirect
 	github.com/docker/go-units v0.5.0 // indirect
@@ -37,6 +32,7 @@ require (
 	github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 // indirect
 	github.com/magiconair/properties v1.8.7 // indirect
 	github.com/mdelapenya/tlscert v0.1.0
+	github.com/moby/docker-image-spec v1.3.1 // indirect
 	github.com/moby/patternmatcher v0.6.0 // indirect
 	github.com/moby/sys/sequential v0.5.0 // indirect
 	github.com/moby/sys/user v0.1.0 // indirect
@@ -45,6 +41,7 @@ require (
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c // indirect
 	github.com/shirou/gopsutil/v3 v3.23.12 // indirect
 	github.com/shoenig/go-m1cpu v0.1.6 // indirect
@@ -56,8 +53,12 @@ require (
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/metric v1.24.0 // indirect
 	go.opentelemetry.io/otel/trace v1.24.0 // indirect
+	golang.org/x/crypto v0.24.0 // indirect
+	golang.org/x/net v0.26.0 // indirect
 	golang.org/x/sys v0.21.0 // indirect
+	google.golang.org/genproto/googleapis/api v0.0.0-20240318140521-94a12d6c2237 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240318140521-94a12d6c2237 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
 replace github.com/testcontainers/testcontainers-go => ../..

--- a/modules/rabbitmq/go.sum
+++ b/modules/rabbitmq/go.sum
@@ -53,7 +53,10 @@ github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+o
 github.com/klauspost/compress v1.17.4 h1:Ej5ixsIri7BrIjBkRZLTo6ghwrEtHFk7ijlczPW4fZ4=
 github.com/klauspost/compress v1.17.4/go.mod h1:/dCuZOvVtNoHsyb+cuJD3itjs3NbnF6KH9zAO4BDxPM=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
+github.com/kr/pretty v0.3.0 h1:WgNl7dwNpEZ6jJ9k1snq4pZsg7DOEN8hP9Xw0Tsjwk0=
+github.com/kr/pretty v0.3.0/go.mod h1:640gp4NfQd8pI5XOwp5fnNeVWj67G7CFk/SaSQn7NBk=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
+github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 h1:6E+4a0GO5zZEnZ81pIr0yLvtUWk2if982qA3F3QD6H4=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0/go.mod h1:zJYVVT2jmtg6P3p1VtQj7WsuWi/y4VnjVBn7F8KPB3I=
@@ -85,6 +88,8 @@ github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c h1:ncq/mPwQF
 github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c/go.mod h1:OmDBASR4679mdNQnz2pUhc2G8CO2JrUAVFDRBDP/hJE=
 github.com/rabbitmq/amqp091-go v1.9.0 h1:qrQtyzB4H8BQgEuJwhmVQqVHB9O4+MNDJCCAcpc3Aoo=
 github.com/rabbitmq/amqp091-go v1.9.0/go.mod h1:+jPrT9iY2eLjRaMSRHUhc3z14E/l85kv/f+6luSD3pc=
+github.com/rogpeppe/go-internal v1.8.1 h1:geMPLpDpQOgVyCg5z5GoRwLHepNdb71NXb67XFkP+Eg=
+github.com/rogpeppe/go-internal v1.8.1/go.mod h1:JeRgkft04UBgHMgCIwADu4Pn6Mtm5d4nPKWu0nJ5d+o=
 github.com/shirou/gopsutil/v3 v3.23.12 h1:z90NtUkp3bMtmICZKpC4+WaknU1eXtp5vtbQ11DgpE4=
 github.com/shirou/gopsutil/v3 v3.23.12/go.mod h1:1FrWgea594Jp7qmjHUUPlJDTPgcsb9mGnXDxavtikzM=
 github.com/shoenig/go-m1cpu v0.1.6 h1:nxdKQNcEB6vzgA2E2bvzKIYRuNj7XNJ4S/aRSwKzFtM=
@@ -184,6 +189,8 @@ google.golang.org/protobuf v1.33.0 h1:uNO2rsAINq/JlFpSdYEKIZ0uKD/R9cpdv0T+yoGwGm
 google.golang.org/protobuf v1.33.0/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/modules/rabbitmq/rabbitmq.go
+++ b/modules/rabbitmq/rabbitmq.go
@@ -133,14 +133,17 @@ func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustom
 	}
 
 	container, err := testcontainers.GenericContainer(ctx, genericContainerReq)
-	if err != nil {
-		return nil, err
+	var c *RabbitMQContainer
+	if container != nil {
+		c = &RabbitMQContainer{
+			Container:     container,
+			AdminUsername: settings.AdminUsername,
+			AdminPassword: settings.AdminPassword,
+		}
 	}
 
-	c := &RabbitMQContainer{
-		Container:     container,
-		AdminUsername: settings.AdminUsername,
-		AdminPassword: settings.AdminPassword,
+	if err != nil {
+		return c, fmt.Errorf("generic container: %w", err)
 	}
 
 	return c, nil

--- a/modules/redis/examples_test.go
+++ b/modules/redis/examples_test.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"path/filepath"
 
+	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/modules/redis"
 )
 
@@ -19,21 +20,21 @@ func ExampleRun() {
 		redis.WithLogLevel(redis.LogLevelVerbose),
 		redis.WithConfigFile(filepath.Join("testdata", "redis7.conf")),
 	)
-	if err != nil {
-		log.Fatalf("failed to start container: %s", err)
-	}
-
-	// Clean up the container
 	defer func() {
-		if err := redisContainer.Terminate(ctx); err != nil {
-			log.Fatalf("failed to terminate container: %s", err)
+		if err := testcontainers.TerminateContainer(redisContainer); err != nil {
+			log.Printf("failed to terminate container: %s", err)
 		}
 	}()
+	if err != nil {
+		log.Printf("failed to start container: %s", err)
+		return
+	}
 	// }
 
 	state, err := redisContainer.State(ctx)
 	if err != nil {
-		log.Fatalf("failed to get container state: %s", err) // nolint:gocritic
+		log.Printf("failed to get container state: %s", err)
+		return
 	}
 
 	fmt.Println(state.Running)

--- a/modules/redis/redis.go
+++ b/modules/redis/redis.go
@@ -69,11 +69,16 @@ func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustom
 	}
 
 	container, err := testcontainers.GenericContainer(ctx, genericContainerReq)
-	if err != nil {
-		return nil, err
+	var c *RedisContainer
+	if container != nil {
+		c = &RedisContainer{Container: container}
 	}
 
-	return &RedisContainer{Container: container}, nil
+	if err != nil {
+		return c, fmt.Errorf("generic container: %w", err)
+	}
+
+	return c, nil
 }
 
 // WithConfigFile sets the config file to be used for the redis container, and sets the command to run the redis server

--- a/modules/redis/redis_test.go
+++ b/modules/redis/redis_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 
+	"github.com/testcontainers/testcontainers-go"
 	tcredis "github.com/testcontainers/testcontainers-go/modules/redis"
 )
 
@@ -18,12 +19,8 @@ func TestIntegrationSetGet(t *testing.T) {
 	ctx := context.Background()
 
 	redisContainer, err := tcredis.Run(ctx, "docker.io/redis:7")
+	testcontainers.CleanupContainer(t, redisContainer)
 	require.NoError(t, err)
-	t.Cleanup(func() {
-		if err := redisContainer.Terminate(ctx); err != nil {
-			t.Fatalf("failed to terminate container: %s", err)
-		}
-	})
 
 	assertSetsGets(t, ctx, redisContainer, 1)
 }
@@ -32,12 +29,8 @@ func TestRedisWithConfigFile(t *testing.T) {
 	ctx := context.Background()
 
 	redisContainer, err := tcredis.Run(ctx, "docker.io/redis:7", tcredis.WithConfigFile(filepath.Join("testdata", "redis7.conf")))
+	testcontainers.CleanupContainer(t, redisContainer)
 	require.NoError(t, err)
-	t.Cleanup(func() {
-		if err := redisContainer.Terminate(ctx); err != nil {
-			t.Fatalf("failed to terminate container: %s", err)
-		}
-	})
 
 	assertSetsGets(t, ctx, redisContainer, 1)
 }
@@ -74,12 +67,8 @@ func TestRedisWithImage(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			redisContainer, err := tcredis.Run(ctx, tt.image, tcredis.WithConfigFile(filepath.Join("testdata", "redis6.conf")))
+			testcontainers.CleanupContainer(t, redisContainer)
 			require.NoError(t, err)
-			t.Cleanup(func() {
-				if err := redisContainer.Terminate(ctx); err != nil {
-					t.Fatalf("failed to terminate container: %s", err)
-				}
-			})
 
 			assertSetsGets(t, ctx, redisContainer, 1)
 		})
@@ -90,12 +79,8 @@ func TestRedisWithLogLevel(t *testing.T) {
 	ctx := context.Background()
 
 	redisContainer, err := tcredis.Run(ctx, "docker.io/redis:7", tcredis.WithLogLevel(tcredis.LogLevelVerbose))
+	testcontainers.CleanupContainer(t, redisContainer)
 	require.NoError(t, err)
-	t.Cleanup(func() {
-		if err := redisContainer.Terminate(ctx); err != nil {
-			t.Fatalf("failed to terminate container: %s", err)
-		}
-	})
 
 	assertSetsGets(t, ctx, redisContainer, 10)
 }
@@ -104,12 +89,8 @@ func TestRedisWithSnapshotting(t *testing.T) {
 	ctx := context.Background()
 
 	redisContainer, err := tcredis.Run(ctx, "docker.io/redis:7", tcredis.WithSnapshotting(10, 1))
+	testcontainers.CleanupContainer(t, redisContainer)
 	require.NoError(t, err)
-	t.Cleanup(func() {
-		if err := redisContainer.Terminate(ctx); err != nil {
-			t.Fatalf("failed to terminate container: %s", err)
-		}
-	})
 
 	assertSetsGets(t, ctx, redisContainer, 10)
 }

--- a/modules/redpanda/examples_test.go
+++ b/modules/redpanda/examples_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 
+	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/modules/redpanda"
 )
 
@@ -25,21 +26,21 @@ func ExampleRun() {
 		redpanda.WithSuperusers("superuser-1", "superuser-2"),
 		redpanda.WithEnableSchemaRegistryHTTPBasicAuth(),
 	)
-	if err != nil {
-		log.Fatalf("failed to start container: %s", err)
-	}
-
-	// Clean up the container
 	defer func() {
-		if err := redpandaContainer.Terminate(ctx); err != nil {
-			log.Fatalf("failed to terminate container: %s", err)
+		if err := testcontainers.TerminateContainer(redpandaContainer); err != nil {
+			log.Printf("failed to terminate container: %s", err)
 		}
 	}()
+	if err != nil {
+		log.Printf("failed to start container: %s", err)
+		return
+	}
 	// }
 
 	state, err := redpandaContainer.State(ctx)
 	if err != nil {
-		log.Fatalf("failed to get container state: %s", err) // nolint:gocritic
+		log.Printf("failed to get container state: %s", err)
+		return
 	}
 
 	fmt.Println(state.Running)

--- a/modules/redpanda/options.go
+++ b/modules/redpanda/options.go
@@ -139,7 +139,7 @@ func WithTLS(cert, key []byte) Option {
 
 // WithListener adds a custom listener to the Redpanda containers. Listener
 // will be aliases to all networks, so they can be accessed from within docker
-// networks. At leas one network must be attached to the container, if not an
+// networks. At least one network must be attached to the container, if not an
 // error will be thrown when starting the container.
 func WithListener(lis string) Option {
 	host, port, err := net.SplitHostPort(lis)

--- a/modules/redpanda/redpanda.go
+++ b/modules/redpanda/redpanda.go
@@ -179,32 +179,36 @@ func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustom
 		)
 	}
 
-	container, err := testcontainers.GenericContainer(ctx, req)
+	ctr, err := testcontainers.GenericContainer(ctx, req)
+	var c *Container
+	if ctr != nil {
+		c = &Container{Container: ctr}
+	}
 	if err != nil {
-		return nil, err
+		return c, fmt.Errorf("generic container: %w", err)
 	}
 
 	// 6. Get mapped port for the Kafka API, so that we can render and then mount
 	// the Redpanda config with the advertised Kafka address.
-	hostIP, err := container.Host(ctx)
+	hostIP, err := ctr.Host(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get container host: %w", err)
+		return c, fmt.Errorf("failed to get container host: %w", err)
 	}
 
-	kafkaPort, err := container.MappedPort(ctx, nat.Port(defaultKafkaAPIPort))
+	kafkaPort, err := ctr.MappedPort(ctx, nat.Port(defaultKafkaAPIPort))
 	if err != nil {
-		return nil, fmt.Errorf("failed to get mapped Kafka port: %w", err)
+		return c, fmt.Errorf("failed to get mapped Kafka port: %w", err)
 	}
 
 	// 7. Render redpanda.yaml config and mount it.
 	nodeConfig, err := renderNodeConfig(settings, hostIP, kafkaPort.Int())
 	if err != nil {
-		return nil, fmt.Errorf("failed to render node config: %w", err)
+		return c, fmt.Errorf("failed to render node config: %w", err)
 	}
 
-	err = container.CopyToContainer(ctx, nodeConfig, filepath.Join(redpandaDir, "redpanda.yaml"), 600)
+	err = ctr.CopyToContainer(ctx, nodeConfig, filepath.Join(redpandaDir, "redpanda.yaml"), 600)
 	if err != nil {
-		return nil, fmt.Errorf("failed to copy redpanda.yaml into container: %w", err)
+		return c, fmt.Errorf("failed to copy redpanda.yaml into container: %w", err)
 	}
 
 	// 8. Wait until Redpanda is ready to serve requests.
@@ -213,29 +217,29 @@ func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustom
 		wait.ForListeningPort(defaultAdminAPIPort),
 		wait.ForListeningPort(defaultSchemaRegistryPort),
 		wait.ForLog("Successfully started Redpanda!"),
-	).WaitUntilReady(ctx, container)
+	).WaitUntilReady(ctx, ctr)
 	if err != nil {
-		return nil, fmt.Errorf("failed to wait for Redpanda readiness: %w", err)
+		return c, fmt.Errorf("failed to wait for Redpanda readiness: %w", err)
 	}
 
-	scheme := "http"
+	c.urlScheme = "http"
 	if settings.EnableTLS {
-		scheme += "s"
+		c.urlScheme += "s"
 	}
 
 	// 9. Create Redpanda Service Accounts if configured to do so.
 	if len(settings.ServiceAccounts) > 0 {
-		adminAPIPort, err := container.MappedPort(ctx, nat.Port(defaultAdminAPIPort))
+		adminAPIPort, err := ctr.MappedPort(ctx, nat.Port(defaultAdminAPIPort))
 		if err != nil {
-			return nil, fmt.Errorf("failed to get mapped Admin API port: %w", err)
+			return c, fmt.Errorf("failed to get mapped Admin API port: %w", err)
 		}
 
-		adminAPIUrl := fmt.Sprintf("%s://%v:%d", scheme, hostIP, adminAPIPort.Int())
+		adminAPIUrl := fmt.Sprintf("%s://%v:%d", c.urlScheme, hostIP, adminAPIPort.Int())
 		adminCl := NewAdminAPIClient(adminAPIUrl)
 		if settings.EnableTLS {
 			cert, err := tls.X509KeyPair(settings.cert, settings.key)
 			if err != nil {
-				return nil, fmt.Errorf("failed to create admin client with cert: %w", err)
+				return c, fmt.Errorf("failed to create admin client with cert: %w", err)
 			}
 			caCertPool := x509.NewCertPool()
 			caCertPool.AppendCertsFromPEM(settings.cert)
@@ -254,12 +258,12 @@ func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustom
 
 		for username, password := range settings.ServiceAccounts {
 			if err := adminCl.CreateUser(ctx, username, password); err != nil {
-				return nil, fmt.Errorf("failed to create service account with username %q: %w", username, err)
+				return c, fmt.Errorf("failed to create service account with username %q: %w", username, err)
 			}
 		}
 	}
 
-	return &Container{Container: container, urlScheme: scheme}, nil
+	return c, nil
 }
 
 // KafkaSeedBroker returns the seed broker that should be used for connecting

--- a/modules/registry/registry.go
+++ b/modules/registry/registry.go
@@ -238,15 +238,17 @@ func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustom
 	}
 
 	container, err := testcontainers.GenericContainer(ctx, genericContainerReq)
-	if err != nil {
-		return nil, err
+	var c *RegistryContainer
+	if container != nil {
+		c = &RegistryContainer{Container: container}
 	}
-
-	c := &RegistryContainer{Container: container}
+	if err != nil {
+		return c, fmt.Errorf("generic container: %w", err)
+	}
 
 	address, err := c.Address(ctx)
 	if err != nil {
-		return c, err
+		return c, fmt.Errorf("address: %w", err)
 	}
 
 	c.RegistryName = strings.TrimPrefix(address, "http://")

--- a/modules/surrealdb/examples_test.go
+++ b/modules/surrealdb/examples_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 
+	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/modules/surrealdb"
 )
 
@@ -13,21 +14,21 @@ func ExampleRun() {
 	ctx := context.Background()
 
 	surrealdbContainer, err := surrealdb.Run(ctx, "surrealdb/surrealdb:v1.1.1")
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	// Clean up the container
 	defer func() {
-		if err := surrealdbContainer.Terminate(ctx); err != nil {
-			log.Fatal(err)
+		if err := testcontainers.TerminateContainer(surrealdbContainer); err != nil {
+			log.Printf("failed to terminate container: %s", err)
 		}
 	}()
+	if err != nil {
+		log.Print(err)
+		return
+	}
 	// }
 
 	state, err := surrealdbContainer.State(ctx)
 	if err != nil {
-		log.Fatal(err) // nolint:gocritic
+		log.Print(err)
+		return
 	}
 
 	fmt.Println(state.Running)

--- a/modules/surrealdb/go.mod
+++ b/modules/surrealdb/go.mod
@@ -3,6 +3,7 @@ module github.com/testcontainers/testcontainers-go/modules/surrealdb
 go 1.22
 
 require (
+	github.com/stretchr/testify v1.9.0
 	github.com/surrealdb/surrealdb.go v0.2.1
 	github.com/testcontainers/testcontainers-go v0.33.0
 )
@@ -16,6 +17,7 @@ require (
 	github.com/containerd/log v0.1.0 // indirect
 	github.com/containerd/platforms v0.2.1 // indirect
 	github.com/cpuguy83/dockercfg v0.3.1 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/distribution/reference v0.6.0 // indirect
 	github.com/docker/docker v27.1.1+incompatible // indirect
 	github.com/docker/go-connections v0.5.0 // indirect
@@ -28,6 +30,7 @@ require (
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/gorilla/websocket v1.5.0 // indirect
 	github.com/klauspost/compress v1.17.4 // indirect
+	github.com/kr/text v0.2.0 // indirect
 	github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 // indirect
 	github.com/magiconair/properties v1.8.7 // indirect
 	github.com/moby/docker-image-spec v1.3.1 // indirect
@@ -39,6 +42,7 @@ require (
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c // indirect
 	github.com/shirou/gopsutil/v3 v3.23.12 // indirect
 	github.com/shoenig/go-m1cpu v0.1.6 // indirect
@@ -55,6 +59,7 @@ require (
 	golang.org/x/sys v0.21.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20240318140521-94a12d6c2237 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240318140521-94a12d6c2237 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
 replace github.com/testcontainers/testcontainers-go => ../..

--- a/modules/surrealdb/go.sum
+++ b/modules/surrealdb/go.sum
@@ -16,6 +16,7 @@ github.com/containerd/platforms v0.2.1 h1:zvwtM3rz2YHPQsF2CHYM8+KtB5dvhISiXh5ZpS
 github.com/containerd/platforms v0.2.1/go.mod h1:XHCb+2/hzowdiut9rkudds9bE5yJ7npe7dG/wG+uFPw=
 github.com/cpuguy83/dockercfg v0.3.1 h1:/FpZ+JaygUR/lZP2NlFI2DVfrOEMAIKP5wWEJdoYe9E=
 github.com/cpuguy83/dockercfg v0.3.1/go.mod h1:sugsbF4//dDlL/i+S+rtpIWp+5h0BHJHfjj5/jFyUJc=
+github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.18 h1:n56/Zwd5o6whRC5PMGretI4IdRLlmBXYNjScPaBgsbY=
 github.com/creack/pty v1.1.18/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -54,6 +55,10 @@ github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/compress v1.17.4 h1:Ej5ixsIri7BrIjBkRZLTo6ghwrEtHFk7ijlczPW4fZ4=
 github.com/klauspost/compress v1.17.4/go.mod h1:/dCuZOvVtNoHsyb+cuJD3itjs3NbnF6KH9zAO4BDxPM=
+github.com/kr/pretty v0.3.0 h1:WgNl7dwNpEZ6jJ9k1snq4pZsg7DOEN8hP9Xw0Tsjwk0=
+github.com/kr/pretty v0.3.0/go.mod h1:640gp4NfQd8pI5XOwp5fnNeVWj67G7CFk/SaSQn7NBk=
+github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
+github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 h1:6E+4a0GO5zZEnZ81pIr0yLvtUWk2if982qA3F3QD6H4=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0/go.mod h1:zJYVVT2jmtg6P3p1VtQj7WsuWi/y4VnjVBn7F8KPB3I=
 github.com/magiconair/properties v1.8.7 h1:IeQXZAiQcpL9mgcAe1Nu6cX9LLw6ExEHKjN0VQdvPDY=
@@ -80,6 +85,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c h1:ncq/mPwQF4JjgDlrVEn3C11VoGHZN7m8qihwgMEtzYw=
 github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c/go.mod h1:OmDBASR4679mdNQnz2pUhc2G8CO2JrUAVFDRBDP/hJE=
+github.com/rogpeppe/go-internal v1.8.1 h1:geMPLpDpQOgVyCg5z5GoRwLHepNdb71NXb67XFkP+Eg=
+github.com/rogpeppe/go-internal v1.8.1/go.mod h1:JeRgkft04UBgHMgCIwADu4Pn6Mtm5d4nPKWu0nJ5d+o=
 github.com/shirou/gopsutil/v3 v3.23.12 h1:z90NtUkp3bMtmICZKpC4+WaknU1eXtp5vtbQ11DgpE4=
 github.com/shirou/gopsutil/v3 v3.23.12/go.mod h1:1FrWgea594Jp7qmjHUUPlJDTPgcsb9mGnXDxavtikzM=
 github.com/shoenig/go-m1cpu v0.1.6 h1:nxdKQNcEB6vzgA2E2bvzKIYRuNj7XNJ4S/aRSwKzFtM=
@@ -178,6 +185,8 @@ google.golang.org/grpc v1.64.1/go.mod h1:hiQF4LFZelK2WKaP6W0L92zGHtiQdZxk8CrSdvy
 google.golang.org/protobuf v1.33.0 h1:uNO2rsAINq/JlFpSdYEKIZ0uKD/R9cpdv0T+yoGwGmI=
 google.golang.org/protobuf v1.33.0/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/modules/surrealdb/surrealdb.go
+++ b/modules/surrealdb/surrealdb.go
@@ -116,9 +116,14 @@ func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustom
 	}
 
 	container, err := testcontainers.GenericContainer(ctx, genericContainerReq)
-	if err != nil {
-		return nil, err
+	var c *SurrealDBContainer
+	if container != nil {
+		c = &SurrealDBContainer{Container: container}
 	}
 
-	return &SurrealDBContainer{Container: container}, nil
+	if err != nil {
+		return c, fmt.Errorf("generic container: %w", err)
+	}
+
+	return c, nil
 }

--- a/modules/valkey/examples_test.go
+++ b/modules/valkey/examples_test.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"path/filepath"
 
+	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/modules/valkey"
 )
 
@@ -19,21 +20,21 @@ func ExampleRun() {
 		valkey.WithLogLevel(valkey.LogLevelVerbose),
 		valkey.WithConfigFile(filepath.Join("testdata", "valkey7.conf")),
 	)
-	if err != nil {
-		log.Fatalf("failed to start container: %s", err)
-	}
-
-	// Clean up the container
 	defer func() {
-		if err := valkeyContainer.Terminate(ctx); err != nil {
-			log.Fatalf("failed to terminate container: %s", err)
+		if err := testcontainers.TerminateContainer(valkeyContainer); err != nil {
+			log.Printf("failed to terminate container: %s", err)
 		}
 	}()
+	if err != nil {
+		log.Printf("failed to start container: %s", err)
+		return
+	}
 	// }
 
 	state, err := valkeyContainer.State(ctx)
 	if err != nil {
-		log.Fatalf("failed to get container state: %s", err) // nolint:gocritic
+		log.Printf("failed to get container state: %s", err)
+		return
 	}
 
 	fmt.Println(state.Running)

--- a/modules/valkey/valkey.go
+++ b/modules/valkey/valkey.go
@@ -71,11 +71,16 @@ func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustom
 	}
 
 	container, err := testcontainers.GenericContainer(ctx, genericContainerReq)
-	if err != nil {
-		return nil, err
+	var c *ValkeyContainer
+	if container != nil {
+		c = &ValkeyContainer{Container: container}
 	}
 
-	return &ValkeyContainer{Container: container}, nil
+	if err != nil {
+		return c, fmt.Errorf("generic container: %w", err)
+	}
+
+	return c, nil
 }
 
 // WithConfigFile sets the config file to be used for the valkey container, and sets the command to run the valkey server

--- a/modules/valkey/valkey_test.go
+++ b/modules/valkey/valkey_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/valkey-io/valkey-go"
 
+	"github.com/testcontainers/testcontainers-go"
 	tcvalkey "github.com/testcontainers/testcontainers-go/modules/valkey"
 )
 
@@ -18,12 +19,8 @@ func TestIntegrationSetGet(t *testing.T) {
 	ctx := context.Background()
 
 	valkeyContainer, err := tcvalkey.Run(ctx, "docker.io/valkey/valkey:7.2.5")
+	testcontainers.CleanupContainer(t, valkeyContainer)
 	require.NoError(t, err)
-	t.Cleanup(func() {
-		if err := valkeyContainer.Terminate(ctx); err != nil {
-			t.Fatalf("failed to terminate container: %s", err)
-		}
-	})
 
 	assertSetsGets(t, ctx, valkeyContainer, 1)
 }
@@ -32,12 +29,8 @@ func TestValkeyWithConfigFile(t *testing.T) {
 	ctx := context.Background()
 
 	valkeyContainer, err := tcvalkey.Run(ctx, "docker.io/valkey/valkey:7.2.5", tcvalkey.WithConfigFile(filepath.Join("testdata", "valkey7.conf")))
+	testcontainers.CleanupContainer(t, valkeyContainer)
 	require.NoError(t, err)
-	t.Cleanup(func() {
-		if err := valkeyContainer.Terminate(ctx); err != nil {
-			t.Fatalf("failed to terminate container: %s", err)
-		}
-	})
 
 	assertSetsGets(t, ctx, valkeyContainer, 1)
 }
@@ -59,12 +52,8 @@ func TestValkeyWithImage(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			valkeyContainer, err := tcvalkey.Run(ctx, tt.image, tcvalkey.WithConfigFile(filepath.Join("testdata", "valkey7.conf")))
+			testcontainers.CleanupContainer(t, valkeyContainer)
 			require.NoError(t, err)
-			t.Cleanup(func() {
-				if err := valkeyContainer.Terminate(ctx); err != nil {
-					t.Fatalf("failed to terminate container: %s", err)
-				}
-			})
 
 			assertSetsGets(t, ctx, valkeyContainer, 1)
 		})
@@ -75,12 +64,8 @@ func TestValkeyWithLogLevel(t *testing.T) {
 	ctx := context.Background()
 
 	valkeyContainer, err := tcvalkey.Run(ctx, "docker.io/valkey/valkey:7.2.5", tcvalkey.WithLogLevel(tcvalkey.LogLevelVerbose))
+	testcontainers.CleanupContainer(t, valkeyContainer)
 	require.NoError(t, err)
-	t.Cleanup(func() {
-		if err := valkeyContainer.Terminate(ctx); err != nil {
-			t.Fatalf("failed to terminate container: %s", err)
-		}
-	})
 
 	assertSetsGets(t, ctx, valkeyContainer, 10)
 }
@@ -89,12 +74,8 @@ func TestValkeyWithSnapshotting(t *testing.T) {
 	ctx := context.Background()
 
 	valkeyContainer, err := tcvalkey.Run(ctx, "docker.io/valkey/valkey:7.2.5", tcvalkey.WithSnapshotting(10, 1))
+	testcontainers.CleanupContainer(t, valkeyContainer)
 	require.NoError(t, err)
-	t.Cleanup(func() {
-		if err := valkeyContainer.Terminate(ctx); err != nil {
-			t.Fatalf("failed to terminate container: %s", err)
-		}
-	})
 
 	assertSetsGets(t, ctx, valkeyContainer, 10)
 }

--- a/modules/vault/examples_test.go
+++ b/modules/vault/examples_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 
+	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/exec"
 	"github.com/testcontainers/testcontainers-go/modules/vault"
 )
@@ -14,21 +15,21 @@ func ExampleRun() {
 	ctx := context.Background()
 
 	vaultContainer, err := vault.Run(ctx, "hashicorp/vault:1.13.0")
-	if err != nil {
-		log.Fatalf("failed to start container: %s", err)
-	}
-
-	// Clean up the container
 	defer func() {
-		if err := vaultContainer.Terminate(ctx); err != nil {
-			log.Fatalf("failed to terminate container: %s", err)
+		if err := testcontainers.TerminateContainer(vaultContainer); err != nil {
+			log.Printf("failed to terminate container: %s", err)
 		}
 	}()
+	if err != nil {
+		log.Printf("failed to start container: %s", err)
+		return
+	}
 	// }
 
 	state, err := vaultContainer.State(ctx)
 	if err != nil {
-		log.Fatalf("failed to get container state: %s", err) // nolint:gocritic
+		log.Printf("failed to get container state: %s", err)
+		return
 	}
 
 	fmt.Println(state.Running)
@@ -42,21 +43,21 @@ func ExampleRun_withToken() {
 	ctx := context.Background()
 
 	vaultContainer, err := vault.Run(ctx, "hashicorp/vault:1.13.0", vault.WithToken("MyToKeN"))
-	if err != nil {
-		log.Fatalf("failed to start container: %s", err)
-	}
-
-	// Clean up the container
 	defer func() {
-		if err := vaultContainer.Terminate(ctx); err != nil {
-			log.Fatalf("failed to terminate container: %s", err)
+		if err := testcontainers.TerminateContainer(vaultContainer); err != nil {
+			log.Printf("failed to terminate container: %s", err)
 		}
 	}()
+	if err != nil {
+		log.Printf("failed to start container: %s", err)
+		return
+	}
 	// }
 
 	state, err := vaultContainer.State(ctx)
 	if err != nil {
-		log.Fatalf("failed to get container state: %s", err) // nolint:gocritic
+		log.Printf("failed to get container state: %s", err)
+		return
 	}
 
 	fmt.Println(state.Running)
@@ -66,7 +67,8 @@ func ExampleRun_withToken() {
 	}
 	exitCode, _, err := vaultContainer.Exec(ctx, cmds, exec.Multiplexed())
 	if err != nil {
-		log.Fatalf("failed to execute command: %s", err)
+		log.Printf("failed to execute command: %s", err)
+		return
 	}
 
 	fmt.Println(exitCode)
@@ -87,21 +89,21 @@ func ExampleRun_withInitCommand() {
 		"write --force auth/approle/role/myrole",      // Create a role
 		"write secret/testing top_secret=password123", // Create a secret
 	))
-	if err != nil {
-		log.Fatalf("failed to start container: %s", err)
-	}
-
-	// Clean up the container
 	defer func() {
-		if err := vaultContainer.Terminate(ctx); err != nil {
-			log.Fatalf("failed to terminate container: %s", err)
+		if err := testcontainers.TerminateContainer(vaultContainer); err != nil {
+			log.Printf("failed to terminate container: %s", err)
 		}
 	}()
+	if err != nil {
+		log.Printf("failed to start container: %s", err)
+		return
+	}
 	// }
 
 	state, err := vaultContainer.State(ctx)
 	if err != nil {
-		log.Fatalf("failed to get container state: %s", err) // nolint:gocritic
+		log.Printf("failed to get container state: %s", err)
+		return
 	}
 
 	fmt.Println(state.Running)

--- a/modules/vault/vault.go
+++ b/modules/vault/vault.go
@@ -52,11 +52,16 @@ func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustom
 	}
 
 	container, err := testcontainers.GenericContainer(ctx, genericContainerReq)
-	if err != nil {
-		return nil, err
+	var c *VaultContainer
+	if container != nil {
+		c = &VaultContainer{Container: container}
 	}
 
-	return &VaultContainer{container}, nil
+	if err != nil {
+		return c, fmt.Errorf("generic container: %w", err)
+	}
+
+	return c, nil
 }
 
 // WithToken is a container option function that sets the root token for the Vault

--- a/modules/vault/vault_test.go
+++ b/modules/vault/vault_test.go
@@ -3,7 +3,6 @@ package vault_test
 import (
 	"context"
 	"io"
-	"log"
 	"net/http"
 	"testing"
 	"time"
@@ -35,6 +34,7 @@ func TestVault(t *testing.T) {
 	}
 
 	vaultContainer, err := testcontainervault.Run(ctx, "hashicorp/vault:1.13.0", opts...)
+	testcontainers.CleanupContainer(t, vaultContainer)
 	require.NoError(t, err)
 
 	// httpHostAddress {
@@ -117,12 +117,5 @@ func TestVault(t *testing.T) {
 			require.NoError(t, err)
 			assert.Equal(t, "bar", s.Data.Data["foo"])
 		})
-	})
-
-	t.Cleanup(func() {
-		// Clean up the vault after the test is complete
-		if err := vaultContainer.Terminate(ctx); err != nil {
-			log.Fatalf("failed to terminate vault: %s", err)
-		}
 	})
 }

--- a/modules/vearch/examples_test.go
+++ b/modules/vearch/examples_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 
+	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/modules/vearch"
 )
 
@@ -13,21 +14,21 @@ func ExampleRun() {
 	ctx := context.Background()
 
 	vearchContainer, err := vearch.Run(ctx, "vearch/vearch:3.5.1")
-	if err != nil {
-		log.Fatalf("failed to start container: %s", err)
-	}
-
-	// Clean up the container
 	defer func() {
-		if err := vearchContainer.Terminate(ctx); err != nil {
-			log.Fatalf("failed to terminate container: %s", err) // nolint:gocritic
+		if err := testcontainers.TerminateContainer(vearchContainer); err != nil {
+			log.Printf("failed to terminate container: %s", err)
 		}
 	}()
+	if err != nil {
+		log.Printf("failed to start container: %s", err)
+		return
+	}
 	// }
 
 	state, err := vearchContainer.State(ctx)
 	if err != nil {
-		log.Fatalf("failed to get container state: %s", err) // nolint:gocritic
+		log.Printf("failed to get container state: %s", err)
+		return
 	}
 
 	fmt.Println(state.Running)

--- a/modules/vearch/go.mod
+++ b/modules/vearch/go.mod
@@ -2,7 +2,10 @@ module github.com/testcontainers/testcontainers-go/modules/vearch
 
 go 1.22.0
 
-require github.com/testcontainers/testcontainers-go v0.33.0
+require (
+	github.com/stretchr/testify v1.9.0
+	github.com/testcontainers/testcontainers-go v0.32.0
+)
 
 require (
 	dario.cat/mergo v1.0.0 // indirect
@@ -13,6 +16,7 @@ require (
 	github.com/containerd/log v0.1.0 // indirect
 	github.com/containerd/platforms v0.2.1 // indirect
 	github.com/cpuguy83/dockercfg v0.3.1 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/distribution/reference v0.6.0 // indirect
 	github.com/docker/docker v27.1.1+incompatible // indirect
 	github.com/docker/go-connections v0.5.0 // indirect
@@ -24,6 +28,7 @@ require (
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/klauspost/compress v1.17.4 // indirect
+	github.com/kr/text v0.2.0 // indirect
 	github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 // indirect
 	github.com/magiconair/properties v1.8.7 // indirect
 	github.com/moby/docker-image-spec v1.3.1 // indirect
@@ -35,6 +40,7 @@ require (
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c // indirect
 	github.com/shirou/gopsutil/v3 v3.23.12 // indirect
 	github.com/shoenig/go-m1cpu v0.1.6 // indirect
@@ -51,6 +57,7 @@ require (
 	golang.org/x/sys v0.21.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20240318140521-94a12d6c2237 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240318140521-94a12d6c2237 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
 replace github.com/testcontainers/testcontainers-go => ../..

--- a/modules/vearch/go.sum
+++ b/modules/vearch/go.sum
@@ -16,6 +16,7 @@ github.com/containerd/platforms v0.2.1 h1:zvwtM3rz2YHPQsF2CHYM8+KtB5dvhISiXh5ZpS
 github.com/containerd/platforms v0.2.1/go.mod h1:XHCb+2/hzowdiut9rkudds9bE5yJ7npe7dG/wG+uFPw=
 github.com/cpuguy83/dockercfg v0.3.1 h1:/FpZ+JaygUR/lZP2NlFI2DVfrOEMAIKP5wWEJdoYe9E=
 github.com/cpuguy83/dockercfg v0.3.1/go.mod h1:sugsbF4//dDlL/i+S+rtpIWp+5h0BHJHfjj5/jFyUJc=
+github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.18 h1:n56/Zwd5o6whRC5PMGretI4IdRLlmBXYNjScPaBgsbY=
 github.com/creack/pty v1.1.18/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -52,6 +53,10 @@ github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/compress v1.17.4 h1:Ej5ixsIri7BrIjBkRZLTo6ghwrEtHFk7ijlczPW4fZ4=
 github.com/klauspost/compress v1.17.4/go.mod h1:/dCuZOvVtNoHsyb+cuJD3itjs3NbnF6KH9zAO4BDxPM=
+github.com/kr/pretty v0.3.0 h1:WgNl7dwNpEZ6jJ9k1snq4pZsg7DOEN8hP9Xw0Tsjwk0=
+github.com/kr/pretty v0.3.0/go.mod h1:640gp4NfQd8pI5XOwp5fnNeVWj67G7CFk/SaSQn7NBk=
+github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
+github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 h1:6E+4a0GO5zZEnZ81pIr0yLvtUWk2if982qA3F3QD6H4=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0/go.mod h1:zJYVVT2jmtg6P3p1VtQj7WsuWi/y4VnjVBn7F8KPB3I=
 github.com/magiconair/properties v1.8.7 h1:IeQXZAiQcpL9mgcAe1Nu6cX9LLw6ExEHKjN0VQdvPDY=
@@ -78,6 +83,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c h1:ncq/mPwQF4JjgDlrVEn3C11VoGHZN7m8qihwgMEtzYw=
 github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c/go.mod h1:OmDBASR4679mdNQnz2pUhc2G8CO2JrUAVFDRBDP/hJE=
+github.com/rogpeppe/go-internal v1.8.1 h1:geMPLpDpQOgVyCg5z5GoRwLHepNdb71NXb67XFkP+Eg=
+github.com/rogpeppe/go-internal v1.8.1/go.mod h1:JeRgkft04UBgHMgCIwADu4Pn6Mtm5d4nPKWu0nJ5d+o=
 github.com/shirou/gopsutil/v3 v3.23.12 h1:z90NtUkp3bMtmICZKpC4+WaknU1eXtp5vtbQ11DgpE4=
 github.com/shirou/gopsutil/v3 v3.23.12/go.mod h1:1FrWgea594Jp7qmjHUUPlJDTPgcsb9mGnXDxavtikzM=
 github.com/shoenig/go-m1cpu v0.1.6 h1:nxdKQNcEB6vzgA2E2bvzKIYRuNj7XNJ4S/aRSwKzFtM=
@@ -174,6 +181,8 @@ google.golang.org/grpc v1.64.1/go.mod h1:hiQF4LFZelK2WKaP6W0L92zGHtiQdZxk8CrSdvy
 google.golang.org/protobuf v1.33.0 h1:uNO2rsAINq/JlFpSdYEKIZ0uKD/R9cpdv0T+yoGwGmI=
 google.golang.org/protobuf v1.33.0/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/modules/vearch/vearch.go
+++ b/modules/vearch/vearch.go
@@ -52,11 +52,16 @@ func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustom
 	}
 
 	container, err := testcontainers.GenericContainer(ctx, genericContainerReq)
-	if err != nil {
-		return nil, err
+	var c *VearchContainer
+	if container != nil {
+		c = &VearchContainer{Container: container}
 	}
 
-	return &VearchContainer{Container: container}, nil
+	if err != nil {
+		return c, fmt.Errorf("generic container: %w", err)
+	}
+
+	return c, nil
 }
 
 // RESTEndpoint returns the REST endpoint of the Vearch container

--- a/modules/vearch/vearch_test.go
+++ b/modules/vearch/vearch_test.go
@@ -5,40 +5,30 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
+	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/modules/vearch"
 )
 
 func TestVearch(t *testing.T) {
 	ctx := context.Background()
 
-	container, err := vearch.Run(ctx, "vearch/vearch:3.5.1")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// Clean up the container after the test is complete
-	t.Cleanup(func() {
-		if err := container.Terminate(ctx); err != nil {
-			t.Fatalf("failed to terminate container: %s", err)
-		}
-	})
+	ctr, err := vearch.Run(ctx, "vearch/vearch:3.5.1")
+	testcontainers.CleanupContainer(t, ctr)
+	require.NoError(t, err)
 
 	t.Run("REST Endpoint", func(tt *testing.T) {
 		// restEndpoint {
-		restEndpoint, err := container.RESTEndpoint(ctx)
+		restEndpoint, err := ctr.RESTEndpoint(ctx)
 		// }
-		if err != nil {
-			tt.Fatalf("failed to get REST endpoint: %s", err)
-		}
+		require.NoError(t, err)
 
 		cli := &http.Client{}
 		resp, err := cli.Get(restEndpoint)
-		if err != nil {
-			tt.Fatalf("failed to perform GET request: %s", err)
-		}
+		require.NoError(t, err)
 		defer resp.Body.Close()
-		if resp.StatusCode != http.StatusOK {
-			tt.Fatalf("unexpected status code: %d", resp.StatusCode)
-		}
+
+		require.Equal(t, http.StatusOK, resp.StatusCode)
 	})
 }

--- a/modules/weaviate/examples_test.go
+++ b/modules/weaviate/examples_test.go
@@ -20,21 +20,21 @@ func ExampleRun() {
 	ctx := context.Background()
 
 	weaviateContainer, err := tcweaviate.Run(ctx, "semitechnologies/weaviate:1.24.5")
-	if err != nil {
-		log.Fatalf("failed to start container: %s", err)
-	}
-
-	// Clean up the container
 	defer func() {
-		if err := weaviateContainer.Terminate(ctx); err != nil {
-			log.Fatalf("failed to terminate container: %s", err) // nolint:gocritic
+		if err := testcontainers.TerminateContainer(weaviateContainer); err != nil {
+			log.Printf("failed to terminate container: %s", err)
 		}
 	}()
+	if err != nil {
+		log.Printf("failed to start container: %s", err)
+		return
+	}
 	// }
 
 	state, err := weaviateContainer.State(ctx)
 	if err != nil {
-		log.Fatalf("failed to get container state: %s", err) // nolint:gocritic
+		log.Printf("failed to get container state: %s", err)
+		return
 	}
 
 	fmt.Println(state.Running)
@@ -48,24 +48,26 @@ func ExampleRun_connectWithClient() {
 	ctx := context.Background()
 
 	weaviateContainer, err := tcweaviate.Run(ctx, "semitechnologies/weaviate:1.23.9")
-	if err != nil {
-		log.Fatalf("failed to start container: %s", err)
-	}
-
 	defer func() {
-		if err := weaviateContainer.Terminate(ctx); err != nil {
-			log.Fatalf("failed to terminate container: %s", err) // nolint:gocritic
+		if err := testcontainers.TerminateContainer(weaviateContainer); err != nil {
+			log.Printf("failed to terminate container: %s", err)
 		}
 	}()
+	if err != nil {
+		log.Printf("failed to start container: %s", err)
+		return
+	}
 
 	scheme, host, err := weaviateContainer.HttpHostAddress(ctx)
 	if err != nil {
-		log.Fatalf("failed to get http schema and host: %s", err) // nolint:gocritic
+		log.Printf("failed to get http schema and host: %s", err)
+		return
 	}
 
 	grpcHost, err := weaviateContainer.GrpcHostAddress(ctx)
 	if err != nil {
-		log.Fatalf("failed to get gRPC host: %s", err) // nolint:gocritic
+		log.Printf("failed to get gRPC host: %s", err)
+		return
 	}
 
 	connectionClient := &http.Client{}
@@ -115,24 +117,26 @@ func ExampleRun_connectWithClientWithModules() {
 	}
 
 	weaviateContainer, err := tcweaviate.Run(ctx, "semitechnologies/weaviate:1.25.5", opts...)
-	if err != nil {
-		log.Fatalf("failed to start container: %s", err)
-	}
-
 	defer func() {
-		if err := weaviateContainer.Terminate(ctx); err != nil {
-			log.Fatalf("failed to terminate container: %s", err) // nolint:gocritic
+		if err := testcontainers.TerminateContainer(weaviateContainer); err != nil {
+			log.Printf("failed to terminate container: %s", err)
 		}
 	}()
+	if err != nil {
+		log.Printf("failed to start container: %s", err)
+		return
+	}
 
 	scheme, host, err := weaviateContainer.HttpHostAddress(ctx)
 	if err != nil {
-		log.Fatalf("failed to get http schema and host: %s", err) // nolint:gocritic
+		log.Printf("failed to get http schema and host: %s", err)
+		return
 	}
 
 	grpcHost, err := weaviateContainer.GrpcHostAddress(ctx)
 	if err != nil {
-		log.Fatalf("failed to get gRPC host: %s", err) // nolint:gocritic
+		log.Printf("failed to get gRPC host: %s", err)
+		return
 	}
 
 	connectionClient := &http.Client{}

--- a/modules/weaviate/go.mod
+++ b/modules/weaviate/go.mod
@@ -3,7 +3,8 @@ module github.com/testcontainers/testcontainers-go/modules/weaviate
 go 1.22
 
 require (
-	github.com/testcontainers/testcontainers-go v0.33.0
+	github.com/stretchr/testify v1.9.0
+	github.com/testcontainers/testcontainers-go v0.32.0
 	github.com/weaviate/weaviate-go-client/v4 v4.13.1
 	google.golang.org/grpc v1.64.1
 )
@@ -20,6 +21,7 @@ require (
 	github.com/containerd/log v0.1.0 // indirect
 	github.com/containerd/platforms v0.2.1 // indirect
 	github.com/cpuguy83/dockercfg v0.3.1 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/distribution/reference v0.6.0 // indirect
 	github.com/docker/docker v27.1.1+incompatible // indirect
 	github.com/docker/go-connections v0.5.0 // indirect
@@ -56,6 +58,7 @@ require (
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c // indirect
 	github.com/shirou/gopsutil/v3 v3.23.12 // indirect
 	github.com/shoenig/go-m1cpu v0.1.6 // indirect

--- a/modules/weaviate/weaviate.go
+++ b/modules/weaviate/weaviate.go
@@ -54,11 +54,16 @@ func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustom
 	}
 
 	container, err := testcontainers.GenericContainer(ctx, genericContainerReq)
-	if err != nil {
-		return nil, err
+	var c *WeaviateContainer
+	if container != nil {
+		c = &WeaviateContainer{Container: container}
 	}
 
-	return &WeaviateContainer{Container: container}, nil
+	if err != nil {
+		return c, fmt.Errorf("generic container: %w", err)
+	}
+
+	return c, nil
 }
 
 // HttpHostAddress returns the schema and host of the Weaviate container.

--- a/modules/weaviate/weaviate_test.go
+++ b/modules/weaviate/weaviate_test.go
@@ -6,53 +6,41 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	wvt "github.com/weaviate/weaviate-go-client/v4/weaviate"
 	wvtgrpc "github.com/weaviate/weaviate-go-client/v4/weaviate/grpc"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/health/grpc_health_v1"
 
+	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/modules/weaviate"
 )
 
 func TestWeaviate(t *testing.T) {
 	ctx := context.Background()
 
-	container, err := weaviate.Run(ctx, "semitechnologies/weaviate:1.25.5")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// Clean up the container after the test is complete
-	t.Cleanup(func() {
-		if err := container.Terminate(ctx); err != nil {
-			t.Fatalf("failed to terminate container: %s", err)
-		}
-	})
+	ctr, err := weaviate.Run(ctx, "semitechnologies/weaviate:1.25.5")
+	testcontainers.CleanupContainer(t, ctr)
+	require.NoError(t, err)
 
 	t.Run("HttpHostAddress", func(tt *testing.T) {
 		// httpHostAddress {
-		schema, host, err := container.HttpHostAddress(ctx)
+		schema, host, err := ctr.HttpHostAddress(ctx)
 		// }
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
 		cli := &http.Client{}
 		resp, err := cli.Get(fmt.Sprintf("%s://%s", schema, host))
-		if err != nil {
-			tt.Fatalf("failed to perform GET request: %s", err)
-		}
+		require.NoError(t, err)
 		defer resp.Body.Close()
 
-		if resp.StatusCode != http.StatusOK {
-			tt.Fatalf("unexpected status code: %d", resp.StatusCode)
-		}
+		require.Equal(t, http.StatusOK, resp.StatusCode)
 	})
 
 	t.Run("GrpcHostAddress", func(tt *testing.T) {
 		// gRPCHostAddress {
-		host, err := container.GrpcHostAddress(ctx)
+		host, err := ctr.GrpcHostAddress(ctx)
 		// }
 		if err != nil {
 			t.Fatal(err)
@@ -76,11 +64,11 @@ func TestWeaviate(t *testing.T) {
 	})
 
 	t.Run("Weaviate client", func(tt *testing.T) {
-		httpScheme, httpHost, err := container.HttpHostAddress(ctx)
+		httpScheme, httpHost, err := ctr.HttpHostAddress(ctx)
 		if err != nil {
 			tt.Fatal(err)
 		}
-		grpcHost, err := container.GrpcHostAddress(ctx)
+		grpcHost, err := ctr.GrpcHostAddress(ctx)
 		if err != nil {
 			tt.Fatal(err)
 		}

--- a/mounts_test.go
+++ b/mounts_test.go
@@ -171,13 +171,14 @@ func TestContainerMounts_PrepareMounts(t *testing.T) {
 }
 
 func TestCreateContainerWithVolume(t *testing.T) {
+	volumeName := "test-volume"
 	// volumeMounts {
 	req := testcontainers.ContainerRequest{
 		Image: "alpine",
 		Mounts: testcontainers.ContainerMounts{
 			{
 				Source: testcontainers.GenericVolumeMountSource{
-					Name: "test-volume",
+					Name: volumeName,
 				},
 				Target: "/data",
 			},
@@ -190,8 +191,8 @@ func TestCreateContainerWithVolume(t *testing.T) {
 		ContainerRequest: req,
 		Started:          true,
 	})
+	testcontainers.CleanupContainer(t, c, testcontainers.RemoveVolumes(volumeName))
 	require.NoError(t, err)
-	terminateContainerOnEnd(t, ctx, c)
 
 	// Check if volume is created
 	client, err := testcontainers.NewDockerClientWithOpts(ctx)
@@ -204,12 +205,13 @@ func TestCreateContainerWithVolume(t *testing.T) {
 }
 
 func TestMountsReceiveRyukLabels(t *testing.T) {
+	volumeName := "app-data"
 	req := testcontainers.ContainerRequest{
 		Image: "alpine",
 		Mounts: testcontainers.ContainerMounts{
 			{
 				Source: testcontainers.GenericVolumeMountSource{
-					Name: "app-data",
+					Name: volumeName,
 				},
 				Target: "/data",
 			},
@@ -223,18 +225,18 @@ func TestMountsReceiveRyukLabels(t *testing.T) {
 
 	// Ensure the volume is removed before creating the container
 	// otherwise the volume will be reused and the labels won't be set.
-	err = client.VolumeRemove(ctx, "app-data", true)
+	err = client.VolumeRemove(ctx, volumeName, true)
 	require.NoError(t, err)
 
 	c, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
 		ContainerRequest: req,
 		Started:          true,
 	})
+	testcontainers.CleanupContainer(t, c, testcontainers.RemoveVolumes(volumeName))
 	require.NoError(t, err)
-	terminateContainerOnEnd(t, ctx, c)
 
 	// Check if volume is created with the expected labels.
-	volume, err := client.VolumeInspect(ctx, "app-data")
+	volume, err := client.VolumeInspect(ctx, volumeName)
 	require.NoError(t, err)
 	require.Equal(t, testcontainers.GenericLabels(), volume.Labels)
 }

--- a/network/examples_test.go
+++ b/network/examples_test.go
@@ -21,7 +21,7 @@ func ExampleNew() {
 	}
 	defer func() {
 		if err := net.Remove(ctx); err != nil {
-			log.Fatalf("failed to remove network: %s", err)
+			log.Printf("failed to remove network: %s", err)
 		}
 	}()
 	// }
@@ -62,7 +62,7 @@ func ExampleNew_withOptions() {
 	}
 	defer func() {
 		if err := net.Remove(ctx); err != nil {
-			log.Fatalf("failed to remove network: %s", err)
+			log.Printf("failed to remove network: %s", err)
 		}
 	}()
 	// }

--- a/options_test.go
+++ b/options_test.go
@@ -93,7 +93,7 @@ func TestWithLogConsumers(t *testing.T) {
 
 	ctx := context.Background()
 	c, err := testcontainers.GenericContainer(ctx, req)
-	terminateContainerOnEnd(t, ctx, c)
+	testcontainers.CleanupContainer(t, c)
 	// we expect an error because the MySQL environment variables are not set
 	// but this is expected because we just want to test the log consumer
 	require.Error(t, err)
@@ -119,11 +119,8 @@ func TestWithStartupCommand(t *testing.T) {
 	assert.Len(t, req.LifecycleHooks[0].PostStarts, 1)
 
 	c, err := testcontainers.GenericContainer(context.Background(), req)
+	testcontainers.CleanupContainer(t, c)
 	require.NoError(t, err)
-	defer func() {
-		err = c.Terminate(context.Background())
-		require.NoError(t, err)
-	}()
 
 	_, reader, err := c.Exec(context.Background(), []string{"ls", "/tmp/.testcontainers"}, exec.Multiplexed())
 	require.NoError(t, err)
@@ -151,11 +148,8 @@ func TestWithAfterReadyCommand(t *testing.T) {
 	assert.Len(t, req.LifecycleHooks[0].PostReadies, 1)
 
 	c, err := testcontainers.GenericContainer(context.Background(), req)
+	testcontainers.CleanupContainer(t, c)
 	require.NoError(t, err)
-	defer func() {
-		err = c.Terminate(context.Background())
-		require.NoError(t, err)
-	}()
 
 	_, reader, err := c.Exec(context.Background(), []string{"ls", "/tmp/.testcontainers"}, exec.Multiplexed())
 	require.NoError(t, err)

--- a/parallel.go
+++ b/parallel.go
@@ -2,6 +2,7 @@ package testcontainers
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 )
@@ -34,22 +35,22 @@ func (gpe ParallelContainersError) Error() string {
 func parallelContainersRunner(
 	ctx context.Context,
 	requests <-chan GenericContainerRequest,
-	errors chan<- ParallelContainersRequestError,
+	errorsCh chan<- ParallelContainersRequestError,
 	containers chan<- Container,
 	wg *sync.WaitGroup,
 ) {
+	defer wg.Done()
 	for req := range requests {
 		c, err := GenericContainer(ctx, req)
 		if err != nil {
-			errors <- ParallelContainersRequestError{
+			errorsCh <- ParallelContainersRequestError{
 				Request: req,
-				Error:   err,
+				Error:   errors.Join(err, TerminateContainer(c)),
 			}
 			continue
 		}
 		containers <- c
 	}
-	wg.Done()
 }
 
 // ParallelContainers creates a generic containers with parameters and run it in parallel mode

--- a/parallel_test.go
+++ b/parallel_test.go
@@ -110,7 +110,7 @@ func TestParallelContainers(t *testing.T) {
 
 			for _, c := range res {
 				c := c
-				terminateContainerOnEnd(t, context.Background(), c)
+				CleanupContainer(t, c)
 			}
 
 			if len(res) != tc.resLen {
@@ -163,5 +163,5 @@ func TestParallelContainersWithReuse(t *testing.T) {
 		t.Fatalf("expected errors: %d, got: %d\n", 0, len(e.Errors))
 	}
 	// Container is reused, only terminate first container
-	terminateContainerOnEnd(t, ctx, res[0])
+	CleanupContainer(t, res[0])
 }

--- a/port_forwarding_test.go
+++ b/port_forwarding_test.go
@@ -80,10 +80,7 @@ func TestExposeHostPorts(t *testing.T) {
 				var err error
 				nw, err = network.New(context.Background())
 				require.NoError(tt, err)
-
-				tt.Cleanup(func() {
-					require.NoError(tt, nw.Remove(context.Background()))
-				})
+				testcontainers.CleanupNetwork(t, nw)
 
 				req.Networks = []string{nw.Name}
 				req.NetworkAliases = map[string][]string{nw.Name: {"myalpine"}}
@@ -97,10 +94,8 @@ func TestExposeHostPorts(t *testing.T) {
 			}
 
 			c, err := testcontainers.GenericContainer(ctx, req)
+			testcontainers.CleanupContainer(t, c)
 			require.NoError(tt, err)
-			tt.Cleanup(func() {
-				require.NoError(tt, c.Terminate(context.Background()))
-			})
 
 			if tc.hasHostAccess {
 				// create a container that has host access, which will
@@ -124,15 +119,11 @@ func httpRequest(t *testing.T, c testcontainers.Container, port int) (int, strin
 		tcexec.Multiplexed(),
 	)
 	// }
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	// read the response
 	bs, err := io.ReadAll(reader)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	return code, string(bs)
 }

--- a/testcontainers_test.go
+++ b/testcontainers_test.go
@@ -1,7 +1,6 @@
 package testcontainers
 
 import (
-	"fmt"
 	"os"
 	"os/exec"
 	"regexp"
@@ -81,5 +80,5 @@ func TestSessionIDHelper(t *testing.T) {
 		t.Skip("Not a real test, used as a test helper")
 	}
 
-	fmt.Printf(">>>%s<<<\n", SessionID())
+	t.Logf(">>>%s<<<\n", SessionID())
 }

--- a/testdata/echoserver.go
+++ b/testdata/echoserver.go
@@ -36,7 +36,8 @@ func main() {
 
 	ln, err := net.Listen("tcp", ":8080")
 	if err != nil {
-		log.Fatal(err)
+		log.Println(err)
+		return
 	}
 
 	fmt.Println("ready")

--- a/testhelpers_test.go
+++ b/testhelpers_test.go
@@ -1,25 +1,6 @@
 package testcontainers_test
 
-import (
-	"context"
-	"testing"
-
-	"github.com/stretchr/testify/require"
-
-	"github.com/testcontainers/testcontainers-go"
-)
-
 const (
 	nginxAlpineImage = "docker.io/nginx:alpine"
 	nginxDefaultPort = "80/tcp"
 )
-
-func terminateContainerOnEnd(tb testing.TB, ctx context.Context, ctr testcontainers.Container) {
-	tb.Helper()
-	if ctr == nil {
-		return
-	}
-	tb.Cleanup(func() {
-		require.NoError(tb, ctr.Terminate(ctx))
-	})
-}

--- a/testing.go
+++ b/testing.go
@@ -3,8 +3,16 @@ package testcontainers
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"testing"
+
+	"github.com/docker/docker/errdefs"
+	"github.com/stretchr/testify/require"
 )
+
+// errAlreadyInProgress is a regular expression that matches the error for a container
+// removal that is already in progress.
+var errAlreadyInProgress = regexp.MustCompile(`removal of container .* is already in progress`)
 
 // SkipIfProviderIsNotHealthy is a utility function capable of skipping tests
 // if the provider is not healthy, or running at all.
@@ -51,3 +59,93 @@ func (lc *StdoutLogConsumer) Accept(l Log) {
 }
 
 // }
+
+// CleanupContainer is a helper function that schedules the container
+// to be stopped / terminated when the test ends.
+//
+// This should be called as a defer directly after (before any error check)
+// of [GenericContainer](...) or a modules Run(...) in a test to ensure the
+// container is stopped when the function ends.
+//
+// before any error check. If container is nil, its a no-op.
+func CleanupContainer(tb testing.TB, container Container, options ...TerminateOption) {
+	tb.Helper()
+
+	tb.Cleanup(func() {
+		noErrorOrIgnored(tb, TerminateContainer(container, options...))
+	})
+}
+
+// CleanupNetwork is a helper function that schedules the network to be
+// removed when the test ends.
+// This should be the first call after NewNetwork(...) in a test before
+// any error check. If network is nil, its a no-op.
+func CleanupNetwork(tb testing.TB, network Network) {
+	tb.Helper()
+
+	tb.Cleanup(func() {
+		noErrorOrIgnored(tb, network.Remove(context.Background()))
+	})
+}
+
+// noErrorOrIgnored is a helper function that checks if the error is nil or an error
+// we can ignore.
+func noErrorOrIgnored(tb testing.TB, err error) {
+	tb.Helper()
+
+	if isCleanupSafe(err) {
+		return
+	}
+
+	require.NoError(tb, err)
+}
+
+// causer is an interface that allows to get the cause of an error.
+type causer interface {
+	Cause() error
+}
+
+// wrapErr is an interface that allows to unwrap an error.
+type wrapErr interface {
+	Unwrap() error
+}
+
+// unwrapErrs is an interface that allows to unwrap multiple errors.
+type unwrapErrs interface {
+	Unwrap() []error
+}
+
+// isCleanupSafe reports whether all errors in err's tree are one of the
+// following, so can safely be ignored:
+//   - nil
+//   - not found
+//   - already in progress
+func isCleanupSafe(err error) bool {
+	if err == nil {
+		return true
+	}
+
+	switch x := err.(type) { //nolint:errorlint // We need to check for interfaces.
+	case errdefs.ErrNotFound:
+		return true
+	case errdefs.ErrConflict:
+		// Terminating a container that is already terminating.
+		if errAlreadyInProgress.MatchString(err.Error()) {
+			return true
+		}
+		return false
+	case causer:
+		return isCleanupSafe(x.Cause())
+	case wrapErr:
+		return isCleanupSafe(x.Unwrap())
+	case unwrapErrs:
+		for _, e := range x.Unwrap() {
+			if !isCleanupSafe(e) {
+				return false
+			}
+		}
+		return true
+	default:
+		return false
+	}
+}

--- a/testing_test.go
+++ b/testing_test.go
@@ -1,7 +1,86 @@
 package testcontainers
 
-import "testing"
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
 
 func ExampleSkipIfProviderIsNotHealthy() {
 	SkipIfProviderIsNotHealthy(&testing.T{})
+}
+
+type notFoundError struct{}
+
+func (notFoundError) NotFound() {}
+
+func (notFoundError) Error() string {
+	return "not found"
+}
+
+func Test_isNotFound(t *testing.T) {
+	tests := map[string]struct {
+		err  error
+		want bool
+	}{
+		"nil": {
+			err:  nil,
+			want: true,
+		},
+		"join-nils": {
+			err:  errors.Join(nil, nil),
+			want: true,
+		},
+		"join-nil-not-found": {
+			err:  errors.Join(nil, notFoundError{}),
+			want: true,
+		},
+		"not-found": {
+			err:  notFoundError{},
+			want: true,
+		},
+		"other": {
+			err:  errors.New("other"),
+			want: false,
+		},
+		"join-other": {
+			err:  errors.Join(nil, notFoundError{}, errors.New("other")),
+			want: false,
+		},
+		"warp": {
+			err:  fmt.Errorf("wrap: %w", notFoundError{}),
+			want: true,
+		},
+		"multi-warp": {
+			err:  fmt.Errorf("wrap: %w", fmt.Errorf("wrap: %w", notFoundError{})),
+			want: true,
+		},
+		"multi-warp-other": {
+			err:  fmt.Errorf("wrap: %w", fmt.Errorf("wrap: %w", errors.New("other"))),
+			want: false,
+		},
+		"multi-warp-other-not-found": {
+			err:  fmt.Errorf("wrap: %w", fmt.Errorf("wrap: %w %w", errors.New("other"), notFoundError{})),
+			want: false,
+		},
+		"multi-warp-not-found-nil": {
+			err:  fmt.Errorf("wrap: %w", fmt.Errorf("wrap: %w %w", nil, notFoundError{})),
+			want: true,
+		},
+		"multi-join-not-found-other": {
+			err:  errors.Join(nil, fmt.Errorf("wrap: %w", errors.Join(notFoundError{}, errors.New("other")))),
+			want: false,
+		},
+		"multi-join-not-found-nil": {
+			err:  errors.Join(nil, fmt.Errorf("wrap: %w", errors.Join(notFoundError{}, nil))),
+			want: true,
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			require.Equal(t, tc.want, isCleanupSafe(tc.err))
+		})
+	}
 }

--- a/wait/exec_test.go
+++ b/wait/exec_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/go-connections/nat"
+	"github.com/stretchr/testify/require"
 
 	"github.com/testcontainers/testcontainers-go"
 	tcexec "github.com/testcontainers/testcontainers-go/exec"
@@ -29,19 +30,20 @@ func ExampleExecStrategy() {
 		ContainerRequest: req,
 		Started:          true,
 	})
-	if err != nil {
-		log.Fatalf("failed to start container: %s", err)
-	}
-
 	defer func() {
-		if err := localstack.Terminate(ctx); err != nil {
-			log.Fatalf("failed to terminate container: %s", err)
+		if err := testcontainers.TerminateContainer(localstack); err != nil {
+			log.Printf("failed to terminate container: %s", err)
 		}
 	}()
+	if err != nil {
+		log.Printf("failed to start container: %s", err)
+		return
+	}
 
 	state, err := localstack.State(ctx)
 	if err != nil {
-		log.Fatalf("failed to get container state: %s", err) // nolint:gocritic
+		log.Printf("failed to get container state: %s", err)
+		return
 	}
 
 	fmt.Println(state.Running)
@@ -203,14 +205,8 @@ func TestExecStrategyWaitUntilReady_CustomResponseMatcher(t *testing.T) {
 	// }
 
 	ctx := context.Background()
-	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{ContainerRequest: dockerReq, Started: true})
-	if err != nil {
-		t.Error(err)
-		return
-	}
-	t.Cleanup(func() {
-		if err := container.Terminate(ctx); err != nil {
-			t.Fatalf("failed to terminate container: %s", err)
-		}
-	})
+	ctr, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{ContainerRequest: dockerReq, Started: true})
+	testcontainers.CleanupContainer(t, ctr)
+	require.NoError(t, err)
+	// }
 }

--- a/wait/file.go
+++ b/wait/file.go
@@ -97,7 +97,7 @@ func (ws *FileStrategy) matchFile(ctx context.Context, target StrategyTarget) er
 	if err != nil {
 		return fmt.Errorf("copy from container: %w", err)
 	}
-	defer rc.Close() //nolint: errcheck // Read close error can't tell us anything useful.
+	defer rc.Close()
 
 	if ws.matcher == nil {
 		// No matcher, just check if the file exists.

--- a/wait/host_port_test.go
+++ b/wait/host_port_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/go-connections/nat"
+	"github.com/stretchr/testify/require"
 
 	"github.com/testcontainers/testcontainers-go/exec"
 )
@@ -152,14 +153,10 @@ func TestHostPortStrategyFailsWhileGettingPortDueToOOMKilledContainer(t *testing
 
 	{
 		err := wg.WaitUntilReady(context.Background(), target)
-		if err == nil {
-			t.Fatal("no error")
-		}
+		require.Error(t, err)
 
 		expected := "container crashed with out-of-memory (OOMKilled)"
-		if err.Error() != expected {
-			t.Fatalf("expected %q, got %q", expected, err.Error())
-		}
+		require.Contains(t, err.Error(), expected)
 	}
 }
 
@@ -190,14 +187,10 @@ func TestHostPortStrategyFailsWhileGettingPortDueToExitedContainer(t *testing.T)
 
 	{
 		err := wg.WaitUntilReady(context.Background(), target)
-		if err == nil {
-			t.Fatal("no error")
-		}
+		require.Error(t, err)
 
 		expected := "container exited with code 1"
-		if err.Error() != expected {
-			t.Fatalf("expected %q, got %q", expected, err.Error())
-		}
+		require.Contains(t, err.Error(), expected)
 	}
 }
 
@@ -227,14 +220,10 @@ func TestHostPortStrategyFailsWhileGettingPortDueToUnexpectedContainerStatus(t *
 
 	{
 		err := wg.WaitUntilReady(context.Background(), target)
-		if err == nil {
-			t.Fatal("no error")
-		}
+		require.Error(t, err)
 
 		expected := "unexpected container status \"dead\""
-		if err.Error() != expected {
-			t.Fatalf("expected %q, got %q", expected, err.Error())
-		}
+		require.Contains(t, err.Error(), expected)
 	}
 }
 
@@ -259,14 +248,10 @@ func TestHostPortStrategyFailsWhileExternalCheckingDueToOOMKilledContainer(t *te
 
 	{
 		err := wg.WaitUntilReady(context.Background(), target)
-		if err == nil {
-			t.Fatal("no error")
-		}
+		require.Error(t, err)
 
 		expected := "container crashed with out-of-memory (OOMKilled)"
-		if err.Error() != expected {
-			t.Fatalf("expected %q, got %q", expected, err.Error())
-		}
+		require.Contains(t, err.Error(), expected)
 	}
 }
 
@@ -292,14 +277,10 @@ func TestHostPortStrategyFailsWhileExternalCheckingDueToExitedContainer(t *testi
 
 	{
 		err := wg.WaitUntilReady(context.Background(), target)
-		if err == nil {
-			t.Fatal("no error")
-		}
+		require.Error(t, err)
 
 		expected := "container exited with code 1"
-		if err.Error() != expected {
-			t.Fatalf("expected %q, got %q", expected, err.Error())
-		}
+		require.Contains(t, err.Error(), expected)
 	}
 }
 
@@ -324,14 +305,10 @@ func TestHostPortStrategyFailsWhileExternalCheckingDueToUnexpectedContainerStatu
 
 	{
 		err := wg.WaitUntilReady(context.Background(), target)
-		if err == nil {
-			t.Fatal("no error")
-		}
+		require.Error(t, err)
 
 		expected := "unexpected container status \"dead\""
-		if err.Error() != expected {
-			t.Fatalf("expected %q, got %q", expected, err.Error())
-		}
+		require.Contains(t, err.Error(), expected)
 	}
 }
 
@@ -375,14 +352,10 @@ func TestHostPortStrategyFailsWhileInternalCheckingDueToOOMKilledContainer(t *te
 
 	{
 		err := wg.WaitUntilReady(context.Background(), target)
-		if err == nil {
-			t.Fatal("no error")
-		}
+		require.Error(t, err)
 
 		expected := "container crashed with out-of-memory (OOMKilled)"
-		if err.Error() != expected {
-			t.Fatalf("expected %q, got %q", expected, err.Error())
-		}
+		require.Contains(t, err.Error(), expected)
 	}
 }
 
@@ -427,14 +400,10 @@ func TestHostPortStrategyFailsWhileInternalCheckingDueToExitedContainer(t *testi
 
 	{
 		err := wg.WaitUntilReady(context.Background(), target)
-		if err == nil {
-			t.Fatal("no error")
-		}
+		require.Error(t, err)
 
 		expected := "container exited with code 1"
-		if err.Error() != expected {
-			t.Fatalf("expected %q, got %q", expected, err.Error())
-		}
+		require.Contains(t, err.Error(), expected)
 	}
 }
 
@@ -478,14 +447,10 @@ func TestHostPortStrategyFailsWhileInternalCheckingDueToUnexpectedContainerStatu
 
 	{
 		err := wg.WaitUntilReady(context.Background(), target)
-		if err == nil {
-			t.Fatal("no error")
-		}
+		require.Error(t, err)
 
 		expected := "unexpected container status \"dead\""
-		if err.Error() != expected {
-			t.Fatalf("expected %q, got %q", expected, err.Error())
-		}
+		require.Contains(t, err.Error(), expected)
 	}
 }
 
@@ -540,7 +505,6 @@ func TestHostPortStrategySucceedsGivenShellIsNotInstalled(t *testing.T) {
 		WithStartupTimeout(5 * time.Second).
 		WithPollInterval(100 * time.Millisecond)
 
-	if err := wg.WaitUntilReady(context.Background(), target); err != nil {
-		t.Fatal(err)
-	}
+	err = wg.WaitUntilReady(context.Background(), target)
+	require.NoError(t, err)
 }

--- a/wait/http_test.go
+++ b/wait/http_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/go-connections/nat"
+	"github.com/stretchr/testify/require"
 
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/wait"
@@ -36,20 +37,21 @@ func ExampleHTTPStrategy() {
 		ContainerRequest: req,
 		Started:          true,
 	})
+	defer func() {
+		if err := testcontainers.TerminateContainer(c); err != nil {
+			log.Printf("failed to terminate container: %s", err)
+		}
+	}()
 	if err != nil {
-		log.Fatalf("failed to start container: %s", err)
+		log.Printf("failed to start container: %s", err)
+		return
 	}
 	// }
 
-	defer func() {
-		if err := c.Terminate(ctx); err != nil {
-			log.Fatalf("failed to terminate container: %s", err)
-		}
-	}()
-
 	state, err := c.State(ctx)
 	if err != nil {
-		log.Fatalf("failed to get container state: %s", err) // nolint:gocritic
+		log.Printf("failed to get container state: %s", err)
+		return
 	}
 
 	fmt.Println(state.Running)
@@ -62,12 +64,14 @@ func ExampleHTTPStrategy_WithHeaders() {
 	capath := filepath.Join("testdata", "root.pem")
 	cafile, err := os.ReadFile(capath)
 	if err != nil {
-		log.Fatalf("can't load ca file: %v", err)
+		log.Printf("can't load ca file: %v", err)
+		return
 	}
 
 	certpool := x509.NewCertPool()
 	if !certpool.AppendCertsFromPEM(cafile) {
-		log.Fatalf("the ca file isn't valid")
+		log.Printf("the ca file isn't valid")
+		return
 	}
 
 	ctx := context.Background()
@@ -94,19 +98,20 @@ func ExampleHTTPStrategy_WithHeaders() {
 		ContainerRequest: req,
 		Started:          true,
 	})
-	if err != nil {
-		log.Fatalf("failed to start container: %s", err)
-	}
-
 	defer func() {
-		if err := c.Terminate(ctx); err != nil {
-			log.Fatalf("failed to terminate container: %s", err)
+		if err := testcontainers.TerminateContainer(c); err != nil {
+			log.Printf("failed to terminate container: %s", err)
 		}
 	}()
+	if err != nil {
+		log.Printf("failed to start container: %s", err)
+		return
+	}
 
 	state, err := c.State(ctx)
 	if err != nil {
-		log.Fatalf("failed to get container state: %s", err) // nolint:gocritic
+		log.Printf("failed to get container state: %s", err)
+		return
 	}
 
 	fmt.Println(state.Running)
@@ -128,20 +133,21 @@ func ExampleHTTPStrategy_WithPort() {
 		ContainerRequest: req,
 		Started:          true,
 	})
+	defer func() {
+		if err := testcontainers.TerminateContainer(c); err != nil {
+			log.Printf("failed to terminate container: %s", err)
+		}
+	}()
 	if err != nil {
-		log.Fatalf("failed to start container: %s", err)
+		log.Printf("failed to start container: %s", err)
+		return
 	}
 	// }
 
-	defer func() {
-		if err := c.Terminate(ctx); err != nil {
-			log.Fatalf("failed to terminate container: %s", err)
-		}
-	}()
-
 	state, err := c.State(ctx)
 	if err != nil {
-		log.Fatalf("failed to get container state: %s", err) // nolint:gocritic
+		log.Printf("failed to get container state: %s", err)
+		return
 	}
 
 	fmt.Println(state.Running)
@@ -162,19 +168,20 @@ func ExampleHTTPStrategy_WithForcedIPv4LocalHost() {
 		ContainerRequest: req,
 		Started:          true,
 	})
-	if err != nil {
-		log.Fatalf("failed to start container: %s", err)
-	}
-
 	defer func() {
-		if err := c.Terminate(ctx); err != nil {
-			log.Fatalf("failed to terminate container: %s", err)
+		if err := testcontainers.TerminateContainer(c); err != nil {
+			log.Printf("failed to terminate container: %s", err)
 		}
 	}()
+	if err != nil {
+		log.Printf("failed to start container: %s", err)
+		return
+	}
 
 	state, err := c.State(ctx)
 	if err != nil {
-		log.Fatalf("failed to get container state: %s", err) // nolint:gocritic
+		log.Printf("failed to get container state: %s", err)
+		return
 	}
 
 	fmt.Println(state.Running)
@@ -196,20 +203,21 @@ func ExampleHTTPStrategy_WithBasicAuth() {
 		ContainerRequest: req,
 		Started:          true,
 	})
+	defer func() {
+		if err := testcontainers.TerminateContainer(gogs); err != nil {
+			log.Printf("failed to terminate container: %s", err)
+		}
+	}()
 	if err != nil {
-		log.Fatalf("failed to start container: %s", err)
+		log.Printf("failed to start container: %s", err)
+		return
 	}
 	// }
 
-	defer func() {
-		if err := gogs.Terminate(ctx); err != nil {
-			log.Fatalf("failed to terminate container: %s", err)
-		}
-	}()
-
 	state, err := gogs.State(ctx)
 	if err != nil {
-		log.Fatalf("failed to get container state: %s", err) // nolint:gocritic
+		log.Printf("failed to get container state: %s", err)
+		return
 	}
 
 	fmt.Println(state.Running)
@@ -220,17 +228,11 @@ func ExampleHTTPStrategy_WithBasicAuth() {
 
 func TestHTTPStrategyWaitUntilReady(t *testing.T) {
 	workdir, err := os.Getwd()
-	if err != nil {
-		t.Error(err)
-		return
-	}
+	require.NoError(t, err)
 
 	capath := filepath.Join(workdir, "testdata", "root.pem")
 	cafile, err := os.ReadFile(capath)
-	if err != nil {
-		t.Errorf("can't load ca file: %v", err)
-		return
-	}
+	require.NoError(t, err)
 
 	certpool := x509.NewCertPool()
 	if !certpool.AppendCertsFromPEM(cafile) {
@@ -254,24 +256,17 @@ func TestHTTPStrategyWaitUntilReady(t *testing.T) {
 			WithMethod(http.MethodPost).WithBody(bytes.NewReader([]byte("ping"))),
 	}
 
-	container, err := testcontainers.GenericContainer(context.Background(),
+	ctr, err := testcontainers.GenericContainer(context.Background(),
 		testcontainers.GenericContainerRequest{ContainerRequest: dockerReq, Started: true})
-	if err != nil {
-		t.Error(err)
-		return
-	}
-	defer container.Terminate(context.Background()) // nolint: errcheck
+	testcontainers.CleanupContainer(t, ctr)
+	require.NoError(t, err)
 
-	host, err := container.Host(context.Background())
-	if err != nil {
-		t.Error(err)
-		return
-	}
-	port, err := container.MappedPort(context.Background(), "6443/tcp")
-	if err != nil {
-		t.Error(err)
-		return
-	}
+	host, err := ctr.Host(context.Background())
+	require.NoError(t, err)
+
+	port, err := ctr.MappedPort(context.Background(), "6443/tcp")
+	require.NoError(t, err)
+
 	client := http.Client{
 		Transport: &http.Transport{
 			TLSClientConfig: tlsconfig,
@@ -289,30 +284,19 @@ func TestHTTPStrategyWaitUntilReady(t *testing.T) {
 		},
 	}
 	resp, err := client.Get(fmt.Sprintf("https://%s:%s", host, port.Port()))
-	if err != nil {
-		t.Error(err)
-		return
-	}
+	require.NoError(t, err)
+
 	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		t.Errorf("status code isn't ok: %s", resp.Status)
-		return
-	}
+	require.Equal(t, http.StatusOK, resp.StatusCode)
 }
 
 func TestHTTPStrategyWaitUntilReadyWithQueryString(t *testing.T) {
 	workdir, err := os.Getwd()
-	if err != nil {
-		t.Error(err)
-		return
-	}
+	require.NoError(t, err)
 
 	capath := filepath.Join(workdir, "testdata", "root.pem")
 	cafile, err := os.ReadFile(capath)
-	if err != nil {
-		t.Errorf("can't load ca file: %v", err)
-		return
-	}
+	require.NoError(t, err)
 
 	certpool := x509.NewCertPool()
 	if !certpool.AppendCertsFromPEM(cafile) {
@@ -335,24 +319,17 @@ func TestHTTPStrategyWaitUntilReadyWithQueryString(t *testing.T) {
 			}),
 	}
 
-	container, err := testcontainers.GenericContainer(context.Background(),
+	ctr, err := testcontainers.GenericContainer(context.Background(),
 		testcontainers.GenericContainerRequest{ContainerRequest: dockerReq, Started: true})
-	if err != nil {
-		t.Error(err)
-		return
-	}
-	defer container.Terminate(context.Background()) // nolint: errcheck
+	testcontainers.CleanupContainer(t, ctr)
+	require.NoError(t, err)
 
-	host, err := container.Host(context.Background())
-	if err != nil {
-		t.Error(err)
-		return
-	}
-	port, err := container.MappedPort(context.Background(), "6443/tcp")
-	if err != nil {
-		t.Error(err)
-		return
-	}
+	host, err := ctr.Host(context.Background())
+	require.NoError(t, err)
+
+	port, err := ctr.MappedPort(context.Background(), "6443/tcp")
+	require.NoError(t, err)
+
 	client := http.Client{
 		Transport: &http.Transport{
 			TLSClientConfig: tlsconfig,
@@ -370,30 +347,19 @@ func TestHTTPStrategyWaitUntilReadyWithQueryString(t *testing.T) {
 		},
 	}
 	resp, err := client.Get(fmt.Sprintf("https://%s:%s", host, port.Port()))
-	if err != nil {
-		t.Error(err)
-		return
-	}
+	require.NoError(t, err)
+
 	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		t.Errorf("status code isn't ok: %s", resp.Status)
-		return
-	}
+	require.Equal(t, http.StatusOK, resp.StatusCode)
 }
 
 func TestHTTPStrategyWaitUntilReadyNoBasicAuth(t *testing.T) {
 	workdir, err := os.Getwd()
-	if err != nil {
-		t.Error(err)
-		return
-	}
+	require.NoError(t, err)
 
 	capath := filepath.Join(workdir, "testdata", "root.pem")
 	cafile, err := os.ReadFile(capath)
-	if err != nil {
-		t.Errorf("can't load ca file: %v", err)
-		return
-	}
+	require.NoError(t, err)
 
 	certpool := x509.NewCertPool()
 	if !certpool.AppendCertsFromPEM(cafile) {
@@ -424,27 +390,16 @@ func TestHTTPStrategyWaitUntilReadyNoBasicAuth(t *testing.T) {
 	// }
 
 	ctx := context.Background()
-	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{ContainerRequest: dockerReq, Started: true})
-	if err != nil {
-		t.Error(err)
-		return
-	}
-	t.Cleanup(func() {
-		if err := container.Terminate(ctx); err != nil {
-			t.Fatalf("failed to terminate container: %s", err)
-		}
-	})
+	ctr, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{ContainerRequest: dockerReq, Started: true})
+	testcontainers.CleanupContainer(t, ctr)
+	require.NoError(t, err)
 
-	host, err := container.Host(ctx)
-	if err != nil {
-		t.Error(err)
-		return
-	}
-	port, err := container.MappedPort(ctx, "6443/tcp")
-	if err != nil {
-		t.Error(err)
-		return
-	}
+	host, err := ctr.Host(ctx)
+	require.NoError(t, err)
+
+	port, err := ctr.MappedPort(ctx, "6443/tcp")
+	require.NoError(t, err)
+
 	client := http.Client{
 		Transport: &http.Transport{
 			TLSClientConfig: tlsconfig,
@@ -462,15 +417,10 @@ func TestHTTPStrategyWaitUntilReadyNoBasicAuth(t *testing.T) {
 		},
 	}
 	resp, err := client.Get(fmt.Sprintf("https://%s:%s", host, port.Port()))
-	if err != nil {
-		t.Error(err)
-		return
-	}
+	require.NoError(t, err)
+
 	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		t.Errorf("status code isn't ok: %s", resp.Status)
-		return
-	}
+	require.Equal(t, http.StatusOK, resp.StatusCode)
 }
 
 func TestHttpStrategyFailsWhileGettingPortDueToOOMKilledContainer(t *testing.T) {
@@ -513,17 +463,9 @@ func TestHttpStrategyFailsWhileGettingPortDueToOOMKilledContainer(t *testing.T) 
 		WithStartupTimeout(500 * time.Millisecond).
 		WithPollInterval(100 * time.Millisecond)
 
-	{
-		err := wg.WaitUntilReady(context.Background(), target)
-		if err == nil {
-			t.Fatal("no error")
-		}
-
-		expected := "container crashed with out-of-memory (OOMKilled)"
-		if err.Error() != expected {
-			t.Fatalf("expected %q, got %q", expected, err.Error())
-		}
-	}
+	err := wg.WaitUntilReady(context.Background(), target)
+	expected := "container crashed with out-of-memory (OOMKilled)"
+	require.EqualError(t, err, expected)
 }
 
 func TestHttpStrategyFailsWhileGettingPortDueToExitedContainer(t *testing.T) {
@@ -567,17 +509,9 @@ func TestHttpStrategyFailsWhileGettingPortDueToExitedContainer(t *testing.T) {
 		WithStartupTimeout(500 * time.Millisecond).
 		WithPollInterval(100 * time.Millisecond)
 
-	{
-		err := wg.WaitUntilReady(context.Background(), target)
-		if err == nil {
-			t.Fatal("no error")
-		}
-
-		expected := "container exited with code 1"
-		if err.Error() != expected {
-			t.Fatalf("expected %q, got %q", expected, err.Error())
-		}
-	}
+	err := wg.WaitUntilReady(context.Background(), target)
+	expected := "container exited with code 1"
+	require.EqualError(t, err, expected)
 }
 
 func TestHttpStrategyFailsWhileGettingPortDueToUnexpectedContainerStatus(t *testing.T) {
@@ -620,17 +554,9 @@ func TestHttpStrategyFailsWhileGettingPortDueToUnexpectedContainerStatus(t *test
 		WithStartupTimeout(500 * time.Millisecond).
 		WithPollInterval(100 * time.Millisecond)
 
-	{
-		err := wg.WaitUntilReady(context.Background(), target)
-		if err == nil {
-			t.Fatal("no error")
-		}
-
-		expected := "unexpected container status \"dead\""
-		if err.Error() != expected {
-			t.Fatalf("expected %q, got %q", expected, err.Error())
-		}
-	}
+	err := wg.WaitUntilReady(context.Background(), target)
+	expected := "unexpected container status \"dead\""
+	require.EqualError(t, err, expected)
 }
 
 func TestHTTPStrategyFailsWhileRequestSendingDueToOOMKilledContainer(t *testing.T) {
@@ -668,17 +594,9 @@ func TestHTTPStrategyFailsWhileRequestSendingDueToOOMKilledContainer(t *testing.
 		WithStartupTimeout(500 * time.Millisecond).
 		WithPollInterval(100 * time.Millisecond)
 
-	{
-		err := wg.WaitUntilReady(context.Background(), target)
-		if err == nil {
-			t.Fatal("no error")
-		}
-
-		expected := "container crashed with out-of-memory (OOMKilled)"
-		if err.Error() != expected {
-			t.Fatalf("expected %q, got %q", expected, err.Error())
-		}
-	}
+	err := wg.WaitUntilReady(context.Background(), target)
+	expected := "container crashed with out-of-memory (OOMKilled)"
+	require.EqualError(t, err, expected)
 }
 
 func TestHttpStrategyFailsWhileRequestSendingDueToExitedContainer(t *testing.T) {
@@ -717,17 +635,9 @@ func TestHttpStrategyFailsWhileRequestSendingDueToExitedContainer(t *testing.T) 
 		WithStartupTimeout(500 * time.Millisecond).
 		WithPollInterval(100 * time.Millisecond)
 
-	{
-		err := wg.WaitUntilReady(context.Background(), target)
-		if err == nil {
-			t.Fatal("no error")
-		}
-
-		expected := "container exited with code 1"
-		if err.Error() != expected {
-			t.Fatalf("expected %q, got %q", expected, err.Error())
-		}
-	}
+	err := wg.WaitUntilReady(context.Background(), target)
+	expected := "container exited with code 1"
+	require.EqualError(t, err, expected)
 }
 
 func TestHttpStrategyFailsWhileRequestSendingDueToUnexpectedContainerStatus(t *testing.T) {
@@ -765,17 +675,9 @@ func TestHttpStrategyFailsWhileRequestSendingDueToUnexpectedContainerStatus(t *t
 		WithStartupTimeout(500 * time.Millisecond).
 		WithPollInterval(100 * time.Millisecond)
 
-	{
-		err := wg.WaitUntilReady(context.Background(), target)
-		if err == nil {
-			t.Fatal("no error")
-		}
-
-		expected := "unexpected container status \"dead\""
-		if err.Error() != expected {
-			t.Fatalf("expected %q, got %q", expected, err.Error())
-		}
-	}
+	err := wg.WaitUntilReady(context.Background(), target)
+	expected := "unexpected container status \"dead\""
+	require.EqualError(t, err, expected)
 }
 
 func TestHttpStrategyFailsWhileGettingPortDueToNoExposedPorts(t *testing.T) {
@@ -812,17 +714,9 @@ func TestHttpStrategyFailsWhileGettingPortDueToNoExposedPorts(t *testing.T) {
 		WithStartupTimeout(500 * time.Millisecond).
 		WithPollInterval(100 * time.Millisecond)
 
-	{
-		err := wg.WaitUntilReady(context.Background(), target)
-		if err == nil {
-			t.Fatal("no error")
-		}
-
-		expected := "No exposed tcp ports or mapped ports - cannot wait for status"
-		if err.Error() != expected {
-			t.Fatalf("expected %q, got %q", expected, err.Error())
-		}
-	}
+	err := wg.WaitUntilReady(context.Background(), target)
+	expected := "No exposed tcp ports or mapped ports - cannot wait for status"
+	require.EqualError(t, err, expected)
 }
 
 func TestHttpStrategyFailsWhileGettingPortDueToOnlyUDPPorts(t *testing.T) {
@@ -866,17 +760,9 @@ func TestHttpStrategyFailsWhileGettingPortDueToOnlyUDPPorts(t *testing.T) {
 		WithStartupTimeout(500 * time.Millisecond).
 		WithPollInterval(100 * time.Millisecond)
 
-	{
-		err := wg.WaitUntilReady(context.Background(), target)
-		if err == nil {
-			t.Fatal("no error")
-		}
-
-		expected := "No exposed tcp ports or mapped ports - cannot wait for status"
-		if err.Error() != expected {
-			t.Fatalf("expected %q, got %q", expected, err.Error())
-		}
-	}
+	err := wg.WaitUntilReady(context.Background(), target)
+	expected := "No exposed tcp ports or mapped ports - cannot wait for status"
+	require.EqualError(t, err, expected)
 }
 
 func TestHttpStrategyFailsWhileGettingPortDueToExposedPortNoBindings(t *testing.T) {
@@ -915,15 +801,7 @@ func TestHttpStrategyFailsWhileGettingPortDueToExposedPortNoBindings(t *testing.
 		WithStartupTimeout(500 * time.Millisecond).
 		WithPollInterval(100 * time.Millisecond)
 
-	{
-		err := wg.WaitUntilReady(context.Background(), target)
-		if err == nil {
-			t.Fatal("no error")
-		}
-
-		expected := "No exposed tcp ports or mapped ports - cannot wait for status"
-		if err.Error() != expected {
-			t.Fatalf("expected %q, got %q", expected, err.Error())
-		}
-	}
+	err := wg.WaitUntilReady(context.Background(), target)
+	expected := "No exposed tcp ports or mapped ports - cannot wait for status"
+	require.EqualError(t, err, expected)
 }

--- a/wait/testdata/main.go
+++ b/wait/testdata/main.go
@@ -83,7 +83,7 @@ func run() error {
 	go func() {
 		log.Println("serving...")
 		if err := server.ListenAndServeTLS("tls.pem", "tls-key.pem"); err != nil && !errors.Is(err, http.ErrServerClosed) {
-			log.Fatal(err)
+			log.Println(err)
 		}
 	}()
 


### PR DESCRIPTION
Ensure that all resources are cleaned up for tests and examples even if they fail.

This leverages new helpers in testcontainers:
* `TerminateContainer` for examples
* `CleanupContainer` and `CleanupNetwork` for tests

These are required ensuring that containers that are created but fail in later actions are returned alongside the error so that clean up can be performed.

Consistently clean up created networks using a new context to ensure that the removal gets run even if original context has timed out or been cancelled.

Use `fmt.Print` instead of `log.Fatal` to ensure that defers are run in all examples again ensuring that clean up is processed.

Call `Stop` from `Terminate` to ensure that child containers are shutdown correctly on clean up as the hard coded timeout using by `ContainerRemove` is too short to allow this to happen correctly.

Clean up of test logic replacing manual checks and asserts with require to make them more concise and hence easier to understand.

Quiet test output by either capturing or disabling output so it's easier to identify issues when tests are run in non verbose mode.

Clarify source of errors with wrapping and update tests to handle.

Ensure that port forwarding container is shutdown if an error occurs during setup so it isn't orphaned.

Shutdown the port forwarding container on both stop and terminate to prevent it being orphaned when the `Stop` is used.

Add missing error checks to tests.

Remove unused `nolint` directives and enable the `nolintlint` to catch any regressions.