### PR TITLE
chore: avoid using of log.Fatal in main in tests

### DIFF
--- a/docker_test.go
+++ b/docker_test.go
@@ -737,14 +737,10 @@ func TestContainerCreationWaitsForLog(t *testing.T) {
 }
 
 func Test_BuildContainerFromDockerfileWithBuildArgs(t *testing.T) {
-	t.Log("getting ctx")
 	ctx := context.Background()
-
-	t.Log("got ctx, creating container request")
 
 	// fromDockerfileWithBuildArgs {
 	ba := "build args value"
-
 	req := ContainerRequest{
 		FromDockerfile: FromDockerfile{
 			Context:    filepath.Join(".", "testdata"),
@@ -770,23 +766,16 @@ func Test_BuildContainerFromDockerfileWithBuildArgs(t *testing.T) {
 	terminateContainerOnEnd(t, ctx, c)
 
 	ep, err := c.Endpoint(ctx, "http")
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	resp, err := http.Get(ep + "/env")
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	defer resp.Body.Close()
 
 	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	assert.Equal(t, 200, resp.StatusCode)
-	assert.Equal(t, ba, string(body))
+	require.NoError(t, err)
+	require.Equal(t, http.StatusAccepted, resp.StatusCode)
+	require.Equal(t, ba, string(body))
 }
 
 func Test_BuildContainerFromDockerfileWithBuildLog(t *testing.T) {

--- a/testdata/echoserver.go
+++ b/testdata/echoserver.go
@@ -10,9 +10,8 @@ import (
 
 func envHandler() http.HandlerFunc {
 	return func(rw http.ResponseWriter, req *http.Request) {
-		_, _ = rw.Write([]byte(os.Getenv("FOO")))
-
 		rw.WriteHeader(http.StatusAccepted)
+		rw.Write([]byte(os.Getenv("FOO"))) //nolint:errcheck // Nothing we can usefully do with the error here.
 	}
 }
 
@@ -21,9 +20,7 @@ func echoHandler(destination *os.File) http.HandlerFunc {
 		echo := req.URL.Query()["echo"][0]
 
 		l := log.New(destination, "echo ", 0)
-
 		l.Println(echo)
-		_ = destination.Sync()
 
 		rw.WriteHeader(http.StatusAccepted)
 	}
@@ -39,10 +36,12 @@ func main() {
 
 	ln, err := net.Listen("tcp", ":8080")
 	if err != nil {
-		panic(err)
+		log.Fatal(err)
 	}
 
 	fmt.Println("ready")
 
-	_ = http.Serve(ln, mux)
+	if err := http.Serve(ln, mux); err != nil {
+		log.Fatal(err)
+	}
 }

--- a/wait/testdata/main.go
+++ b/wait/testdata/main.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/base64"
 	"errors"
+	"fmt"
 	"io"
 	"log"
 	"net/http"
@@ -15,7 +16,7 @@ import (
 	"time"
 )
 
-func main() {
+func run() error {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/", func(w http.ResponseWriter, req *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -93,5 +94,15 @@ func main() {
 	log.Println("stopping...")
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 	defer cancel()
-	_ = server.Shutdown(ctx)
+	if err := server.Shutdown(ctx); err != nil {
+		return fmt.Errorf("shutdown: %w", err)
+	}
+
+	return nil
+}
+
+func main() {
+	if err := run(); err != nil {
+		log.Fatal(err)
+	}
 }


### PR DESCRIPTION
Remove use of log fatal which prevents defers and correct order of Write and WriteHeader.