### PR TITLE
fix: check if the discovered docker socket responds

### DIFF
--- a/docker_client.go
+++ b/docker_client.go
@@ -79,8 +79,8 @@ func (c *DockerClient) Info(ctx context.Context) (system.Info, error) {
 		dockerInfo.OperatingSystem, dockerInfo.MemTotal/1024/1024,
 		infoLabels,
 		internal.Version,
-		core.ExtractDockerHost(ctx),
-		core.ExtractDockerSocket(ctx),
+		core.MustExtractDockerHost(ctx),
+		core.MustExtractDockerSocket(ctx),
 		core.SessionID(),
 		core.ProcessID(),
 	)

--- a/docs/features/configuration.md
+++ b/docs/features/configuration.md
@@ -85,7 +85,7 @@ See [Docker environment variables](https://docs.docker.com/engine/reference/comm
     3. `${HOME}/.docker/desktop/docker.sock`.
     4. `/run/user/${UID}/docker.sock`, where `${UID}` is the user ID of the current user.
 
-7. The default Docker socket including schema will be returned if none of the above are set.
+7. The library panics if none of the above are set, meaning that the Docker host was not detected.
 
 ## Docker socket path detection
 
@@ -109,4 +109,4 @@ Path to Docker's socket. Used by Ryuk, Docker Compose, and a few other container
 
 6. Else, the default location of the docker socket is used: `/var/run/docker.sock`
 
-In any case, if the docker socket schema is `tcp://`, the default docker socket path will be returned.
+The library panics if the Docker host cannot be discovered.

--- a/image_test.go
+++ b/image_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestImageList(t *testing.T) {
-	t.Setenv("DOCKER_HOST", core.ExtractDockerHost(context.Background()))
+	t.Setenv("DOCKER_HOST", core.MustExtractDockerHost(context.Background()))
 
 	provider, err := ProviderDocker.GetProvider()
 	if err != nil {
@@ -54,7 +54,7 @@ func TestImageList(t *testing.T) {
 }
 
 func TestSaveImages(t *testing.T) {
-	t.Setenv("DOCKER_HOST", core.ExtractDockerHost(context.Background()))
+	t.Setenv("DOCKER_HOST", core.MustExtractDockerHost(context.Background()))
 
 	provider, err := ProviderDocker.GetProvider()
 	if err != nil {

--- a/internal/core/client.go
+++ b/internal/core/client.go
@@ -14,7 +14,7 @@ import (
 func NewClient(ctx context.Context, ops ...client.Opt) (*client.Client, error) {
 	tcConfig := config.Read()
 
-	dockerHost := ExtractDockerHost(ctx)
+	dockerHost := MustExtractDockerHost(ctx)
 
 	opts := []client.Opt{client.FromEnv, client.WithAPIVersionNegotiation()}
 	if dockerHost != "" {

--- a/internal/core/docker_host.go
+++ b/internal/core/docker_host.go
@@ -59,7 +59,7 @@ func DefaultGatewayIP() (string, error) {
 // defaultCallbackCheckFn Use a vanilla Docker client to check if the Docker host is reachable.
 // It will avoid recursive calls to this function.
 var defaultCallbackCheckFn = func(ctx context.Context, host string) error {
-	cli, err := client.NewClientWithOpts(client.FromEnv, client.WithHost(host))
+	cli, err := client.NewClientWithOpts(client.FromEnv, client.WithHost(host), client.WithAPIVersionNegotiation())
 	if err != nil {
 		return err
 	}

--- a/internal/core/docker_host.go
+++ b/internal/core/docker_host.go
@@ -116,22 +116,6 @@ func extractDockerHost(ctx context.Context) string {
 			continue
 		}
 
-		// check if the docker host responds to an Info request
-		// we are going to use the default Docker client to check if the host is reachable
-		// which will avoid recursive calls to this function
-		cli, err := client.NewClientWithOpts(client.WithHost(dockerHost))
-		if err != nil {
-			outerErr = fmt.Errorf("%w: %w", outerErr, err)
-			continue
-		}
-		defer cli.Close()
-
-		_, err = cli.Info(ctx)
-		if err != nil {
-			outerErr = fmt.Errorf("%w: %w", outerErr, err)
-			continue
-		}
-
 		return dockerHost
 	}
 
@@ -157,7 +141,8 @@ func extractDockerSocket(ctx context.Context) string {
 // and receiving an instance of the Docker API client interface.
 // This internal method is handy for testing purposes, passing a mock type simulating the desired behaviour.
 func extractDockerSocketFromClient(ctx context.Context, cli client.APIClient) string {
-	// check that the socket is not a tcp or unix socket
+	// check that the socket is not a tcp or unix socket,
+	// and that it is reachable.
 	checkDockerSocketFn := func(socket string) string {
 		// this use case will cover the case when the docker host is a tcp socket
 		if strings.HasPrefix(socket, TCPSchema) {
@@ -166,6 +151,11 @@ func extractDockerSocketFromClient(ctx context.Context, cli client.APIClient) st
 
 		if strings.HasPrefix(socket, DockerSocketSchema) {
 			return strings.Replace(socket, DockerSocketSchema, "", 1)
+		}
+
+		_, err := cli.Info(ctx)
+		if err != nil {
+			return DockerSocketPath
 		}
 
 		return socket

--- a/internal/core/docker_host.go
+++ b/internal/core/docker_host.go
@@ -133,9 +133,7 @@ func extractDockerHost(ctx context.Context) string {
 			continue
 		}
 
-		err = defaultCallbackCheckFn(ctx, dockerHost)
-		if err != nil {
-			outerErr = fmt.Errorf("%w: %w", outerErr, err)
+		if err = defaultCallbackCheckFn(ctx, dockerHost); err != nil {
 			continue
 		}
 

--- a/internal/core/docker_host.go
+++ b/internal/core/docker_host.go
@@ -116,22 +116,6 @@ func extractDockerHost(ctx context.Context) string {
 			continue
 		}
 
-		// check if the docker host responds to an Info request
-		// we are going to use the default Docker client to check if the host is reachable
-		// which will avoid recursive calls to this function
-		cli, err := client.NewClientWithOpts(client.WithHost(dockerHost))
-		if err != nil {
-			outerErr = fmt.Errorf("%w: %w", outerErr, err)
-			continue
-		}
-		defer cli.Close()
-
-		_, err = cli.Info(ctx)
-		if err != nil {
-			outerErr = fmt.Errorf("%w: %w", outerErr, err)
-			continue
-		}
-
 		return dockerHost
 	}
 

--- a/internal/core/docker_host.go
+++ b/internal/core/docker_host.go
@@ -63,12 +63,12 @@ var defaultCallbackCheckFn = func(ctx context.Context, host string) error {
 	if err != nil {
 		return err
 	}
+	defer cli.Close()
 
 	_, err = cli.Info(ctx)
 	if err != nil {
 		return err
 	}
-	defer cli.Close()
 
 	return nil
 }

--- a/internal/core/docker_host.go
+++ b/internal/core/docker_host.go
@@ -109,7 +109,7 @@ func ExtractDockerHost(ctx context.Context) string {
 //  5. If the socket contains the unix schema, the schema is removed (e.g. unix:///var/run/docker.sock -> /var/run/docker.sock)
 //  6. Else, the default location of the docker socket is used (/var/run/docker.sock)
 //
-// In any case, if the docker socket schema is "tcp://", the default docker socket path will be returned.
+// It panics if a Docker client cannot be created, or the Docker host cannot be discovered.
 func ExtractDockerSocket(ctx context.Context) string {
 	dockerSocketPathOnce.Do(func() {
 		dockerSocketPathCache = extractDockerSocket(ctx)
@@ -151,7 +151,7 @@ func extractDockerHost(ctx context.Context) (string, error) {
 // extractDockerSocket Extracts the docker socket from the different alternatives, without caching the result.
 // It will internally use the default Docker client, calling the internal method extractDockerSocketFromClient with it.
 // This internal method is handy for testing purposes.
-// If a Docker client cannot be created, the program will panic.
+// It panics if a Docker client cannot be created, or the Docker host is not discovered.
 func extractDockerSocket(ctx context.Context) string {
 	cli, err := NewClient(ctx)
 	if err != nil {
@@ -165,6 +165,7 @@ func extractDockerSocket(ctx context.Context) string {
 // extractDockerSocketFromClient Extracts the docker socket from the different alternatives, without caching the result,
 // and receiving an instance of the Docker API client interface.
 // This internal method is handy for testing purposes, passing a mock type simulating the desired behaviour.
+// It panics if the Docker Info call errors, or the Docker host is not discovered.
 func extractDockerSocketFromClient(ctx context.Context, cli client.APIClient) string {
 	// check that the socket is not a tcp or unix socket
 	checkDockerSocketFn := func(socket string) string {

--- a/internal/core/docker_host.go
+++ b/internal/core/docker_host.go
@@ -134,7 +134,7 @@ func extractDockerHost(ctx context.Context) (string, error) {
 	for _, dockerHostFn := range dockerHostFns {
 		dockerHost, err := dockerHostFn(ctx)
 		if err != nil {
-			if !isHostNotFound(err) {
+			if !isHostNotSet(err) {
 				errs = append(errs, err)
 			}
 			continue
@@ -222,7 +222,7 @@ func extractDockerSocketFromClient(ctx context.Context, cli client.APIClient) st
 
 // isHostNotSet returns true if the error is related to the Docker host
 // not being set, false otherwise.
-func isHostNotFound(err error) bool {
+func isHostNotSet(err error) bool {
 	switch {
 	case errors.Is(err, ErrTestcontainersHostNotSetInProperties),
 		errors.Is(err, ErrDockerHostNotSet),

--- a/internal/core/docker_host.go
+++ b/internal/core/docker_host.go
@@ -56,9 +56,9 @@ func DefaultGatewayIP() (string, error) {
 	return ip, nil
 }
 
-// Use a vanilla Docker client to check if the Docker host is reachable.
+// defaultCallbackCheck Use a vanilla Docker client to check if the Docker host is reachable.
 // It will avoid recursive calls to this function.
-var defaultCallbackCheckFn = func(host string) error {
+func defaultCallbackCheck(host string) error {
 	cli, err := client.NewClientWithOpts(client.FromEnv, client.WithHost(host))
 	if err != nil {
 		return err
@@ -90,7 +90,7 @@ func ExtractDockerHost(ctx context.Context, callbackChecks ...func(host string) 
 		// and to avoid changing the code base, passing zero callbacks will mean the default one,
 		// which checks that the host is reachable.
 		if len(callbackChecks) == 0 {
-			callbackChecks = append(callbackChecks, defaultCallbackCheckFn)
+			callbackChecks = append(callbackChecks, defaultCallbackCheck)
 		}
 
 		dockerHostCache = extractDockerHost(ctx, callbackChecks...)
@@ -167,7 +167,7 @@ func extractDockerSocket(ctx context.Context) string {
 	}
 	defer cli.Close()
 
-	return extractDockerSocketFromClient(ctx, cli, defaultCallbackCheckFn)
+	return extractDockerSocketFromClient(ctx, cli, defaultCallbackCheck)
 }
 
 // extractDockerSocketFromClient Extracts the docker socket from the different alternatives, without caching the result,

--- a/internal/core/docker_host.go
+++ b/internal/core/docker_host.go
@@ -116,6 +116,22 @@ func extractDockerHost(ctx context.Context) string {
 			continue
 		}
 
+		// check if the docker host responds to an Info request
+		// we are going to use the default Docker client to check if the host is reachable
+		// which will avoid recursive calls to this function
+		cli, err := client.NewClientWithOpts(client.WithHost(dockerHost))
+		if err != nil {
+			outerErr = fmt.Errorf("%w: %w", outerErr, err)
+			continue
+		}
+		defer cli.Close()
+
+		_, err = cli.Info(ctx)
+		if err != nil {
+			outerErr = fmt.Errorf("%w: %w", outerErr, err)
+			continue
+		}
+
 		return dockerHost
 	}
 

--- a/internal/core/docker_host.go
+++ b/internal/core/docker_host.go
@@ -105,7 +105,7 @@ func MustExtractDockerHost(ctx context.Context) string {
 //  1. Docker host from the "tc.host" property in the ~/.testcontainers.properties file.
 //  2. The TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE environment variable.
 //  3. Using a Docker client, check if the Info().OperativeSystem is "Docker Desktop" and return the default docker socket path for rootless docker.
-//  4. Else, Get the current Docker Host from the existing strategies: see ExtractDockerHost.
+//  4. Else, Get the current Docker Host from the existing strategies: see MustExtractDockerHost.
 //  5. If the socket contains the unix schema, the schema is removed (e.g. unix:///var/run/docker.sock -> /var/run/docker.sock)
 //  6. Else, the default location of the docker socket is used (/var/run/docker.sock)
 //

--- a/internal/core/docker_host.go
+++ b/internal/core/docker_host.go
@@ -229,7 +229,6 @@ func isHostNotFound(err error) bool {
 		errors.Is(err, ErrDockerSocketNotSetInContext),
 		errors.Is(err, ErrDockerSocketNotSetInProperties),
 		errors.Is(err, ErrSocketNotFoundInPath),
-		errors.Is(err, ErrDockerSocketNotSetInProperties),
 		errors.Is(err, ErrXDGRuntimeDirNotSet),
 		errors.Is(err, ErrRootlessDockerNotFoundHomeRunDir),
 		errors.Is(err, ErrRootlessDockerNotFoundHomeDesktopDir),

--- a/internal/core/docker_host_test.go
+++ b/internal/core/docker_host_test.go
@@ -102,8 +102,7 @@ func TestExtractDockerHost(t *testing.T) {
 		mockCallbackCheck(t, testCallbackCheckError)
 
 		host, err := extractDockerHost(context.Background())
-		require.ErrorIs(t, err, ErrDockerSocketNotSetInContext)
-		require.ErrorIs(t, err, ErrDockerSocketNotSetInProperties)
+		require.Error(t, err)
 		require.Equal(t, "", host)
 	})
 

--- a/internal/core/docker_host_test.go
+++ b/internal/core/docker_host_test.go
@@ -50,10 +50,10 @@ func testCallbackCheckError(_ context.Context, _ string) error {
 }
 
 func mockCallbackCheck(t *testing.T, fn func(_ context.Context, _ string) error) {
-	oldCheck := defaultCallbackCheckFn
-	defaultCallbackCheckFn = fn
+	oldCheck := dockerHostCheck
+	dockerHostCheck = fn
 	t.Cleanup(func() {
-		defaultCallbackCheckFn = oldCheck
+		dockerHostCheck = oldCheck
 	})
 }
 
@@ -71,13 +71,13 @@ func TestExtractDockerHost(t *testing.T) {
 		expected := "/path/to/docker.sock"
 		t.Setenv("DOCKER_HOST", expected)
 
-		host := ExtractDockerHost(context.Background())
+		host := MustExtractDockerHost(context.Background())
 
 		assert.Equal(t, expected, host)
 
 		t.Setenv("DOCKER_HOST", "/path/to/another/docker.sock")
 
-		host = ExtractDockerHost(context.Background())
+		host = MustExtractDockerHost(context.Background())
 		require.Equal(t, expected, host)
 	})
 

--- a/internal/core/docker_host_test.go
+++ b/internal/core/docker_host_test.go
@@ -2,12 +2,14 @@ package core
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/docker/docker/api/types/system"
 	"github.com/docker/docker/client"
+	"github.com/docker/docker/errdefs"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -271,12 +273,17 @@ func TestExtractDockerHost(t *testing.T) {
 // different operating systems.
 type mockCli struct {
 	client.APIClient
-	OS string
+	OS           string
+	notReachable bool
 }
 
 // Info returns a mock implementation of types.Info, which is handy for detecting the operating system,
 // which is used to determine the default docker socket path.
 func (m mockCli) Info(ctx context.Context) (system.Info, error) {
+	if m.notReachable {
+		return system.Info{}, errdefs.Unavailable(fmt.Errorf("Docker is not reachable"))
+	}
+
 	return system.Info{
 		OperatingSystem: m.OS,
 	}, nil
@@ -408,6 +415,29 @@ func TestExtractDockerSocketFromClient(t *testing.T) {
 		os.Unsetenv("DOCKER_HOST")
 
 		socket := extractDockerSocketFromClient(ctx, mockCli{OS: "Ubuntu"})
+
+		assert.Equal(t, "/this/is/a/sample.sock", socket)
+	})
+
+	t.Run("Unix Docker Socket is not reachable, so Info panics", func(t *testing.T) {
+		defer func() {
+			if r := recover(); r == nil {
+				t.Errorf("The code did not panic")
+			}
+		}()
+
+		content := "docker.host=" + DockerSocketSchema + "/this/is/a/sample.sock"
+		setupTestcontainersProperties(t, content)
+		setupDockerSocketNotFound(t)
+
+		t.Cleanup(resetSocketOverrideFn)
+
+		ctx := context.Background()
+		os.Unsetenv("TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE")
+		os.Unsetenv("DOCKER_HOST")
+
+		// force a non
+		socket := extractDockerSocketFromClient(ctx, mockCli{notReachable: true})
 
 		assert.Equal(t, "/this/is/a/sample.sock", socket)
 	})

--- a/internal/core/docker_host_test.go
+++ b/internal/core/docker_host_test.go
@@ -461,14 +461,10 @@ func TestExtractDockerSocketFromClient(t *testing.T) {
 
 		mockCallbackCheck(t, testCallbackCheckError)
 
-		// check that panic is raised
-		defer func() {
-			if r := recover(); r == nil {
-				t.Errorf("The code did not panic")
-			}
-		}()
-
-		socket := extractDockerSocketFromClient(ctx, mockCli{OS: "Ubuntu"})
+		var socket string
+		require.Panics(t, func() {
+			socket = extractDockerSocketFromClient(ctx, mockCli{OS: "Ubuntu"})
+		})
 
 		// the default Docker host without schema is returned because we cannot any other host
 		require.Equal(t, "", socket)

--- a/internal/core/docker_host_test.go
+++ b/internal/core/docker_host_test.go
@@ -41,11 +41,11 @@ var resetSocketOverrideFn = func() {
 	os.Setenv("TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE", originalDockerSocketOverride)
 }
 
-var testCallbackCheckPassing = func(_ context.Context, _ string) error {
+func testCallbackCheckPassing(_ context.Context, _ string) error {
 	return nil
 }
 
-var testCallbackCheckError = func(_ context.Context, _ string) error {
+func testCallbackCheckError(_ context.Context, _ string) error {
 	return fmt.Errorf("could not check the Docker host")
 }
 

--- a/internal/core/docker_host_test.go
+++ b/internal/core/docker_host_test.go
@@ -461,13 +461,10 @@ func TestExtractDockerSocketFromClient(t *testing.T) {
 
 		mockCallbackCheck(t, testCallbackCheckError)
 
-		var socket string
 		require.Panics(t, func() {
-			socket = extractDockerSocketFromClient(ctx, mockCli{OS: "Ubuntu"})
+			// no need to check for the returned socket, as it must panic
+			_ = extractDockerSocketFromClient(ctx, mockCli{OS: "Ubuntu"})
 		})
-
-		// the default Docker host without schema is returned because we cannot any other host
-		require.Equal(t, "", socket)
 	})
 }
 

--- a/internal/core/docker_rootless.go
+++ b/internal/core/docker_rootless.go
@@ -53,18 +53,24 @@ func rootlessDockerSocketPath(_ context.Context) (string, error) {
 		rootlessSocketPathFromRunDir,
 	}
 
-	outerErr := ErrRootlessDockerNotFound
+	var errs []error
 	for _, socketPathFn := range socketPathFns {
 		s, err := socketPathFn()
 		if err != nil {
-			outerErr = fmt.Errorf("%w: %w", outerErr, err)
+			if !isHostNotFound(err) {
+				errs = append(errs, err)
+			}
 			continue
 		}
 
 		return DockerSocketSchema + s, nil
 	}
 
-	return "", outerErr
+	if len(errs) > 0 {
+		return "", errors.Join(errs...)
+	}
+
+	return "", ErrRootlessDockerNotFound
 }
 
 func fileExists(f string) bool {

--- a/internal/core/docker_rootless.go
+++ b/internal/core/docker_rootless.go
@@ -57,7 +57,7 @@ func rootlessDockerSocketPath(_ context.Context) (string, error) {
 	for _, socketPathFn := range socketPathFns {
 		s, err := socketPathFn()
 		if err != nil {
-			if !isHostNotFound(err) {
+			if !isHostNotSet(err) {
 				errs = append(errs, err)
 			}
 			continue

--- a/internal/core/docker_rootless_test.go
+++ b/internal/core/docker_rootless_test.go
@@ -178,7 +178,7 @@ func TestRootlessDockerSocketPath(t *testing.T) {
 		setupRootlessNotFound(t)
 
 		socketPath, err := rootlessDockerSocketPath(context.Background())
-		require.Error(t, err)
+		require.ErrorIs(t, err, ErrRootlessDockerNotFoundXDGRuntimeDir)
 		assert.Empty(t, socketPath)
 	})
 }

--- a/internal/core/docker_rootless_test.go
+++ b/internal/core/docker_rootless_test.go
@@ -178,14 +178,8 @@ func TestRootlessDockerSocketPath(t *testing.T) {
 		setupRootlessNotFound(t)
 
 		socketPath, err := rootlessDockerSocketPath(context.Background())
-		require.ErrorIs(t, err, ErrRootlessDockerNotFound)
+		require.Error(t, err)
 		assert.Empty(t, socketPath)
-
-		// the wrapped error includes all the locations that were checked
-		require.ErrorContains(t, err, ErrRootlessDockerNotFoundXDGRuntimeDir.Error())
-		require.ErrorContains(t, err, ErrRootlessDockerNotFoundHomeRunDir.Error())
-		require.ErrorContains(t, err, ErrRootlessDockerNotFoundHomeDesktopDir.Error())
-		require.ErrorContains(t, err, ErrRootlessDockerNotFoundRunDir.Error())
 	})
 }
 

--- a/modules/localstack/localstack.go
+++ b/modules/localstack/localstack.go
@@ -74,7 +74,7 @@ func RunContainer(ctx context.Context, opts ...testcontainers.ContainerCustomize
 // Run creates an instance of the LocalStack container type
 // - overrideReq: a function that can be used to override the default container request, usually used to set the image version, environment variables for localstack, etc.
 func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustomizer) (*LocalStackContainer, error) {
-	dockerHost := testcontainers.MustExtractDockerSocket()
+	dockerHost := testcontainers.MustExtractDockerSocket(ctx)
 
 	req := testcontainers.ContainerRequest{
 		Image:        img,

--- a/modules/localstack/localstack.go
+++ b/modules/localstack/localstack.go
@@ -74,7 +74,7 @@ func RunContainer(ctx context.Context, opts ...testcontainers.ContainerCustomize
 // Run creates an instance of the LocalStack container type
 // - overrideReq: a function that can be used to override the default container request, usually used to set the image version, environment variables for localstack, etc.
 func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustomizer) (*LocalStackContainer, error) {
-	dockerHost := testcontainers.ExtractDockerSocket()
+	dockerHost := testcontainers.MustExtractDockerSocket()
 
 	req := testcontainers.ContainerRequest{
 		Image:        img,

--- a/provider.go
+++ b/provider.go
@@ -147,7 +147,7 @@ func NewDockerProvider(provOpts ...DockerProviderOption) (*DockerProvider, error
 
 	return &DockerProvider{
 		DockerProviderOptions: o,
-		host:                  core.ExtractDockerHost(ctx),
+		host:                  core.MustExtractDockerHost(ctx),
 		client:                c,
 		config:                config.Read(),
 	}, nil

--- a/provider_test.go
+++ b/provider_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestProviderTypeGetProviderAutodetect(t *testing.T) {
-	dockerHost := core.ExtractDockerHost(context.Background())
+	dockerHost := core.MustExtractDockerHost(context.Background())
 	const podmanSocket = "unix://$XDG_RUNTIME_DIR/podman/podman.sock"
 
 	tests := []struct {

--- a/reaper.go
+++ b/reaper.go
@@ -233,7 +233,7 @@ func reuseReaperContainer(ctx context.Context, sessionID string, provider Reaper
 // newReaper creates a Reaper with a sessionID to identify containers and a
 // provider to use. Do not call this directly, use reuseOrCreateReaper instead.
 func newReaper(ctx context.Context, sessionID string, provider ReaperProvider) (*Reaper, error) {
-	dockerHostMount := core.ExtractDockerSocket(ctx)
+	dockerHostMount := core.MustExtractDockerSocket(ctx)
 
 	reaper := &Reaper{
 		Provider:  provider,

--- a/reaper_test.go
+++ b/reaper_test.go
@@ -91,7 +91,7 @@ func createContainerRequest(customize func(ContainerRequest) ContainerRequest) C
 		ExposedPorts: []string{"8080/tcp"},
 		Labels:       core.DefaultLabels(testSessionID),
 		HostConfigModifier: func(hostConfig *container.HostConfig) {
-			hostConfig.Binds = []string{core.ExtractDockerSocket(context.Background()) + ":/var/run/docker.sock"}
+			hostConfig.Binds = []string{core.MustExtractDockerSocket(context.Background()) + ":/var/run/docker.sock"}
 		},
 		WaitingFor: wait.ForListeningPort(nat.Port("8080/tcp")),
 		Env: map[string]string{
@@ -376,7 +376,7 @@ func Test_NewReaper(t *testing.T) {
 			name: "docker-host in context",
 			req: createContainerRequest(func(req ContainerRequest) ContainerRequest {
 				req.HostConfigModifier = func(hostConfig *container.HostConfig) {
-					hostConfig.Binds = []string{core.ExtractDockerSocket(context.Background()) + ":/var/run/docker.sock"}
+					hostConfig.Binds = []string{core.MustExtractDockerSocket(context.Background()) + ":/var/run/docker.sock"}
 				}
 				return req
 			}),

--- a/testcontainers.go
+++ b/testcontainers.go
@@ -6,6 +6,11 @@ import (
 	"github.com/testcontainers/testcontainers-go/internal/core"
 )
 
+// Deprecated: use MustExtractDockerHost instead.
+func ExtractDockerSocket() string {
+	return MustExtractDockerSocket()
+}
+
 // ExtractDockerSocket Extracts the docker socket from the different alternatives, removing the socket schema.
 // Use this function to get the docker socket path, not the host (e.g. mounting the socket in a container).
 // This function does not consider Windows containers at the moment.
@@ -19,8 +24,8 @@ import (
 //  6. Else, the default location of the docker socket is used (/var/run/docker.sock)
 //
 // It panics if a Docker client cannot be created, or the Docker host cannot be discovered.
-func ExtractDockerSocket() string {
-	return core.ExtractDockerSocket(context.Background())
+func MustExtractDockerSocket() string {
+	return core.MustExtractDockerSocket(context.Background())
 }
 
 // SessionID returns a unique session ID for the current test session. Because each Go package

--- a/testcontainers.go
+++ b/testcontainers.go
@@ -8,10 +8,10 @@ import (
 
 // Deprecated: use MustExtractDockerHost instead.
 func ExtractDockerSocket() string {
-	return MustExtractDockerSocket()
+	return MustExtractDockerSocket(context.Background())
 }
 
-// ExtractDockerSocket Extracts the docker socket from the different alternatives, removing the socket schema.
+// MustExtractDockerSocket Extracts the docker socket from the different alternatives, removing the socket schema.
 // Use this function to get the docker socket path, not the host (e.g. mounting the socket in a container).
 // This function does not consider Windows containers at the moment.
 // The possible alternatives are:
@@ -24,8 +24,8 @@ func ExtractDockerSocket() string {
 //  6. Else, the default location of the docker socket is used (/var/run/docker.sock)
 //
 // It panics if a Docker client cannot be created, or the Docker host cannot be discovered.
-func MustExtractDockerSocket() string {
-	return core.MustExtractDockerSocket(context.Background())
+func MustExtractDockerSocket(ctx context.Context) string {
+	return core.MustExtractDockerSocket(ctx)
 }
 
 // SessionID returns a unique session ID for the current test session. Because each Go package

--- a/testcontainers.go
+++ b/testcontainers.go
@@ -18,7 +18,7 @@ import (
 //  5. If the socket contains the unix schema, the schema is removed (e.g. unix:///var/run/docker.sock -> /var/run/docker.sock)
 //  6. Else, the default location of the docker socket is used (/var/run/docker.sock)
 //
-// In any case, if the docker socket schema is "tcp://", the default docker socket path will be returned.
+// It panics if a Docker client cannot be created, or the Docker host cannot be discovered.
 func ExtractDockerSocket() string {
 	return core.ExtractDockerSocket(context.Background())
 }

--- a/testcontainers.go
+++ b/testcontainers.go
@@ -19,7 +19,7 @@ func ExtractDockerSocket() string {
 //  1. Docker host from the "tc.host" property in the ~/.testcontainers.properties file.
 //  2. The TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE environment variable.
 //  3. Using a Docker client, check if the Info().OperativeSystem is "Docker Desktop" and return the default docker socket path for rootless docker.
-//  4. Else, Get the current Docker Host from the existing strategies: see ExtractDockerHost.
+//  4. Else, Get the current Docker Host from the existing strategies: see MustExtractDockerHost.
 //  5. If the socket contains the unix schema, the schema is removed (e.g. unix:///var/run/docker.sock -> /var/run/docker.sock)
 //  6. Else, the default location of the docker socket is used (/var/run/docker.sock)
 //


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
This PR adds a check for each discovered Docker host in order to verify if a vanilla Docker client can talk to that host.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
It will remove the confusion when a testcontainers.properties file exists and the Testcontainers Desktop (TCD) app has been used in the past, adding a `tc.host` entry in the properties. In the case TCD is not running, and the container runtime is running (i.e. Docker Desktop), then the latter should be used. Before this fix, the code will cause the discovery algorithm to get the tc.host entry first (it simply exists) and use it, even though it's not responding.

With this fix we'll fail if that Docker host is not accessible, continuing with the Docker host resolution.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes #2622

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
