### PR TITLE
fix(postgres): Apply default snapshot name if no name specified

### DIFF
--- a/modules/postgres/options.go
+++ b/modules/postgres/options.go
@@ -7,11 +7,13 @@ import (
 type options struct {
 	// SQLDriverName is the name of the SQL driver to use.
 	SQLDriverName string
+	Snapshot      string
 }
 
 func defaultOptions() options {
 	return options{
 		SQLDriverName: "postgres",
+		Snapshot:      defaultSnapshotName,
 	}
 }
 

--- a/modules/postgres/postgres.go
+++ b/modules/postgres/postgres.go
@@ -177,6 +177,7 @@ func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustom
 			password:      req.Env["POSTGRES_PASSWORD"],
 			user:          req.Env["POSTGRES_USER"],
 			sqlDriverName: settings.SQLDriverName,
+			snapshotName:  settings.Snapshot,
 		}
 	}
 

--- a/modules/postgres/postgres_test.go
+++ b/modules/postgres/postgres_test.go
@@ -203,73 +203,95 @@ func TestWithInitScript(t *testing.T) {
 }
 
 func TestSnapshot(t *testing.T) {
-	// snapshotAndReset {
-	ctx := context.Background()
+	tests := []struct {
+		name    string
+		options []postgres.SnapshotOption
+	}{
+		{
+			name:    "snapshot/default",
+			options: nil,
+		},
 
-	// 1. Start the postgres ctr and run any migrations on it
-	ctr, err := postgres.Run(
-		ctx,
-		"docker.io/postgres:16-alpine",
-		postgres.WithDatabase(dbname),
-		postgres.WithUsername(user),
-		postgres.WithPassword(password),
-		postgres.BasicWaitStrategies(),
-		postgres.WithSQLDriver("pgx"),
-	)
-	testcontainers.CleanupContainer(t, ctr)
-	require.NoError(t, err)
+		{
+			name: "snapshot/custom",
+			options: []postgres.SnapshotOption{
+				postgres.WithSnapshotName("custom-snapshot"),
+			},
+		},
+	}
 
-	// Run any migrations on the database
-	_, _, err = ctr.Exec(ctx, []string{"psql", "-U", user, "-d", dbname, "-c", "CREATE TABLE users (id SERIAL, name TEXT NOT NULL, age INT NOT NULL)"})
-	require.NoError(t, err)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// snapshotAndReset {
+			ctx := context.Background()
 
-	// 2. Create a snapshot of the database to restore later
-	err = ctr.Snapshot(ctx, postgres.WithSnapshotName("test-snapshot"))
-	require.NoError(t, err)
-
-	dbURL, err := ctr.ConnectionString(ctx)
-	require.NoError(t, err)
-
-	t.Run("Test inserting a user", func(t *testing.T) {
-		t.Cleanup(func() {
-			// 3. In each test, reset the DB to its snapshot state.
-			err = ctr.Restore(ctx)
+			// 1. Start the postgres ctr and run any migrations on it
+			ctr, err := postgres.Run(
+				ctx,
+				"docker.io/postgres:16-alpine",
+				postgres.WithDatabase(dbname),
+				postgres.WithUsername(user),
+				postgres.WithPassword(password),
+				postgres.BasicWaitStrategies(),
+				postgres.WithSQLDriver("pgx"),
+			)
+			testcontainers.CleanupContainer(t, ctr)
 			require.NoError(t, err)
-		})
 
-		conn, err := pgx.Connect(context.Background(), dbURL)
-		require.NoError(t, err)
-		defer conn.Close(context.Background())
-
-		_, err = conn.Exec(ctx, "INSERT INTO users(name, age) VALUES ($1, $2)", "test", 42)
-		require.NoError(t, err)
-
-		var name string
-		var age int64
-		err = conn.QueryRow(context.Background(), "SELECT name, age FROM users LIMIT 1").Scan(&name, &age)
-		require.NoError(t, err)
-
-		require.Equal(t, "test", name)
-		require.EqualValues(t, 42, age)
-	})
-
-	// 4. Run as many tests as you need, they will each get a clean database
-	t.Run("Test querying empty DB", func(t *testing.T) {
-		t.Cleanup(func() {
-			err = ctr.Restore(ctx)
+			// Run any migrations on the database
+			_, _, err = ctr.Exec(ctx, []string{"psql", "-U", user, "-d", dbname, "-c", "CREATE TABLE users (id SERIAL, name TEXT NOT NULL, age INT NOT NULL)"})
 			require.NoError(t, err)
+
+			// 2. Create a snapshot of the database to restore later
+			// tt.options comes the test case, it can be specified as e.g. `postgres.WithSnapshotName("custom-snapshot")` or omitted, to use default name
+			err = ctr.Snapshot(ctx, tt.options...)
+			require.NoError(t, err)
+
+			dbURL, err := ctr.ConnectionString(ctx)
+			require.NoError(t, err)
+
+			t.Run("Test inserting a user", func(t *testing.T) {
+				t.Cleanup(func() {
+					// 3. In each test, reset the DB to its snapshot state.
+					err = ctr.Restore(ctx)
+					require.NoError(t, err)
+				})
+
+				conn, err := pgx.Connect(context.Background(), dbURL)
+				require.NoError(t, err)
+				defer conn.Close(context.Background())
+
+				_, err = conn.Exec(ctx, "INSERT INTO users(name, age) VALUES ($1, $2)", "test", 42)
+				require.NoError(t, err)
+
+				var name string
+				var age int64
+				err = conn.QueryRow(context.Background(), "SELECT name, age FROM users LIMIT 1").Scan(&name, &age)
+				require.NoError(t, err)
+
+				require.Equal(t, "test", name)
+				require.EqualValues(t, 42, age)
+			})
+
+			// 4. Run as many tests as you need, they will each get a clean database
+			t.Run("Test querying empty DB", func(t *testing.T) {
+				t.Cleanup(func() {
+					err = ctr.Restore(ctx)
+					require.NoError(t, err)
+				})
+
+				conn, err := pgx.Connect(context.Background(), dbURL)
+				require.NoError(t, err)
+				defer conn.Close(context.Background())
+
+				var name string
+				var age int64
+				err = conn.QueryRow(context.Background(), "SELECT name, age FROM users LIMIT 1").Scan(&name, &age)
+				require.ErrorIs(t, err, pgx.ErrNoRows)
+			})
+			// }
 		})
-
-		conn, err := pgx.Connect(context.Background(), dbURL)
-		require.NoError(t, err)
-		defer conn.Close(context.Background())
-
-		var name string
-		var age int64
-		err = conn.QueryRow(context.Background(), "SELECT name, age FROM users LIMIT 1").Scan(&name, &age)
-		require.ErrorIs(t, err, pgx.ErrNoRows)
-	})
-	// }
+	}
 }
 
 func TestSnapshotWithOverrides(t *testing.T) {


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?

Restores the original behavior of the Postgres snapshot functionality, that would use a default snapshot name, if no snapshot name was specified.

## Why is it important?

Without this change, #2600 is a breaking change, that requires user to make changes to their test code, manually specifying a snapshot name.

## Related issues

- Fixes regression from #2600


## How to test this PR

Multiple test cases for the default and custom snapshot name were added to `postgres_test.TestSnapshot()`.

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
