### PR TITLE
feat(mongodb): Wait for mongodb module with a replicaset to finish

### DIFF
--- a/modules/mongodb/mongodb.go
+++ b/modules/mongodb/mongodb.go
@@ -3,6 +3,7 @@ package mongodb
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/wait"
@@ -89,6 +90,10 @@ func WithPassword(password string) testcontainers.CustomizeRequestOption {
 func WithReplicaSet(replSetName string) testcontainers.CustomizeRequestOption {
 	return func(req *testcontainers.GenericContainerRequest) error {
 		req.Cmd = append(req.Cmd, "--replSet", replSetName)
+		req.WaitingFor = wait.ForAll(
+			wait.ForExec(eval("rs.status().ok")),
+			wait.ForListeningPort("27017/tcp"),
+		).WithDeadline(60 * time.Second)
 		req.LifecycleHooks = append(req.LifecycleHooks, testcontainers.ContainerLifecycleHooks{
 			PostStarts: []testcontainers.ContainerHook{
 				func(ctx context.Context, c testcontainers.Container) error {

--- a/modules/mongodb/mongodb.go
+++ b/modules/mongodb/mongodb.go
@@ -91,8 +91,8 @@ func WithReplicaSet(replSetName string) testcontainers.CustomizeRequestOption {
 	return func(req *testcontainers.GenericContainerRequest) error {
 		req.Cmd = append(req.Cmd, "--replSet", replSetName)
 		req.WaitingFor = wait.ForAll(
+			req.WaitingFor,
 			wait.ForExec(eval("rs.status().ok")),
-			wait.ForListeningPort("27017/tcp"),
 		).WithDeadline(60 * time.Second)
 		req.LifecycleHooks = append(req.LifecycleHooks, testcontainers.ContainerLifecycleHooks{
 			PostStarts: []testcontainers.ContainerHook{

--- a/modules/mongodb/mongodb_test.go
+++ b/modules/mongodb/mongodb_test.go
@@ -49,6 +49,13 @@ func TestMongoDB(t *testing.T) {
 				mongodb.WithReplicaSet("rs"),
 			},
 		},
+		{
+			name: "With Replica set and mongo:7",
+			img:  "mongo:7",
+			opts: []testcontainers.ContainerCustomizer{
+				mongodb.WithReplicaSet("rs"),
+			},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/modules/mongodb/mongodb_test.go
+++ b/modules/mongodb/mongodb_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
 
@@ -67,12 +68,15 @@ func TestMongoDB(t *testing.T) {
 			// Force direct connection to the container to avoid the replica set
 			// connection string that is returned by the container itself when
 			// using the replica set option.
-			mongoClient, err := mongo.Connect(ctx, options.Client().ApplyURI(endpoint+"/?connect=direct"))
+			mongoClient, err := mongo.Connect(ctx, options.Client().ApplyURI(endpoint).SetDirect(true))
 			require.NoError(tt, err)
 
 			err = mongoClient.Ping(ctx, nil)
 			require.NoError(tt, err)
 			require.Equal(t, "test", mongoClient.Database("test").Name())
+
+			_, err = mongoClient.Database("testcontainer").Collection("test").InsertOne(context.Background(), bson.M{})
+			require.NoError(tt, err)
 		})
 	}
 }


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?

This will add a test for writing to the mongodb module replica set so we can catch the error `(NotWritablePrimary) not primary`. It also adds a new wait strategy when using `mongodb.WithReplicaSet()` that waits for replica set status to be available.

## Why is it important?

We get flaky tests in our CI (seems to be present on slow hardware) and they fail sometimes since we try to write to a mongodb container which isn't ready.


## How to test this PR

There are tests added to test for this error. Tests will randomly fail when the wait strategy in `WithReplicaSet` is removed. 