### PR TITLE
chore: bump ryuk to 0.11.0

### DIFF
--- a/docs/features/configuration.md
+++ b/docs/features/configuration.md
@@ -50,9 +50,9 @@ Please read more about customizing images in the [Image name substitution](image
 1. If your environment already implements automatic cleanup of containers after the execution,
 but does not allow starting privileged containers, you can turn off the Ryuk container by setting
 `TESTCONTAINERS_RYUK_DISABLED` **environment variable** , or the  `ryuk.disabled` **property** to `true`.
-1. You can specify the connection timeout for Ryuk by setting the `TESTCONTAINERS_RYUK_CONNECTION_TIMEOUT` **environment variable**, or the `ryuk.connection.timeout` **property**. The default value is 1 minute.
-1. You can specify the reconnection timeout for Ryuk by setting the `TESTCONTAINERS_RYUK_RECONNECTION_TIMEOUT` **environment variable**, or the `ryuk.reconnection.timeout` **property**. The default value is 10 seconds.
-1. You can configure Ryuk to run in verbose mode by setting any of the `ryuk.verbose` **property** or the `TESTCONTAINERS_RYUK_VERBOSE` **environment variable**. The default value is `false`.
+1. You can specify the connection timeout for Ryuk by setting the `RYUK_CONNECTION_TIMEOUT` **environment variable**, or the `ryuk.connection.timeout` **property**. The default value is 1 minute.
+1. You can specify the reconnection timeout for Ryuk by setting the `RYUK_RECONNECTION_TIMEOUT` **environment variable**, or the `ryuk.reconnection.timeout` **property**. The default value is 10 seconds.
+1. You can configure Ryuk to run in verbose mode by setting any of the `ryuk.verbose` **property** or the `RYUK_VERBOSE` **environment variable**. The default value is `false`.
 
 !!!info
     For more information about Ryuk, see [Garbage Collector](garbage_collector.md).
@@ -61,6 +61,12 @@ but does not allow starting privileged containers, you can turn off the Ryuk con
     If using Ryuk and the Compose module, please increase the `ryuk.connection.timeout` to at least 5 minutes.
     This is because the Compose module may take longer to start all the services. Besides, the `ryuk.reconnection.timeout`
     should be increased to at least 30 seconds. For further information, please check [https://github.com/testcontainers/testcontainers-go/pull/2485](https://github.com/testcontainers/testcontainers-go/pull/2485).
+
+!!!warn
+    The following environment variables for configuring Ryuk have been deprecated:
+    `TESTCONTAINERS_RYUK_CONNECTION_TIMEOUT`, `TESTCONTAINERS_RYUK_RECONNECTION_TIMEOUT` and
+    `TESTCONTAINERS_RYUK_VERBOSE` have been replaced by `RYUK_CONNECTION_TIMEOUT`
+    `RYUK_RECONNECTION_TIMEOUT` and `RYUK_VERBOSE` respectively.
 
 ## Docker host detection
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -11,7 +11,7 @@ import (
 	"github.com/magiconair/properties"
 )
 
-const ReaperDefaultImage = "testcontainers/ryuk:0.10.2"
+const ReaperDefaultImage = "testcontainers/ryuk:0.11.0"
 
 var (
 	tcConfig     Config

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -68,17 +68,17 @@ type Config struct {
 
 	// RyukReconnectionTimeout is the time to wait before attempting to reconnect to the Garbage Collector container.
 	//
-	// Environment variable: TESTCONTAINERS_RYUK_RECONNECTION_TIMEOUT
+	// Environment variable: RYUK_RECONNECTION_TIMEOUT
 	RyukReconnectionTimeout time.Duration `properties:"ryuk.reconnection.timeout,default=10s"`
 
 	// RyukConnectionTimeout is the time to wait before timing out when connecting to the Garbage Collector container.
 	//
-	// Environment variable: TESTCONTAINERS_RYUK_CONNECTION_TIMEOUT
+	// Environment variable: RYUK_CONNECTION_TIMEOUT
 	RyukConnectionTimeout time.Duration `properties:"ryuk.connection.timeout,default=1m"`
 
 	// RyukVerbose is a flag to enable or disable verbose logging for the Garbage Collector.
 	//
-	// Environment variable: TESTCONTAINERS_RYUK_VERBOSE
+	// Environment variable: RYUK_VERBOSE
 	RyukVerbose bool `properties:"ryuk.verbose,default=false"`
 
 	// TestcontainersHost is the address of the Testcontainers host.
@@ -126,17 +126,17 @@ func read() Config {
 			config.RyukPrivileged = ryukPrivilegedEnv == "true"
 		}
 
-		ryukVerboseEnv := os.Getenv("TESTCONTAINERS_RYUK_VERBOSE")
+		ryukVerboseEnv := readTestcontainersEnv("RYUK_VERBOSE")
 		if parseBool(ryukVerboseEnv) {
 			config.RyukVerbose = ryukVerboseEnv == "true"
 		}
 
-		ryukReconnectionTimeoutEnv := os.Getenv("TESTCONTAINERS_RYUK_RECONNECTION_TIMEOUT")
+		ryukReconnectionTimeoutEnv := readTestcontainersEnv("RYUK_RECONNECTION_TIMEOUT")
 		if timeout, err := time.ParseDuration(ryukReconnectionTimeoutEnv); err == nil {
 			config.RyukReconnectionTimeout = timeout
 		}
 
-		ryukConnectionTimeoutEnv := os.Getenv("TESTCONTAINERS_RYUK_CONNECTION_TIMEOUT")
+		ryukConnectionTimeoutEnv := readTestcontainersEnv("RYUK_CONNECTION_TIMEOUT")
 		if timeout, err := time.ParseDuration(ryukConnectionTimeoutEnv); err == nil {
 			config.RyukConnectionTimeout = timeout
 		}
@@ -167,4 +167,19 @@ func read() Config {
 func parseBool(input string) bool {
 	_, err := strconv.ParseBool(input)
 	return err == nil
+}
+
+// readTestcontainersEnv reads the environment variable with the given name.
+// It checks for the environment variable with the given name first, and then
+// checks for the environment variable with the given name prefixed with "TESTCONTAINERS_".
+func readTestcontainersEnv(envVar string) string {
+	value := os.Getenv(envVar)
+	if value != "" {
+		return value
+	}
+
+	// TODO: remove this prefix after the next major release
+	const prefix string = "TESTCONTAINERS_"
+
+	return os.Getenv(prefix + envVar)
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -23,9 +23,9 @@ func resetTestEnv(t *testing.T) {
 	t.Setenv("TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX", "")
 	t.Setenv("TESTCONTAINERS_RYUK_DISABLED", "")
 	t.Setenv("TESTCONTAINERS_RYUK_CONTAINER_PRIVILEGED", "")
-	t.Setenv("TESTCONTAINERS_RYUK_VERBOSE", "")
-	t.Setenv("TESTCONTAINERS_RYUK_RECONNECTION_TIMEOUT", "")
-	t.Setenv("TESTCONTAINERS_RYUK_CONNECTION_TIMEOUT", "")
+	t.Setenv("RYUK_VERBOSE", "")
+	t.Setenv("RYUK_RECONNECTION_TIMEOUT", "")
+	t.Setenv("RYUK_CONNECTION_TIMEOUT", "")
 }
 
 func TestReadConfig(t *testing.T) {
@@ -77,8 +77,8 @@ func TestReadTCConfig(t *testing.T) {
 		t.Setenv("TESTCONTAINERS_RYUK_DISABLED", "true")
 		t.Setenv("TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX", defaultHubPrefix)
 		t.Setenv("TESTCONTAINERS_RYUK_CONTAINER_PRIVILEGED", "true")
-		t.Setenv("TESTCONTAINERS_RYUK_RECONNECTION_TIMEOUT", "13s")
-		t.Setenv("TESTCONTAINERS_RYUK_CONNECTION_TIMEOUT", "12s")
+		t.Setenv("RYUK_RECONNECTION_TIMEOUT", "13s")
+		t.Setenv("RYUK_CONNECTION_TIMEOUT", "12s")
 
 		config := read()
 
@@ -125,9 +125,9 @@ func TestReadTCConfig(t *testing.T) {
 		t.Setenv("TESTCONTAINERS_RYUK_DISABLED", "true")
 		t.Setenv("TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX", defaultHubPrefix)
 		t.Setenv("TESTCONTAINERS_RYUK_CONTAINER_PRIVILEGED", "true")
-		t.Setenv("TESTCONTAINERS_RYUK_VERBOSE", "true")
-		t.Setenv("TESTCONTAINERS_RYUK_RECONNECTION_TIMEOUT", "13s")
-		t.Setenv("TESTCONTAINERS_RYUK_CONNECTION_TIMEOUT", "12s")
+		t.Setenv("RYUK_VERBOSE", "true")
+		t.Setenv("RYUK_RECONNECTION_TIMEOUT", "13s")
+		t.Setenv("RYUK_CONNECTION_TIMEOUT", "12s")
 
 		config := read()
 		expected := Config{
@@ -278,8 +278,8 @@ func TestReadTCConfig(t *testing.T) {
 				"With Ryuk container timeouts configured using env vars",
 				``,
 				map[string]string{
-					"TESTCONTAINERS_RYUK_RECONNECTION_TIMEOUT": "13s",
-					"TESTCONTAINERS_RYUK_CONNECTION_TIMEOUT":   "12s",
+					"RYUK_RECONNECTION_TIMEOUT": "13s",
+					"RYUK_CONNECTION_TIMEOUT":   "12s",
 				},
 				Config{
 					RyukReconnectionTimeout: 13 * time.Second,
@@ -291,8 +291,8 @@ func TestReadTCConfig(t *testing.T) {
 				`ryuk.connection.timeout=22s
 	ryuk.reconnection.timeout=23s`,
 				map[string]string{
-					"TESTCONTAINERS_RYUK_RECONNECTION_TIMEOUT": "13s",
-					"TESTCONTAINERS_RYUK_CONNECTION_TIMEOUT":   "12s",
+					"RYUK_RECONNECTION_TIMEOUT": "13s",
+					"RYUK_CONNECTION_TIMEOUT":   "12s",
 				},
 				Config{
 					RyukReconnectionTimeout: 13 * time.Second,
@@ -377,7 +377,7 @@ func TestReadTCConfig(t *testing.T) {
 				"With Ryuk verbose using an env var and properties. Env var wins (0)",
 				`ryuk.verbose=true`,
 				map[string]string{
-					"TESTCONTAINERS_RYUK_VERBOSE": "true",
+					"RYUK_VERBOSE": "true",
 				},
 				Config{
 					RyukVerbose:             true,
@@ -389,7 +389,7 @@ func TestReadTCConfig(t *testing.T) {
 				"With Ryuk verbose using an env var and properties. Env var wins (1)",
 				`ryuk.verbose=false`,
 				map[string]string{
-					"TESTCONTAINERS_RYUK_VERBOSE": "true",
+					"RYUK_VERBOSE": "true",
 				},
 				Config{
 					RyukVerbose:             true,
@@ -401,7 +401,7 @@ func TestReadTCConfig(t *testing.T) {
 				"With Ryuk verbose using an env var and properties. Env var wins (2)",
 				`ryuk.verbose=true`,
 				map[string]string{
-					"TESTCONTAINERS_RYUK_VERBOSE": "false",
+					"RYUK_VERBOSE": "false",
 				},
 				defaultConfig,
 			},
@@ -409,7 +409,7 @@ func TestReadTCConfig(t *testing.T) {
 				"With Ryuk verbose using an env var and properties. Env var wins (3)",
 				`ryuk.verbose=false`,
 				map[string]string{
-					"TESTCONTAINERS_RYUK_VERBOSE": "false",
+					"RYUK_VERBOSE": "false",
 				},
 				defaultConfig,
 			},


### PR DESCRIPTION
- **chore: bump ryuk**
- **chore: use new ryuk variables, with a deprecation path**

<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
It uses the latest ryuk (0.11.0), updating the environment variables that are already in use in tc-go to configure ryuk to use the new format (without the `TESTCONTAINERS_` prefix).

The old variables are deprecated but in the mean time the code will still read them as a part of a deprecation path.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
Consume the latest Ryuk, which comes with more improvements regarding reliability.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->


<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
