### PR TITLE
fix(grafana): update module path

### DIFF
--- a/modules/grafana-lgtm/examples_test.go
+++ b/modules/grafana-lgtm/examples_test.go
@@ -27,7 +27,7 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"github.com/testcontainers/testcontainers-go"
-	"github.com/testcontainers/testcontainers-go/modules/grafanalgtm"
+	grafanalgtm "github.com/testcontainers/testcontainers-go/modules/grafana-lgtm"
 )
 
 func ExampleRun() {

--- a/modules/grafana-lgtm/go.mod
+++ b/modules/grafana-lgtm/go.mod
@@ -1,4 +1,4 @@
-module github.com/testcontainers/testcontainers-go/modules/grafanalgtm
+module github.com/testcontainers/testcontainers-go/modules/grafana-lgtm
 
 go 1.22
 

--- a/modules/grafana-lgtm/grafana_test.go
+++ b/modules/grafana-lgtm/grafana_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/testcontainers/testcontainers-go"
-	"github.com/testcontainers/testcontainers-go/modules/grafanalgtm"
+	grafanalgtm "github.com/testcontainers/testcontainers-go/modules/grafana-lgtm"
 )
 
 func TestGrafanaLGTM(t *testing.T) {


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
It updates the module path from `grafanalgtm` to `grafana-lgtm`.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
During the release process of the modules, the git tag for each module uses the directory name as tag name, so it was wrong for grafana: its directory is `grafana-lgtm` and the module used `grafanalgtm`.

As a consequence, the pkg.go.dev site did not recognize the Grafana module.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes #2745

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
