### PR TITLE
feat(compose): select services via profiles

### DIFF
--- a/modules/compose/compose.go
+++ b/modules/compose/compose.go
@@ -32,6 +32,7 @@ type composeStackOptions struct {
 	Paths          []string
 	temporaryPaths map[string]bool
 	Logger         testcontainers.Logging
+	Profiles       []string
 }
 
 type ComposeStackOption interface {
@@ -116,6 +117,11 @@ func WithStackReaders(readers ...io.Reader) ComposeStackOption {
 	return ComposeStackReaders(readers)
 }
 
+// WithProfiles allows to enable/disable services based on the profiles defined in the compose file.
+func WithProfiles(profiles ...string) ComposeStackOption {
+	return ComposeProfiles(profiles)
+}
+
 func NewDockerCompose(filePaths ...string) (*dockerCompose, error) {
 	return NewDockerComposeWith(WithStackFiles(filePaths...))
 }
@@ -125,6 +131,7 @@ func NewDockerComposeWith(opts ...ComposeStackOption) (*dockerCompose, error) {
 		Identifier:     uuid.New().String(),
 		temporaryPaths: make(map[string]bool),
 		Logger:         testcontainers.Logger,
+		Profiles:       nil,
 	}
 
 	for i := range opts {
@@ -168,6 +175,7 @@ func NewDockerComposeWith(opts ...ComposeStackOption) (*dockerCompose, error) {
 		configs:          composeOptions.Paths,
 		temporaryConfigs: composeOptions.temporaryPaths,
 		logger:           composeOptions.Logger,
+		projectProfiles:  composeOptions.Profiles,
 		composeService:   compose.NewComposeService(dockerCli),
 		dockerClient:     dockerCli.Client(),
 		waitStrategies:   make(map[string]wait.Strategy),

--- a/modules/compose/compose_api.go
+++ b/modules/compose/compose_api.go
@@ -153,6 +153,13 @@ func (f ComposeStackFiles) applyToComposeStack(o *composeStackOptions) error {
 	return nil
 }
 
+type ComposeProfiles []string
+
+func (p ComposeProfiles) applyToComposeStack(o *composeStackOptions) error {
+	o.Profiles = append(o.Profiles, p...)
+	return nil
+}
+
 type StackIdentifier string
 
 func (f StackIdentifier) applyToComposeStack(o *composeStackOptions) error {
@@ -211,6 +218,9 @@ type dockerCompose struct {
 	// options used to compile the compose project
 	// e.g. environment settings, ...
 	projectOptions []cli.ProjectOptionsFn
+
+	// profiles applied to the compose project after compilation.
+	projectProfiles []string
 
 	// compiled compose project
 	// can be nil if the stack wasn't started yet
@@ -510,6 +520,13 @@ func (d *dockerCompose) compileProject(ctx context.Context) (*types.Project, err
 	proj, err := compiledOptions.LoadProject(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("load project: %w", err)
+	}
+
+	if len(d.projectProfiles) > 0 {
+		proj, err = proj.WithProfiles(d.projectProfiles)
+		if err != nil {
+			return nil, fmt.Errorf("with profiles: %w", err)
+		}
 	}
 
 	for i, s := range proj.Services {

--- a/modules/compose/compose_builder_test.go
+++ b/modules/compose/compose_builder_test.go
@@ -14,6 +14,12 @@ const (
 	testdataPackage = "testdata"
 )
 
+func RenderComposeProfiles(t *testing.T) string {
+	t.Helper()
+
+	return writeTemplate(t, "docker-compose-profiles.yml")
+}
+
 func RenderComposeComplex(t *testing.T) (string, []int) {
 	t.Helper()
 

--- a/modules/compose/testdata/docker-compose-profiles.yml
+++ b/modules/compose/testdata/docker-compose-profiles.yml
@@ -1,0 +1,25 @@
+services:
+  starts-always:
+    image: docker.io/nginx:stable-alpine
+    ports:
+      - ":80"
+    # profiles: none defined, therefore always starts.
+  only-dev:
+    image: docker.io/nginx:stable-alpine
+    ports:
+      - ":80"
+    profiles:
+      - dev
+  dev-or-test:
+    image: docker.io/nginx:stable-alpine
+    ports:
+      - ":80"
+    profiles:
+      - dev
+      - test
+  only-prod:
+    image: docker.io/nginx:stable-alpine
+    ports:
+      - ":80"
+    profiles:
+      - prod


### PR DESCRIPTION
## What does this PR do?
This PR adds the option to use [Compose profiles](https://docs.docker.com/compose/profiles) to enable/disable services based on the profiles defined in the compose file:

```golang
func WithProfiles(profiles ...string) ComposeStackOption
```

The current behavior is not changed unless `WithProfiles` is used.
## Why is it important?
We would like to use our existing Compose files with `testcontainers-go/modules/compose` to set up test environments locally and in our pipelines.

However, our workflow relies on Compose profiles, which currently makes the use of `testcontainers-go/modules/compose` impossible, as only services without profiles are enabled by default.

Our workaround is to set up the test environment via the Compose CLI, but we think this could be well automated if `testcontainers-go` supported Compose profiles.

## Related issues
- Relates testcontainers/testcontainers-java#5041 where as a workaround, `withOptions("--profiles foo")` is suggested. This is not possible with `testcontainers-go` as it relies directly on the Go module and does not wrap the CLI.
## How to test this PR
To only run the tests for this individual feature, you can run `go test -v -run TestDockerComposeAPIWithProfiles` in `modules/compose`.

In addition to the unit tests, reviewers can try their own Compose files with profiles:
```golang
func ExampleWithProfiles() error {
    ctx := context.Background()

    filesOpt := compose.WithStackFiles("compose.yaml")
    profilesOpt := compose.WithProfiles("test", "dev")
    stack, err := compose.NewDockerComposeWith(filesOpt, profilesOpt)
    if err != nil {
       return fmt.Errorf("new docker compose: %w", err)
    }
    fmt.Println("stack up")
    if err := stack.Up(ctx); err != nil {
       return fmt.Errorf("stack up: %w", err)
    }
    fmt.Println("stack down")
    if err := stack.Down(ctx); err != nil {
       return fmt.Errorf("stack down: %w", err)
    }
    return nil
}
```

## Follow-ups
From my perspective, this feature is self-contained.

If this gets merged and released, we will adapt our workflow to use `testcontainers-go/modules/compose` for setting up test environments. This might generate more insights and follow-ups.