### PR TITLE
chore: enable usestdlibvars linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -10,6 +10,7 @@ linters:
     - nonamedreturns
     - testifylint
     - thelper
+    - usestdlibvars
 
 linters-settings:
   errorlint:

--- a/modules/elasticsearch/elasticsearch_test.go
+++ b/modules/elasticsearch/elasticsearch_test.go
@@ -87,7 +87,7 @@ func TestElasticsearch(t *testing.T) {
 
 			httpClient := configureHTTPClient(esContainer)
 
-			req, err := http.NewRequest("GET", esContainer.Settings.Address, nil)
+			req, err := http.NewRequest(http.MethodGet, esContainer.Settings.Address, nil)
 			require.NoError(t, err)
 
 			// set the password for the request using the Authentication header
@@ -202,7 +202,7 @@ func TestElasticsearch8WithoutCredentials(t *testing.T) {
 
 	httpClient := configureHTTPClient(ctr)
 
-	req, err := http.NewRequest("GET", ctr.Settings.Address, nil)
+	req, err := http.NewRequest(http.MethodGet, ctr.Settings.Address, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/modules/ollama/examples_test.go
+++ b/modules/ollama/examples_test.go
@@ -85,7 +85,7 @@ func ExampleRun_withModel_llama2_http() {
 	"prompt":"Why is the sky blue?"
 }`
 
-	req, err := http.NewRequest("POST", fmt.Sprintf("%s/api/generate", connectionStr), strings.NewReader(payload))
+	req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("%s/api/generate", connectionStr), strings.NewReader(payload))
 	if err != nil {
 		log.Printf("failed to create request: %s", err)
 		return

--- a/modules/opensearch/opensearch_test.go
+++ b/modules/opensearch/opensearch_test.go
@@ -24,7 +24,7 @@ func TestOpenSearch(t *testing.T) {
 
 		client := &http.Client{}
 
-		req, err := http.NewRequest("GET", address, nil)
+		req, err := http.NewRequest(http.MethodGet, address, nil)
 		require.NoError(t, err)
 
 		resp, err := client.Do(req)


### PR DESCRIPTION
## What does this PR do?

Setup [usestdlibvars](https://golangci-lint.run/usage/linters/#usestdlibvars) linter and apply it’s recommandations .

## Why is it important?

usestdlibvars detect the possibility to use variables/constants from the Go standard library.

<!-- Signed-off-by: Matthieu MOREL <matthieu.morel35@gmail.com> -->