### PR TITLE
fix: update module container struct name and missing imports

### DIFF
--- a/modulegen/_template/examples_test.go.tmpl
+++ b/modulegen/_template/examples_test.go.tmpl
@@ -1,15 +1,15 @@
-{{ $entrypoint := Entrypoint }}{{ $image := Image }}{{ $lower := ToLower }}{{ $title := Title }}package {{ $lower }}_test
+{{ $entrypoint := Entrypoint }}{{ $image := Image }}{{ $lower := ToLower }}package {{ $lower }}_test
 
 import (
 	"context"
 	"fmt"
 	"log"
 
+	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/{{ ParentDir }}/{{ $lower }}"
 )
 
 func Example{{ $entrypoint }}() {
-	// run{{ $title }}Container {
 	ctx := context.Background()
 
 	{{ $lower }}Container, err := {{ $lower }}.{{ $entrypoint }}(ctx, "{{ $image }}")

--- a/modulegen/_template/module.go.tmpl
+++ b/modulegen/_template/module.go.tmpl
@@ -7,13 +7,13 @@ import (
 	"github.com/testcontainers/testcontainers-go"
 )
 
-// {{ $containerName }} represents the {{ $title }} container type used in the module
-type {{ $containerName }} struct {
+// Container represents the {{ $title }} container type used in the module
+type Container struct {
 	testcontainers.Container
 }
 
 // {{ $entrypoint }} creates an instance of the {{ $title }} container type
-func {{ $entrypoint }}(ctx context.Context, img string, opts ...testcontainers.ContainerCustomizer) (*{{ $containerName }}, error) {
+func {{ $entrypoint }}(ctx context.Context, img string, opts ...testcontainers.ContainerCustomizer) (*Container, error) {
 	req := testcontainers.ContainerRequest{
 		Image: img,
 	}
@@ -30,9 +30,9 @@ func {{ $entrypoint }}(ctx context.Context, img string, opts ...testcontainers.C
 	}
 
 	container, err := testcontainers.GenericContainer(ctx, genericContainerReq)
-	var c *{{ $containerName }}
+	var c *Container
 	if container != nil {
-		c = &{{ $containerName }}{Container: container}
+		c = &Container{Container: container}
 	}
 
 	if err != nil {

--- a/modulegen/_template/module.md.tmpl
+++ b/modulegen/_template/module.md.tmpl
@@ -1,4 +1,4 @@
-{{ $lower := ToLower }}{{ $title := Title }}# {{ $title }}
+{{ $entrypoint := Entrypoint }}{{ $lower := ToLower }}{{ $title := Title }}# {{ $title }}
 
 Not available until the next release of testcontainers-go <a href="https://github.com/testcontainers/testcontainers-go"><span class="tc-version">:material-tag: main</span></a>
 
@@ -17,7 +17,7 @@ go get github.com/testcontainers/testcontainers-go/{{ ParentDir }}/{{ $lower }}
 ## Usage example
 
 <!--codeinclude-->
-[Creating a {{ $title }} container](../../{{ ParentDir }}/{{ $lower }}/examples_test.go) inside_block:run{{ $title }}Container
+[Creating a {{ $title }} container](../../{{ ParentDir }}/{{ $lower }}/examples_test.go) inside_block:Example{{ $entrypoint }}
 <!--/codeinclude-->
 
 ## Module Reference

--- a/modulegen/_template/module_test.go.tmpl
+++ b/modulegen/_template/module_test.go.tmpl
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/{{ ParentDir }}/{{ $lower }}"
 )
 

--- a/modulegen/internal/context/types.go
+++ b/modulegen/internal/context/types.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
-	"unicode"
-	"unicode/utf8"
 
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
@@ -22,16 +20,7 @@ type TestcontainersModule struct {
 // ContainerName returns the name of the container, which is the lower-cased title of the example
 // If the title is set, it will be used instead of the name
 func (m *TestcontainersModule) ContainerName() string {
-	name := m.Lower()
-
-	if m.IsModule {
-		name = m.Title()
-	} else if m.TitleName != "" {
-		r, n := utf8.DecodeRuneInString(m.TitleName)
-		name = string(unicode.ToLower(r)) + m.TitleName[n:]
-	}
-
-	return name + "Container"
+	return "Container"
 }
 
 // Entrypoint returns the name of the entrypoint function, which is the lower-cased title of the example

--- a/modulegen/main_test.go
+++ b/modulegen/main_test.go
@@ -17,11 +17,10 @@ import (
 
 func TestModule(t *testing.T) {
 	tests := []struct {
-		name                  string
-		module                context.TestcontainersModule
-		expectedContainerName string
-		expectedEntrypoint    string
-		expectedTitle         string
+		name               string
+		module             context.TestcontainersModule
+		expectedEntrypoint string
+		expectedTitle      string
 	}{
 		{
 			name: "Module with title",
@@ -31,9 +30,8 @@ func TestModule(t *testing.T) {
 				Image:     "mongodb:latest",
 				TitleName: "MongoDB",
 			},
-			expectedContainerName: "MongoDBContainer",
-			expectedEntrypoint:    "Run",
-			expectedTitle:         "MongoDB",
+			expectedEntrypoint: "Run",
+			expectedTitle:      "MongoDB",
 		},
 		{
 			name: "Module without title",
@@ -42,9 +40,8 @@ func TestModule(t *testing.T) {
 				IsModule: true,
 				Image:    "mongodb:latest",
 			},
-			expectedContainerName: "MongodbContainer",
-			expectedEntrypoint:    "Run",
-			expectedTitle:         "Mongodb",
+			expectedEntrypoint: "Run",
+			expectedTitle:      "Mongodb",
 		},
 		{
 			name: "Example with title",
@@ -54,9 +51,8 @@ func TestModule(t *testing.T) {
 				Image:     "mongodb:latest",
 				TitleName: "MongoDB",
 			},
-			expectedContainerName: "mongoDBContainer",
-			expectedEntrypoint:    "run",
-			expectedTitle:         "MongoDB",
+			expectedEntrypoint: "run",
+			expectedTitle:      "MongoDB",
 		},
 		{
 			name: "Example without title",
@@ -65,9 +61,9 @@ func TestModule(t *testing.T) {
 				IsModule: false,
 				Image:    "mongodb:latest",
 			},
-			expectedContainerName: "mongodbContainer",
-			expectedEntrypoint:    "run",
-			expectedTitle:         "Mongodb",
+
+			expectedEntrypoint: "run",
+			expectedTitle:      "Mongodb",
 		},
 	}
 
@@ -77,7 +73,7 @@ func TestModule(t *testing.T) {
 
 			assert.Equal(t, "mongodb", module.Lower())
 			assert.Equal(t, test.expectedTitle, module.Title())
-			assert.Equal(t, test.expectedContainerName, module.ContainerName())
+			assert.Equal(t, "Container", module.ContainerName())
 			assert.Equal(t, test.expectedEntrypoint, module.Entrypoint())
 		})
 	}
@@ -366,6 +362,7 @@ func assertModuleDocContent(t *testing.T, module context.TestcontainersModule, m
 
 	lower := module.Lower()
 	title := module.Title()
+	entrypoint := module.Entrypoint()
 
 	data := sanitiseContent(content)
 	assert.Equal(t, "# "+title, data[0])
@@ -376,7 +373,7 @@ func assertModuleDocContent(t *testing.T, module context.TestcontainersModule, m
 	assert.Equal(t, "Please run the following command to add the "+title+" module to your Go dependencies:", data[10])
 	assert.Equal(t, "go get github.com/testcontainers/testcontainers-go/"+module.ParentDir()+"/"+lower, data[13])
 	assert.Equal(t, "<!--codeinclude-->", data[18])
-	assert.Equal(t, "[Creating a "+title+" container](../../"+module.ParentDir()+"/"+lower+"/examples_test.go) inside_block:run"+title+"Container", data[19])
+	assert.Equal(t, "[Creating a "+title+" container](../../"+module.ParentDir()+"/"+lower+"/examples_test.go) inside_block:Example"+entrypoint, data[19])
 	assert.Equal(t, "<!--/codeinclude-->", data[20])
 	assert.Equal(t, "The "+title+" module exposes one entrypoint function to create the "+title+" container, and this function receives three parameters:", data[31])
 	assert.True(t, strings.HasSuffix(data[34], "(*"+title+"Container, error)"))
@@ -391,13 +388,12 @@ func assertExamplesTestContent(t *testing.T, module context.TestcontainersModule
 
 	lower := module.Lower()
 	entrypoint := module.Entrypoint()
-	title := module.Title()
 
 	data := sanitiseContent(content)
 	assert.Equal(t, "package "+lower+"_test", data[0])
-	assert.Equal(t, "\t\"github.com/testcontainers/testcontainers-go/modules/"+lower+"\"", data[7])
-	assert.Equal(t, "func Example"+entrypoint+"() {", data[10])
-	assert.Equal(t, "\t// run"+title+"Container {", data[11])
+	assert.Equal(t, "\t\"github.com/testcontainers/testcontainers-go\"", data[7])
+	assert.Equal(t, "\t\"github.com/testcontainers/testcontainers-go/modules/"+lower+"\"", data[8])
+	assert.Equal(t, "func Example"+entrypoint+"() {", data[11])
 	assert.Equal(t, "\t"+lower+"Container, err := "+lower+"."+entrypoint+"(ctx, \""+module.Image+"\")", data[14])
 	assert.Equal(t, "\tfmt.Println(state.Running)", data[32])
 	assert.Equal(t, "\t// Output:", data[34])
@@ -411,8 +407,8 @@ func assertModuleTestContent(t *testing.T, module context.TestcontainersModule, 
 
 	data := sanitiseContent(content)
 	assert.Equal(t, "package "+module.Lower()+"_test", data[0])
-	assert.Equal(t, "func Test"+module.Title()+"(t *testing.T) {", data[11])
-	assert.Equal(t, "\tctr, err := "+module.Lower()+"."+module.Entrypoint()+"(ctx, \""+module.Image+"\")", data[14])
+	assert.Equal(t, "func Test"+module.Title()+"(t *testing.T) {", data[12])
+	assert.Equal(t, "\tctr, err := "+module.Lower()+"."+module.Entrypoint()+"(ctx, \""+module.Image+"\")", data[15])
 }
 
 // assert content module
@@ -427,7 +423,7 @@ func assertModuleContent(t *testing.T, module context.TestcontainersModule, exam
 
 	data := sanitiseContent(content)
 	require.Equal(t, "package "+lower, data[0])
-	require.Equal(t, "// "+containerName+" represents the "+exampleName+" container type used in the module", data[9])
+	require.Equal(t, "// Container represents the "+exampleName+" container type used in the module", data[9])
 	require.Equal(t, "type "+containerName+" struct {", data[10])
 	require.Equal(t, "// "+entrypoint+" creates an instance of the "+exampleName+" container type", data[14])
 	require.Equal(t, "func "+entrypoint+"(ctx context.Context, img string, opts ...testcontainers.ContainerCustomizer) (*"+containerName+", error) {", data[15])


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?

Fixes the following in modulegen : 
- The generated name of the struct for the module is now `Container` leading to more idiomatic go (e.g postgres.Container)
- Missing imports in test generated files
- Removed `// run{{ $title }}Container {` from the example test as we can use the name of the Example{{$entrypoint}} instead

## Why is it important?

New generated modules will be more idiomatic and won't have to fix imports manually

## Related issues

No related issue but a request was made in this PR https://github.com/testcontainers/testcontainers-go/pull/2825#discussion_r1801841535 to name the container struct as `Container` from now on in preparation of v1

## How to test this PR

Generate a new module