### PR TITLE
break: use a docker image type for modules

### DIFF
--- a/image.go
+++ b/image.go
@@ -4,6 +4,21 @@ import (
 	"context"
 )
 
+// DockerImage represents a Docker image as a string.
+// Valid examples:
+// - "alpine:3.12"
+// - "docker.io/nginx:latest"
+// - "my-registry.local:5000/my-image:my-tag"
+type DockerImage string
+
+func NewDockerImage(image string) DockerImage {
+	return DockerImage(image)
+}
+
+func (d DockerImage) String() string {
+	return string(d)
+}
+
 // ImageInfo represents a summary information of an image
 type ImageInfo struct {
 	ID   string

--- a/modules/artemis/artemis.go
+++ b/modules/artemis/artemis.go
@@ -85,10 +85,10 @@ func RunContainer(ctx context.Context, opts ...testcontainers.ContainerCustomize
 }
 
 // Run creates an instance of the Artemis container type with a given image
-func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustomizer) (*Container, error) {
+func Run(ctx context.Context, img testcontainers.DockerImage, opts ...testcontainers.ContainerCustomizer) (*Container, error) {
 	req := testcontainers.GenericContainerRequest{
 		ContainerRequest: testcontainers.ContainerRequest{
-			Image: img,
+			Image: img.String(),
 			Env: map[string]string{
 				"ARTEMIS_USER":     "artemis",
 				"ARTEMIS_PASSWORD": "artemis",

--- a/modules/azurite/azurite.go
+++ b/modules/azurite/azurite.go
@@ -75,9 +75,9 @@ func RunContainer(ctx context.Context, opts ...testcontainers.ContainerCustomize
 }
 
 // Run creates an instance of the Azurite container type
-func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustomizer) (*AzuriteContainer, error) {
+func Run(ctx context.Context, img testcontainers.DockerImage, opts ...testcontainers.ContainerCustomizer) (*AzuriteContainer, error) {
 	req := testcontainers.ContainerRequest{
-		Image:        img,
+		Image:        img.String(),
 		ExposedPorts: []string{BlobPort, QueuePort, TablePort},
 		Env:          map[string]string{},
 		Entrypoint:   []string{"azurite"},

--- a/modules/cassandra/cassandra.go
+++ b/modules/cassandra/cassandra.go
@@ -81,9 +81,9 @@ func RunContainer(ctx context.Context, opts ...testcontainers.ContainerCustomize
 }
 
 // Run creates an instance of the Cassandra container type
-func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustomizer) (*CassandraContainer, error) {
+func Run(ctx context.Context, img testcontainers.DockerImage, opts ...testcontainers.ContainerCustomizer) (*CassandraContainer, error) {
 	req := testcontainers.ContainerRequest{
-		Image:        img,
+		Image:        img.String(),
 		ExposedPorts: []string{string(port)},
 		Env: map[string]string{
 			"CASSANDRA_SNITCH":          "GossipingPropertyFileSnitch",

--- a/modules/chroma/chroma.go
+++ b/modules/chroma/chroma.go
@@ -20,9 +20,9 @@ func RunContainer(ctx context.Context, opts ...testcontainers.ContainerCustomize
 }
 
 // Run creates an instance of the Chroma container type
-func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustomizer) (*ChromaContainer, error) {
+func Run(ctx context.Context, img testcontainers.DockerImage, opts ...testcontainers.ContainerCustomizer) (*ChromaContainer, error) {
 	req := testcontainers.ContainerRequest{
-		Image:        img,
+		Image:        img.String(),
 		ExposedPorts: []string{"8000/tcp"},
 		WaitingFor: wait.ForAll(
 			wait.ForListeningPort("8000/tcp"),

--- a/modules/clickhouse/clickhouse.go
+++ b/modules/clickhouse/clickhouse.go
@@ -221,9 +221,9 @@ func RunContainer(ctx context.Context, opts ...testcontainers.ContainerCustomize
 }
 
 // Run creates an instance of the ClickHouse container type
-func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustomizer) (*ClickHouseContainer, error) {
+func Run(ctx context.Context, img testcontainers.DockerImage, opts ...testcontainers.ContainerCustomizer) (*ClickHouseContainer, error) {
 	req := testcontainers.ContainerRequest{
-		Image: img,
+		Image: img.String(),
 		Env: map[string]string{
 			"CLICKHOUSE_USER":     defaultUser,
 			"CLICKHOUSE_PASSWORD": defaultUser,

--- a/modules/cockroachdb/cockroachdb.go
+++ b/modules/cockroachdb/cockroachdb.go
@@ -74,11 +74,11 @@ func RunContainer(ctx context.Context, opts ...testcontainers.ContainerCustomize
 }
 
 // Run creates an instance of the CockroachDB container type
-func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustomizer) (*CockroachDBContainer, error) {
+func Run(ctx context.Context, img testcontainers.DockerImage, opts ...testcontainers.ContainerCustomizer) (*CockroachDBContainer, error) {
 	o := defaultOptions()
 	req := testcontainers.GenericContainerRequest{
 		ContainerRequest: testcontainers.ContainerRequest{
-			Image: img,
+			Image: img.String(),
 			ExposedPorts: []string{
 				defaultSQLPort,
 				defaultAdminPort,

--- a/modules/consul/consul.go
+++ b/modules/consul/consul.go
@@ -69,10 +69,10 @@ func RunContainer(ctx context.Context, opts ...testcontainers.ContainerCustomize
 }
 
 // Run creates an instance of the Consul container type
-func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustomizer) (*ConsulContainer, error) {
+func Run(ctx context.Context, img testcontainers.DockerImage, opts ...testcontainers.ContainerCustomizer) (*ConsulContainer, error) {
 	containerReq := testcontainers.GenericContainerRequest{
 		ContainerRequest: testcontainers.ContainerRequest{
-			Image: img,
+			Image: img.String(),
 			ExposedPorts: []string{
 				defaultHttpApiPort + "/tcp",
 				defaultBrokerPort + "/tcp",

--- a/modules/couchbase/couchbase.go
+++ b/modules/couchbase/couchbase.go
@@ -63,7 +63,7 @@ func RunContainer(ctx context.Context, opts ...testcontainers.ContainerCustomize
 }
 
 // Run creates an instance of the Couchbase container type
-func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustomizer) (*CouchbaseContainer, error) {
+func Run(ctx context.Context, img testcontainers.DockerImage, opts ...testcontainers.ContainerCustomizer) (*CouchbaseContainer, error) {
 	config := &Config{
 		enabledServices:  make([]Service, 0),
 		username:         "Administrator",
@@ -72,7 +72,7 @@ func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustom
 	}
 
 	req := testcontainers.ContainerRequest{
-		Image:        img,
+		Image:        img.String(),
 		ExposedPorts: []string{MGMT_PORT + "/tcp", MGMT_SSL_PORT + "/tcp"},
 	}
 

--- a/modules/couchbase/options.go
+++ b/modules/couchbase/options.go
@@ -13,7 +13,7 @@ type Config struct {
 	password         string
 	isEnterprise     bool
 	buckets          []bucket
-	imageName        string
+	imageName        testcontainers.DockerImage
 	indexStorageMode indexStorageMode
 }
 
@@ -90,7 +90,7 @@ func WithBuckets(bucket ...bucket) bucketCustomizer {
 // Deprecated: Use testcontainers.WithImage instead.
 func WithImageName(imageName string) Option {
 	return func(c *Config) {
-		c.imageName = imageName
+		c.imageName = testcontainers.NewDockerImage(imageName)
 	}
 }
 

--- a/modules/dolt/dolt.go
+++ b/modules/dolt/dolt.go
@@ -45,9 +45,9 @@ func RunContainer(ctx context.Context, opts ...testcontainers.ContainerCustomize
 }
 
 // Run creates an instance of the Dolt container type
-func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustomizer) (*DoltContainer, error) {
+func Run(ctx context.Context, img testcontainers.DockerImage, opts ...testcontainers.ContainerCustomizer) (*DoltContainer, error) {
 	req := testcontainers.ContainerRequest{
-		Image:        img,
+		Image:        img.String(),
 		ExposedPorts: []string{"3306/tcp", "33060/tcp"},
 		Env: map[string]string{
 			"DOLT_USER":     defaultUser,

--- a/modules/elasticsearch/elasticsearch.go
+++ b/modules/elasticsearch/elasticsearch.go
@@ -20,9 +20,9 @@ const (
 
 const (
 	// Deprecated: it will be removed in the next major version
-	DefaultBaseImage = "docker.elastic.co/elasticsearch/elasticsearch"
+	DefaultBaseImage testcontainers.DockerImage = "docker.elastic.co/elasticsearch/elasticsearch"
 	// Deprecated: it will be removed in the next major version
-	DefaultBaseImageOSS = "docker.elastic.co/elasticsearch/elasticsearch-oss"
+	DefaultBaseImageOSS testcontainers.DockerImage = "docker.elastic.co/elasticsearch/elasticsearch-oss"
 )
 
 // ElasticsearchContainer represents the Elasticsearch container type used in the module
@@ -38,10 +38,10 @@ func RunContainer(ctx context.Context, opts ...testcontainers.ContainerCustomize
 }
 
 // Run creates an instance of the Elasticsearch container type
-func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustomizer) (*ElasticsearchContainer, error) {
+func Run(ctx context.Context, img testcontainers.DockerImage, opts ...testcontainers.ContainerCustomizer) (*ElasticsearchContainer, error) {
 	req := testcontainers.GenericContainerRequest{
 		ContainerRequest: testcontainers.ContainerRequest{
-			Image: img,
+			Image: img.String(),
 			Env: map[string]string{
 				"discovery.type": "single-node",
 				"cluster.routing.allocation.disk.threshold_enabled": "false",

--- a/modules/elasticsearch/elasticsearch_test.go
+++ b/modules/elasticsearch/elasticsearch_test.go
@@ -34,7 +34,7 @@ func TestElasticsearch(t *testing.T) {
 
 	tests := []struct {
 		name               string
-		image              string
+		image              testcontainers.DockerImage
 		passwordCustomiser testcontainers.ContainerCustomizer
 	}{
 		{

--- a/modules/elasticsearch/version.go
+++ b/modules/elasticsearch/version.go
@@ -9,7 +9,7 @@ import (
 
 // isOSS returns true if the base image (without tag) is an OSS image
 func isOSS(image string) bool {
-	return strings.HasPrefix(image, DefaultBaseImageOSS)
+	return strings.HasPrefix(image, DefaultBaseImageOSS.String())
 }
 
 // isAtLeastVersion returns true if the base image (without tag) is in a version or above

--- a/modules/gcloud/bigquery.go
+++ b/modules/gcloud/bigquery.go
@@ -16,10 +16,10 @@ func RunBigQueryContainer(ctx context.Context, opts ...testcontainers.ContainerC
 
 // RunBigQuery creates an instance of the GCloud container type for BigQuery.
 // The URI will always use http:// as the protocol.
-func RunBigQuery(ctx context.Context, img string, opts ...testcontainers.ContainerCustomizer) (*GCloudContainer, error) {
+func RunBigQuery(ctx context.Context, img testcontainers.DockerImage, opts ...testcontainers.ContainerCustomizer) (*GCloudContainer, error) {
 	req := testcontainers.GenericContainerRequest{
 		ContainerRequest: testcontainers.ContainerRequest{
-			Image:        img,
+			Image:        img.String(),
 			ExposedPorts: []string{"9050/tcp", "9060/tcp"},
 			WaitingFor:   wait.ForHTTP("/discovery/v1/apis/bigquery/v2/rest").WithPort("9050/tcp").WithStartupTimeout(time.Second * 5),
 		},

--- a/modules/gcloud/bigtable.go
+++ b/modules/gcloud/bigtable.go
@@ -15,10 +15,10 @@ func RunBigTableContainer(ctx context.Context, opts ...testcontainers.ContainerC
 }
 
 // RunBigTable creates an instance of the GCloud container type for BigTable.
-func RunBigTable(ctx context.Context, img string, opts ...testcontainers.ContainerCustomizer) (*GCloudContainer, error) {
+func RunBigTable(ctx context.Context, img testcontainers.DockerImage, opts ...testcontainers.ContainerCustomizer) (*GCloudContainer, error) {
 	req := testcontainers.GenericContainerRequest{
 		ContainerRequest: testcontainers.ContainerRequest{
-			Image:        img,
+			Image:        img.String(),
 			ExposedPorts: []string{"9000/tcp"},
 			WaitingFor:   wait.ForLog("running"),
 		},

--- a/modules/gcloud/datastore.go
+++ b/modules/gcloud/datastore.go
@@ -15,10 +15,10 @@ func RunDatastoreContainer(ctx context.Context, opts ...testcontainers.Container
 }
 
 // RunDatastore creates an instance of the GCloud container type for Datastore.
-func RunDatastore(ctx context.Context, img string, opts ...testcontainers.ContainerCustomizer) (*GCloudContainer, error) {
+func RunDatastore(ctx context.Context, img testcontainers.DockerImage, opts ...testcontainers.ContainerCustomizer) (*GCloudContainer, error) {
 	req := testcontainers.GenericContainerRequest{
 		ContainerRequest: testcontainers.ContainerRequest{
-			Image:        img,
+			Image:        img.String(),
 			ExposedPorts: []string{"8081/tcp"},
 			WaitingFor:   wait.ForHTTP("/").WithPort("8081/tcp"),
 		},

--- a/modules/gcloud/firestore.go
+++ b/modules/gcloud/firestore.go
@@ -15,10 +15,10 @@ func RunFirestoreContainer(ctx context.Context, opts ...testcontainers.Container
 }
 
 // RunFirestore creates an instance of the GCloud container type for Firestore.
-func RunFirestore(ctx context.Context, img string, opts ...testcontainers.ContainerCustomizer) (*GCloudContainer, error) {
+func RunFirestore(ctx context.Context, img testcontainers.DockerImage, opts ...testcontainers.ContainerCustomizer) (*GCloudContainer, error) {
 	req := testcontainers.GenericContainerRequest{
 		ContainerRequest: testcontainers.ContainerRequest{
-			Image:        img,
+			Image:        img.String(),
 			ExposedPorts: []string{"8080/tcp"},
 			WaitingFor:   wait.ForLog("running"),
 		},

--- a/modules/gcloud/pubsub.go
+++ b/modules/gcloud/pubsub.go
@@ -15,10 +15,10 @@ func RunPubsubContainer(ctx context.Context, opts ...testcontainers.ContainerCus
 }
 
 // RunPubsub creates an instance of the GCloud container type for Pubsub.
-func RunPubsub(ctx context.Context, img string, opts ...testcontainers.ContainerCustomizer) (*GCloudContainer, error) {
+func RunPubsub(ctx context.Context, img testcontainers.DockerImage, opts ...testcontainers.ContainerCustomizer) (*GCloudContainer, error) {
 	req := testcontainers.GenericContainerRequest{
 		ContainerRequest: testcontainers.ContainerRequest{
-			Image:        img,
+			Image:        img.String(),
 			ExposedPorts: []string{"8085/tcp"},
 			WaitingFor:   wait.ForLog("started"),
 		},

--- a/modules/gcloud/spanner.go
+++ b/modules/gcloud/spanner.go
@@ -14,10 +14,10 @@ func RunSpannerContainer(ctx context.Context, opts ...testcontainers.ContainerCu
 }
 
 // RunSpanner creates an instance of the GCloud container type for Spanner.
-func RunSpanner(ctx context.Context, img string, opts ...testcontainers.ContainerCustomizer) (*GCloudContainer, error) {
+func RunSpanner(ctx context.Context, img testcontainers.DockerImage, opts ...testcontainers.ContainerCustomizer) (*GCloudContainer, error) {
 	req := testcontainers.GenericContainerRequest{
 		ContainerRequest: testcontainers.ContainerRequest{
-			Image:        img,
+			Image:        img.String(),
 			ExposedPorts: []string{"9010/tcp"},
 			WaitingFor:   wait.ForLog("Cloud Spanner emulator running"),
 		},

--- a/modules/grafana-lgtm/grafana.go
+++ b/modules/grafana-lgtm/grafana.go
@@ -25,9 +25,9 @@ type GrafanaLGTMContainer struct {
 }
 
 // Run creates an instance of the Grafana LGTM container type
-func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustomizer) (*GrafanaLGTMContainer, error) {
+func Run(ctx context.Context, img testcontainers.DockerImage, opts ...testcontainers.ContainerCustomizer) (*GrafanaLGTMContainer, error) {
 	req := testcontainers.ContainerRequest{
-		Image:        img,
+		Image:        img.String(),
 		ExposedPorts: []string{GrafanaPort, LokiPort, TempoPort, OtlpGrpcPort, OtlpHttpPort, PrometheusPort},
 		WaitingFor:   wait.ForLog(".*The OpenTelemetry collector and the Grafana LGTM stack are up and running.*\\s").AsRegexp().WithOccurrence(1),
 	}

--- a/modules/inbucket/inbucket.go
+++ b/modules/inbucket/inbucket.go
@@ -54,9 +54,9 @@ func RunContainer(ctx context.Context, opts ...testcontainers.ContainerCustomize
 }
 
 // Run creates an instance of the Inbucket container type
-func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustomizer) (*InbucketContainer, error) {
+func Run(ctx context.Context, img testcontainers.DockerImage, opts ...testcontainers.ContainerCustomizer) (*InbucketContainer, error) {
 	req := testcontainers.ContainerRequest{
-		Image:        img,
+		Image:        img.String(),
 		ExposedPorts: []string{"2500/tcp", "9000/tcp", "1100/tcp"},
 		WaitingFor: wait.ForAll(
 			wait.ForListeningPort("2500/tcp"),

--- a/modules/influxdb/influxdb.go
+++ b/modules/influxdb/influxdb.go
@@ -22,9 +22,9 @@ func RunContainer(ctx context.Context, opts ...testcontainers.ContainerCustomize
 }
 
 // Run creates an instance of the InfluxDB container type
-func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustomizer) (*InfluxDbContainer, error) {
+func Run(ctx context.Context, img testcontainers.DockerImage, opts ...testcontainers.ContainerCustomizer) (*InfluxDbContainer, error) {
 	req := testcontainers.ContainerRequest{
-		Image:        img,
+		Image:        img.String(),
 		ExposedPorts: []string{"8086/tcp", "8088/tcp"},
 		Env: map[string]string{
 			"INFLUXDB_BIND_ADDRESS":          ":8088",

--- a/modules/influxdb/influxdb_test.go
+++ b/modules/influxdb/influxdb_test.go
@@ -96,7 +96,7 @@ func TestWithConfigFile(t *testing.T) {
 	influxVersion := "1.8.10"
 
 	influxDbContainer, err := influxdb.Run(context.Background(),
-		"influxdb:"+influxVersion,
+		testcontainers.NewDockerImage("influxdb:"+influxVersion),
 		influxdb.WithConfigFile(filepath.Join("testdata", "influxdb.conf")),
 	)
 	require.NoError(t, err)

--- a/modules/k3s/k3s.go
+++ b/modules/k3s/k3s.go
@@ -54,14 +54,14 @@ func RunContainer(ctx context.Context, opts ...testcontainers.ContainerCustomize
 }
 
 // Run creates an instance of the K3s container type
-func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustomizer) (*K3sContainer, error) {
+func Run(ctx context.Context, img testcontainers.DockerImage, opts ...testcontainers.ContainerCustomizer) (*K3sContainer, error) {
 	host, err := getContainerHost(ctx, opts...)
 	if err != nil {
 		return nil, err
 	}
 
 	req := testcontainers.ContainerRequest{
-		Image: img,
+		Image: img.String(),
 		ExposedPorts: []string{
 			defaultKubeSecurePort,
 			defaultRancherWebhookPort,

--- a/modules/k6/k6.go
+++ b/modules/k6/k6.go
@@ -167,9 +167,9 @@ func RunContainer(ctx context.Context, opts ...testcontainers.ContainerCustomize
 }
 
 // Run creates an instance of the K6 container type
-func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustomizer) (*K6Container, error) {
+func Run(ctx context.Context, img testcontainers.DockerImage, opts ...testcontainers.ContainerCustomizer) (*K6Container, error) {
 	req := testcontainers.ContainerRequest{
-		Image:      img,
+		Image:      img.String(),
 		Cmd:        []string{"run"},
 		WaitingFor: wait.ForExit(),
 	}

--- a/modules/kafka/kafka.go
+++ b/modules/kafka/kafka.go
@@ -43,9 +43,9 @@ func RunContainer(ctx context.Context, opts ...testcontainers.ContainerCustomize
 }
 
 // Run creates an instance of the Kafka container type
-func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustomizer) (*KafkaContainer, error) {
+func Run(ctx context.Context, img testcontainers.DockerImage, opts ...testcontainers.ContainerCustomizer) (*KafkaContainer, error) {
 	req := testcontainers.ContainerRequest{
-		Image:        img,
+		Image:        img.String(),
 		ExposedPorts: []string{string(publicPort)},
 		Env: map[string]string{
 			// envVars {

--- a/modules/localstack/localstack.go
+++ b/modules/localstack/localstack.go
@@ -73,11 +73,11 @@ func RunContainer(ctx context.Context, opts ...testcontainers.ContainerCustomize
 
 // Run creates an instance of the LocalStack container type
 // - overrideReq: a function that can be used to override the default container request, usually used to set the image version, environment variables for localstack, etc.
-func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustomizer) (*LocalStackContainer, error) {
+func Run(ctx context.Context, img testcontainers.DockerImage, opts ...testcontainers.ContainerCustomizer) (*LocalStackContainer, error) {
 	dockerHost := testcontainers.ExtractDockerSocket()
 
 	req := testcontainers.ContainerRequest{
-		Image:        img,
+		Image:        img.String(),
 		WaitingFor:   wait.ForHTTP("/_localstack/health").WithPort("4566/tcp").WithStartupTimeout(120 * time.Second),
 		ExposedPorts: []string{fmt.Sprintf("%d/tcp", defaultPort)},
 		Env:          map[string]string{},

--- a/modules/localstack/localstack_test.go
+++ b/modules/localstack/localstack_test.go
@@ -120,7 +120,7 @@ func TestRunContainer(t *testing.T) {
 
 		container, err := Run(
 			ctx,
-			fmt.Sprintf("localstack/localstack:%s", tt.version),
+			testcontainers.NewDockerImage(fmt.Sprintf("localstack/localstack:%s", tt.version)),
 		)
 
 		t.Run("Localstack:"+tt.version+" - multiple services exposed on same port", func(t *testing.T) {

--- a/modules/mariadb/mariadb.go
+++ b/modules/mariadb/mariadb.go
@@ -126,9 +126,9 @@ func RunContainer(ctx context.Context, opts ...testcontainers.ContainerCustomize
 }
 
 // Run creates an instance of the MariaDB container type
-func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustomizer) (*MariaDBContainer, error) {
+func Run(ctx context.Context, img testcontainers.DockerImage, opts ...testcontainers.ContainerCustomizer) (*MariaDBContainer, error) {
 	req := testcontainers.ContainerRequest{
-		Image:        img,
+		Image:        img.String(),
 		ExposedPorts: []string{"3306/tcp", "33060/tcp"},
 		Env: map[string]string{
 			"MARIADB_USER":     defaultUser,

--- a/modules/milvus/milvus.go
+++ b/modules/milvus/milvus.go
@@ -48,14 +48,14 @@ func RunContainer(ctx context.Context, opts ...testcontainers.ContainerCustomize
 }
 
 // Run creates an instance of the Milvus container type
-func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustomizer) (*MilvusContainer, error) {
+func Run(ctx context.Context, img testcontainers.DockerImage, opts ...testcontainers.ContainerCustomizer) (*MilvusContainer, error) {
 	config, err := renderEmbedEtcdConfig(defaultClientPort)
 	if err != nil {
 		return nil, fmt.Errorf("render config: %w", err)
 	}
 
 	req := testcontainers.ContainerRequest{
-		Image:        img,
+		Image:        img.String(),
 		ExposedPorts: []string{"19530/tcp", "9091/tcp", "2379/tcp"},
 		Env: map[string]string{
 			"ETCD_USE_EMBED":     "true",

--- a/modules/minio/minio.go
+++ b/modules/minio/minio.go
@@ -63,9 +63,9 @@ func RunContainer(ctx context.Context, opts ...testcontainers.ContainerCustomize
 }
 
 // Run creates an instance of the Minio container type
-func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustomizer) (*MinioContainer, error) {
+func Run(ctx context.Context, img testcontainers.DockerImage, opts ...testcontainers.ContainerCustomizer) (*MinioContainer, error) {
 	req := testcontainers.ContainerRequest{
-		Image:        img,
+		Image:        img.String(),
 		ExposedPorts: []string{"9000/tcp"},
 		WaitingFor:   wait.ForHTTP("/minio/health/live").WithPort("9000"),
 		Env: map[string]string{

--- a/modules/mockserver/mockserver.go
+++ b/modules/mockserver/mockserver.go
@@ -20,9 +20,9 @@ func RunContainer(ctx context.Context, opts ...testcontainers.ContainerCustomize
 }
 
 // Run creates an instance of the MockServer container type
-func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustomizer) (*MockServerContainer, error) {
+func Run(ctx context.Context, img testcontainers.DockerImage, opts ...testcontainers.ContainerCustomizer) (*MockServerContainer, error) {
 	req := testcontainers.ContainerRequest{
-		Image:        img,
+		Image:        img.String(),
 		ExposedPorts: []string{"1080/tcp"},
 		WaitingFor: wait.ForAll(
 			wait.ForLog("started on port: 1080"),

--- a/modules/mongodb/mongodb.go
+++ b/modules/mongodb/mongodb.go
@@ -22,9 +22,9 @@ func RunContainer(ctx context.Context, opts ...testcontainers.ContainerCustomize
 }
 
 // Run creates an instance of the MongoDB container type
-func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustomizer) (*MongoDBContainer, error) {
+func Run(ctx context.Context, img testcontainers.DockerImage, opts ...testcontainers.ContainerCustomizer) (*MongoDBContainer, error) {
 	req := testcontainers.ContainerRequest{
-		Image:        img,
+		Image:        img.String(),
 		ExposedPorts: []string{"27017/tcp"},
 		WaitingFor: wait.ForAll(
 			wait.ForLog("Waiting for connections"),

--- a/modules/mongodb/mongodb_test.go
+++ b/modules/mongodb/mongodb_test.go
@@ -14,7 +14,7 @@ import (
 func TestMongoDB(t *testing.T) {
 	type tests struct {
 		name string
-		img  string
+		img  testcontainers.DockerImage
 		opts []testcontainers.ContainerCustomizer
 	}
 	testCases := []tests{

--- a/modules/mssql/mssql.go
+++ b/modules/mssql/mssql.go
@@ -48,9 +48,9 @@ func RunContainer(ctx context.Context, opts ...testcontainers.ContainerCustomize
 }
 
 // Run creates an instance of the MSSQLServer container type
-func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustomizer) (*MSSQLServerContainer, error) {
+func Run(ctx context.Context, img testcontainers.DockerImage, opts ...testcontainers.ContainerCustomizer) (*MSSQLServerContainer, error) {
 	req := testcontainers.ContainerRequest{
-		Image:        img,
+		Image:        img.String(),
 		ExposedPorts: []string{defaultPort},
 		Env: map[string]string{
 			"MSSQL_SA_PASSWORD": defaultPassword,

--- a/modules/mysql/mysql.go
+++ b/modules/mysql/mysql.go
@@ -50,9 +50,9 @@ func RunContainer(ctx context.Context, opts ...testcontainers.ContainerCustomize
 }
 
 // Run creates an instance of the MySQL container type
-func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustomizer) (*MySQLContainer, error) {
+func Run(ctx context.Context, img testcontainers.DockerImage, opts ...testcontainers.ContainerCustomizer) (*MySQLContainer, error) {
 	req := testcontainers.ContainerRequest{
-		Image:        img,
+		Image:        img.String(),
 		ExposedPorts: []string{"3306/tcp", "33060/tcp"},
 		Env: map[string]string{
 			"MYSQL_USER":     defaultUser,

--- a/modules/nats/nats.go
+++ b/modules/nats/nats.go
@@ -28,9 +28,9 @@ func RunContainer(ctx context.Context, opts ...testcontainers.ContainerCustomize
 }
 
 // Run creates an instance of the NATS container type
-func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustomizer) (*NATSContainer, error) {
+func Run(ctx context.Context, img testcontainers.DockerImage, opts ...testcontainers.ContainerCustomizer) (*NATSContainer, error) {
 	req := testcontainers.ContainerRequest{
-		Image:        img,
+		Image:        img.String(),
 		ExposedPorts: []string{defaultClientPort, defaultRoutingPort, defaultMonitoringPort},
 		Cmd:          []string{"-DV", "-js"},
 		WaitingFor:   wait.ForLog("Listening for client connections on 0.0.0.0:4222"),

--- a/modules/neo4j/neo4j.go
+++ b/modules/neo4j/neo4j.go
@@ -48,10 +48,10 @@ func RunContainer(ctx context.Context, opts ...testcontainers.ContainerCustomize
 }
 
 // Run creates an instance of the Neo4j container type
-func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustomizer) (*Neo4jContainer, error) {
+func Run(ctx context.Context, img testcontainers.DockerImage, opts ...testcontainers.ContainerCustomizer) (*Neo4jContainer, error) {
 	httpPort, _ := nat.NewPort("tcp", defaultHttpPort)
 	request := testcontainers.ContainerRequest{
-		Image: img,
+		Image: img.String(),
 		Env: map[string]string{
 			"NEO4J_AUTH": "none",
 		},

--- a/modules/neo4j/neo4j_test.go
+++ b/modules/neo4j/neo4j_test.go
@@ -9,6 +9,7 @@ import (
 
 	neo "github.com/neo4j/neo4j-go-driver/v5/neo4j"
 
+	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/modules/neo4j"
 )
 
@@ -64,7 +65,7 @@ func TestNeo4jWithEnterpriseLicense(t *testing.T) {
 
 	ctx := context.Background()
 
-	images := map[string]string{
+	images := map[string]testcontainers.DockerImage{
 		"StandardEdition":   "docker.io/neo4j:4.4",
 		"EnterpriseEdition": "docker.io/neo4j:4.4-enterprise",
 	}

--- a/modules/ollama/ollama_test.go
+++ b/modules/ollama/ollama_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/google/uuid"
 
+	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/exec"
 	"github.com/testcontainers/testcontainers-go/modules/ollama"
 )
@@ -71,7 +72,7 @@ func TestOllama(t *testing.T) {
 
 		// Defining the target image name based on the default image and a random string.
 		// Users can change the way this is generated, but it should be unique.
-		targetImage := fmt.Sprintf("%s-%s", ollama.DefaultOllamaImage, strings.ToLower(uuid.New().String()[:4]))
+		targetImage := testcontainers.NewDockerImage(fmt.Sprintf("%s-%s", ollama.DefaultOllamaImage, strings.ToLower(uuid.New().String()[:4])))
 
 		err := container.Commit(context.Background(), targetImage)
 		// }

--- a/modules/openfga/openfga.go
+++ b/modules/openfga/openfga.go
@@ -46,9 +46,9 @@ func RunContainer(ctx context.Context, opts ...testcontainers.ContainerCustomize
 }
 
 // Run creates an instance of the OpenFGA container type
-func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustomizer) (*OpenFGAContainer, error) {
+func Run(ctx context.Context, img testcontainers.DockerImage, opts ...testcontainers.ContainerCustomizer) (*OpenFGAContainer, error) {
 	req := testcontainers.ContainerRequest{
-		Image:        img,
+		Image:        img.String(),
 		Cmd:          []string{"run"},
 		ExposedPorts: []string{"3000/tcp", "8080/tcp", "8081/tcp"},
 		WaitingFor: wait.ForAll(

--- a/modules/openldap/openldap.go
+++ b/modules/openldap/openldap.go
@@ -129,9 +129,9 @@ func RunContainer(ctx context.Context, opts ...testcontainers.ContainerCustomize
 }
 
 // Run creates an instance of the OpenLDAP container type
-func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustomizer) (*OpenLDAPContainer, error) {
+func Run(ctx context.Context, img testcontainers.DockerImage, opts ...testcontainers.ContainerCustomizer) (*OpenLDAPContainer, error) {
 	req := testcontainers.ContainerRequest{
-		Image: img,
+		Image: img.String(),
 		Env: map[string]string{
 			"LDAP_ADMIN_USERNAME": defaultUser,
 			"LDAP_ADMIN_PASSWORD": defaultPassword,

--- a/modules/opensearch/opensearch.go
+++ b/modules/opensearch/opensearch.go
@@ -34,9 +34,9 @@ func RunContainer(ctx context.Context, opts ...testcontainers.ContainerCustomize
 }
 
 // Run creates an instance of the OpenSearch container type
-func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustomizer) (*OpenSearchContainer, error) {
+func Run(ctx context.Context, img testcontainers.DockerImage, opts ...testcontainers.ContainerCustomizer) (*OpenSearchContainer, error) {
 	req := testcontainers.ContainerRequest{
-		Image:        img,
+		Image:        img.String(),
 		ExposedPorts: []string{defaultHTTPPort, "9600/tcp"},
 		Env: map[string]string{
 			"discovery.type":              "single-node",

--- a/modules/postgres/postgres.go
+++ b/modules/postgres/postgres.go
@@ -140,9 +140,9 @@ func RunContainer(ctx context.Context, opts ...testcontainers.ContainerCustomize
 }
 
 // Run creates an instance of the Postgres container type
-func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustomizer) (*PostgresContainer, error) {
+func Run(ctx context.Context, img testcontainers.DockerImage, opts ...testcontainers.ContainerCustomizer) (*PostgresContainer, error) {
 	req := testcontainers.ContainerRequest{
-		Image: img,
+		Image: img.String(),
 		Env: map[string]string{
 			"POSTGRES_USER":     defaultUser,
 			"POSTGRES_PASSWORD": defaultPassword,

--- a/modules/postgres/postgres_test.go
+++ b/modules/postgres/postgres_test.go
@@ -32,7 +32,7 @@ func TestPostgres(t *testing.T) {
 
 	tests := []struct {
 		name  string
-		image string
+		image testcontainers.DockerImage
 	}{
 		{
 			name:  "Postgres",

--- a/modules/pulsar/pulsar.go
+++ b/modules/pulsar/pulsar.go
@@ -144,9 +144,9 @@ func RunContainer(ctx context.Context, opts ...testcontainers.ContainerCustomize
 //   - the log message "Successfully updated the policies on namespace public/default"
 //
 // - command: "/bin/bash -c /pulsar/bin/apply-config-from-env.py /pulsar/conf/standalone.conf && bin/pulsar standalone --no-functions-worker -nss"
-func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustomizer) (*Container, error) {
+func Run(ctx context.Context, img testcontainers.DockerImage, opts ...testcontainers.ContainerCustomizer) (*Container, error) {
 	req := testcontainers.ContainerRequest{
-		Image:        img,
+		Image:        img.String(),
 		Env:          map[string]string{},
 		ExposedPorts: []string{defaultPulsarPort, defaultPulsarAdminPort},
 		WaitingFor:   defaultWaitStrategies,

--- a/modules/qdrant/qdrant.go
+++ b/modules/qdrant/qdrant.go
@@ -21,9 +21,9 @@ func RunContainer(ctx context.Context, opts ...testcontainers.ContainerCustomize
 }
 
 // Run creates an instance of the Qdrant container type
-func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustomizer) (*QdrantContainer, error) {
+func Run(ctx context.Context, img testcontainers.DockerImage, opts ...testcontainers.ContainerCustomizer) (*QdrantContainer, error) {
 	req := testcontainers.ContainerRequest{
-		Image:        img,
+		Image:        img.String(),
 		ExposedPorts: []string{"6333/tcp", "6334/tcp"},
 		WaitingFor: wait.ForAll(
 			wait.ForListeningPort("6333/tcp").WithStartupTimeout(5*time.Second),

--- a/modules/rabbitmq/rabbitmq.go
+++ b/modules/rabbitmq/rabbitmq.go
@@ -73,9 +73,9 @@ func RunContainer(ctx context.Context, opts ...testcontainers.ContainerCustomize
 }
 
 // Run creates an instance of the RabbitMQ container type
-func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustomizer) (*RabbitMQContainer, error) {
+func Run(ctx context.Context, img testcontainers.DockerImage, opts ...testcontainers.ContainerCustomizer) (*RabbitMQContainer, error) {
 	req := testcontainers.ContainerRequest{
-		Image: img,
+		Image: img.String(),
 		Env: map[string]string{
 			"RABBITMQ_DEFAULT_USER": defaultUser,
 			"RABBITMQ_DEFAULT_PASS": defaultPassword,

--- a/modules/redis/redis.go
+++ b/modules/redis/redis.go
@@ -50,9 +50,9 @@ func RunContainer(ctx context.Context, opts ...testcontainers.ContainerCustomize
 }
 
 // Run creates an instance of the Redis container type
-func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustomizer) (*RedisContainer, error) {
+func Run(ctx context.Context, img testcontainers.DockerImage, opts ...testcontainers.ContainerCustomizer) (*RedisContainer, error) {
 	req := testcontainers.ContainerRequest{
-		Image:        img,
+		Image:        img.String(),
 		ExposedPorts: []string{"6379/tcp"},
 		WaitingFor:   wait.ForLog("* Ready to accept connections"),
 	}

--- a/modules/redis/redis_test.go
+++ b/modules/redis/redis_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 
+	"github.com/testcontainers/testcontainers-go"
 	tcredis "github.com/testcontainers/testcontainers-go/modules/redis"
 )
 
@@ -47,7 +48,7 @@ func TestRedisWithImage(t *testing.T) {
 
 	tests := []struct {
 		name  string
-		image string
+		image testcontainers.DockerImage
 	}{
 		{
 			name:  "Redis6",

--- a/modules/redpanda/redpanda.go
+++ b/modules/redpanda/redpanda.go
@@ -59,7 +59,7 @@ func RunContainer(ctx context.Context, opts ...testcontainers.ContainerCustomize
 }
 
 // Run creates an instance of the Redpanda container type
-func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustomizer) (*Container, error) {
+func Run(ctx context.Context, img testcontainers.DockerImage, opts ...testcontainers.ContainerCustomizer) (*Container, error) {
 	tmpDir, err := os.MkdirTemp("", "redpanda")
 	if err != nil {
 		return nil, fmt.Errorf("failed to create directory: %w", err)
@@ -70,7 +70,7 @@ func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustom
 	// Some (e.g. Image) may be overridden by providing an option argument to this function.
 	req := testcontainers.GenericContainerRequest{
 		ContainerRequest: testcontainers.ContainerRequest{
-			Image: img,
+			Image: img.String(),
 			User:  "root:root",
 			// Files: Will be added later after we've rendered our YAML templates.
 			ExposedPorts: []string{

--- a/modules/registry/registry.go
+++ b/modules/registry/registry.go
@@ -212,9 +212,9 @@ func RunContainer(ctx context.Context, opts ...testcontainers.ContainerCustomize
 }
 
 // Run creates an instance of the Registry container type
-func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustomizer) (*RegistryContainer, error) {
+func Run(ctx context.Context, img testcontainers.DockerImage, opts ...testcontainers.ContainerCustomizer) (*RegistryContainer, error) {
 	req := testcontainers.ContainerRequest{
-		Image:        img,
+		Image:        img.String(),
 		ExposedPorts: []string{registryPort},
 		Env: map[string]string{
 			// convenient for testing

--- a/modules/surrealdb/surrealdb.go
+++ b/modules/surrealdb/surrealdb.go
@@ -86,9 +86,9 @@ func RunContainer(ctx context.Context, opts ...testcontainers.ContainerCustomize
 }
 
 // Run creates an instance of the SurrealDB container type
-func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustomizer) (*SurrealDBContainer, error) {
+func Run(ctx context.Context, img testcontainers.DockerImage, opts ...testcontainers.ContainerCustomizer) (*SurrealDBContainer, error) {
 	req := testcontainers.ContainerRequest{
-		Image: img,
+		Image: img.String(),
 		Env: map[string]string{
 			"SURREAL_USER":           "root",
 			"SURREAL_PASS":           "root",

--- a/modules/valkey/valkey.go
+++ b/modules/valkey/valkey.go
@@ -52,9 +52,9 @@ func RunContainer(ctx context.Context, opts ...testcontainers.ContainerCustomize
 }
 
 // Run creates an instance of the Valkey container type
-func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustomizer) (*ValkeyContainer, error) {
+func Run(ctx context.Context, img testcontainers.DockerImage, opts ...testcontainers.ContainerCustomizer) (*ValkeyContainer, error) {
 	req := testcontainers.ContainerRequest{
-		Image:        img,
+		Image:        img.String(),
 		ExposedPorts: []string{"6379/tcp"},
 		WaitingFor:   wait.ForLog("* Ready to accept connections"),
 	}

--- a/modules/valkey/valkey_test.go
+++ b/modules/valkey/valkey_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/valkey-io/valkey-go"
 
+	"github.com/testcontainers/testcontainers-go"
 	tcvalkey "github.com/testcontainers/testcontainers-go/modules/valkey"
 )
 
@@ -47,7 +48,7 @@ func TestValkeyWithImage(t *testing.T) {
 
 	tests := []struct {
 		name  string
-		image string
+		image testcontainers.DockerImage
 	}{
 		// There is only one release of Valkey at the time of writing
 		{

--- a/modules/vault/vault.go
+++ b/modules/vault/vault.go
@@ -27,9 +27,9 @@ func RunContainer(ctx context.Context, opts ...testcontainers.ContainerCustomize
 }
 
 // Run creates an instance of the Vault container type
-func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustomizer) (*VaultContainer, error) {
+func Run(ctx context.Context, img testcontainers.DockerImage, opts ...testcontainers.ContainerCustomizer) (*VaultContainer, error) {
 	req := testcontainers.ContainerRequest{
-		Image:        img,
+		Image:        img.String(),
 		ExposedPorts: []string{defaultPort + "/tcp"},
 		HostConfigModifier: func(hc *container.HostConfig) {
 			hc.CapAdd = []string{"IPC_LOCK"}

--- a/modules/vearch/vearch.go
+++ b/modules/vearch/vearch.go
@@ -21,9 +21,9 @@ func RunContainer(ctx context.Context, opts ...testcontainers.ContainerCustomize
 }
 
 // Run creates an instance of the Vearch container type
-func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustomizer) (*VearchContainer, error) {
+func Run(ctx context.Context, img testcontainers.DockerImage, opts ...testcontainers.ContainerCustomizer) (*VearchContainer, error) {
 	req := testcontainers.ContainerRequest{
-		Image:        img,
+		Image:        img.String(),
 		ExposedPorts: []string{"8817/tcp", "9001/tcp"},
 		Cmd:          []string{"-conf=/vearch/config.toml", "all"},
 		Privileged:   true,

--- a/modules/weaviate/weaviate.go
+++ b/modules/weaviate/weaviate.go
@@ -26,9 +26,9 @@ func RunContainer(ctx context.Context, opts ...testcontainers.ContainerCustomize
 }
 
 // Run creates an instance of the Weaviate container type
-func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustomizer) (*WeaviateContainer, error) {
+func Run(ctx context.Context, img testcontainers.DockerImage, opts ...testcontainers.ContainerCustomizer) (*WeaviateContainer, error) {
 	req := testcontainers.ContainerRequest{
-		Image:        img,
+		Image:        img.String(),
 		Cmd:          []string{"--host", "0.0.0.0", "--scheme", "http", "--port", "8080"},
 		ExposedPorts: []string{httpPort, grpcPort},
 		Env: map[string]string{


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
It adds a new type alias for string to represent Docker image names, which will be used in the signature of all the Run functions in the modules.

All calls to Run with an untyped string will not break, but users of the lib passing a typed string will have to change it to a `testcontainers.DockerImage`.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
It will allow providing support for the compatible-for feature in testcontainers-java, among other Docker image validations.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->


<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
