### PR TITLE
Add conditional execution for Windows CI

### DIFF
--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   test-windows:
+    if: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event.client_payload.slash_command.command == 'windows-test' }}
     runs-on: [self-hosted, Windows, X64, desktop-windows-intel]
     timeout-minutes: 30
     steps:


### PR DESCRIPTION
Test should execute on `main` branch or in PRs if `/windows-test`
is added in comments.
