### PR TITLE
chore: golangci-lint 1.61.0

### DIFF
--- a/.github/workflows/ci-test-go.yml
+++ b/.github/workflows/ci-test-go.yml
@@ -73,7 +73,7 @@ jobs:
 
       - name: golangci-lint
         if: ${{ inputs.platform == 'ubuntu-latest' }}
-        uses: golangci/golangci-lint-action@9d1e0624a798bb64f6c3cea93db47765312263dc # v5
+        uses: golangci/golangci-lint-action@aaa42aa0628b4ae2578232a66b541047968fac86 # v6.1.0
         with:
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
           version: v1.59.1

--- a/.github/workflows/ci-test-go.yml
+++ b/.github/workflows/ci-test-go.yml
@@ -76,7 +76,7 @@ jobs:
         uses: golangci/golangci-lint-action@aaa42aa0628b4ae2578232a66b541047968fac86 # v6.1.0
         with:
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
-          version: v1.59.1
+          version: v1.61.0
           # Optional: working directory, useful for monorepos
           working-directory: ${{ inputs.project-directory }}
           # Optional: golangci-lint command line arguments.

--- a/commons-test.mk
+++ b/commons-test.mk
@@ -6,7 +6,7 @@ define go_install
 endef
 
 $(GOBIN)/golangci-lint:
-	$(call go_install,github.com/golangci/golangci-lint/cmd/golangci-lint@v1.59.1)
+	$(call go_install,github.com/golangci/golangci-lint/cmd/golangci-lint@v1.61.0)
 
 $(GOBIN)/gotestsum:
 	$(call go_install,gotest.tools/gotestsum@latest)

--- a/container.go
+++ b/container.go
@@ -520,7 +520,7 @@ func (c *ContainerRequest) validateMounts() error {
 
 	c.HostConfigModifier(&hostConfig)
 
-	if hostConfig.Binds != nil && len(hostConfig.Binds) > 0 {
+	if len(hostConfig.Binds) > 0 {
 		for _, bind := range hostConfig.Binds {
 			parts := strings.Split(bind, ":")
 			if len(parts) != 2 {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -517,7 +516,7 @@ func TestReadTCConfig(t *testing.T) {
 			},
 		}
 		for _, tt := range tests {
-			t.Run(fmt.Sprintf(tt.name), func(t *testing.T) {
+			t.Run(tt.name, func(t *testing.T) {
 				tmpDir := t.TempDir()
 				t.Setenv("HOME", tmpDir)
 				t.Setenv("USERPROFILE", tmpDir) // Windows support

--- a/modules/consul/consul_test.go
+++ b/modules/consul/consul_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	capi "github.com/hashicorp/consul/api"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/testcontainers/testcontainers-go"
@@ -47,11 +46,11 @@ func TestConsul(t *testing.T) {
 			// Check if API is up
 			host, err := ctr.ApiEndpoint(ctx)
 			require.NoError(t, err)
-			assert.NotEmpty(t, len(host))
+			require.NotEmpty(t, host)
 
 			res, err := http.Get("http://" + host)
 			require.NoError(t, err)
-			assert.Equal(t, http.StatusOK, res.StatusCode)
+			require.Equal(t, http.StatusOK, res.StatusCode)
 
 			cfg := capi.DefaultConfig()
 			cfg.Address = host


### PR DESCRIPTION
Update golangci-lint to v1.61.0 and update the action to v6.1.0.