### PR TITLE
Fix trailing slash on Image Prefix

### DIFF
--- a/docker_test.go
+++ b/docker_test.go
@@ -2280,3 +2280,31 @@ func TestDockerProvider_attemptToPullImage_retries(t *testing.T) {
 		})
 	}
 }
+
+func TestCustomPrefixTrailingSlashIsProperlyRemovedIfPresent(t *testing.T) {
+	hubPrefixWithTrailingSlash := "public.ecr.aws/"
+	dockerImage := "amazonlinux/amazonlinux:2023"
+
+	ctx := context.Background()
+	req := ContainerRequest{
+		Image:             dockerImage,
+		ImageSubstitutors: []ImageSubstitutor{newPrependHubRegistry(hubPrefixWithTrailingSlash)},
+	}
+
+	c, err := GenericContainer(ctx, GenericContainerRequest{
+		ContainerRequest: req,
+		Started:          true,
+	})
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		terminateContainerOnEnd(t, ctx, c)
+	}()
+
+	// enforce the concrete type, as GenericContainer returns an interface,
+	// which will be changed in future implementations of the library
+	dockerContainer := c.(*DockerContainer)
+	assert.Equal(t, fmt.Sprintf("%s%s", hubPrefixWithTrailingSlash, dockerImage), dockerContainer.Image)
+}

--- a/docker_test.go
+++ b/docker_test.go
@@ -2295,7 +2295,6 @@ func TestCustomPrefixTrailingSlashIsProperlyRemovedIfPresent(t *testing.T) {
 		ContainerRequest: req,
 		Started:          true,
 	})
-
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/options.go
+++ b/options.go
@@ -3,6 +3,7 @@ package testcontainers
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"time"
 
 	"dario.cat/mergo"
@@ -155,7 +156,12 @@ func (c CustomHubSubstitutor) Substitute(image string) (string, error) {
 		}
 	}
 
-	return fmt.Sprintf("%s/%s", c.hub, image), nil
+	result, err := url.JoinPath(c.hub, image)
+	if err != nil {
+		return "", err
+	}
+
+	return result, nil
 }
 
 // prependHubRegistry represents a way to prepend a custom Hub registry to the image name,
@@ -198,7 +204,12 @@ func (p prependHubRegistry) Substitute(image string) (string, error) {
 		}
 	}
 
-	return fmt.Sprintf("%s/%s", p.prefix, image), nil
+	result, err := url.JoinPath(p.prefix, image)
+	if err != nil {
+		return "", err
+	}
+
+	return result, nil
 }
 
 // WithImageSubstitutors sets the image substitutors for a container


### PR DESCRIPTION
## What does this PR do?
Fixes Trailing Slash on Image Prefix.

## Why is it important?
Because we need to manually remove the Trailing Slash specifically for Go Projects. Where we want consistency between Testcontainers Java and Go

## Related issues
- Closes #2746 

## How to test this PR
Unit Test Created