### PR TITLE
fix(registry): wait for

### DIFF
--- a/docker_auth_test.go
+++ b/docker_auth_test.go
@@ -286,7 +286,7 @@ func prepareLocalRegistryWithAuth(t *testing.T) string {
 				ContainerFilePath: "/data",
 			},
 		},
-		WaitingFor: wait.ForExposedPort(),
+		WaitingFor: wait.ForHTTP("/").WithPort("5000/tcp"),
 	}
 	// }
 
@@ -310,9 +310,6 @@ func prepareLocalRegistryWithAuth(t *testing.T) string {
 	t.Cleanup(func() {
 		removeImageFromLocalCache(t, addr+"/redis:5.0-alpine")
 	})
-
-	_, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
 
 	return addr
 }

--- a/modules/registry/registry.go
+++ b/modules/registry/registry.go
@@ -220,10 +220,9 @@ func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustom
 			// convenient for testing
 			"REGISTRY_STORAGE_DELETE_ENABLED": "true",
 		},
-		WaitingFor: wait.ForAll(
-			wait.ForExposedPort(),
-			wait.ForLog("listening on [::]:5000").WithStartupTimeout(10*time.Second),
-		),
+		WaitingFor: wait.ForHTTP("/").
+			WithPort(registryPort).
+			WithStartupTimeout(10 * time.Second),
 	}
 
 	genericContainerReq := testcontainers.GenericContainerRequest{


### PR DESCRIPTION
Switch registry containers to wait for http response to ensure the container is ready to serve requests, which was causing random test failures.

Also remove unnecessary context creation.