### PR TITLE
golangci-lint: enable thelper linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,14 +1,15 @@
 linters:
   enable:
+    - errcheck
     - errorlint
     - gci
     - gocritic
     - gofumpt
     - misspell
+    - nolintlint
     - nonamedreturns
     - testifylint
-    - errcheck
-    - nolintlint
+    - thelper
 
 linters-settings:
   errorlint:
@@ -30,16 +31,6 @@ linters-settings:
     disable:
       - float-compare
       - go-require
-    enable:
-      - bool-compare
-      - compares
-      - empty
-      - error-is-as
-      - error-nil
-      - expected-actual
-      - len
-      - require-error
-      - suite-dont-use-pkg
-      - suite-extra-assert-call
+    enable-all: true
 run:
   timeout: 5m

--- a/docker_auth_test.go
+++ b/docker_auth_test.go
@@ -170,6 +170,7 @@ func TestBuildContainerFromDockerfile(t *testing.T) {
 
 // removeImageFromLocalCache removes the image from the local cache
 func removeImageFromLocalCache(t *testing.T, img string) {
+	t.Helper()
 	ctx := context.Background()
 
 	testcontainersClient, err := NewDockerClientWithOpts(ctx, client.WithVersion(daemonMaxVersion))
@@ -263,6 +264,7 @@ func TestCreateContainerFromPrivateRegistry(t *testing.T) {
 }
 
 func prepareLocalRegistryWithAuth(t *testing.T) string {
+	t.Helper()
 	ctx := context.Background()
 	wd, err := os.Getwd()
 	require.NoError(t, err)
@@ -359,6 +361,7 @@ func setAuthConfig(t *testing.T, host, username, password string) string {
 // which can be used to connect to the local registry.
 // This avoids the issues with localhost on WSL.
 func localAddress(t *testing.T) string {
+	t.Helper()
 	if os.Getenv("WSL_DISTRO_NAME") == "" {
 		return "localhost"
 	}

--- a/docker_test.go
+++ b/docker_test.go
@@ -1345,6 +1345,7 @@ func TestContainerInspect_RawInspectIsCleanedOnStop(t *testing.T) {
 }
 
 func readHostname(tb testing.TB, containerId string) string {
+	tb.Helper()
 	containerClient, err := NewDockerClientWithOpts(context.Background())
 	if err != nil {
 		tb.Fatalf("Failed to create Docker client: %v", err)
@@ -1917,6 +1918,7 @@ func TestNetworkModeWithContainerReference(t *testing.T) {
 
 // creates a temporary dir in which the files will be extracted. Then it will compare the bytes of each file in the source with the bytes from the copied-from-container file
 func assertExtractedFiles(t *testing.T, ctx context.Context, container Container, hostFilePath string, containerFilePath string) {
+	t.Helper()
 	// create all copied files into a temporary dir
 	tmpDir := t.TempDir()
 

--- a/generic_test.go
+++ b/generic_test.go
@@ -164,6 +164,7 @@ func TestGenericReusableContainerInSubprocess(t *testing.T) {
 }
 
 func createReuseContainerInSubprocess(t *testing.T) string {
+	t.Helper()
 	// force verbosity in subprocesses, so that the output is printed
 	cmd := exec.Command(os.Args[0], "-test.run=TestHelperContainerStarterProcess", "-test.v=true")
 	cmd.Env = append(os.Environ(), "GO_WANT_HELPER_PROCESS=1")

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -19,6 +19,7 @@ const (
 // unset environment variables to avoid side effects
 // execute this function before each test
 func resetTestEnv(t *testing.T) {
+	t.Helper()
 	t.Setenv("TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX", "")
 	t.Setenv("TESTCONTAINERS_RYUK_DISABLED", "")
 	t.Setenv("TESTCONTAINERS_RYUK_CONTAINER_PRIVILEGED", "")

--- a/internal/core/docker_host_test.go
+++ b/internal/core/docker_host_test.go
@@ -50,6 +50,7 @@ func testCallbackCheckError(_ context.Context, _ string) error {
 }
 
 func mockCallbackCheck(t *testing.T, fn func(_ context.Context, _ string) error) {
+	t.Helper()
 	oldCheck := dockerHostCheck
 	dockerHostCheck = fn
 	t.Cleanup(func() {
@@ -515,10 +516,12 @@ func createTmpDockerSocket(parent string) error {
 // setupDockerHostNotFound sets up the environment for the test case where the DOCKER_HOST environment variable is
 // already set (e.g. rootless docker) therefore we need to unset it before the test
 func setupDockerHostNotFound(t *testing.T) {
+	t.Helper()
 	t.Setenv("DOCKER_HOST", "")
 }
 
 func setupDockerSocket(t *testing.T) string {
+	t.Helper()
 	t.Cleanup(func() {
 		DockerSocketPath = originalDockerSocketPath
 		DockerSocketPathWithSchema = originalDockerSocketPathWithSchema
@@ -536,6 +539,7 @@ func setupDockerSocket(t *testing.T) string {
 }
 
 func setupDockerSocketNotFound(t *testing.T) {
+	t.Helper()
 	t.Cleanup(func() {
 		DockerSocketPath = originalDockerSocketPath
 		DockerSocketPathWithSchema = originalDockerSocketPathWithSchema
@@ -548,6 +552,7 @@ func setupDockerSocketNotFound(t *testing.T) {
 }
 
 func setupTestcontainersProperties(t *testing.T, content string) {
+	t.Helper()
 	t.Cleanup(func() {
 		// reset the properties file after the test
 		config.Reset()

--- a/internal/core/docker_rootless_test.go
+++ b/internal/core/docker_rootless_test.go
@@ -184,6 +184,7 @@ func TestRootlessDockerSocketPath(t *testing.T) {
 }
 
 func setupRootlessNotFound(t *testing.T) {
+	t.Helper()
 	t.Cleanup(func() {
 		baseRunDir = originalBaseRunDir
 		os.Setenv("XDG_RUNTIME_DIR", originalXDGRuntimeDir)

--- a/modulegen/context_test.go
+++ b/modulegen/context_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 func getTestRootContext(t *testing.T) context.Context {
+	t.Helper()
 	current, err := os.Getwd()
 	require.NoError(t, err)
 	return context.New(filepath.Dir(current))

--- a/modulegen/main_test.go
+++ b/modulegen/main_test.go
@@ -357,6 +357,7 @@ func TestGenerateModule(t *testing.T) {
 
 // assert content module file in the docs
 func assertModuleDocContent(t *testing.T, module context.TestcontainersModule, moduleDocFile string) {
+	t.Helper()
 	content, err := os.ReadFile(moduleDocFile)
 	require.NoError(t, err)
 
@@ -383,6 +384,7 @@ func assertModuleDocContent(t *testing.T, module context.TestcontainersModule, m
 
 // assert content module test
 func assertExamplesTestContent(t *testing.T, module context.TestcontainersModule, examplesTestFile string) {
+	t.Helper()
 	content, err := os.ReadFile(examplesTestFile)
 	require.NoError(t, err)
 
@@ -402,6 +404,7 @@ func assertExamplesTestContent(t *testing.T, module context.TestcontainersModule
 
 // assert content module test
 func assertModuleTestContent(t *testing.T, module context.TestcontainersModule, exampleTestFile string) {
+	t.Helper()
 	content, err := os.ReadFile(exampleTestFile)
 	require.NoError(t, err)
 
@@ -413,6 +416,7 @@ func assertModuleTestContent(t *testing.T, module context.TestcontainersModule, 
 
 // assert content module
 func assertModuleContent(t *testing.T, module context.TestcontainersModule, exampleFile string) {
+	t.Helper()
 	content, err := os.ReadFile(exampleFile)
 	require.NoError(t, err)
 
@@ -437,6 +441,7 @@ func assertModuleContent(t *testing.T, module context.TestcontainersModule, exam
 
 // assert content GitHub workflow for the module
 func assertModuleGithubWorkflowContent(t *testing.T, moduleWorkflowFile string) {
+	t.Helper()
 	content, err := os.ReadFile(moduleWorkflowFile)
 	require.NoError(t, err)
 
@@ -454,6 +459,7 @@ func assertModuleGithubWorkflowContent(t *testing.T, moduleWorkflowFile string) 
 
 // assert content go.mod
 func assertGoModContent(t *testing.T, module context.TestcontainersModule, tcVersion string, goModFile string) {
+	t.Helper()
 	content, err := os.ReadFile(goModFile)
 	require.NoError(t, err)
 
@@ -465,6 +471,7 @@ func assertGoModContent(t *testing.T, module context.TestcontainersModule, tcVer
 
 // assert content Makefile
 func assertMakefileContent(t *testing.T, module context.TestcontainersModule, makefile string) {
+	t.Helper()
 	content, err := os.ReadFile(makefile)
 	require.NoError(t, err)
 
@@ -474,6 +481,7 @@ func assertMakefileContent(t *testing.T, module context.TestcontainersModule, ma
 
 // assert content in the nav items from mkdocs.yml
 func assertMkdocsNavItems(t *testing.T, module context.TestcontainersModule, originalConfig *mkdocs.Config, tmpCtx context.Context) {
+	t.Helper()
 	config, err := mkdocs.ReadConfig(tmpCtx.MkdocsConfigFile())
 	require.NoError(t, err)
 

--- a/modulegen/mkdocs_test.go
+++ b/modulegen/mkdocs_test.go
@@ -82,6 +82,7 @@ func TestNavItems(t *testing.T) {
 }
 
 func copyInitialMkdocsConfig(t *testing.T, tmpCtx context.Context) error {
+	t.Helper()
 	ctx := getTestRootContext(t)
 	return mkdocs.CopyConfig(ctx.MkdocsConfigFile(), tmpCtx.MkdocsConfigFile())
 }

--- a/modules/artemis/artemis_test.go
+++ b/modules/artemis/artemis_test.go
@@ -57,6 +57,7 @@ func TestArtemis(t *testing.T) {
 			user: "artemis",
 			pass: "artemis",
 			hook: func(t *testing.T, container *artemis.Container) {
+				t.Helper()
 				expectQueue(t, container, "ArgsTestQueue")
 			},
 		},

--- a/modules/clickhouse/clickhouse_test.go
+++ b/modules/clickhouse/clickhouse_test.go
@@ -254,6 +254,7 @@ func TestClickHouseWithZookeeper(t *testing.T) {
 }
 
 func performReplicatedCRUD(t *testing.T, conn driver.Conn) ([]Test, error) {
+	t.Helper()
 	return backoff.RetryNotifyWithData(
 		func() ([]Test, error) {
 			err := conn.Exec(context.Background(), "CREATE TABLE replicated_test_table (id UInt64) ENGINE = ReplicatedMergeTree('/clickhouse/tables/{shard}/mdb.data_transfer_cp_cdc', '{replica}') PRIMARY KEY (id) ORDER BY (id) SETTINGS index_granularity = 8192;")
@@ -292,6 +293,7 @@ func performReplicatedCRUD(t *testing.T, conn driver.Conn) ([]Test, error) {
 }
 
 func performCRUD(t *testing.T, conn driver.Conn) ([]Test, error) {
+	t.Helper()
 	return backoff.RetryNotifyWithData(
 		func() ([]Test, error) {
 			err := conn.Exec(context.Background(), "create table if not exists test_table (id UInt64) engine = MergeTree PRIMARY KEY (id) ORDER BY (id) SETTINGS index_granularity = 8192;")

--- a/modules/compose/compose_builder_test.go
+++ b/modules/compose/compose_builder_test.go
@@ -135,6 +135,7 @@ func getFreePort(t *testing.T) int {
 }
 
 func writeTemplate(t *testing.T, templateFile string, port ...int) string {
+	t.Helper()
 	return writeTemplateWithSrvType(t, templateFile, "api", port...)
 }
 

--- a/modules/compose/compose_test.go
+++ b/modules/compose/compose_test.go
@@ -446,6 +446,7 @@ func TestLocalDockerComposeWithVolume(t *testing.T) {
 }
 
 func assertVolumeDoesNotExist(tb testing.TB, volumeName string) {
+	tb.Helper()
 	containerClient, err := testcontainers.NewDockerClientWithOpts(context.Background())
 	if err != nil {
 		tb.Fatalf("Failed to get provider: %v", err)
@@ -471,6 +472,7 @@ func assertContainerEnvironmentVariables(
 	present map[string]string,
 	absent map[string]string,
 ) {
+	tb.Helper()
 	containerClient, err := testcontainers.NewDockerClientWithOpts(context.Background())
 	if err != nil {
 		tb.Fatalf("Failed to get provider: %v", err)

--- a/modules/couchbase/couchbase_test.go
+++ b/modules/couchbase/couchbase_test.go
@@ -113,6 +113,7 @@ func TestEventingServiceWithCommunityContainer(t *testing.T) {
 }
 
 func testBucketUsage(t *testing.T, bucket *gocb.Bucket) {
+	t.Helper()
 	err := bucket.WaitUntilReady(5*time.Second, nil)
 	if err != nil {
 		t.Fatalf("could not connect bucket: %s", err)

--- a/modules/dolt/dolt_test.go
+++ b/modules/dolt/dolt_test.go
@@ -70,6 +70,7 @@ func TestDoltWithPublicRemoteCloneUrl(t *testing.T) {
 }
 
 func createTestCredsFile(t *testing.T) string {
+	t.Helper()
 	file, err := os.CreateTemp(t.TempDir(), "prefix")
 	if err != nil {
 		t.Fatal(err)

--- a/modules/kafka/consumer_test.go
+++ b/modules/kafka/consumer_test.go
@@ -16,6 +16,7 @@ type TestKafkaConsumer struct {
 }
 
 func NewTestKafkaConsumer(t *testing.T) (*TestKafkaConsumer, <-chan bool, <-chan bool, func()) {
+	t.Helper()
 	kc := &TestKafkaConsumer{
 		t:      t,
 		ready:  make(chan bool, 1),

--- a/modules/kafka/kafka_test.go
+++ b/modules/kafka/kafka_test.go
@@ -84,6 +84,7 @@ func TestKafka_invalidVersion(t *testing.T) {
 // assertAdvertisedListeners checks that the advertised listeners are set correctly:
 // - The BROKER:// protocol is using the hostname of the Kafka container
 func assertAdvertisedListeners(t *testing.T, container testcontainers.Container) {
+	t.Helper()
 	inspect, err := container.Inspect(context.Background())
 	require.NoError(t, err)
 

--- a/modules/mariadb/mariadb_test.go
+++ b/modules/mariadb/mariadb_test.go
@@ -144,6 +144,7 @@ func TestMariaDBWithScripts(t *testing.T) {
 }
 
 func assertDataCanBeFetched(t *testing.T, ctx context.Context, container *mariadb.MariaDBContainer) {
+	t.Helper()
 	connectionString, err := container.ConnectionString(ctx)
 	require.NoError(t, err)
 	db, err := sql.Open("mysql", connectionString)

--- a/modules/neo4j/neo4j_test.go
+++ b/modules/neo4j/neo4j_test.go
@@ -163,6 +163,7 @@ func setupNeo4j(ctx context.Context) (*neo4j.Neo4jContainer, error) {
 }
 
 func createDriver(t *testing.T, ctx context.Context, container *neo4j.Neo4jContainer) neo.DriverWithContext {
+	t.Helper()
 	// boltURL {
 	boltUrl, err := container.BoltUrl(ctx)
 	// }
@@ -182,6 +183,7 @@ func createDriver(t *testing.T, ctx context.Context, container *neo4j.Neo4jConta
 }
 
 func getContainerEnv(t *testing.T, ctx context.Context, container *neo4j.Neo4jContainer) string {
+	t.Helper()
 	exec, reader, err := container.Exec(ctx, []string{"env"})
 	if err != nil {
 		t.Fatalf("expected env to successfully run but did not: %s", err)

--- a/modules/ollama/ollama_test.go
+++ b/modules/ollama/ollama_test.go
@@ -75,6 +75,7 @@ func TestOllama(t *testing.T) {
 // For that, it checks if the response of the /api/tags endpoint
 // contains the model name.
 func assertLoadedModel(t *testing.T, c *ollama.OllamaContainer) {
+	t.Helper()
 	url, err := c.ConnectionString(context.Background())
 	require.NoError(t, err)
 

--- a/modules/redis/redis_test.go
+++ b/modules/redis/redis_test.go
@@ -96,6 +96,7 @@ func TestRedisWithSnapshotting(t *testing.T) {
 }
 
 func assertSetsGets(t *testing.T, ctx context.Context, redisContainer *tcredis.RedisContainer, keyCount int) {
+	t.Helper()
 	// connectionString {
 	uri, err := redisContainer.ConnectionString(ctx)
 	// }
@@ -109,6 +110,7 @@ func assertSetsGets(t *testing.T, ctx context.Context, redisContainer *tcredis.R
 
 	client := redis.NewClient(options)
 	defer func(t *testing.T, ctx context.Context, client *redis.Client) {
+		t.Helper()
 		require.NoError(t, flushRedis(ctx, *client))
 	}(t, ctx, client)
 

--- a/modules/valkey/valkey_test.go
+++ b/modules/valkey/valkey_test.go
@@ -81,6 +81,7 @@ func TestValkeyWithSnapshotting(t *testing.T) {
 }
 
 func assertSetsGets(t *testing.T, ctx context.Context, valkeyContainer *tcvalkey.ValkeyContainer, keyCount int) {
+	t.Helper()
 	// connectionString {
 	uri, err := valkeyContainer.ConnectionString(ctx)
 	// }
@@ -95,6 +96,7 @@ func assertSetsGets(t *testing.T, ctx context.Context, valkeyContainer *tcvalkey
 	client, err := valkey.NewClient(options)
 	require.NoError(t, err)
 	defer func(t *testing.T, ctx context.Context, client *valkey.Client) {
+		t.Helper()
 		require.NoError(t, flushValkey(ctx, *client))
 	}(t, ctx, &client)
 

--- a/port_forwarding_test.go
+++ b/port_forwarding_test.go
@@ -112,6 +112,7 @@ func TestExposeHostPorts(t *testing.T) {
 }
 
 func httpRequest(t *testing.T, c testcontainers.Container, port int) (int, string) {
+	t.Helper()
 	// wgetHostInternal {
 	code, reader, err := c.Exec(
 		context.Background(),
@@ -129,6 +130,7 @@ func httpRequest(t *testing.T, c testcontainers.Container, port int) (int, strin
 }
 
 func assertContainerHasHostAccess(t *testing.T, c testcontainers.Container, ports ...int) {
+	t.Helper()
 	for _, port := range ports {
 		code, response := httpRequest(t, c, port)
 		if code != 0 {
@@ -142,6 +144,7 @@ func assertContainerHasHostAccess(t *testing.T, c testcontainers.Container, port
 }
 
 func assertContainerHasNoHostAccess(t *testing.T, c testcontainers.Container, ports ...int) {
+	t.Helper()
 	for _, port := range ports {
 		_, response := httpRequest(t, c, port)
 

--- a/reaper_test.go
+++ b/reaper_test.go
@@ -199,6 +199,7 @@ func testContainerStop(t *testing.T) {
 
 // testContainerTerminate tests terminating a container.
 func testContainerTerminate(t *testing.T) {
+	t.Helper()
 	ctx := context.Background()
 
 	nginxA, err := GenericContainer(ctx, GenericContainerRequest{

--- a/testing.go
+++ b/testing.go
@@ -19,6 +19,7 @@ var errAlreadyInProgress = regexp.MustCompile(`removal of container .* is alread
 // This is a function designed to be used in your test, when Docker is not mandatory for CI/CD.
 // In this way tests that depend on Testcontainers won't run if the provider is provisioned correctly.
 func SkipIfProviderIsNotHealthy(t *testing.T) {
+	t.Helper()
 	ctx := context.Background()
 	provider, err := ProviderDocker.GetProvider()
 	if err != nil {
@@ -33,6 +34,7 @@ func SkipIfProviderIsNotHealthy(t *testing.T) {
 // SkipIfDockerDesktop is a utility function capable of skipping tests
 // if tests are run using Docker Desktop.
 func SkipIfDockerDesktop(t *testing.T, ctx context.Context) {
+	t.Helper()
 	cli, err := NewDockerClientWithOpts(ctx)
 	if err != nil {
 		t.Fatalf("failed to create docker client: %s", err)


### PR DESCRIPTION
## What does this PR do?

Setup [thelper](https://golangci-lint.run/usage/linters/#thelper) linter and apply it’s recommandations .

## Why is it important?

Thelper detects tests helpers which is not start with t.Helper() method.

Signed-off-by: Matthieu MOREL <matthieu.morel35@gmail.com>