### PR TITLE
fix: container logging deadlocks

### DIFF
--- a/docker_test.go
+++ b/docker_test.go
@@ -240,6 +240,15 @@ func TestContainerReturnItsContainerID(t *testing.T) {
 	}
 }
 
+// testLogConsumer is a simple implementation of LogConsumer that logs to the test output.
+type testLogConsumer struct {
+	t *testing.T
+}
+
+func (l *testLogConsumer) Accept(log Log) {
+	l.t.Log(log.LogType + ": " + strings.TrimSpace(string(log.Content)))
+}
+
 func TestContainerTerminationResetsState(t *testing.T) {
 	ctx := context.Background()
 
@@ -249,6 +258,9 @@ func TestContainerTerminationResetsState(t *testing.T) {
 			Image: nginxAlpineImage,
 			ExposedPorts: []string{
 				nginxDefaultPort,
+			},
+			LogConsumerCfg: &LogConsumerConfig{
+				Consumers: []LogConsumer{&testLogConsumer{t: t}},
 			},
 		},
 		Started: true,
@@ -273,6 +285,9 @@ func TestContainerStateAfterTermination(t *testing.T) {
 				Image: nginxAlpineImage,
 				ExposedPorts: []string{
 					nginxDefaultPort,
+				},
+				LogConsumerCfg: &LogConsumerConfig{
+					Consumers: []LogConsumer{&testLogConsumer{t: t}},
 				},
 			},
 			Started: true,

--- a/lifecycle.go
+++ b/lifecycle.go
@@ -190,7 +190,6 @@ var defaultLogConsumersHook = func(cfg *LogConsumerConfig) ContainerLifecycleHoo
 				}
 
 				dockerContainer := c.(*DockerContainer)
-
 				return dockerContainer.stopLogProduction()
 			},
 		},


### PR DESCRIPTION
Refactor container log handling simplifying the logic fixing various issues with error handling and race conditions between the complex combinations of multiple channels that have been causing random deadlocks in tests.

The new version has simple for loop with an inter call to ContainerLogs and stdcopy.StdCopy leveraging an adapter between io.Writer and LogConsumer.

This could be used to easily expose separate stdout and stderr handlers.