### PR TITLE
fix: do not override ImageBuildOptions.Labels when building from a Dockerfile

### DIFF
--- a/container.go
+++ b/container.go
@@ -460,7 +460,14 @@ func (c *ContainerRequest) BuildOptions() (types.ImageBuildOptions, error) {
 	}
 
 	if !c.ShouldKeepBuiltImage() {
-		buildOptions.Labels = core.DefaultLabels(core.SessionID())
+		dst := core.DefaultLabels(core.SessionID())
+		if err = core.MergeCustomLabels(dst, c.Labels); err != nil {
+			return types.ImageBuildOptions{}, err
+		}
+		if err = core.MergeCustomLabels(dst, buildOptions.Labels); err != nil {
+			return types.ImageBuildOptions{}, err
+		}
+		buildOptions.Labels = dst
 	}
 
 	// Do this as late as possible to ensure we don't leak the context on error/panic.

--- a/container.go
+++ b/container.go
@@ -460,7 +460,7 @@ func (c *ContainerRequest) BuildOptions() (types.ImageBuildOptions, error) {
 	}
 
 	if !c.ShouldKeepBuiltImage() {
-		dst := core.DefaultLabels(core.SessionID())
+		dst := GenericLabels()
 		if err = core.MergeCustomLabels(dst, c.Labels); err != nil {
 			return types.ImageBuildOptions{}, err
 		}

--- a/container_test.go
+++ b/container_test.go
@@ -305,7 +305,6 @@ func Test_BuildImageWithContexts(t *testing.T) {
 }
 
 func TestCustomLabelsImage(t *testing.T) {
-	// --- Given ---
 	const (
 		myLabelName  = "org.my.label"
 		myLabelValue = "my-label-value"
@@ -319,10 +318,8 @@ func TestCustomLabelsImage(t *testing.T) {
 		},
 	}
 
-	// --- When ---
 	ctr, err := testcontainers.GenericContainer(ctx, req)
 
-	// --- Then ---
 	require.NoError(t, err)
 	t.Cleanup(func() { assert.NoError(t, ctr.Terminate(ctx)) })
 
@@ -332,7 +329,6 @@ func TestCustomLabelsImage(t *testing.T) {
 }
 
 func TestCustomLabelsBuildOptionsModifier(t *testing.T) {
-	// --- Given ---
 	const (
 		myLabelName        = "org.my.label"
 		myLabelValue       = "my-label-value"
@@ -356,10 +352,8 @@ func TestCustomLabelsBuildOptionsModifier(t *testing.T) {
 		},
 	}
 
-	// --- When ---
 	ctr, err := testcontainers.GenericContainer(ctx, req)
 
-	// --- Then ---
 	require.NoError(t, err)
 	t.Cleanup(func() { assert.NoError(t, ctr.Terminate(ctx)) })
 

--- a/container_test.go
+++ b/container_test.go
@@ -365,8 +365,8 @@ func TestCustomLabelsBuildOptionsModifier(t *testing.T) {
 
 	ctrJSON, err := ctr.Inspect(ctx)
 	require.NoError(t, err)
-	assert.Equal(t, myLabelValue, ctrJSON.Config.Labels[myLabelName])
-	assert.Equal(t, myBuildOptionValue, ctrJSON.Config.Labels[myBuildOptionLabel])
+	require.Equal(t, myLabelValue, ctrJSON.Config.Labels[myLabelName])
+	require.Equal(t, myBuildOptionValue, ctrJSON.Config.Labels[myBuildOptionLabel])
 }
 
 func Test_GetLogsFromFailedContainer(t *testing.T) {

--- a/container_test.go
+++ b/container_test.go
@@ -353,9 +353,8 @@ func TestCustomLabelsBuildOptionsModifier(t *testing.T) {
 	}
 
 	ctr, err := testcontainers.GenericContainer(ctx, req)
-
+	testcontainers.CleanupContainer(t, ctr)
 	require.NoError(t, err)
-	t.Cleanup(func() { assert.NoError(t, ctr.Terminate(ctx)) })
 
 	ctrJSON, err := ctr.Inspect(ctx)
 	require.NoError(t, err)

--- a/internal/core/labels.go
+++ b/internal/core/labels.go
@@ -35,8 +35,7 @@ func MergeCustomLabels(dst, src map[string]string) error {
 	}
 	for key, value := range src {
 		if strings.HasPrefix(key, LabelBase) {
-			format := "cannot use prefix %q for custom labels"
-			return fmt.Errorf(format, LabelBase)
+			return fmt.Errorf("key %q has %q prefix", key, LabelBase)
 		}
 		dst[key] = value
 	}

--- a/internal/core/labels.go
+++ b/internal/core/labels.go
@@ -1,6 +1,9 @@
 package core
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/testcontainers/testcontainers-go/internal"
 )
 
@@ -20,4 +23,21 @@ func DefaultLabels(sessionID string) map[string]string {
 		LabelSessionID: sessionID,
 		LabelVersion:   internal.Version,
 	}
+}
+
+// MergeCustomLabels sets labels from src to dst. Returns error if src label
+// name has [LabelBase] prefix.
+//
+// NOTICE: Default labels must not be nil.
+func MergeCustomLabels(dst, src map[string]string) error {
+	for key := range src {
+		if strings.HasPrefix(key, LabelBase) {
+			format := "cannot use prefix %q for custom labels"
+			return fmt.Errorf(format, LabelBase)
+		}
+	}
+	for key, value := range src {
+		dst[key] = value
+	}
+	return nil
 }

--- a/internal/core/labels.go
+++ b/internal/core/labels.go
@@ -31,8 +31,8 @@ func DefaultLabels(sessionID string) map[string]string {
 //
 // NOTICE: The dst labels must not be nil so we can set the labels.
 func MergeCustomLabels(dst, src map[string]string) error {
-	if dst == nil && len(src) > 0 {
-		return errors.New("cannot merge custom labels because destination map is nil")
+	if dst == nil {
+		return errors.New("destination map is nil")
 	}
 	for key, value := range src {
 		if strings.HasPrefix(key, LabelBase) {

--- a/internal/core/labels.go
+++ b/internal/core/labels.go
@@ -26,10 +26,9 @@ func DefaultLabels(sessionID string) map[string]string {
 	}
 }
 
-// MergeCustomLabels sets labels from src to dst. Returns error if src label
-// name has [LabelBase] prefix.
-//
-// NOTICE: The dst labels must not be nil so we can set the labels.
+// MergeCustomLabels sets labels from src to dst.
+// If a key in src has [LabelBase] prefix returns an error.
+// If dst is nil returns an error.
 func MergeCustomLabels(dst, src map[string]string) error {
 	if dst == nil {
 		return errors.New("destination map is nil")

--- a/internal/core/labels.go
+++ b/internal/core/labels.go
@@ -30,13 +30,12 @@ func DefaultLabels(sessionID string) map[string]string {
 //
 // NOTICE: dst labels must not be nil.
 func MergeCustomLabels(dst, src map[string]string) error {
-	for key := range src {
+	for key, value := range src {
 		if strings.HasPrefix(key, LabelBase) {
 			format := "cannot use prefix %q for custom labels"
 			return fmt.Errorf(format, LabelBase)
 		}
-	}
-	for key, value := range src {
+
 		dst[key] = value
 	}
 	return nil

--- a/internal/core/labels.go
+++ b/internal/core/labels.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -28,14 +29,16 @@ func DefaultLabels(sessionID string) map[string]string {
 // MergeCustomLabels sets labels from src to dst. Returns error if src label
 // name has [LabelBase] prefix.
 //
-// NOTICE: dst labels must not be nil.
+// NOTICE: The dst labels must not be nil so we can set the labels.
 func MergeCustomLabels(dst, src map[string]string) error {
+	if dst == nil && len(src) > 0 {
+		return errors.New("cannot merge custom labels because destination map is nil")
+	}
 	for key, value := range src {
 		if strings.HasPrefix(key, LabelBase) {
 			format := "cannot use prefix %q for custom labels"
 			return fmt.Errorf(format, LabelBase)
 		}
-
 		dst[key] = value
 	}
 	return nil

--- a/internal/core/labels.go
+++ b/internal/core/labels.go
@@ -28,7 +28,7 @@ func DefaultLabels(sessionID string) map[string]string {
 // MergeCustomLabels sets labels from src to dst. Returns error if src label
 // name has [LabelBase] prefix.
 //
-// NOTICE: Default labels must not be nil.
+// NOTICE: dst labels must not be nil.
 func MergeCustomLabels(dst, src map[string]string) error {
 	for key := range src {
 		if strings.HasPrefix(key, LabelBase) {

--- a/internal/core/labels_test.go
+++ b/internal/core/labels_test.go
@@ -22,7 +22,7 @@ func TestMergeCustomLabels(t *testing.T) {
 
 		err := MergeCustomLabels(dst, src)
 
-		require.EqualError(t, err, `cannot use prefix "org.testcontainers" for custom labels`)
+		require.EqualError(t, err, `key "org.testcontainers.lang" has "org.testcontainers" prefix`)
 		require.Equal(t, map[string]string{"A": "1", "B": "X"}, dst)
 	})
 

--- a/internal/core/labels_test.go
+++ b/internal/core/labels_test.go
@@ -18,14 +18,11 @@ func TestMergeCustomLabels(t *testing.T) {
 	})
 
 	t.Run("src cannot have keys starting with LabelBase", func(t *testing.T) {
-		// --- Given ---
 		dst := map[string]string{"A": "1", "B": "2"}
 		src := map[string]string{"B": "X", LabelLang: "go"}
 
-		// --- When ---
 		err := MergeCustomLabels(dst, src)
 
-		// --- Then ---
 		require.EqualError(t, err, `cannot use prefix "org.testcontainers" for custom labels`)
 		assert.Equal(t, map[string]string{"A": "1", "B": "2"}, dst)
 	})

--- a/internal/core/labels_test.go
+++ b/internal/core/labels_test.go
@@ -16,7 +16,7 @@ func TestMergeCustomLabels(t *testing.T) {
 		require.Equal(t, map[string]string{"A": "1", "B": "X", "C": "3"}, dst)
 	})
 
-	t.Run("src cannot have keys starting with LabelBase", func(t *testing.T) {
+	t.Run("invalid-prefix", func(t *testing.T) {
 		dst := map[string]string{"A": "1", "B": "2"}
 		src := map[string]string{"B": "X", LabelLang: "go"}
 

--- a/internal/core/labels_test.go
+++ b/internal/core/labels_test.go
@@ -3,7 +3,6 @@ package core
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -25,5 +24,21 @@ func TestMergeCustomLabels(t *testing.T) {
 
 		require.EqualError(t, err, `cannot use prefix "org.testcontainers" for custom labels`)
 		require.Equal(t, map[string]string{"A": "1", "B": "X"}, dst)
+	})
+
+	t.Run("nil destination and empty source", func(t *testing.T) {
+		src := map[string]string{}
+
+		err := MergeCustomLabels(nil, src)
+
+		require.NoError(t, err)
+	})
+
+	t.Run("nil destination", func(t *testing.T) {
+		src := map[string]string{"A": "1"}
+
+		err := MergeCustomLabels(nil, src)
+
+		require.Error(t, err)
 	})
 }

--- a/internal/core/labels_test.go
+++ b/internal/core/labels_test.go
@@ -1,0 +1,36 @@
+package core
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMergeCustomLabels(t *testing.T) {
+	t.Run("merge success", func(t *testing.T) {
+		// --- Given ---
+		dst := map[string]string{"A": "1", "B": "2"}
+		src := map[string]string{"B": "X", "C": "3"}
+
+		// --- When ---
+		err := MergeCustomLabels(dst, src)
+
+		// --- Then ---
+		assert.NoError(t, err)
+		assert.Equal(t, map[string]string{"A": "1", "B": "X", "C": "3"}, dst)
+	})
+
+	t.Run("src cannot have keys starting with LabelBase", func(t *testing.T) {
+		// --- Given ---
+		dst := map[string]string{"A": "1", "B": "2"}
+		src := map[string]string{"B": "X", LabelLang: "go"}
+
+		// --- When ---
+		err := MergeCustomLabels(dst, src)
+
+		// --- Then ---
+		want := `cannot use prefix "org.testcontainers" for custom labels`
+		assert.Error(t, err, want)
+		assert.Equal(t, map[string]string{"A": "1", "B": "2"}, dst)
+	})
+}

--- a/internal/core/labels_test.go
+++ b/internal/core/labels_test.go
@@ -26,14 +26,6 @@ func TestMergeCustomLabels(t *testing.T) {
 		require.Equal(t, map[string]string{"A": "1", "B": "X"}, dst)
 	})
 
-	t.Run("nil destination and empty source", func(t *testing.T) {
-		src := map[string]string{}
-
-		err := MergeCustomLabels(nil, src)
-
-		require.NoError(t, err)
-	})
-
 	t.Run("nil-destination", func(t *testing.T) {
 		src := map[string]string{"A": "1"}
 		err := MergeCustomLabels(nil, src)

--- a/internal/core/labels_test.go
+++ b/internal/core/labels_test.go
@@ -30,8 +30,7 @@ func TestMergeCustomLabels(t *testing.T) {
 		err := MergeCustomLabels(dst, src)
 
 		// --- Then ---
-		want := `cannot use prefix "org.testcontainers" for custom labels`
-		require.Error(t, err, want)
+		require.EqualError(t, err, `cannot use prefix "org.testcontainers" for custom labels`)
 		assert.Equal(t, map[string]string{"A": "1", "B": "2"}, dst)
 	})
 }

--- a/internal/core/labels_test.go
+++ b/internal/core/labels_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestMergeCustomLabels(t *testing.T) {
-	t.Run("merge success", func(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
 		dst := map[string]string{"A": "1", "B": "2"}
 		src := map[string]string{"B": "X", "C": "3"}
 

--- a/internal/core/labels_test.go
+++ b/internal/core/labels_test.go
@@ -24,6 +24,6 @@ func TestMergeCustomLabels(t *testing.T) {
 		err := MergeCustomLabels(dst, src)
 
 		require.EqualError(t, err, `cannot use prefix "org.testcontainers" for custom labels`)
-		assert.Equal(t, map[string]string{"A": "1", "B": "X"}, dst)
+		require.Equal(t, map[string]string{"A": "1", "B": "X"}, dst)
 	})
 }

--- a/internal/core/labels_test.go
+++ b/internal/core/labels_test.go
@@ -34,11 +34,9 @@ func TestMergeCustomLabels(t *testing.T) {
 		require.NoError(t, err)
 	})
 
-	t.Run("nil destination", func(t *testing.T) {
+	t.Run("nil-destination", func(t *testing.T) {
 		src := map[string]string{"A": "1"}
-
 		err := MergeCustomLabels(nil, src)
-
 		require.Error(t, err)
 	})
 }

--- a/internal/core/labels_test.go
+++ b/internal/core/labels_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestMergeCustomLabels(t *testing.T) {
@@ -16,7 +17,7 @@ func TestMergeCustomLabels(t *testing.T) {
 		err := MergeCustomLabels(dst, src)
 
 		// --- Then ---
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, map[string]string{"A": "1", "B": "X", "C": "3"}, dst)
 	})
 
@@ -30,7 +31,7 @@ func TestMergeCustomLabels(t *testing.T) {
 
 		// --- Then ---
 		want := `cannot use prefix "org.testcontainers" for custom labels`
-		assert.Error(t, err, want)
+		require.Error(t, err, want)
 		assert.Equal(t, map[string]string{"A": "1", "B": "2"}, dst)
 	})
 }

--- a/internal/core/labels_test.go
+++ b/internal/core/labels_test.go
@@ -9,14 +9,10 @@ import (
 
 func TestMergeCustomLabels(t *testing.T) {
 	t.Run("merge success", func(t *testing.T) {
-		// --- Given ---
 		dst := map[string]string{"A": "1", "B": "2"}
 		src := map[string]string{"B": "X", "C": "3"}
 
-		// --- When ---
 		err := MergeCustomLabels(dst, src)
-
-		// --- Then ---
 		require.NoError(t, err)
 		require.Equal(t, map[string]string{"A": "1", "B": "X", "C": "3"}, dst)
 	})

--- a/internal/core/labels_test.go
+++ b/internal/core/labels_test.go
@@ -18,7 +18,7 @@ func TestMergeCustomLabels(t *testing.T) {
 
 		// --- Then ---
 		require.NoError(t, err)
-		assert.Equal(t, map[string]string{"A": "1", "B": "X", "C": "3"}, dst)
+		require.Equal(t, map[string]string{"A": "1", "B": "X", "C": "3"}, dst)
 	})
 
 	t.Run("src cannot have keys starting with LabelBase", func(t *testing.T) {

--- a/internal/core/labels_test.go
+++ b/internal/core/labels_test.go
@@ -24,6 +24,6 @@ func TestMergeCustomLabels(t *testing.T) {
 		err := MergeCustomLabels(dst, src)
 
 		require.EqualError(t, err, `cannot use prefix "org.testcontainers" for custom labels`)
-		assert.Equal(t, map[string]string{"A": "1", "B": "2"}, dst)
+		assert.Equal(t, map[string]string{"A": "1", "B": "X"}, dst)
 	})
 }


### PR DESCRIPTION
Closes #2632.