### PR TITLE
fix: use `Contains` or `ErrorContains` with testify

### DIFF
--- a/container_test.go
+++ b/container_test.go
@@ -376,8 +376,7 @@ func Test_GetLogsFromFailedContainer(t *testing.T) {
 		Started:          true,
 	})
 	testcontainers.CleanupContainer(t, c)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "container exited with code 0")
+	require.ErrorContains(t, err, "container exited with code 0")
 
 	logs, logErr := c.Logs(ctx)
 	require.NoError(t, logErr)

--- a/docker_test.go
+++ b/docker_test.go
@@ -1478,7 +1478,7 @@ func TestDockerCreateContainerWithFiles(t *testing.T) {
 			CleanupContainer(t, nginxC)
 
 			if err != nil {
-				require.Contains(t, err.Error(), tc.errMsg)
+				require.ErrorContains(t, err, tc.errMsg)
 			} else {
 				for _, f := range tc.files {
 					require.NoError(t, err)

--- a/generic_test.go
+++ b/generic_test.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"os"
 	"os/exec"
-	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -138,8 +137,8 @@ func TestGenericReusableContainerInSubprocess(t *testing.T) {
 
 			t.Log(output)
 			// check is reuse container with WaitingFor work correctly.
-			require.True(t, strings.Contains(output, "⏳ Waiting for container id"))
-			require.True(t, strings.Contains(output, "🔔 Container is ready"))
+			require.Contains(t, output, "⏳ Waiting for container id")
+			require.Contains(t, output, "🔔 Container is ready")
 		}()
 	}
 

--- a/modules/redpanda/redpanda_test.go
+++ b/modules/redpanda/redpanda_test.go
@@ -507,8 +507,7 @@ func TestRedpandaListener_InvalidPort(t *testing.T) {
 		network.WithNetwork([]string{"redpanda-host"}, RPNetwork),
 	)
 	testcontainers.CleanupContainer(t, ctr)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "invalid port on listener redpanda:99092")
+	require.ErrorContains(t, err, "invalid port on listener redpanda:99092")
 }
 
 func TestRedpandaListener_NoNetwork(t *testing.T) {
@@ -520,9 +519,7 @@ func TestRedpandaListener_NoNetwork(t *testing.T) {
 		redpanda.WithListener("redpanda:99092"),
 	)
 	testcontainers.CleanupContainer(t, ctr)
-	require.Error(t, err)
-
-	require.Contains(t, err.Error(), "container must be attached to at least one network")
+	require.ErrorContains(t, err, "container must be attached to at least one network")
 }
 
 func TestRedpandaBootstrapConfig(t *testing.T) {

--- a/modules/registry/registry_test.go
+++ b/modules/registry/registry_test.go
@@ -207,8 +207,7 @@ func TestRunContainer_wrongData(t *testing.T) {
 		Started: true,
 	})
 	testcontainers.CleanupContainer(t, redisC)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "manifest unknown")
+	require.ErrorContains(t, err, "manifest unknown")
 }
 
 // setAuthConfig sets the DOCKER_AUTH_CONFIG environment variable with

--- a/options_test.go
+++ b/options_test.go
@@ -96,8 +96,7 @@ func TestWithLogConsumers(t *testing.T) {
 	testcontainers.CleanupContainer(t, c)
 	// we expect an error because the MySQL environment variables are not set
 	// but this is expected because we just want to test the log consumer
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "container exited with code 1")
+	require.ErrorContains(t, err, "container exited with code 1")
 	require.NotEmpty(t, lc.msgs)
 }
 

--- a/wait/host_port_test.go
+++ b/wait/host_port_test.go
@@ -155,10 +155,7 @@ func TestHostPortStrategyFailsWhileGettingPortDueToOOMKilledContainer(t *testing
 
 	{
 		err := wg.WaitUntilReady(context.Background(), target)
-		require.Error(t, err)
-
-		expected := "container crashed with out-of-memory (OOMKilled)"
-		require.Contains(t, err.Error(), expected)
+		require.ErrorContains(t, err, "container crashed with out-of-memory (OOMKilled)")
 	}
 }
 
@@ -189,10 +186,7 @@ func TestHostPortStrategyFailsWhileGettingPortDueToExitedContainer(t *testing.T)
 
 	{
 		err := wg.WaitUntilReady(context.Background(), target)
-		require.Error(t, err)
-
-		expected := "container exited with code 1"
-		require.Contains(t, err.Error(), expected)
+		require.ErrorContains(t, err, "container exited with code 1")
 	}
 }
 
@@ -222,10 +216,7 @@ func TestHostPortStrategyFailsWhileGettingPortDueToUnexpectedContainerStatus(t *
 
 	{
 		err := wg.WaitUntilReady(context.Background(), target)
-		require.Error(t, err)
-
-		expected := "unexpected container status \"dead\""
-		require.Contains(t, err.Error(), expected)
+		require.ErrorContains(t, err, "unexpected container status \"dead\"")
 	}
 }
 
@@ -250,10 +241,7 @@ func TestHostPortStrategyFailsWhileExternalCheckingDueToOOMKilledContainer(t *te
 
 	{
 		err := wg.WaitUntilReady(context.Background(), target)
-		require.Error(t, err)
-
-		expected := "container crashed with out-of-memory (OOMKilled)"
-		require.Contains(t, err.Error(), expected)
+		require.ErrorContains(t, err, "container crashed with out-of-memory (OOMKilled)")
 	}
 }
 
@@ -279,10 +267,7 @@ func TestHostPortStrategyFailsWhileExternalCheckingDueToExitedContainer(t *testi
 
 	{
 		err := wg.WaitUntilReady(context.Background(), target)
-		require.Error(t, err)
-
-		expected := "container exited with code 1"
-		require.Contains(t, err.Error(), expected)
+		require.ErrorContains(t, err, "container exited with code 1")
 	}
 }
 
@@ -307,10 +292,7 @@ func TestHostPortStrategyFailsWhileExternalCheckingDueToUnexpectedContainerStatu
 
 	{
 		err := wg.WaitUntilReady(context.Background(), target)
-		require.Error(t, err)
-
-		expected := "unexpected container status \"dead\""
-		require.Contains(t, err.Error(), expected)
+		require.ErrorContains(t, err, "unexpected container status \"dead\"")
 	}
 }
 
@@ -354,10 +336,7 @@ func TestHostPortStrategyFailsWhileInternalCheckingDueToOOMKilledContainer(t *te
 
 	{
 		err := wg.WaitUntilReady(context.Background(), target)
-		require.Error(t, err)
-
-		expected := "container crashed with out-of-memory (OOMKilled)"
-		require.Contains(t, err.Error(), expected)
+		require.ErrorContains(t, err, "container crashed with out-of-memory (OOMKilled)")
 	}
 }
 
@@ -402,10 +381,7 @@ func TestHostPortStrategyFailsWhileInternalCheckingDueToExitedContainer(t *testi
 
 	{
 		err := wg.WaitUntilReady(context.Background(), target)
-		require.Error(t, err)
-
-		expected := "container exited with code 1"
-		require.Contains(t, err.Error(), expected)
+		require.ErrorContains(t, err, "container exited with code 1")
 	}
 }
 
@@ -449,10 +425,7 @@ func TestHostPortStrategyFailsWhileInternalCheckingDueToUnexpectedContainerStatu
 
 	{
 		err := wg.WaitUntilReady(context.Background(), target)
-		require.Error(t, err)
-
-		expected := "unexpected container status \"dead\""
-		require.Contains(t, err.Error(), expected)
+		require.ErrorContains(t, err, "unexpected container status \"dead\"")
 	}
 }
 


### PR DESCRIPTION
## What does this PR do?

It uses  `require.Contains(t,...)` or `require.ErrorContains(t, err,...)` when possible
It also removes `require.Error(t, err,...)` as it is redundant with `require.ErrorContains(t, err,...)` behavior

## Why is it important?

To simplify code and not omit to check that error happened befort checking it's message content.

Signed-off-by: Matthieu MOREL <matthieu.morel35@gmail.com>