### PR TITLE
chore(deps): bump minimal Go version from 1.21 to 1.22

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,7 +2,7 @@
 // README at: https://github.com/devcontainers/templates/tree/main/src/go
 {
 	"name": "Go",
-	"image": "mcr.microsoft.com/devcontainers/go:1.21-bookworm",
+	"image": "mcr.microsoft.com/devcontainers/go:1.22-bookworm",
 
 	// Features to add to the dev container. More info: https://containers.dev/features.
 	// "features": {},

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.21.x, 1.x]
+        go-version: [1.22.x, 1.x]
         platform: [ubuntu-latest, macos-latest]
     uses: ./.github/workflows/ci-test-go.yml
     with:
@@ -44,7 +44,7 @@ jobs:
     name: "Test with reaper off"
     strategy:
       matrix:
-        go-version: [1.21.x, 1.x]
+        go-version: [1.22.x, 1.x]
     uses: ./.github/workflows/ci-test-go.yml
     with:
       go-version: ${{ matrix.go-version }}
@@ -61,7 +61,7 @@ jobs:
     name: "Test with Rootless Docker"
     strategy:
       matrix:
-        go-version: [1.21.x, 1.x]
+        go-version: [1.22.x, 1.x]
         platform: [ubuntu-latest]
     uses: ./.github/workflows/ci-test-go.yml
     with:
@@ -76,7 +76,7 @@ jobs:
   test-module-generator:
     strategy:
       matrix:
-        go-version: [1.21.x, 1.x]
+        go-version: [1.22.x, 1.x]
         platform: [ubuntu-latest, macos-latest, windows-latest]
     uses: ./.github/workflows/ci-test-go.yml
     with:
@@ -92,7 +92,7 @@ jobs:
     needs: test
     strategy:
       matrix:
-        go-version: [1.21.x, 1.x]
+        go-version: [1.22.x, 1.x]
         platform: [ubuntu-latest]
         module: [artemis, azurite, cassandra, chroma, clickhouse, cockroachdb, compose, consul, couchbase, dolt, elasticsearch, gcloud, grafana-lgtm, inbucket, influxdb, k3s, k6, kafka, localstack, mariadb, milvus, minio, mockserver, mongodb, mssql, mysql, nats, neo4j, ollama, openfga, openldap, opensearch, postgres, pulsar, qdrant, rabbitmq, redis, redpanda, registry, surrealdb, valkey, vault, vearch, weaviate]
     uses: ./.github/workflows/ci-test-go.yml
@@ -112,7 +112,7 @@ jobs:
         module: [nginx, toxiproxy]
     uses: ./.github/workflows/ci-test-go.yml
     with:
-      go-version: "1.21.x"
+      go-version: "1.22.x"
       fail-fast: true
       platform: 'ubuntu-latest'
       project-directory: examples/${{ matrix.module }}

--- a/docs/system_requirements/ci/aws_codebuild.md
+++ b/docs/system_requirements/ci/aws_codebuild.md
@@ -11,7 +11,7 @@ version: 0.2
 phases:
   install:
     runtime-versions:
-      golang: 1.21
+      golang: 1.22
   build:
     commands:
       - go test ./...

--- a/docs/system_requirements/ci/concourse_ci.md
+++ b/docs/system_requirements/ci/concourse_ci.md
@@ -36,7 +36,7 @@ jobs:
             start_docker
 
             cd repo
-            docker run -it --rm -v "$PWD:$PWD" -w "$PWD" -v /var/run/docker.sock:/var/run/docker.sock golang:1.21 go test ./...
+            docker run -it --rm -v "$PWD:$PWD" -w "$PWD" -v /var/run/docker.sock:/var/run/docker.sock golang:1.22 go test ./...
 ```
 
 Finally, you can use Concourse's [fly CLI](https://concourse-ci.org/fly.html) to set the pipeline and trigger the job:

--- a/docs/system_requirements/ci/dind_patterns.md
+++ b/docs/system_requirements/ci/dind_patterns.md
@@ -24,7 +24,7 @@ $ tree .
 └── platform
     └── integration_test.go
 
-$ docker run -it --rm -v $PWD:$PWD -w $PWD -v /var/run/docker.sock:/var/run/docker.sock golang:1.21 go test ./... -v
+$ docker run -it --rm -v $PWD:$PWD -w $PWD -v /var/run/docker.sock:/var/run/docker.sock golang:1.22 go test ./... -v
 ```
 
 Where:
@@ -45,7 +45,7 @@ The same can be achieved with Docker Compose:
 
 ```yaml
 tests:
-  image: golang:1.21
+  image: golang:1.22
   stop_signal: SIGKILL
   stdin_open: true
   tty: true

--- a/docs/system_requirements/ci/gitlab_ci.md
+++ b/docs/system_requirements/ci/gitlab_ci.md
@@ -57,7 +57,7 @@ variables:
   DOCKER_DRIVER: overlay2
 
 test:
- image: golang:1.21
+ image: golang:1.22
  stage: test
  script: go test ./... -v
 ```

--- a/docs/system_requirements/ci/tekton.md
+++ b/docs/system_requirements/ci/tekton.md
@@ -16,7 +16,7 @@ spec:
     - name: source
   steps:
     - name: read
-      image: golang:1.21
+      image: golang:1.22
       workingDir: $(workspaces.source.path)
       script: go test ./... -v
       volumeMounts:

--- a/docs/system_requirements/ci/travis.md
+++ b/docs/system_requirements/ci/travis.md
@@ -7,7 +7,7 @@ is the minimal required config.
 language: go
 go:
 - 1.x
-- "1.21"
+- "1.22"
 
 services:
 - docker

--- a/examples/nginx/go.mod
+++ b/examples/nginx/go.mod
@@ -1,6 +1,6 @@
 module github.com/testcontainers/testcontainers-go/examples/nginx
 
-go 1.21
+go 1.22
 
 require github.com/testcontainers/testcontainers-go v0.33.0
 

--- a/examples/toxiproxy/go.mod
+++ b/examples/toxiproxy/go.mod
@@ -1,6 +1,6 @@
 module github.com/testcontainers/testcontainers-go/examples/toxiproxy
 
-go 1.21
+go 1.22
 
 require (
 	github.com/Shopify/toxiproxy/v2 v2.8.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/testcontainers/testcontainers-go
 
-go 1.21
+go 1.22
 
 require (
 	dario.cat/mergo v1.0.0

--- a/modulegen/_template/ci.yml.tmpl
+++ b/modulegen/_template/ci.yml.tmpl
@@ -26,7 +26,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.21.x, 1.x]
+        go-version: [1.22.x, 1.x]
         platform: [ubuntu-latest, macos-latest]
     uses: ./.github/workflows/ci-test-go.yml
     with:
@@ -44,7 +44,7 @@ jobs:
     name: "Test with reaper off"
     strategy:
       matrix:
-        go-version: [1.21.x, 1.x]
+        go-version: [1.22.x, 1.x]
     uses: ./.github/workflows/ci-test-go.yml
     with:
       go-version: {{ "${{ matrix.go-version }}" }}
@@ -61,7 +61,7 @@ jobs:
     name: "Test with Rootless Docker"
     strategy:
       matrix:
-        go-version: [1.21.x, 1.x]
+        go-version: [1.22.x, 1.x]
         platform: [ubuntu-latest]
     uses: ./.github/workflows/ci-test-go.yml
     with:
@@ -76,7 +76,7 @@ jobs:
   test-module-generator:
     strategy:
       matrix:
-        go-version: [1.21.x, 1.x]
+        go-version: [1.22.x, 1.x]
         platform: [ubuntu-latest, macos-latest, windows-latest]
     uses: ./.github/workflows/ci-test-go.yml
     with:
@@ -92,7 +92,7 @@ jobs:
     needs: test
     strategy:
       matrix:
-        go-version: [1.21.x, 1.x]
+        go-version: [1.22.x, 1.x]
         platform: [ubuntu-latest]
         module: [{{ .Modules }}]
     uses: ./.github/workflows/ci-test-go.yml
@@ -112,7 +112,7 @@ jobs:
         module: [{{ .Examples }}]
     uses: ./.github/workflows/ci-test-go.yml
     with:
-      go-version: "1.21.x"
+      go-version: "1.22.x"
       fail-fast: true
       platform: 'ubuntu-latest'
       project-directory: {{ "examples/${{ matrix.module }}" }}

--- a/modulegen/go.mod
+++ b/modulegen/go.mod
@@ -1,6 +1,6 @@
 module github.com/testcontainers/testcontainers-go/modulegen
 
-go 1.21
+go 1.22
 
 require (
 	github.com/spf13/cobra v1.8.0

--- a/modules/artemis/go.mod
+++ b/modules/artemis/go.mod
@@ -1,6 +1,6 @@
 module github.com/testcontainers/testcontainers-go/modules/artemis
 
-go 1.21
+go 1.22
 
 require (
 	github.com/docker/go-connections v0.5.0

--- a/modules/azurite/go.mod
+++ b/modules/azurite/go.mod
@@ -1,6 +1,6 @@
 module github.com/testcontainers/testcontainers-go/modules/azurite
 
-go 1.21
+go 1.22
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.11.1

--- a/modules/cassandra/go.mod
+++ b/modules/cassandra/go.mod
@@ -1,6 +1,6 @@
 module github.com/testcontainers/testcontainers-go/modules/cassandra
 
-go 1.21
+go 1.22
 
 require (
 	github.com/docker/go-connections v0.5.0

--- a/modules/chroma/go.mod
+++ b/modules/chroma/go.mod
@@ -1,6 +1,6 @@
 module github.com/testcontainers/testcontainers-go/modules/chroma
 
-go 1.21
+go 1.22
 
 require (
 	github.com/amikos-tech/chroma-go v0.1.2

--- a/modules/clickhouse/go.mod
+++ b/modules/clickhouse/go.mod
@@ -1,6 +1,6 @@
 module github.com/testcontainers/testcontainers-go/modules/clickhouse
 
-go 1.21
+go 1.22
 
 require (
 	github.com/ClickHouse/clickhouse-go/v2 v2.20.0

--- a/modules/cockroachdb/go.mod
+++ b/modules/cockroachdb/go.mod
@@ -1,6 +1,6 @@
 module github.com/testcontainers/testcontainers-go/modules/cockroachdb
 
-go 1.21
+go 1.22
 
 require (
 	github.com/docker/go-connections v0.5.0

--- a/modules/compose/go.mod
+++ b/modules/compose/go.mod
@@ -1,6 +1,6 @@
 module github.com/testcontainers/testcontainers-go/modules/compose
 
-go 1.21
+go 1.22
 
 replace github.com/testcontainers/testcontainers-go => ../..
 

--- a/modules/consul/go.mod
+++ b/modules/consul/go.mod
@@ -1,6 +1,6 @@
 module github.com/testcontainers/testcontainers-go/modules/consul
 
-go 1.21
+go 1.22
 
 require (
 	github.com/hashicorp/consul/api v1.27.0

--- a/modules/couchbase/go.mod
+++ b/modules/couchbase/go.mod
@@ -1,6 +1,6 @@
 module github.com/testcontainers/testcontainers-go/modules/couchbase
 
-go 1.21
+go 1.22
 
 toolchain go1.21.7
 

--- a/modules/dolt/go.mod
+++ b/modules/dolt/go.mod
@@ -1,6 +1,6 @@
 module github.com/testcontainers/testcontainers-go/modules/dolt
 
-go 1.21
+go 1.22
 
 require (
 	github.com/go-sql-driver/mysql v1.7.1

--- a/modules/elasticsearch/go.mod
+++ b/modules/elasticsearch/go.mod
@@ -1,6 +1,6 @@
 module github.com/testcontainers/testcontainers-go/modules/elasticsearch
 
-go 1.21
+go 1.22
 
 require (
 	github.com/elastic/go-elasticsearch/v8 v8.12.1

--- a/modules/gcloud/go.mod
+++ b/modules/gcloud/go.mod
@@ -1,6 +1,6 @@
 module github.com/testcontainers/testcontainers-go/modules/gcloud
 
-go 1.21
+go 1.22
 
 require (
 	cloud.google.com/go/bigquery v1.59.1

--- a/modules/grafana-lgtm/go.mod
+++ b/modules/grafana-lgtm/go.mod
@@ -1,6 +1,6 @@
 module github.com/testcontainers/testcontainers-go/modules/grafanalgtm
 
-go 1.21
+go 1.22
 
 require (
 	github.com/docker/go-connections v0.5.0

--- a/modules/inbucket/go.mod
+++ b/modules/inbucket/go.mod
@@ -1,6 +1,6 @@
 module github.com/testcontainers/testcontainers-go/modules/inbucket
 
-go 1.21
+go 1.22
 
 require (
 	github.com/inbucket/inbucket v2.0.0+incompatible

--- a/modules/influxdb/go.mod
+++ b/modules/influxdb/go.mod
@@ -1,6 +1,6 @@
 module github.com/testcontainers/testcontainers-go/modules/influxdb
 
-go 1.21
+go 1.22
 
 require (
 	github.com/influxdata/influxdb1-client v0.0.0-20220302092344-a9ab5670611c

--- a/modules/k3s/go.mod
+++ b/modules/k3s/go.mod
@@ -1,6 +1,6 @@
 module github.com/testcontainers/testcontainers-go/modules/k3s
 
-go 1.21
+go 1.22
 
 require (
 	github.com/docker/docker v27.1.1+incompatible

--- a/modules/k6/go.mod
+++ b/modules/k6/go.mod
@@ -1,6 +1,6 @@
 module github.com/testcontainers/testcontainers-go/modules/k6
 
-go 1.21
+go 1.22
 
 require (
 	github.com/docker/docker v27.1.1+incompatible

--- a/modules/kafka/go.mod
+++ b/modules/kafka/go.mod
@@ -1,6 +1,6 @@
 module github.com/testcontainers/testcontainers-go/modules/kafka
 
-go 1.21
+go 1.22
 
 require (
 	github.com/IBM/sarama v1.42.1

--- a/modules/localstack/go.mod
+++ b/modules/localstack/go.mod
@@ -1,6 +1,6 @@
 module github.com/testcontainers/testcontainers-go/modules/localstack
 
-go 1.21
+go 1.22
 
 require (
 	github.com/aws/aws-sdk-go v1.50.31

--- a/modules/mariadb/go.mod
+++ b/modules/mariadb/go.mod
@@ -1,6 +1,6 @@
 module github.com/testcontainers/testcontainers-go/modules/mariadb
 
-go 1.21
+go 1.22
 
 require (
 	github.com/go-sql-driver/mysql v1.7.1

--- a/modules/milvus/go.mod
+++ b/modules/milvus/go.mod
@@ -1,6 +1,6 @@
 module github.com/testcontainers/testcontainers-go/modules/milvus
 
-go 1.21
+go 1.22
 
 require (
 	github.com/milvus-io/milvus-sdk-go/v2 v2.3.6

--- a/modules/minio/go.mod
+++ b/modules/minio/go.mod
@@ -1,6 +1,6 @@
 module github.com/testcontainers/testcontainers-go/modules/minio
 
-go 1.21
+go 1.22
 
 require (
 	github.com/minio/minio-go/v7 v7.0.68

--- a/modules/mockserver/go.mod
+++ b/modules/mockserver/go.mod
@@ -1,6 +1,6 @@
 module github.com/testcontainers/testcontainers-go/modules/mockserver
 
-go 1.21
+go 1.22
 
 require (
 	github.com/BraspagDevelopers/mock-server-client v0.2.2

--- a/modules/mongodb/go.mod
+++ b/modules/mongodb/go.mod
@@ -1,6 +1,6 @@
 module github.com/testcontainers/testcontainers-go/modules/mongodb
 
-go 1.21
+go 1.22
 
 require (
 	github.com/testcontainers/testcontainers-go v0.33.0

--- a/modules/mssql/go.mod
+++ b/modules/mssql/go.mod
@@ -1,6 +1,6 @@
 module github.com/testcontainers/testcontainers-go/modules/mssql
 
-go 1.21
+go 1.22
 
 require (
 	github.com/microsoft/go-mssqldb v1.7.0

--- a/modules/mysql/go.mod
+++ b/modules/mysql/go.mod
@@ -1,6 +1,6 @@
 module github.com/testcontainers/testcontainers-go/modules/mysql
 
-go 1.21
+go 1.22
 
 require (
 	github.com/go-sql-driver/mysql v1.7.1

--- a/modules/nats/go.mod
+++ b/modules/nats/go.mod
@@ -1,6 +1,6 @@
 module github.com/testcontainers/testcontainers-go/modules/nats
 
-go 1.21
+go 1.22
 
 require (
 	github.com/nats-io/nats.go v1.33.1

--- a/modules/neo4j/go.mod
+++ b/modules/neo4j/go.mod
@@ -1,6 +1,6 @@
 module github.com/testcontainers/testcontainers-go/modules/neo4j
 
-go 1.21
+go 1.22
 
 require (
 	github.com/docker/go-connections v0.5.0

--- a/modules/ollama/go.mod
+++ b/modules/ollama/go.mod
@@ -1,6 +1,6 @@
 module github.com/testcontainers/testcontainers-go/modules/ollama
 
-go 1.21
+go 1.22
 
 require (
 	github.com/docker/docker v27.1.1+incompatible

--- a/modules/openfga/go.mod
+++ b/modules/openfga/go.mod
@@ -1,6 +1,6 @@
 module github.com/testcontainers/testcontainers-go/modules/openfga
 
-go 1.21
+go 1.22
 
 require (
 	github.com/openfga/go-sdk v0.3.5

--- a/modules/openldap/go.mod
+++ b/modules/openldap/go.mod
@@ -1,6 +1,6 @@
 module github.com/testcontainers/testcontainers-go/modules/openldap
 
-go 1.21
+go 1.22
 
 require (
 	github.com/go-ldap/ldap/v3 v3.4.6

--- a/modules/opensearch/go.mod
+++ b/modules/opensearch/go.mod
@@ -1,6 +1,6 @@
 module github.com/testcontainers/testcontainers-go/modules/opensearch
 
-go 1.21
+go 1.22
 
 require (
 	github.com/docker/docker v27.1.1+incompatible

--- a/modules/postgres/go.mod
+++ b/modules/postgres/go.mod
@@ -1,6 +1,6 @@
 module github.com/testcontainers/testcontainers-go/modules/postgres
 
-go 1.21
+go 1.22
 
 require (
 	github.com/docker/go-connections v0.5.0

--- a/modules/pulsar/go.mod
+++ b/modules/pulsar/go.mod
@@ -1,6 +1,6 @@
 module github.com/testcontainers/testcontainers-go/modules/pulsar
 
-go 1.21
+go 1.22
 
 require (
 	github.com/apache/pulsar-client-go v0.10.0

--- a/modules/qdrant/go.mod
+++ b/modules/qdrant/go.mod
@@ -1,6 +1,6 @@
 module github.com/testcontainers/testcontainers-go/modules/qdrant
 
-go 1.21
+go 1.22
 
 require (
 	github.com/qdrant/go-client v1.7.0

--- a/modules/rabbitmq/go.mod
+++ b/modules/rabbitmq/go.mod
@@ -1,6 +1,6 @@
 module github.com/testcontainers/testcontainers-go/modules/rabbitmq
 
-go 1.21
+go 1.22
 
 require (
 	github.com/docker/go-connections v0.5.0

--- a/modules/redis/go.mod
+++ b/modules/redis/go.mod
@@ -1,6 +1,6 @@
 module github.com/testcontainers/testcontainers-go/modules/redis
 
-go 1.21
+go 1.22
 
 require (
 	github.com/go-redis/redis/v8 v8.11.5

--- a/modules/redpanda/go.mod
+++ b/modules/redpanda/go.mod
@@ -1,6 +1,6 @@
 module github.com/testcontainers/testcontainers-go/modules/redpanda
 
-go 1.21
+go 1.22
 
 require (
 	github.com/docker/go-connections v0.5.0

--- a/modules/registry/go.mod
+++ b/modules/registry/go.mod
@@ -1,6 +1,6 @@
 module github.com/testcontainers/testcontainers-go/modules/registry
 
-go 1.21
+go 1.22
 
 require (
 	github.com/cpuguy83/dockercfg v0.3.1

--- a/modules/surrealdb/go.mod
+++ b/modules/surrealdb/go.mod
@@ -1,6 +1,6 @@
 module github.com/testcontainers/testcontainers-go/modules/surrealdb
 
-go 1.21
+go 1.22
 
 require (
 	github.com/surrealdb/surrealdb.go v0.2.1

--- a/modules/valkey/go.mod
+++ b/modules/valkey/go.mod
@@ -1,6 +1,6 @@
 module github.com/testcontainers/testcontainers-go/modules/valkey
 
-go 1.21
+go 1.22
 
 require (
 	github.com/google/uuid v1.6.0

--- a/modules/vault/go.mod
+++ b/modules/vault/go.mod
@@ -1,6 +1,6 @@
 module github.com/testcontainers/testcontainers-go/modules/vault
 
-go 1.21
+go 1.22
 
 require (
 	github.com/docker/docker v27.1.1+incompatible

--- a/modules/weaviate/go.mod
+++ b/modules/weaviate/go.mod
@@ -1,6 +1,6 @@
 module github.com/testcontainers/testcontainers-go/modules/weaviate
 
-go 1.21
+go 1.22
 
 require (
 	github.com/testcontainers/testcontainers-go v0.33.0

--- a/scripts/bump-go.sh
+++ b/scripts/bump-go.sh
@@ -21,7 +21,7 @@ readonly CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 readonly DRY_RUN="${DRY_RUN:-true}"
 readonly ROOT_DIR="$(dirname "$CURRENT_DIR")"
 readonly GO_MOD_FILE="${ROOT_DIR}/go.mod"
-readonly DEVCONTAINER_IMAGE_PREFIX="go:0-"
+readonly DEVCONTAINER_IMAGE_PREFIX="go:"
 
 function main() {
   echo "Updating Go version:"

--- a/wait/testdata/go.mod
+++ b/wait/testdata/go.mod
@@ -1,3 +1,3 @@
 module httptest
 
-go 1.21
+go 1.22


### PR DESCRIPTION
- **fix: update devcontainer image**
- **chore: bump minimal Go version to 1.22**

<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
It updates the bump-go shell script to update the image for the devcontainer, and runs the script to update all the necessary paths.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
Go 1.21 reached EOL on 13 Aug 2024. 

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->


<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
