### PR TITLE
fix: enable formatter.require-f-funcs from testifylint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -32,5 +32,7 @@ linters-settings:
       - float-compare
       - go-require
     enable-all: true
+    formatter:
+      require-f-funcs: true
 run:
   timeout: 5m

--- a/container_test.go
+++ b/container_test.go
@@ -376,8 +376,7 @@ func Test_GetLogsFromFailedContainer(t *testing.T) {
 		Started:          true,
 	})
 	testcontainers.CleanupContainer(t, c)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "container exited with code 0")
+	require.ErrorContains(t, err, "container exited with code 0")
 
 	logs, logErr := c.Logs(ctx)
 	require.NoError(t, logErr)

--- a/docker_test.go
+++ b/docker_test.go
@@ -305,9 +305,9 @@ func TestContainerStateAfterTermination(t *testing.T) {
 		require.NoError(t, err)
 
 		state, err := nginx.State(ctx)
-		require.Error(t, err, "expected error from container inspect.")
+		require.Errorf(t, err, "expected error from container inspect.")
 
-		require.Nil(t, state, "expected nil container inspect.")
+		require.Nilf(t, state, "expected nil container inspect.")
 	})
 
 	t.Run("Nil State after termination if raw as already set", func(t *testing.T) {
@@ -317,16 +317,16 @@ func TestContainerStateAfterTermination(t *testing.T) {
 		require.NoError(t, err)
 
 		state, err := nginx.State(ctx)
-		require.NoError(t, err, "unexpected error from container inspect before container termination.")
-		require.NotNil(t, state, "unexpected nil container inspect before container termination.")
+		require.NoErrorf(t, err, "unexpected error from container inspect before container termination.")
+		require.NotNilf(t, state, "unexpected nil container inspect before container termination.")
 
 		// terminate the container before the raw state is set
 		err = nginx.Terminate(ctx)
 		require.NoError(t, err)
 
 		state, err = nginx.State(ctx)
-		require.Error(t, err, "expected error from container inspect after container termination.")
-		require.Nil(t, state, "unexpected nil container inspect after container termination.")
+		require.Errorf(t, err, "expected error from container inspect after container termination.")
+		require.Nilf(t, state, "unexpected nil container inspect after container termination.")
 	})
 }
 
@@ -678,7 +678,7 @@ func TestContainerCreationTimesOutWithHttp(t *testing.T) {
 		Started: true,
 	})
 	CleanupContainer(t, nginxC)
-	require.Error(t, err, "expected timeout")
+	require.Errorf(t, err, "expected timeout")
 }
 
 func TestContainerCreationWaitsForLogContextTimeout(t *testing.T) {
@@ -1477,8 +1477,8 @@ func TestDockerCreateContainerWithFiles(t *testing.T) {
 			})
 			CleanupContainer(t, nginxC)
 
-			if err != nil {
-				require.Contains(t, err.Error(), tc.errMsg)
+			if len(tc.errMsg) > 0 {
+				require.ErrorContains(t, err, tc.errMsg)
 			} else {
 				for _, f := range tc.files {
 					require.NoError(t, err)
@@ -1939,7 +1939,7 @@ func assertExtractedFiles(t *testing.T, ctx context.Context, container Container
 		// copy file by file, as there is a limitation in the Docker client to copy an entiry directory from the container
 		// paths for the container files are using Linux path separators
 		fd, err := container.CopyFileFromContainer(ctx, fp)
-		require.NoError(t, err, "Path not found in container: %s", fp)
+		require.NoErrorf(t, err, "Path not found in container: %s", fp)
 		defer fd.Close()
 
 		targetPath := filepath.Join(tmpDir, srcFile.Name())
@@ -2017,7 +2017,7 @@ func TestImageBuiltFromDockerfile_KeepBuiltImage(t *testing.T) {
 			ctx := context.Background()
 			// Set up CLI.
 			provider, err := NewDockerProvider()
-			require.NoError(t, err, "get docker provider should not fail")
+			require.NoErrorf(t, err, "get docker provider should not fail")
 			defer func() { _ = provider.Close() }()
 			cli := provider.Client()
 			// Create container.
@@ -2032,14 +2032,14 @@ func TestImageBuiltFromDockerfile_KeepBuiltImage(t *testing.T) {
 				},
 			})
 			CleanupContainer(t, c)
-			require.NoError(t, err, "create container should not fail")
+			require.NoErrorf(t, err, "create container should not fail")
 			// Get the image ID.
 			containerInspect, err := c.Inspect(ctx)
-			require.NoError(t, err, "container inspect should not fail")
+			require.NoErrorf(t, err, "container inspect should not fail")
 
 			containerName := containerInspect.Name
 			containerDetails, err := cli.ContainerInspect(ctx, containerName)
-			require.NoError(t, err, "inspect container should not fail")
+			require.NoErrorf(t, err, "inspect container should not fail")
 			containerImage := containerDetails.Image
 			t.Cleanup(func() {
 				_, _ = cli.ImageRemove(ctx, containerImage, image.RemoveOptions{
@@ -2049,12 +2049,12 @@ func TestImageBuiltFromDockerfile_KeepBuiltImage(t *testing.T) {
 			})
 			// Now, we terminate the container and check whether the image still exists.
 			err = c.Terminate(ctx)
-			require.NoError(t, err, "terminate container should not fail")
+			require.NoErrorf(t, err, "terminate container should not fail")
 			_, _, err = cli.ImageInspectWithRaw(ctx, containerImage)
 			if tt.keepBuiltImage {
-				require.NoError(t, err, "image should still exist")
+				require.NoErrorf(t, err, "image should still exist")
 			} else {
-				require.Error(t, err, "image should not exist any more")
+				require.Errorf(t, err, "image should not exist any more")
 			}
 		})
 	}

--- a/file_test.go
+++ b/file_test.go
@@ -45,9 +45,9 @@ func Test_IsDir(t *testing.T) {
 		t.Run(test.filepath, func(t *testing.T) {
 			result, err := isDir(test.filepath)
 			if test.err != nil {
-				require.Error(t, err, "expected error")
+				require.Errorf(t, err, "expected error")
 			} else {
-				require.NoError(t, err, "not expected error")
+				require.NoErrorf(t, err, "not expected error")
 			}
 			assert.Equal(t, test.expected, result)
 		})

--- a/generic_test.go
+++ b/generic_test.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"os"
 	"os/exec"
-	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -138,8 +137,8 @@ func TestGenericReusableContainerInSubprocess(t *testing.T) {
 
 			t.Log(output)
 			// check is reuse container with WaitingFor work correctly.
-			require.True(t, strings.Contains(output, "⏳ Waiting for container id"))
-			require.True(t, strings.Contains(output, "🔔 Container is ready"))
+			require.Contains(t, output, "⏳ Waiting for container id")
+			require.Contains(t, output, "🔔 Container is ready")
 		}()
 	}
 
@@ -170,7 +169,7 @@ func createReuseContainerInSubprocess(t *testing.T) string {
 	cmd.Env = append(os.Environ(), "GO_WANT_HELPER_PROCESS=1")
 
 	output, err := cmd.CombinedOutput()
-	require.NoError(t, err, string(output))
+	require.NoErrorf(t, err, string(output))
 
 	return string(output)
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -533,7 +533,7 @@ func TestReadTCConfig(t *testing.T) {
 				//
 				config := read()
 
-				assert.Equal(t, tt.expected, config, "Configuration doesn't not match")
+				assert.Equalf(t, tt.expected, config, "Configuration doesn't not match")
 			})
 		}
 	})

--- a/internal/core/images_test.go
+++ b/internal/core/images_test.go
@@ -222,7 +222,7 @@ func TestExtractRegistry(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			actual := ExtractRegistry(test.image, IndexDockerIO)
-			assert.Equal(t, test.expected, actual, "expected %s, got %s", test.expected, actual)
+			assert.Equalf(t, test.expected, actual, "expected %s, got %s", test.expected, actual)
 		})
 	}
 }

--- a/lifecycle_test.go
+++ b/lifecycle_test.go
@@ -75,18 +75,18 @@ func TestPreCreateModifierHook(t *testing.T) {
 
 		// assertions
 
-		assert.Equal(
+		assert.Equalf(
 			t,
 			[]string{"a=b"},
 			inputConfig.Env,
 			"Docker config's env should be overwritten by the modifier",
 		)
-		assert.Equal(t,
+		assert.Equalf(t,
 			nat.PortSet(nat.PortSet{"80/tcp": struct{}{}}),
 			inputConfig.ExposedPorts,
 			"Docker config's exposed ports should be overwritten by the modifier",
 		)
-		assert.Equal(
+		assert.Equalf(
 			t,
 			[]mount.Mount{
 				{
@@ -102,7 +102,7 @@ func TestPreCreateModifierHook(t *testing.T) {
 			"Host config's mounts should be mapped to Docker types",
 		)
 
-		assert.Equal(t, nat.PortMap{
+		assert.Equalf(t, nat.PortMap{
 			"80/tcp": []nat.PortBinding{
 				{
 					HostIP:   "",
@@ -113,13 +113,13 @@ func TestPreCreateModifierHook(t *testing.T) {
 			"Host config's port bindings should be overwritten by the modifier",
 		)
 
-		assert.Equal(
+		assert.Equalf(
 			t,
 			[]string{"b"},
 			inputNetworkingConfig.EndpointsConfig["a"].Aliases,
 			"Networking config's aliases should be overwritten by the modifier",
 		)
-		assert.Equal(
+		assert.Equalf(
 			t,
 			[]string{"link1", "link2"},
 			inputNetworkingConfig.EndpointsConfig["a"].Links,
@@ -155,13 +155,13 @@ func TestPreCreateModifierHook(t *testing.T) {
 
 		// assertions
 
-		assert.Equal(
+		assert.Equalf(
 			t,
 			nat.PortSet(nat.PortSet{}),
 			inputConfig.ExposedPorts,
 			"Docker config's exposed ports should be empty",
 		)
-		assert.Equal(t,
+		assert.Equalf(t,
 			nat.PortMap{},
 			inputHostConfig.PortBindings,
 			"Host config's portBinding should be empty",
@@ -196,12 +196,12 @@ func TestPreCreateModifierHook(t *testing.T) {
 
 		// assertions
 
-		assert.Equal(t, req.AutoRemove, inputHostConfig.AutoRemove, "Deprecated AutoRemove should come from the container request")
-		assert.Equal(t, strslice.StrSlice(req.CapAdd), inputHostConfig.CapAdd, "Deprecated CapAdd should come from the container request")
-		assert.Equal(t, strslice.StrSlice(req.CapDrop), inputHostConfig.CapDrop, "Deprecated CapDrop should come from the container request")
-		assert.Equal(t, req.Binds, inputHostConfig.Binds, "Deprecated Binds should come from the container request")
-		assert.Equal(t, req.ExtraHosts, inputHostConfig.ExtraHosts, "Deprecated ExtraHosts should come from the container request")
-		assert.Equal(t, req.Resources, inputHostConfig.Resources, "Deprecated Resources should come from the container request")
+		assert.Equalf(t, req.AutoRemove, inputHostConfig.AutoRemove, "Deprecated AutoRemove should come from the container request")
+		assert.Equalf(t, strslice.StrSlice(req.CapAdd), inputHostConfig.CapAdd, "Deprecated CapAdd should come from the container request")
+		assert.Equalf(t, strslice.StrSlice(req.CapDrop), inputHostConfig.CapDrop, "Deprecated CapDrop should come from the container request")
+		assert.Equalf(t, req.Binds, inputHostConfig.Binds, "Deprecated Binds should come from the container request")
+		assert.Equalf(t, req.ExtraHosts, inputHostConfig.ExtraHosts, "Deprecated ExtraHosts should come from the container request")
+		assert.Equalf(t, req.Resources, inputHostConfig.Resources, "Deprecated Resources should come from the container request")
 	})
 
 	t.Run("Request contains more than one network including aliases", func(t *testing.T) {
@@ -237,13 +237,13 @@ func TestPreCreateModifierHook(t *testing.T) {
 
 		// assertions
 
-		assert.Equal(
+		assert.Equalf(
 			t,
 			req.NetworkAliases[networkName],
 			inputNetworkingConfig.EndpointsConfig[networkName].Aliases,
 			"Networking config's aliases should come from the container request",
 		)
-		assert.Equal(
+		assert.Equalf(
 			t,
 			dockerNetwork.ID,
 			inputNetworkingConfig.EndpointsConfig[networkName].NetworkID,
@@ -281,12 +281,12 @@ func TestPreCreateModifierHook(t *testing.T) {
 
 		// assertions
 
-		require.Empty(
+		require.Emptyf(
 			t,
 			inputNetworkingConfig.EndpointsConfig[networkName].Aliases,
 			"Networking config's aliases should be empty",
 		)
-		assert.Equal(
+		assert.Equalf(
 			t,
 			dockerNetwork.ID,
 			inputNetworkingConfig.EndpointsConfig[networkName].NetworkID,
@@ -935,7 +935,7 @@ func TestPrintContainerLogsOnError(t *testing.T) {
 				break
 			}
 		}
-		assert.True(t, found, "container log line not found in the output of the logger: %s", line)
+		assert.Truef(t, found, "container log line not found in the output of the logger: %s", line)
 	}
 }
 

--- a/modulegen/main_test.go
+++ b/modulegen/main_test.go
@@ -508,7 +508,7 @@ func assertMkdocsNavItems(t *testing.T, module context.TestcontainersModule, ori
 	assert.True(t, found)
 
 	// first item is the index
-	assert.Equal(t, parentDir+"/index.md", navItems[0], navItems)
+	assert.Equal(t, parentDir+"/index.md", navItems[0])
 }
 
 func sanitiseContent(bytes []byte) []string {

--- a/modulegen/mkdocs_test.go
+++ b/modulegen/mkdocs_test.go
@@ -77,7 +77,7 @@ func TestNavItems(t *testing.T) {
 				continue
 			}
 		}
-		assert.True(t, found, "example %s is not present in the docs", example)
+		assert.Truef(t, found, "example %s is not present in the docs", example)
 	}
 }
 

--- a/modules/artemis/artemis_test.go
+++ b/modules/artemis/artemis_test.go
@@ -75,16 +75,16 @@ func TestArtemis(t *testing.T) {
 			require.NoError(t, err)
 
 			res, err := http.Get(u)
-			require.NoError(t, err, "failed to access console")
+			require.NoErrorf(t, err, "failed to access console")
 			res.Body.Close()
-			require.Equal(t, http.StatusOK, res.StatusCode, "failed to access console")
+			require.Equalf(t, http.StatusOK, res.StatusCode, "failed to access console")
 
 			if test.user != "" {
-				assert.Equal(t, test.user, ctr.User(), "unexpected user")
+				assert.Equalf(t, test.user, ctr.User(), "unexpected user")
 			}
 
 			if test.pass != "" {
-				assert.Equal(t, test.pass, ctr.Password(), "unexpected password")
+				assert.Equalf(t, test.pass, ctr.Password(), "unexpected password")
 			}
 
 			// brokerEndpoint {
@@ -98,22 +98,22 @@ func TestArtemis(t *testing.T) {
 			}
 
 			conn, err := stomp.Dial("tcp", host, opt...)
-			require.NoError(t, err, "failed to connect")
+			require.NoErrorf(t, err, "failed to connect")
 			t.Cleanup(func() { require.NoError(t, conn.Disconnect()) })
 
 			sub, err := conn.Subscribe("test", stomp.AckAuto)
-			require.NoError(t, err, "failed to subscribe")
+			require.NoErrorf(t, err, "failed to subscribe")
 			t.Cleanup(func() { require.NoError(t, sub.Unsubscribe()) })
 
 			err = conn.Send("test", "", []byte("test"))
-			require.NoError(t, err, "failed to send")
+			require.NoErrorf(t, err, "failed to send")
 
 			ticker := time.NewTicker(10 * time.Second)
 			select {
 			case <-ticker.C:
 				t.Fatal("timed out waiting for message")
 			case msg := <-sub.C:
-				require.Equal(t, "test", string(msg.Body), "received unexpected message")
+				require.Equalf(t, "test", string(msg.Body), "received unexpected message")
 			}
 
 			if test.hook != nil {
@@ -130,12 +130,12 @@ func expectQueue(t *testing.T, container *artemis.Container, queueName string) {
 	require.NoError(t, err)
 
 	r, err := http.Get(u + `/jolokia/read/org.apache.activemq.artemis:broker="0.0.0.0"/QueueNames`)
-	require.NoError(t, err, "failed to request QueueNames")
+	require.NoErrorf(t, err, "failed to request QueueNames")
 	defer r.Body.Close()
 
 	var res struct{ Value []string }
 	err = json.NewDecoder(r.Body).Decode(&res)
-	require.NoError(t, err, "failed to decode QueueNames response")
+	require.NoErrorf(t, err, "failed to decode QueueNames response")
 
 	require.Containsf(t, res.Value, queueName, "should contain queue")
 }

--- a/modules/compose/compose_api_test.go
+++ b/modules/compose/compose_api_test.go
@@ -25,20 +25,20 @@ import (
 func TestDockerComposeAPI(t *testing.T) {
 	path, _ := RenderComposeSimple(t)
 	compose, err := NewDockerCompose(path)
-	require.NoError(t, err, "NewDockerCompose()")
+	require.NoErrorf(t, err, "NewDockerCompose()")
 
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 
 	err = compose.Up(ctx, Wait(true))
 	cleanup(t, compose)
-	require.NoError(t, err, "compose.Up()")
+	require.NoErrorf(t, err, "compose.Up()")
 }
 
 func TestDockerComposeAPIStrategyForInvalidService(t *testing.T) {
 	path, _ := RenderComposeSimple(t)
 	compose, err := NewDockerCompose(path)
-	require.NoError(t, err, "NewDockerCompose()")
+	require.NoErrorf(t, err, "NewDockerCompose()")
 
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
@@ -59,7 +59,7 @@ func TestDockerComposeAPIStrategyForInvalidService(t *testing.T) {
 func TestDockerComposeAPIWithWaitLogStrategy(t *testing.T) {
 	path, _ := RenderComposeComplex(t)
 	compose, err := NewDockerCompose(path)
-	require.NoError(t, err, "NewDockerCompose()")
+	require.NoErrorf(t, err, "NewDockerCompose()")
 
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
@@ -68,7 +68,7 @@ func TestDockerComposeAPIWithWaitLogStrategy(t *testing.T) {
 		WaitForService("api-mysql", wait.NewLogStrategy("started").WithStartupTimeout(10*time.Second).WithOccurrence(1)).
 		Up(ctx, Wait(true))
 	cleanup(t, compose)
-	require.NoError(t, err, "compose.Up()")
+	require.NoErrorf(t, err, "compose.Up()")
 
 	serviceNames := compose.Services()
 
@@ -80,7 +80,7 @@ func TestDockerComposeAPIWithWaitLogStrategy(t *testing.T) {
 func TestDockerComposeAPIWithRunServices(t *testing.T) {
 	path, _ := RenderComposeComplex(t)
 	compose, err := NewDockerCompose(path)
-	require.NoError(t, err, "NewDockerCompose()")
+	require.NoErrorf(t, err, "NewDockerCompose()")
 
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
@@ -89,12 +89,12 @@ func TestDockerComposeAPIWithRunServices(t *testing.T) {
 		WaitForService("api-nginx", wait.NewHTTPStrategy("/").WithPort("80/tcp").WithStartupTimeout(10*time.Second)).
 		Up(ctx, Wait(true), RunServices("api-nginx"))
 	cleanup(t, compose)
-	require.NoError(t, err, "compose.Up()")
+	require.NoErrorf(t, err, "compose.Up()")
 
 	serviceNames := compose.Services()
 
 	_, err = compose.ServiceContainer(context.Background(), "api-mysql")
-	require.Error(t, err, "Make sure there is no mysql container")
+	require.Errorf(t, err, "Make sure there is no mysql container")
 
 	assert.Len(t, serviceNames, 1)
 	assert.Contains(t, serviceNames, "api-nginx")
@@ -136,7 +136,7 @@ func TestDockerComposeAPIWithProfiles(t *testing.T) {
 	for name, test := range testcases {
 		t.Run(name, func(t *testing.T) {
 			compose, err := NewDockerComposeWith(WithStackFiles(path), WithProfiles(test.withProfiles...))
-			require.NoError(t, err, "NewDockerCompose()")
+			require.NoErrorf(t, err, "NewDockerCompose()")
 
 			ctx, cancel := context.WithCancel(context.Background())
 			t.Cleanup(cancel)
@@ -146,7 +146,7 @@ func TestDockerComposeAPIWithProfiles(t *testing.T) {
 			}
 			err = compose.Up(ctx, Wait(true))
 			cleanup(t, compose)
-			require.NoError(t, err, "compose.Up()")
+			require.NoErrorf(t, err, "compose.Up()")
 
 			assert.ElementsMatch(t, test.wantServices, compose.Services())
 		})
@@ -156,7 +156,7 @@ func TestDockerComposeAPIWithProfiles(t *testing.T) {
 func TestDockerComposeAPI_TestcontainersLabelsArePresent(t *testing.T) {
 	path, _ := RenderComposeComplex(t)
 	compose, err := NewDockerCompose(path)
-	require.NoError(t, err, "NewDockerCompose()")
+	require.NoErrorf(t, err, "NewDockerCompose()")
 
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
@@ -165,7 +165,7 @@ func TestDockerComposeAPI_TestcontainersLabelsArePresent(t *testing.T) {
 		WaitForService("api-mysql", wait.NewLogStrategy("started").WithStartupTimeout(10*time.Second).WithOccurrence(1)).
 		Up(ctx, Wait(true))
 	cleanup(t, compose)
-	require.NoError(t, err, "compose.Up()")
+	require.NoErrorf(t, err, "compose.Up()")
 
 	serviceNames := compose.Services()
 
@@ -176,14 +176,14 @@ func TestDockerComposeAPI_TestcontainersLabelsArePresent(t *testing.T) {
 	// all the services in the compose has the Testcontainers Labels
 	for _, serviceName := range serviceNames {
 		c, err := compose.ServiceContainer(context.Background(), serviceName)
-		require.NoError(t, err, "compose.ServiceContainer()")
+		require.NoErrorf(t, err, "compose.ServiceContainer()")
 
 		inspect, err := compose.dockerClient.ContainerInspect(ctx, c.GetContainerID())
-		require.NoError(t, err, "dockerClient.ContainerInspect()")
+		require.NoErrorf(t, err, "dockerClient.ContainerInspect()")
 
 		for key, label := range testcontainers.GenericLabels() {
-			assert.Contains(t, inspect.Config.Labels, key, "Label %s is not present in container %s", key, c.GetContainerID())
-			assert.Equal(t, label, inspect.Config.Labels[key], "Label %s value is not correct in container %s", key, c.GetContainerID())
+			assert.Containsf(t, inspect.Config.Labels, key, "Label %s is not present in container %s", key, c.GetContainerID())
+			assert.Equalf(t, label, inspect.Config.Labels[key], "Label %s value is not correct in container %s", key, c.GetContainerID())
 		}
 	}
 }
@@ -197,7 +197,7 @@ func TestDockerComposeAPI_WithReaper(t *testing.T) {
 
 	path, _ := RenderComposeComplex(t)
 	compose, err := NewDockerCompose(path)
-	require.NoError(t, err, "NewDockerCompose()")
+	require.NoErrorf(t, err, "NewDockerCompose()")
 
 	// reaper is enabled, so we don't need to manually stop the containers: Ryuk will do it for us
 
@@ -208,7 +208,7 @@ func TestDockerComposeAPI_WithReaper(t *testing.T) {
 		WaitForService("api-mysql", wait.NewLogStrategy("started").WithStartupTimeout(10*time.Second).WithOccurrence(1)).
 		Up(ctx, Wait(true))
 	cleanup(t, compose)
-	require.NoError(t, err, "compose.Up()")
+	require.NoErrorf(t, err, "compose.Up()")
 
 	serviceNames := compose.Services()
 
@@ -226,7 +226,7 @@ func TestDockerComposeAPI_WithoutReaper(t *testing.T) {
 
 	path, _ := RenderComposeComplex(t)
 	compose, err := NewDockerCompose(path)
-	require.NoError(t, err, "NewDockerCompose()")
+	require.NoErrorf(t, err, "NewDockerCompose()")
 
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
@@ -235,7 +235,7 @@ func TestDockerComposeAPI_WithoutReaper(t *testing.T) {
 		WaitForService("api-mysql", wait.NewLogStrategy("started").WithStartupTimeout(10*time.Second).WithOccurrence(1)).
 		Up(ctx, Wait(true))
 	cleanup(t, compose)
-	require.NoError(t, err, "compose.Up()")
+	require.NoErrorf(t, err, "compose.Up()")
 
 	serviceNames := compose.Services()
 
@@ -249,14 +249,14 @@ func TestDockerComposeAPIWithStopServices(t *testing.T) {
 	compose, err := NewDockerComposeWith(
 		WithStackFiles(path),
 		WithLogger(testcontainers.TestLogger(t)))
-	require.NoError(t, err, "NewDockerCompose()")
+	require.NoErrorf(t, err, "NewDockerCompose()")
 
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 
 	err = compose.Up(ctx, Wait(true))
 	cleanup(t, compose)
-	require.NoError(t, err, "compose.Up()")
+	require.NoErrorf(t, err, "compose.Up()")
 
 	serviceNames := compose.Services()
 
@@ -266,11 +266,11 @@ func TestDockerComposeAPIWithStopServices(t *testing.T) {
 
 	// close mysql container in purpose
 	mysqlContainer, err := compose.ServiceContainer(context.Background(), "api-mysql")
-	require.NoError(t, err, "Get mysql container")
+	require.NoErrorf(t, err, "Get mysql container")
 
 	stopTimeout := 10 * time.Second
 	err = mysqlContainer.Stop(ctx, &stopTimeout)
-	require.NoError(t, err, "Stop mysql container")
+	require.NoErrorf(t, err, "Stop mysql container")
 
 	// check container status
 	state, err := mysqlContainer.State(ctx)
@@ -282,7 +282,7 @@ func TestDockerComposeAPIWithStopServices(t *testing.T) {
 func TestDockerComposeAPIWithWaitForService(t *testing.T) {
 	path, _ := RenderComposeSimple(t)
 	compose, err := NewDockerCompose(path)
-	require.NoError(t, err, "NewDockerCompose()")
+	require.NoErrorf(t, err, "NewDockerCompose()")
 
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
@@ -294,7 +294,7 @@ func TestDockerComposeAPIWithWaitForService(t *testing.T) {
 		WaitForService("api-nginx", wait.NewHTTPStrategy("/").WithPort("80/tcp").WithStartupTimeout(10*time.Second)).
 		Up(ctx, Wait(true))
 	cleanup(t, compose)
-	require.NoError(t, err, "compose.Up()")
+	require.NoErrorf(t, err, "compose.Up()")
 
 	serviceNames := compose.Services()
 
@@ -305,7 +305,7 @@ func TestDockerComposeAPIWithWaitForService(t *testing.T) {
 func TestDockerComposeAPIWithWaitHTTPStrategy(t *testing.T) {
 	path, _ := RenderComposeSimple(t)
 	compose, err := NewDockerCompose(path)
-	require.NoError(t, err, "NewDockerCompose()")
+	require.NoErrorf(t, err, "NewDockerCompose()")
 
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
@@ -317,7 +317,7 @@ func TestDockerComposeAPIWithWaitHTTPStrategy(t *testing.T) {
 		WaitForService("api-nginx", wait.NewHTTPStrategy("/").WithPort("80/tcp").WithStartupTimeout(10*time.Second)).
 		Up(ctx, Wait(true))
 	cleanup(t, compose)
-	require.NoError(t, err, "compose.Up()")
+	require.NoErrorf(t, err, "compose.Up()")
 
 	serviceNames := compose.Services()
 
@@ -328,7 +328,7 @@ func TestDockerComposeAPIWithWaitHTTPStrategy(t *testing.T) {
 func TestDockerComposeAPIWithContainerName(t *testing.T) {
 	path := RenderComposeWithName(t)
 	compose, err := NewDockerCompose(path)
-	require.NoError(t, err, "NewDockerCompose()")
+	require.NoErrorf(t, err, "NewDockerCompose()")
 
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
@@ -340,7 +340,7 @@ func TestDockerComposeAPIWithContainerName(t *testing.T) {
 		WaitForService("api-nginx", wait.NewHTTPStrategy("/").WithPort("80/tcp").WithStartupTimeout(10*time.Second)).
 		Up(ctx, Wait(true))
 	cleanup(t, compose)
-	require.NoError(t, err, "compose.Up()")
+	require.NoErrorf(t, err, "compose.Up()")
 
 	serviceNames := compose.Services()
 
@@ -351,7 +351,7 @@ func TestDockerComposeAPIWithContainerName(t *testing.T) {
 func TestDockerComposeAPIWithWaitStrategy_NoExposedPorts(t *testing.T) {
 	path := RenderComposeWithoutExposedPorts(t)
 	compose, err := NewDockerCompose(path)
-	require.NoError(t, err, "NewDockerCompose()")
+	require.NoErrorf(t, err, "NewDockerCompose()")
 
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
@@ -360,7 +360,7 @@ func TestDockerComposeAPIWithWaitStrategy_NoExposedPorts(t *testing.T) {
 		WaitForService("api-nginx", wait.ForLog("Configuration complete; ready for start up")).
 		Up(ctx, Wait(true))
 	cleanup(t, compose)
-	require.NoError(t, err, "compose.Up()")
+	require.NoErrorf(t, err, "compose.Up()")
 
 	serviceNames := compose.Services()
 
@@ -371,7 +371,7 @@ func TestDockerComposeAPIWithWaitStrategy_NoExposedPorts(t *testing.T) {
 func TestDockerComposeAPIWithMultipleWaitStrategies(t *testing.T) {
 	path, _ := RenderComposeComplex(t)
 	compose, err := NewDockerCompose(path)
-	require.NoError(t, err, "NewDockerCompose()")
+	require.NoErrorf(t, err, "NewDockerCompose()")
 
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
@@ -381,7 +381,7 @@ func TestDockerComposeAPIWithMultipleWaitStrategies(t *testing.T) {
 		WaitForService("api-nginx", wait.NewHTTPStrategy("/").WithPort("80/tcp").WithStartupTimeout(10*time.Second)).
 		Up(ctx, Wait(true))
 	cleanup(t, compose)
-	require.NoError(t, err, "compose.Up()")
+	require.NoErrorf(t, err, "compose.Up()")
 
 	serviceNames := compose.Services()
 
@@ -393,7 +393,7 @@ func TestDockerComposeAPIWithMultipleWaitStrategies(t *testing.T) {
 func TestDockerComposeAPIWithFailedStrategy(t *testing.T) {
 	path, _ := RenderComposeSimple(t)
 	compose, err := NewDockerCompose(path)
-	require.NoError(t, err, "NewDockerCompose()")
+	require.NoErrorf(t, err, "NewDockerCompose()")
 
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
@@ -407,7 +407,7 @@ func TestDockerComposeAPIWithFailedStrategy(t *testing.T) {
 	cleanup(t, compose)
 	// Verify that an error is thrown and not nil
 	// A specific error message matcher is not asserted since the docker library can change the return message, breaking this test
-	require.Error(t, err, "Expected error to be thrown because of a wrong suplied wait strategy")
+	require.Errorf(t, err, "Expected error to be thrown because of a wrong suplied wait strategy")
 
 	serviceNames := compose.Services()
 
@@ -418,14 +418,14 @@ func TestDockerComposeAPIWithFailedStrategy(t *testing.T) {
 func TestDockerComposeAPIComplex(t *testing.T) {
 	path, _ := RenderComposeComplex(t)
 	compose, err := NewDockerCompose(path)
-	require.NoError(t, err, "NewDockerCompose()")
+	require.NoErrorf(t, err, "NewDockerCompose()")
 
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 
 	err = compose.Up(ctx, Wait(true))
 	cleanup(t, compose)
-	require.NoError(t, err, "compose.Up()")
+	require.NoErrorf(t, err, "compose.Up()")
 
 	serviceNames := compose.Services()
 
@@ -447,7 +447,7 @@ services:
 `
 
 	compose, err := NewDockerComposeWith(WithStackReaders(strings.NewReader(composeContent)), identifier)
-	require.NoError(t, err, "NewDockerCompose()")
+	require.NoErrorf(t, err, "NewDockerCompose()")
 
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
@@ -459,20 +459,20 @@ services:
 		}).
 		Up(ctx, Wait(true))
 	cleanup(t, compose)
-	require.NoError(t, err, "compose.Up()")
+	require.NoErrorf(t, err, "compose.Up()")
 
 	serviceNames := compose.Services()
 
 	assert.Len(t, serviceNames, 1)
 	assert.Contains(t, serviceNames, "api-nginx")
 
-	require.NoError(t, compose.Down(context.Background(), RemoveOrphans(true), RemoveVolumes(true), RemoveImagesLocal), "compose.Down()")
+	require.NoErrorf(t, compose.Down(context.Background(), RemoveOrphans(true), RemoveVolumes(true), RemoveImagesLocal), "compose.Down()")
 
 	// check files where removed
 	f, err := os.Stat(compose.configs[0])
-	require.Error(t, err, "File should be removed")
-	require.True(t, os.IsNotExist(err), "File should be removed")
-	require.Nil(t, f, "File should be removed")
+	require.Errorf(t, err, "File should be removed")
+	require.Truef(t, os.IsNotExist(err), "File should be removed")
+	require.Nilf(t, f, "File should be removed")
 }
 
 func TestDockerComposeAPIWithStackReaderAndComposeFile(t *testing.T) {
@@ -491,7 +491,7 @@ services:
 		WithStackFiles(simple),
 		WithStackReaders(strings.NewReader(composeContent)),
 	)
-	require.NoError(t, err, "NewDockerCompose()")
+	require.NoErrorf(t, err, "NewDockerCompose()")
 
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
@@ -503,7 +503,7 @@ services:
 		}).
 		Up(ctx, Wait(true))
 	cleanup(t, compose)
-	require.NoError(t, err, "compose.Up()")
+	require.NoErrorf(t, err, "compose.Up()")
 
 	serviceNames := compose.Services()
 
@@ -525,7 +525,7 @@ func TestDockerComposeAPIWithEnvironment(t *testing.T) {
 	path, _ := RenderComposeSimple(t)
 
 	compose, err := NewDockerComposeWith(WithStackFiles(path), identifier)
-	require.NoError(t, err, "NewDockerCompose()")
+	require.NoErrorf(t, err, "NewDockerCompose()")
 
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
@@ -536,7 +536,7 @@ func TestDockerComposeAPIWithEnvironment(t *testing.T) {
 		}).
 		Up(ctx, Wait(true))
 	cleanup(t, compose)
-	require.NoError(t, err, "compose.Up()")
+	require.NoErrorf(t, err, "compose.Up()")
 
 	serviceNames := compose.Services()
 
@@ -561,7 +561,7 @@ func TestDockerComposeAPIWithMultipleComposeFiles(t *testing.T) {
 	identifier := testNameHash(t.Name())
 
 	compose, err := NewDockerComposeWith(composeFiles, identifier)
-	require.NoError(t, err, "NewDockerCompose()")
+	require.NoErrorf(t, err, "NewDockerCompose()")
 
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
@@ -573,7 +573,7 @@ func TestDockerComposeAPIWithMultipleComposeFiles(t *testing.T) {
 		}).
 		Up(ctx, Wait(true))
 	cleanup(t, compose)
-	require.NoError(t, err, "compose.Up()")
+	require.NoErrorf(t, err, "compose.Up()")
 
 	serviceNames := compose.Services()
 
@@ -593,7 +593,7 @@ func TestDockerComposeAPIWithMultipleComposeFiles(t *testing.T) {
 func TestDockerComposeAPIWithVolume(t *testing.T) {
 	path := RenderComposeWithVolume(t)
 	compose, err := NewDockerCompose(path)
-	require.NoError(t, err, "NewDockerCompose()")
+	require.NoErrorf(t, err, "NewDockerCompose()")
 
 	cleanup(t, compose)
 
@@ -601,20 +601,20 @@ func TestDockerComposeAPIWithVolume(t *testing.T) {
 	t.Cleanup(cancel)
 
 	err = compose.Up(ctx, Wait(true))
-	require.NoError(t, err, "compose.Up()")
+	require.NoErrorf(t, err, "compose.Up()")
 }
 
 func TestDockerComposeAPIWithRecreate(t *testing.T) {
 	path, _ := RenderComposeComplex(t)
 	compose, err := NewDockerCompose(path)
-	require.NoError(t, err, "NewDockerCompose()")
+	require.NoErrorf(t, err, "NewDockerCompose()")
 
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 
 	err = compose.Up(ctx, WithRecreate(api.RecreateNever), WithRecreateDependencies(api.RecreateNever), Wait(true))
 	cleanup(t, compose)
-	require.NoError(t, err, "compose.Up()")
+	require.NoErrorf(t, err, "compose.Up()")
 }
 
 func TestDockerComposeAPIVolumesDeletedOnDown(t *testing.T) {
@@ -622,25 +622,25 @@ func TestDockerComposeAPIVolumesDeletedOnDown(t *testing.T) {
 	identifier := uuid.New().String()
 	stackFiles := WithStackFiles(path)
 	compose, err := NewDockerComposeWith(stackFiles, StackIdentifier(identifier))
-	require.NoError(t, err, "NewDockerCompose()")
+	require.NoErrorf(t, err, "NewDockerCompose()")
 
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 
 	err = compose.Up(ctx, Wait(true))
 	cleanup(t, compose)
-	require.NoError(t, err, "compose.Up()")
+	require.NoErrorf(t, err, "compose.Up()")
 
 	err = compose.Down(context.Background(), RemoveOrphans(true), RemoveVolumes(true), RemoveImagesLocal)
-	require.NoError(t, err, "compose.Down()")
+	require.NoErrorf(t, err, "compose.Down()")
 
 	volumeListFilters := filters.NewArgs()
 	// the "mydata" identifier comes from the "testdata/docker-compose-volume.yml" file
 	volumeListFilters.Add("name", fmt.Sprintf("%s_mydata", identifier))
 	volumeList, err := compose.dockerClient.VolumeList(ctx, volume.ListOptions{Filters: volumeListFilters})
-	require.NoError(t, err, "compose.dockerClient.VolumeList()")
+	require.NoErrorf(t, err, "compose.dockerClient.VolumeList()")
 
-	require.Empty(t, volumeList.Volumes, "Volumes are not cleaned up")
+	require.Emptyf(t, volumeList.Volumes, "Volumes are not cleaned up")
 }
 
 func TestDockerComposeAPIWithBuild(t *testing.T) {
@@ -648,7 +648,7 @@ func TestDockerComposeAPIWithBuild(t *testing.T) {
 
 	path := RenderComposeWithBuild(t)
 	compose, err := NewDockerCompose(path)
-	require.NoError(t, err, "NewDockerCompose()")
+	require.NoErrorf(t, err, "NewDockerCompose()")
 
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
@@ -657,13 +657,13 @@ func TestDockerComposeAPIWithBuild(t *testing.T) {
 		WaitForService("api-echo", wait.ForHTTP("/env").WithPort("8080/tcp")).
 		Up(ctx, Wait(true))
 	cleanup(t, compose)
-	require.NoError(t, err, "compose.Up()")
+	require.NoErrorf(t, err, "compose.Up()")
 }
 
 func TestDockerComposeApiWithWaitForShortLifespanService(t *testing.T) {
 	path := filepath.Join(testdataPackage, "docker-compose-short-lifespan.yml")
 	compose, err := NewDockerCompose(path)
-	require.NoError(t, err, "NewDockerCompose()")
+	require.NoErrorf(t, err, "NewDockerCompose()")
 
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
@@ -674,7 +674,7 @@ func TestDockerComposeApiWithWaitForShortLifespanService(t *testing.T) {
 		WaitForService("falafel", wait.ForExit().WithExitTimeout(10*time.Second)).
 		Up(ctx)
 	cleanup(t, compose)
-	require.NoError(t, err, "compose.Up()")
+	require.NoErrorf(t, err, "compose.Up()")
 
 	services := compose.Services()
 
@@ -691,7 +691,7 @@ func testNameHash(name string) StackIdentifier {
 func cleanup(t *testing.T, compose *dockerCompose) {
 	t.Helper()
 	t.Cleanup(func() {
-		require.NoError(t, compose.Down(
+		require.NoErrorf(t, compose.Down(
 			context.Background(),
 			RemoveOrphans(true),
 			RemoveVolumes(true),

--- a/modules/compose/compose_test.go
+++ b/modules/compose/compose_test.go
@@ -132,7 +132,7 @@ func TestLocalDockerComposeStrategyForInvalidService(t *testing.T) {
 		// Appending with _1 as given in the Java Test-Containers Example
 		WithExposedService(compose.Format("non-existent-srv", "1"), ports[0], wait.NewLogStrategy("started").WithStartupTimeout(10*time.Second).WithOccurrence(1)).
 		Invoke()
-	require.Error(t, err.Error, "Expected error to be thrown because service with wait strategy is not running")
+	require.Errorf(t, err.Error, "Expected error to be thrown because service with wait strategy is not running")
 
 	assert.Len(t, compose.Services, 1)
 	assert.Contains(t, compose.Services, "local-nginx")
@@ -329,7 +329,7 @@ func TestLocalDockerComposeWithFailedStrategy(t *testing.T) {
 		Invoke()
 	// Verify that an error is thrown and not nil
 	// A specific error message matcher is not asserted since the docker library can change the return message, breaking this test
-	require.Error(t, err.Error, "Expected error to be thrown because of a wrong suplied wait strategy")
+	require.Errorf(t, err.Error, "Expected error to be thrown because of a wrong suplied wait strategy")
 
 	assert.Len(t, compose.Services, 1)
 	assert.Contains(t, compose.Services, "local-nginx")

--- a/modules/redpanda/redpanda_test.go
+++ b/modules/redpanda/redpanda_test.go
@@ -71,7 +71,7 @@ func TestRedpanda(t *testing.T) {
 
 	// Test produce to unknown topic
 	results := kafkaCl.ProduceSync(ctx, &kgo.Record{Topic: "test", Value: []byte("test message")})
-	require.Error(t, results.FirstErr(), kerr.UnknownTopicOrPartition)
+	require.Error(t, results.FirstErr(), kerr.UnknownTopicOrPartition) //nolint:testifylint
 }
 
 func TestRedpandaWithAuthentication(t *testing.T) {
@@ -330,7 +330,7 @@ func TestRedpandaWithTLS(t *testing.T) {
 		Host:      "localhost,127.0.0.1",
 		ParentDir: tmp,
 	})
-	require.NotNil(t, cert, "failed to generate cert")
+	require.NotNilf(t, cert, "failed to generate cert")
 
 	ctx := context.Background()
 
@@ -352,7 +352,7 @@ func TestRedpandaWithTLS(t *testing.T) {
 	// Test Admin API
 	adminAPIURL, err := ctr.AdminAPIAddress(ctx)
 	require.NoError(t, err)
-	require.True(t, strings.HasPrefix(adminAPIURL, "https://"), "AdminAPIAddress should return https url")
+	require.Truef(t, strings.HasPrefix(adminAPIURL, "https://"), "AdminAPIAddress should return https url")
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("%s/v1/cluster/health_overview", adminAPIURL), nil)
 	require.NoError(t, err)
 	resp, err := httpCl.Do(req)
@@ -363,7 +363,7 @@ func TestRedpandaWithTLS(t *testing.T) {
 	// Test Schema Registry API
 	schemaRegistryURL, err := ctr.SchemaRegistryAddress(ctx)
 	require.NoError(t, err)
-	require.True(t, strings.HasPrefix(adminAPIURL, "https://"), "SchemaRegistryAddress should return https url")
+	require.Truef(t, strings.HasPrefix(adminAPIURL, "https://"), "SchemaRegistryAddress should return https url")
 	req, err = http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("%s/subjects", schemaRegistryURL), nil)
 	require.NoError(t, err)
 	resp, err = httpCl.Do(req)
@@ -383,7 +383,7 @@ func TestRedpandaWithTLS(t *testing.T) {
 
 	// Test produce to unknown topic
 	results := kafkaCl.ProduceSync(ctx, &kgo.Record{Topic: "test", Value: []byte("test message")})
-	require.Error(t, results.FirstErr(), kerr.UnknownTopicOrPartition)
+	require.Error(t, results.FirstErr(), kerr.UnknownTopicOrPartition) //nolint:testifylint
 }
 
 func TestRedpandaWithTLSAndSASL(t *testing.T) {
@@ -394,7 +394,7 @@ func TestRedpandaWithTLSAndSASL(t *testing.T) {
 		Host:      "localhost,127.0.0.1",
 		ParentDir: tmp,
 	})
-	require.NotNil(t, cert, "failed to generate cert")
+	require.NotNilf(t, cert, "failed to generate cert")
 
 	ctx := context.Background()
 
@@ -507,8 +507,7 @@ func TestRedpandaListener_InvalidPort(t *testing.T) {
 		network.WithNetwork([]string{"redpanda-host"}, RPNetwork),
 	)
 	testcontainers.CleanupContainer(t, ctr)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "invalid port on listener redpanda:99092")
+	require.ErrorContains(t, err, "invalid port on listener redpanda:99092")
 }
 
 func TestRedpandaListener_NoNetwork(t *testing.T) {
@@ -520,9 +519,7 @@ func TestRedpandaListener_NoNetwork(t *testing.T) {
 		redpanda.WithListener("redpanda:99092"),
 	)
 	testcontainers.CleanupContainer(t, ctr)
-	require.Error(t, err)
-
-	require.Contains(t, err.Error(), "container must be attached to at least one network")
+	require.ErrorContains(t, err, "container must be attached to at least one network")
 }
 
 func TestRedpandaBootstrapConfig(t *testing.T) {

--- a/modules/registry/registry_test.go
+++ b/modules/registry/registry_test.go
@@ -207,8 +207,7 @@ func TestRunContainer_wrongData(t *testing.T) {
 		Started: true,
 	})
 	testcontainers.CleanupContainer(t, redisC)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "manifest unknown")
+	require.ErrorContains(t, err, "manifest unknown")
 }
 
 // setAuthConfig sets the DOCKER_AUTH_CONFIG environment variable with

--- a/options_test.go
+++ b/options_test.go
@@ -96,8 +96,7 @@ func TestWithLogConsumers(t *testing.T) {
 	testcontainers.CleanupContainer(t, c)
 	// we expect an error because the MySQL environment variables are not set
 	// but this is expected because we just want to test the log consumer
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "container exited with code 1")
+	require.ErrorContains(t, err, "container exited with code 1")
 	require.NotEmpty(t, lc.msgs)
 }
 

--- a/reaper_test.go
+++ b/reaper_test.go
@@ -347,16 +347,16 @@ func testNewReaper(ctx context.Context, t *testing.T, cfg config.Config, expecte
 	// We should have errored out see mockReaperProvider.RunContainer.
 	require.ErrorIs(t, err, errExpected)
 
-	require.Equal(t, expected.Image, provider.req.Image, "expected image doesn't match the submitted request")
-	require.Equal(t, expected.ExposedPorts, provider.req.ExposedPorts, "expected exposed ports don't match the submitted request")
-	require.Equal(t, expected.Labels, provider.req.Labels, "expected labels don't match the submitted request")
-	require.Equal(t, expected.Mounts, provider.req.Mounts, "expected mounts don't match the submitted request")
-	require.Equal(t, expected.WaitingFor, provider.req.WaitingFor, "expected waitingFor don't match the submitted request")
-	require.Equal(t, expected.Env, provider.req.Env, "expected env doesn't match the submitted request")
+	require.Equalf(t, expected.Image, provider.req.Image, "expected image doesn't match the submitted request")
+	require.Equalf(t, expected.ExposedPorts, provider.req.ExposedPorts, "expected exposed ports don't match the submitted request")
+	require.Equalf(t, expected.Labels, provider.req.Labels, "expected labels don't match the submitted request")
+	require.Equalf(t, expected.Mounts, provider.req.Mounts, "expected mounts don't match the submitted request")
+	require.Equalf(t, expected.WaitingFor, provider.req.WaitingFor, "expected waitingFor don't match the submitted request")
+	require.Equalf(t, expected.Env, provider.req.Env, "expected env doesn't match the submitted request")
 
 	// checks for reaper's preCreationCallback fields
-	require.Equal(t, container.NetworkMode(Bridge), provider.hostConfig.NetworkMode, "expected networkMode doesn't match the submitted request")
-	require.True(t, provider.hostConfig.AutoRemove, "expected networkMode doesn't match the submitted request")
+	require.Equalf(t, container.NetworkMode(Bridge), provider.hostConfig.NetworkMode, "expected networkMode doesn't match the submitted request")
+	require.Truef(t, provider.hostConfig.AutoRemove, "expected networkMode doesn't match the submitted request")
 }
 
 func Test_ReaperReusedIfHealthy(t *testing.T) {
@@ -377,22 +377,22 @@ func Test_ReaperReusedIfHealthy(t *testing.T) {
 
 	reaper, err := spawner.reaper(context.WithValue(ctx, core.DockerHostContextKey, provider.(*DockerProvider).host), testSessionID, provider)
 	cleanupReaper(t, reaper, spawner)
-	require.NoError(t, err, "creating the Reaper should not error")
+	require.NoErrorf(t, err, "creating the Reaper should not error")
 
 	reaperReused, err := spawner.reaper(context.WithValue(ctx, core.DockerHostContextKey, provider.(*DockerProvider).host), testSessionID, provider)
 	cleanupReaper(t, reaper, spawner)
-	require.NoError(t, err, "reusing the Reaper should not error")
+	require.NoErrorf(t, err, "reusing the Reaper should not error")
 
 	// Ensure the internal state of both reaper instances is the same
-	require.Equal(t, reaper.SessionID, reaperReused.SessionID, "expecting the same SessionID")
-	require.Equal(t, reaper.Endpoint, reaperReused.Endpoint, "expecting the same reaper endpoint")
-	require.Equal(t, reaper.Provider, reaperReused.Provider, "expecting the same container provider")
-	require.Equal(t, reaper.container.GetContainerID(), reaperReused.container.GetContainerID(), "expecting the same container ID")
-	require.Equal(t, reaper.container.SessionID(), reaperReused.container.SessionID(), "expecting the same session ID")
+	require.Equalf(t, reaper.SessionID, reaperReused.SessionID, "expecting the same SessionID")
+	require.Equalf(t, reaper.Endpoint, reaperReused.Endpoint, "expecting the same reaper endpoint")
+	require.Equalf(t, reaper.Provider, reaperReused.Provider, "expecting the same container provider")
+	require.Equalf(t, reaper.container.GetContainerID(), reaperReused.container.GetContainerID(), "expecting the same container ID")
+	require.Equalf(t, reaper.container.SessionID(), reaperReused.container.SessionID(), "expecting the same session ID")
 
 	termSignal, err := reaper.Connect()
 	cleanupTermSignal(t, termSignal)
-	require.NoError(t, err, "connecting to Reaper should be successful")
+	require.NoErrorf(t, err, "connecting to Reaper should be successful")
 }
 
 func Test_RecreateReaperIfTerminated(t *testing.T) {
@@ -406,7 +406,7 @@ func Test_RecreateReaperIfTerminated(t *testing.T) {
 	ctx := context.Background()
 	reaper, err := spawner.reaper(context.WithValue(ctx, core.DockerHostContextKey, provider.(*DockerProvider).host), testSessionID, provider)
 	cleanupReaper(t, reaper, spawner)
-	require.NoError(t, err, "creating the Reaper should not error")
+	require.NoErrorf(t, err, "creating the Reaper should not error")
 
 	termSignal, err := reaper.Connect()
 	if termSignal != nil {
@@ -443,12 +443,12 @@ func Test_RecreateReaperIfTerminated(t *testing.T) {
 
 	recreatedReaper, err := spawner.reaper(context.WithValue(ctx, core.DockerHostContextKey, provider.(*DockerProvider).host), testSessionID, provider)
 	cleanupReaper(t, recreatedReaper, spawner)
-	require.NoError(t, err, "creating the Reaper should not error")
-	require.NotEqual(t, reaper.container.GetContainerID(), recreatedReaper.container.GetContainerID(), "expected different container ID")
+	require.NoErrorf(t, err, "creating the Reaper should not error")
+	require.NotEqualf(t, reaper.container.GetContainerID(), recreatedReaper.container.GetContainerID(), "expected different container ID")
 
 	recreatedTermSignal, err := recreatedReaper.Connect()
 	cleanupTermSignal(t, recreatedTermSignal)
-	require.NoError(t, err, "connecting to Reaper should be successful")
+	require.NoErrorf(t, err, "connecting to Reaper should be successful")
 }
 
 func TestReaper_reuseItFromOtherTestProgramUsingDocker(t *testing.T) {
@@ -474,7 +474,7 @@ func TestReaper_reuseItFromOtherTestProgramUsingDocker(t *testing.T) {
 
 	reaper, err := spawner.reaper(context.WithValue(ctx, core.DockerHostContextKey, provider.(*DockerProvider).host), testSessionID, provider)
 	cleanupReaper(t, reaper, spawner)
-	require.NoError(t, err, "creating the Reaper should not error")
+	require.NoErrorf(t, err, "creating the Reaper should not error")
 
 	// Explicitly reset the reaper instance to nil to simulate another test
 	// program in the same session accessing the same reaper.
@@ -482,18 +482,18 @@ func TestReaper_reuseItFromOtherTestProgramUsingDocker(t *testing.T) {
 
 	reaperReused, err := spawner.reaper(context.WithValue(ctx, core.DockerHostContextKey, provider.(*DockerProvider).host), testSessionID, provider)
 	cleanupReaper(t, reaper, spawner)
-	require.NoError(t, err, "reusing the Reaper should not error")
+	require.NoErrorf(t, err, "reusing the Reaper should not error")
 
 	// Ensure that the internal state of both reaper instances is the same.
-	require.Equal(t, reaper.SessionID, reaperReused.SessionID, "expecting the same SessionID")
-	require.Equal(t, reaper.Endpoint, reaperReused.Endpoint, "expecting the same reaper endpoint")
-	require.Equal(t, reaper.Provider, reaperReused.Provider, "expecting the same container provider")
-	require.Equal(t, reaper.container.GetContainerID(), reaperReused.container.GetContainerID(), "expecting the same container ID")
-	require.Equal(t, reaper.container.SessionID(), reaperReused.container.SessionID(), "expecting the same session ID")
+	require.Equalf(t, reaper.SessionID, reaperReused.SessionID, "expecting the same SessionID")
+	require.Equalf(t, reaper.Endpoint, reaperReused.Endpoint, "expecting the same reaper endpoint")
+	require.Equalf(t, reaper.Provider, reaperReused.Provider, "expecting the same container provider")
+	require.Equalf(t, reaper.container.GetContainerID(), reaperReused.container.GetContainerID(), "expecting the same container ID")
+	require.Equalf(t, reaper.container.SessionID(), reaperReused.container.SessionID(), "expecting the same session ID")
 
 	termSignal, err := reaper.Connect()
 	cleanupTermSignal(t, termSignal)
-	require.NoError(t, err, "connecting to Reaper should be successful")
+	require.NoErrorf(t, err, "connecting to Reaper should be successful")
 }
 
 // TestReaper_ReuseRunning tests whether reusing the reaper if using
@@ -514,7 +514,7 @@ func TestReaper_ReuseRunning(t *testing.T) {
 	sessionID := SessionID()
 
 	dockerProvider, err := NewDockerProvider()
-	require.NoError(t, err, "new docker provider should not fail")
+	require.NoErrorf(t, err, "new docker provider should not fail")
 
 	obtainedReaperContainerIDs := make([]string, concurrency)
 	var wg sync.WaitGroup
@@ -535,14 +535,14 @@ func TestReaper_ReuseRunning(t *testing.T) {
 	// Assure that all calls returned the same container.
 	firstContainerID := obtainedReaperContainerIDs[0]
 	for i, containerID := range obtainedReaperContainerIDs {
-		require.Equal(t, firstContainerID, containerID, "call %d should have returned same container id", i)
+		require.Equalf(t, firstContainerID, containerID, "call %d should have returned same container id", i)
 	}
 }
 
 func TestSpawnerBackoff(t *testing.T) {
 	b := spawner.backoff()
 	for i := 0; i < 100; i++ {
-		require.LessOrEqual(t, b.NextBackOff(), time.Millisecond*250, "backoff should not exceed max interval")
+		require.LessOrEqualf(t, b.NextBackOff(), time.Millisecond*250, "backoff should not exceed max interval")
 	}
 }
 

--- a/wait/host_port_test.go
+++ b/wait/host_port_test.go
@@ -155,10 +155,7 @@ func TestHostPortStrategyFailsWhileGettingPortDueToOOMKilledContainer(t *testing
 
 	{
 		err := wg.WaitUntilReady(context.Background(), target)
-		require.Error(t, err)
-
-		expected := "container crashed with out-of-memory (OOMKilled)"
-		require.Contains(t, err.Error(), expected)
+		require.ErrorContains(t, err, "container crashed with out-of-memory (OOMKilled)")
 	}
 }
 
@@ -189,10 +186,7 @@ func TestHostPortStrategyFailsWhileGettingPortDueToExitedContainer(t *testing.T)
 
 	{
 		err := wg.WaitUntilReady(context.Background(), target)
-		require.Error(t, err)
-
-		expected := "container exited with code 1"
-		require.Contains(t, err.Error(), expected)
+		require.ErrorContains(t, err, "container exited with code 1")
 	}
 }
 
@@ -222,10 +216,7 @@ func TestHostPortStrategyFailsWhileGettingPortDueToUnexpectedContainerStatus(t *
 
 	{
 		err := wg.WaitUntilReady(context.Background(), target)
-		require.Error(t, err)
-
-		expected := "unexpected container status \"dead\""
-		require.Contains(t, err.Error(), expected)
+		require.ErrorContains(t, err, "unexpected container status \"dead\"")
 	}
 }
 
@@ -250,10 +241,7 @@ func TestHostPortStrategyFailsWhileExternalCheckingDueToOOMKilledContainer(t *te
 
 	{
 		err := wg.WaitUntilReady(context.Background(), target)
-		require.Error(t, err)
-
-		expected := "container crashed with out-of-memory (OOMKilled)"
-		require.Contains(t, err.Error(), expected)
+		require.ErrorContains(t, err, "container crashed with out-of-memory (OOMKilled)")
 	}
 }
 
@@ -279,10 +267,7 @@ func TestHostPortStrategyFailsWhileExternalCheckingDueToExitedContainer(t *testi
 
 	{
 		err := wg.WaitUntilReady(context.Background(), target)
-		require.Error(t, err)
-
-		expected := "container exited with code 1"
-		require.Contains(t, err.Error(), expected)
+		require.ErrorContains(t, err, "container exited with code 1")
 	}
 }
 
@@ -307,10 +292,7 @@ func TestHostPortStrategyFailsWhileExternalCheckingDueToUnexpectedContainerStatu
 
 	{
 		err := wg.WaitUntilReady(context.Background(), target)
-		require.Error(t, err)
-
-		expected := "unexpected container status \"dead\""
-		require.Contains(t, err.Error(), expected)
+		require.ErrorContains(t, err, "unexpected container status \"dead\"")
 	}
 }
 
@@ -354,10 +336,7 @@ func TestHostPortStrategyFailsWhileInternalCheckingDueToOOMKilledContainer(t *te
 
 	{
 		err := wg.WaitUntilReady(context.Background(), target)
-		require.Error(t, err)
-
-		expected := "container crashed with out-of-memory (OOMKilled)"
-		require.Contains(t, err.Error(), expected)
+		require.ErrorContains(t, err, "container crashed with out-of-memory (OOMKilled)")
 	}
 }
 
@@ -402,10 +381,7 @@ func TestHostPortStrategyFailsWhileInternalCheckingDueToExitedContainer(t *testi
 
 	{
 		err := wg.WaitUntilReady(context.Background(), target)
-		require.Error(t, err)
-
-		expected := "container exited with code 1"
-		require.Contains(t, err.Error(), expected)
+		require.ErrorContains(t, err, "container exited with code 1")
 	}
 }
 
@@ -449,10 +425,7 @@ func TestHostPortStrategyFailsWhileInternalCheckingDueToUnexpectedContainerStatu
 
 	{
 		err := wg.WaitUntilReady(context.Background(), target)
-		require.Error(t, err)
-
-		expected := "unexpected container status \"dead\""
-		require.Contains(t, err.Error(), expected)
+		require.ErrorContains(t, err, "unexpected container status \"dead\"")
 	}
 }
 


### PR DESCRIPTION
## What does this PR do?

Setup formatter.require-f-funcs from [testifylint](https://golangci-lint.run/usage/linters/#testifylint) linter and apply it’s recommandations .

## Why is it important?

To require f-assertions if format string is used.

Signed-off-by: Matthieu MOREL <matthieu.morel35@gmail.com>