### PR TITLE
chore: update ryuk to 0.10.2

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -11,7 +11,7 @@ import (
 	"github.com/magiconair/properties"
 )
 
-const ReaperDefaultImage = "testcontainers/ryuk:0.10.0"
+const ReaperDefaultImage = "testcontainers/ryuk:0.10.2"
 
 var (
 	tcConfig     Config


### PR DESCRIPTION
Update the ryuk version so that shutdown processing is fast after a TERM signal.