### PR TITLE
fix(postgres): duplicate snapshot name

### DIFF
--- a/modules/postgres/postgres.go
+++ b/modules/postgres/postgres.go
@@ -217,6 +217,7 @@ func (c *PostgresContainer) Snapshot(ctx context.Context, opts ...SnapshotOption
 	// execute the commands to create the snapshot, in order
 	if err := c.execCommandsSQL(ctx,
 		// Drop the snapshot database if it already exists
+		fmt.Sprintf(`UPDATE pg_database SET datistemplate = FALSE WHERE datname = '%s'`, snapshotName),
 		fmt.Sprintf(`DROP DATABASE IF EXISTS "%s"`, snapshotName),
 		// Create a copy of the database to another database to use as a template now that it was fully migrated
 		fmt.Sprintf(`CREATE DATABASE "%s" WITH TEMPLATE "%s" OWNER "%s"`, snapshotName, c.dbName, c.user),


### PR DESCRIPTION
Fix postgres snapshot name reuse by removing its template flag before trying to delete it.

Fixes #2822