### PR TITLE
fix #2767 allow missing repository config

### DIFF
--- a/docker_auth_test.go
+++ b/docker_auth_test.go
@@ -414,4 +414,12 @@ func Test_getDockerAuthConfigs(t *testing.T) {
 		}
 		require.Equal(t, expected, got)
 	})
+
+	t.Run("none", func(t *testing.T) {
+		// make sure no config is set
+		t.Setenv("DOCKER_CONFIG", "not existing")
+		got, err := getDockerAuthConfigs()
+		require.NoError(t, err)
+		require.Empty(t, got)
+	})
 }


### PR DESCRIPTION
## What does this PR do?

- allow missing docher auth config file -- replace registry cache key with a key generated by any defined config
- allow no provided config

## Why is it important?

Configuring authentication is not mandatory as long as they can all be anonymously accessed.

## Related issues
- Closes #2767

## How to test this PR
- Added a test & it should not break existing ones
