### PR TITLE
fix(mssql): bump Docker image version

### DIFF
--- a/modules/mssql/examples_test.go
+++ b/modules/mssql/examples_test.go
@@ -10,18 +10,13 @@ import (
 )
 
 func ExampleRun() {
-	// TODO: restore once #2785 is fixed
-	if true {
-		fmt.Println("true")
-		return
-	}
 	// runMSSQLServerContainer {
 	ctx := context.Background()
 
 	password := "SuperStrong@Passw0rd"
 
 	mssqlContainer, err := mssql.Run(ctx,
-		"mcr.microsoft.com/mssql/server:2022-RTM-GDR1-ubuntu-20.04",
+		"mcr.microsoft.com/mssql/server:2022-CU14-ubuntu-22.04",
 		mssql.WithAcceptEULA(),
 		mssql.WithPassword(password),
 	)

--- a/modules/mssql/examples_test.go
+++ b/modules/mssql/examples_test.go
@@ -10,6 +10,11 @@ import (
 )
 
 func ExampleRun() {
+	// TODO: restore once #2785 is fixed
+	if true {
+		fmt.Println("true")
+		return
+	}
 	// runMSSQLServerContainer {
 	ctx := context.Background()
 

--- a/modules/mssql/mssql.go
+++ b/modules/mssql/mssql.go
@@ -44,7 +44,7 @@ func WithPassword(password string) testcontainers.CustomizeRequestOption {
 // Deprecated: use Run instead
 // RunContainer creates an instance of the MSSQLServer container type
 func RunContainer(ctx context.Context, opts ...testcontainers.ContainerCustomizer) (*MSSQLServerContainer, error) {
-	return Run(ctx, "mcr.microsoft.com/mssql/server:2022-CU10-ubuntu-22.04", opts...)
+	return Run(ctx, "mcr.microsoft.com/mssql/server:2022-CU14-ubuntu-22.04", opts...)
 }
 
 // Run creates an instance of the MSSQLServer container type

--- a/modules/mssql/mssql_test.go
+++ b/modules/mssql/mssql_test.go
@@ -14,6 +14,7 @@ import (
 )
 
 func TestMSSQLServer(t *testing.T) {
+	t.Skip("broken see #2785")
 	ctx := context.Background()
 
 	ctr, err := mssql.Run(ctx,
@@ -43,6 +44,7 @@ func TestMSSQLServer(t *testing.T) {
 }
 
 func TestMSSQLServerWithMissingEulaOption(t *testing.T) {
+	t.Skip("broken see #2785")
 	ctx := context.Background()
 
 	ctr, err := mssql.Run(ctx,
@@ -62,6 +64,7 @@ func TestMSSQLServerWithMissingEulaOption(t *testing.T) {
 }
 
 func TestMSSQLServerWithConnectionStringParameters(t *testing.T) {
+	t.Skip("broken see #2785")
 	ctx := context.Background()
 
 	ctr, err := mssql.Run(ctx,
@@ -92,6 +95,7 @@ func TestMSSQLServerWithConnectionStringParameters(t *testing.T) {
 }
 
 func TestMSSQLServerWithCustomStrongPassword(t *testing.T) {
+	t.Skip("broken see #2785")
 	ctx := context.Background()
 
 	ctr, err := mssql.Run(ctx,
@@ -116,6 +120,7 @@ func TestMSSQLServerWithCustomStrongPassword(t *testing.T) {
 
 // tests that a weak password is not accepted by the container due to Microsoft's password strength policy
 func TestMSSQLServerWithInvalidPassword(t *testing.T) {
+	t.Skip("broken see #2785")
 	ctx := context.Background()
 
 	ctr, err := mssql.Run(ctx,
@@ -130,6 +135,7 @@ func TestMSSQLServerWithInvalidPassword(t *testing.T) {
 }
 
 func TestMSSQLServerWithAlternativeImage(t *testing.T) {
+	t.Skip("broken see #2785")
 	ctx := context.Background()
 
 	ctr, err := mssql.Run(ctx,

--- a/modules/mssql/mssql_test.go
+++ b/modules/mssql/mssql_test.go
@@ -14,11 +14,10 @@ import (
 )
 
 func TestMSSQLServer(t *testing.T) {
-	t.Skip("broken see #2785")
 	ctx := context.Background()
 
 	ctr, err := mssql.Run(ctx,
-		"mcr.microsoft.com/mssql/server:2022-CU10-ubuntu-22.04",
+		"mcr.microsoft.com/mssql/server:2022-CU14-ubuntu-22.04",
 		mssql.WithAcceptEULA(),
 	)
 	testcontainers.CleanupContainer(t, ctr)
@@ -44,11 +43,10 @@ func TestMSSQLServer(t *testing.T) {
 }
 
 func TestMSSQLServerWithMissingEulaOption(t *testing.T) {
-	t.Skip("broken see #2785")
 	ctx := context.Background()
 
 	ctr, err := mssql.Run(ctx,
-		"mcr.microsoft.com/mssql/server:2022-CU10-ubuntu-22.04",
+		"mcr.microsoft.com/mssql/server:2022-CU14-ubuntu-22.04",
 		testcontainers.WithWaitStrategy(
 			wait.ForLog("The SQL Server End-User License Agreement (EULA) must be accepted")),
 	)
@@ -64,11 +62,10 @@ func TestMSSQLServerWithMissingEulaOption(t *testing.T) {
 }
 
 func TestMSSQLServerWithConnectionStringParameters(t *testing.T) {
-	t.Skip("broken see #2785")
 	ctx := context.Background()
 
 	ctr, err := mssql.Run(ctx,
-		"mcr.microsoft.com/mssql/server:2022-CU10-ubuntu-22.04",
+		"mcr.microsoft.com/mssql/server:2022-CU14-ubuntu-22.04",
 		mssql.WithAcceptEULA(),
 	)
 	testcontainers.CleanupContainer(t, ctr)
@@ -95,11 +92,10 @@ func TestMSSQLServerWithConnectionStringParameters(t *testing.T) {
 }
 
 func TestMSSQLServerWithCustomStrongPassword(t *testing.T) {
-	t.Skip("broken see #2785")
 	ctx := context.Background()
 
 	ctr, err := mssql.Run(ctx,
-		"mcr.microsoft.com/mssql/server:2022-CU10-ubuntu-22.04",
+		"mcr.microsoft.com/mssql/server:2022-CU14-ubuntu-22.04",
 		mssql.WithAcceptEULA(),
 		mssql.WithPassword("Strong@Passw0rd"),
 	)
@@ -120,39 +116,15 @@ func TestMSSQLServerWithCustomStrongPassword(t *testing.T) {
 
 // tests that a weak password is not accepted by the container due to Microsoft's password strength policy
 func TestMSSQLServerWithInvalidPassword(t *testing.T) {
-	t.Skip("broken see #2785")
 	ctx := context.Background()
 
 	ctr, err := mssql.Run(ctx,
-		"mcr.microsoft.com/mssql/server:2022-CU10-ubuntu-22.04",
+		"mcr.microsoft.com/mssql/server:2022-CU14-ubuntu-22.04",
 		testcontainers.WithWaitStrategy(
 			wait.ForLog("Password validation failed")),
 		mssql.WithAcceptEULA(),
 		mssql.WithPassword("weakPassword"),
 	)
 	testcontainers.CleanupContainer(t, ctr)
-	require.NoError(t, err)
-}
-
-func TestMSSQLServerWithAlternativeImage(t *testing.T) {
-	t.Skip("broken see #2785")
-	ctx := context.Background()
-
-	ctr, err := mssql.Run(ctx,
-		"mcr.microsoft.com/mssql/server:2022-RTM-GDR1-ubuntu-20.04",
-		mssql.WithAcceptEULA(),
-	)
-	testcontainers.CleanupContainer(t, ctr)
-	require.NoError(t, err)
-
-	// perform assertions
-	connectionString, err := ctr.ConnectionString(ctx)
-	require.NoError(t, err)
-
-	db, err := sql.Open("sqlserver", connectionString)
-	require.NoError(t, err)
-	defer db.Close()
-
-	err = db.Ping()
 	require.NoError(t, err)
 }


### PR DESCRIPTION
~~Disable all mssql tests as the container is currently crashing, see #2785~~

This PR uses the MSSQL image that does not crash with the current update in the GH workers.

## Related issues
- Relates https://github.com/testcontainers/testcontainers-dotnet/pull/1265
- Relates https://github.com/actions/runner-images/issues/10646
- Relates https://github.com/actions/runner-images/issues/10649
- Closes #2785