### PR TITLE
docs: go get latest (potentially untagged) module in quickstart

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -12,7 +12,7 @@ Please read the [system requirements](../system_requirements/) page before you s
 We use [go mod](https://blog.golang.org/using-go-modules) and you can get it installed via:
 
 ```
-go get github.com/testcontainers/testcontainers-go
+go get github.com/testcontainers/testcontainers-go@main
 ```
 
 ## 3. Spin up Redis


### PR DESCRIPTION
Using a go get without the version installs the latest tagged release. The documentation on the website can be more recent, potentially relying on functionality that's not in the latest tagged release yet.


## What does this PR do?

Instruct to go get @main in quickstart.

## Why is it important?

Using a go get without the version installs the latest tagged release. The documentation on the website can be more recent, potentially relying on functionality that's not in the latest tagged release yet.

## Related issues

#511