### PR TITLE
fix: handle 127 error code for podman compatibility

### DIFF
--- a/wait/host_port.go
+++ b/wait/host_port.go
@@ -24,8 +24,10 @@ var (
 	_ StrategyTimeout = (*HostPortStrategy)(nil)
 )
 
-var errShellNotExecutable = errors.New("/bin/sh command not executable")
-var errShellNotFound = errors.New("/bin/sh command not found")
+var (
+	errShellNotExecutable = errors.New("/bin/sh command not executable")
+	errShellNotFound      = errors.New("/bin/sh command not found")
+)
 
 type HostPortStrategy struct {
 	// Port is a string containing port number and protocol in the format "80/tcp"
@@ -167,7 +169,7 @@ func (hp *HostPortStrategy) WaitUntilReady(ctx context.Context, target StrategyT
 		default:
 			return fmt.Errorf("internal check: %w", err)
 		}
-	}	
+	}
 
 	return nil
 }

--- a/wait/host_port.go
+++ b/wait/host_port.go
@@ -209,7 +209,7 @@ func internalCheck(ctx context.Context, internalPort nat.Port, target StrategyTa
 
 		if exitCode == 0 {
 			break
-		} else if exitCode == 126 {
+		} else if exitCode == 126 || exitCode == 127 {
 			return errShellNotExecutable
 		}
 	}

--- a/wait/host_port_test.go
+++ b/wait/host_port_test.go
@@ -456,16 +456,12 @@ func TestHostPortStrategyFailsWhileInternalCheckingDueToUnexpectedContainerStatu
 
 func TestHostPortStrategySucceedsGivenShellIsNotInstalled(t *testing.T) {
 	listener, err := net.Listen("tcp", "localhost:0")
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	defer listener.Close()
 
 	rawPort := listener.Addr().(*net.TCPAddr).Port
 	port, err := nat.NewPort("tcp", strconv.Itoa(rawPort))
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	target := &MockStrategyTarget{
 		HostImpl: func(_ context.Context) (string, error) {
@@ -511,16 +507,12 @@ func TestHostPortStrategySucceedsGivenShellIsNotInstalled(t *testing.T) {
 
 func TestHostPortStrategySucceedsGivenShellIsNotFound(t *testing.T) {
 	listener, err := net.Listen("tcp", "localhost:0")
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	defer listener.Close()
 
 	rawPort := listener.Addr().(*net.TCPAddr).Port
 	port, err := nat.NewPort("tcp", strconv.Itoa(rawPort))
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	target := &MockStrategyTarget{
 		HostImpl: func(_ context.Context) (string, error) {

--- a/wait/host_port_test.go
+++ b/wait/host_port_test.go
@@ -508,3 +508,58 @@ func TestHostPortStrategySucceedsGivenShellIsNotInstalled(t *testing.T) {
 	err = wg.WaitUntilReady(context.Background(), target)
 	require.NoError(t, err)
 }
+
+func TestHostPortStrategySucceedsGivenShellIsNotFound(t *testing.T) {
+	listener, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer listener.Close()
+
+	rawPort := listener.Addr().(*net.TCPAddr).Port
+	port, err := nat.NewPort("tcp", strconv.Itoa(rawPort))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	target := &MockStrategyTarget{
+		HostImpl: func(_ context.Context) (string, error) {
+			return "localhost", nil
+		},
+		InspectImpl: func(_ context.Context) (*types.ContainerJSON, error) {
+			return &types.ContainerJSON{
+				NetworkSettings: &types.NetworkSettings{
+					NetworkSettingsBase: types.NetworkSettingsBase{
+						Ports: nat.PortMap{
+							"80": []nat.PortBinding{
+								{
+									HostIP:   "0.0.0.0",
+									HostPort: port.Port(),
+								},
+							},
+						},
+					},
+				},
+			}, nil
+		},
+		MappedPortImpl: func(_ context.Context, _ nat.Port) (nat.Port, error) {
+			return port, nil
+		},
+		StateImpl: func(_ context.Context) (*types.ContainerState, error) {
+			return &types.ContainerState{
+				Running: true,
+			}, nil
+		},
+		ExecImpl: func(_ context.Context, _ []string, _ ...exec.ProcessOption) (int, io.Reader, error) {
+			// This is the error that would be returned if the shell is not found.
+			return exitCmdNotFound, nil, nil
+		},
+	}
+
+	wg := NewHostPortStrategy("80").
+		WithStartupTimeout(5 * time.Second).
+		WithPollInterval(100 * time.Millisecond)
+
+	err = wg.WaitUntilReady(context.Background(), target)
+	require.NoError(t, err)
+}

--- a/wait/host_port_test.go
+++ b/wait/host_port_test.go
@@ -497,7 +497,7 @@ func TestHostPortStrategySucceedsGivenShellIsNotInstalled(t *testing.T) {
 		},
 		ExecImpl: func(_ context.Context, _ []string, _ ...exec.ProcessOption) (int, io.Reader, error) {
 			// This is the error that would be returned if the shell is not installed.
-			return 126, nil, nil
+			return exitEaccess, nil, nil
 		},
 	}
 

--- a/wait/host_port_test.go
+++ b/wait/host_port_test.go
@@ -563,3 +563,105 @@ func TestHostPortStrategySucceedsGivenShellIsNotFound(t *testing.T) {
 	err = wg.WaitUntilReady(context.Background(), target)
 	require.NoError(t, err)
 }
+
+func TestInternalCheckFailsGivenShellIsNotInstalled(t *testing.T) {
+	listener, err := net.Listen("tcp", "localhost:0")
+	require.NoError(t, err)
+	defer listener.Close()
+
+	rawPort := listener.Addr().(*net.TCPAddr).Port
+	port, err := nat.NewPort("tcp", strconv.Itoa(rawPort))
+	require.NoError(t, err)
+
+	target := &MockStrategyTarget{
+		HostImpl: func(_ context.Context) (string, error) {
+			return "localhost", nil
+		},
+		InspectImpl: func(_ context.Context) (*types.ContainerJSON, error) {
+			return &types.ContainerJSON{
+				NetworkSettings: &types.NetworkSettings{
+					NetworkSettingsBase: types.NetworkSettingsBase{
+						Ports: nat.PortMap{
+							"80": []nat.PortBinding{
+								{
+									HostIP:   "0.0.0.0",
+									HostPort: port.Port(),
+								},
+							},
+						},
+					},
+				},
+			}, nil
+		},
+		MappedPortImpl: func(_ context.Context, _ nat.Port) (nat.Port, error) {
+			return port, nil
+		},
+		StateImpl: func(_ context.Context) (*types.ContainerState, error) {
+			return &types.ContainerState{
+				Running: true,
+			}, nil
+		},
+		ExecImpl: func(_ context.Context, _ []string, _ ...exec.ProcessOption) (int, io.Reader, error) {
+			// This is the error that would be returned if the shell is not installed.
+			return exitEaccess, nil, nil
+		},
+	}
+
+	{
+		err := internalCheck(context.Background(), "80", target)
+		require.Error(t, err)
+
+		require.Contains(t, err.Error(), errShellNotExecutable.Error())
+	}
+}
+
+func TestInternalCheckFailsGivenShellIsNotFound(t *testing.T) {
+	listener, err := net.Listen("tcp", "localhost:0")
+	require.NoError(t, err)
+	defer listener.Close()
+
+	rawPort := listener.Addr().(*net.TCPAddr).Port
+	port, err := nat.NewPort("tcp", strconv.Itoa(rawPort))
+	require.NoError(t, err)
+
+	target := &MockStrategyTarget{
+		HostImpl: func(_ context.Context) (string, error) {
+			return "localhost", nil
+		},
+		InspectImpl: func(_ context.Context) (*types.ContainerJSON, error) {
+			return &types.ContainerJSON{
+				NetworkSettings: &types.NetworkSettings{
+					NetworkSettingsBase: types.NetworkSettingsBase{
+						Ports: nat.PortMap{
+							"80": []nat.PortBinding{
+								{
+									HostIP:   "0.0.0.0",
+									HostPort: port.Port(),
+								},
+							},
+						},
+					},
+				},
+			}, nil
+		},
+		MappedPortImpl: func(_ context.Context, _ nat.Port) (nat.Port, error) {
+			return port, nil
+		},
+		StateImpl: func(_ context.Context) (*types.ContainerState, error) {
+			return &types.ContainerState{
+				Running: true,
+			}, nil
+		},
+		ExecImpl: func(_ context.Context, _ []string, _ ...exec.ProcessOption) (int, io.Reader, error) {
+			// This is the error that would be returned if the shell is not found.
+			return exitCmdNotFound, nil, nil
+		},
+	}
+
+	{
+		err := internalCheck(context.Background(), "80", target)
+		require.Error(t, err)
+
+		require.Contains(t, err.Error(), errShellNotFound.Error())
+	}
+}


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?

- Handle 127 error code for podman compatibility.
- After merging this, we still need to disable ryuk for tests to work with Podman. Raised an issue for this: https://github.com/testcontainers/testcontainers-go/issues/2781

## Why is it important?

- Docker has a bug where it overrides exit code = 127 with exit code = 126. However, Podman handles these error codes separately.
- While testing etcd module, my container was returning exit code = 127 on Podman. test-containers.go didn't know what to do with 127 error code as it follows the moby project so, it was stuck in an infinite loop.
- Although, the container was up but the code was panicking.

## Related issues

- Some relevant PRs in other projects:
  - https://github.com/containers/podman/issues/367
  - https://github.com/moby/moby/issues/45795

## How to test this PR

- Output for `podman exec -ti <containerid> /bin/sh -c "echo test"; echo $?`

```
podman exec -ti 3604e691a9efbaa916bdeaa365f7481a04aca79722c430d3cc285b671215cfec /bin/sh -c "echo test"; echo $?
Error: crun: executable file `/bin/sh` not found in $PATH: No such file or directory: OCI runtime attempted to invoke a command that was not found
127
```

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
