### PR TITLE
chore: use require.Len instead of assert.Len

### DIFF
--- a/lifecycle_test.go
+++ b/lifecycle_test.go
@@ -781,7 +781,7 @@ func TestCombineLifecycleHooks(t *testing.T) {
 
 	// There are 5 lifecycles (create, start, ready, stop, terminate),
 	// but ready has only half of the hooks (it only has post), so we have 90 hooks in total.
-	assert.Len(t, prints, 90)
+	require.Len(t, prints, 90)
 
 	// The order of the hooks is:
 	// - pre-X hooks: first default (2*2), then user-defined (3*2)

--- a/modulegen/main_test.go
+++ b/modulegen/main_test.go
@@ -494,7 +494,7 @@ func assertMkdocsNavItems(t *testing.T, module context.TestcontainersModule, ori
 		expectedEntries = originalConfig.Nav[3].Modules
 	}
 
-	assert.Len(t, navItems, len(expectedEntries)+1)
+	require.Len(t, navItems, len(expectedEntries)+1)
 
 	// the module should be in the nav
 	found := false

--- a/modulegen/mkdocs_test.go
+++ b/modulegen/mkdocs_test.go
@@ -64,7 +64,7 @@ func TestNavItems(t *testing.T) {
 	require.NoError(t, err)
 
 	// we have to remove the index.md file from the examples docs
-	assert.Len(t, examples, len(examplesDocs)-1)
+	require.Len(t, examples, len(examplesDocs)-1)
 
 	// all example modules exist in the documentation
 	for _, example := range examples {

--- a/modules/compose/compose_api_test.go
+++ b/modules/compose/compose_api_test.go
@@ -58,7 +58,7 @@ func TestDockerComposeAPIStrategyForInvalidService(t *testing.T) {
 
 	serviceNames := compose.Services()
 
-	assert.Len(t, serviceNames, 1)
+	require.Len(t, serviceNames, 1)
 	assert.Contains(t, serviceNames, "api-nginx")
 }
 
@@ -102,7 +102,7 @@ func TestDockerComposeAPIWithRunServices(t *testing.T) {
 	_, err = compose.ServiceContainer(context.Background(), "api-mysql")
 	require.Error(t, err, "Make sure there is no mysql container")
 
-	assert.Len(t, serviceNames, 1)
+	require.Len(t, serviceNames, 1)
 	assert.Contains(t, serviceNames, "api-nginx")
 }
 
@@ -304,7 +304,7 @@ func TestDockerComposeAPIWithWaitForService(t *testing.T) {
 
 	serviceNames := compose.Services()
 
-	assert.Len(t, serviceNames, 1)
+	require.Len(t, serviceNames, 1)
 	assert.Contains(t, serviceNames, "api-nginx")
 }
 
@@ -327,7 +327,7 @@ func TestDockerComposeAPIWithWaitHTTPStrategy(t *testing.T) {
 
 	serviceNames := compose.Services()
 
-	assert.Len(t, serviceNames, 1)
+	require.Len(t, serviceNames, 1)
 	assert.Contains(t, serviceNames, "api-nginx")
 }
 
@@ -350,7 +350,7 @@ func TestDockerComposeAPIWithContainerName(t *testing.T) {
 
 	serviceNames := compose.Services()
 
-	assert.Len(t, serviceNames, 1)
+	require.Len(t, serviceNames, 1)
 	assert.Contains(t, serviceNames, "api-nginx")
 }
 
@@ -370,7 +370,7 @@ func TestDockerComposeAPIWithWaitStrategy_NoExposedPorts(t *testing.T) {
 
 	serviceNames := compose.Services()
 
-	assert.Len(t, serviceNames, 1)
+	require.Len(t, serviceNames, 1)
 	assert.Contains(t, serviceNames, "api-nginx")
 }
 
@@ -417,7 +417,7 @@ func TestDockerComposeAPIWithFailedStrategy(t *testing.T) {
 
 	serviceNames := compose.Services()
 
-	assert.Len(t, serviceNames, 1)
+	require.Len(t, serviceNames, 1)
 	assert.Contains(t, serviceNames, "api-nginx")
 }
 
@@ -469,7 +469,7 @@ services:
 
 	serviceNames := compose.Services()
 
-	assert.Len(t, serviceNames, 1)
+	require.Len(t, serviceNames, 1)
 	assert.Contains(t, serviceNames, "api-nginx")
 
 	require.NoError(t, compose.Down(context.Background(), RemoveOrphans(true), RemoveVolumes(true), RemoveImagesLocal), "compose.Down()")
@@ -513,7 +513,7 @@ services:
 
 	serviceNames := compose.Services()
 
-	assert.Len(t, serviceNames, 2)
+	require.Len(t, serviceNames, 2)
 	assert.Contains(t, serviceNames, "api-nginx")
 	assert.Contains(t, serviceNames, "api-postgres")
 
@@ -546,7 +546,7 @@ func TestDockerComposeAPIWithEnvironment(t *testing.T) {
 
 	serviceNames := compose.Services()
 
-	assert.Len(t, serviceNames, 1)
+	require.Len(t, serviceNames, 1)
 	assert.Contains(t, serviceNames, "api-nginx")
 
 	present := map[string]string{
@@ -583,7 +583,7 @@ func TestDockerComposeAPIWithMultipleComposeFiles(t *testing.T) {
 
 	serviceNames := compose.Services()
 
-	assert.Len(t, serviceNames, 3)
+	require.Len(t, serviceNames, 3)
 	assert.Contains(t, serviceNames, "api-nginx")
 	assert.Contains(t, serviceNames, "api-mysql")
 	assert.Contains(t, serviceNames, "api-postgres")
@@ -684,7 +684,7 @@ func TestDockerComposeApiWithWaitForShortLifespanService(t *testing.T) {
 
 	services := compose.Services()
 
-	assert.Len(t, services, 2)
+	require.Len(t, services, 2)
 	assert.Contains(t, services, "falafel")
 	assert.Contains(t, services, "tzatziki")
 }

--- a/modules/compose/compose_test.go
+++ b/modules/compose/compose_test.go
@@ -134,7 +134,7 @@ func TestLocalDockerComposeStrategyForInvalidService(t *testing.T) {
 		Invoke()
 	require.Error(t, err.Error, "Expected error to be thrown because service with wait strategy is not running")
 
-	assert.Len(t, compose.Services, 1)
+	require.Len(t, compose.Services, 1)
 	assert.Contains(t, compose.Services, "local-nginx")
 }
 
@@ -157,7 +157,7 @@ func TestLocalDockerComposeWithWaitLogStrategy(t *testing.T) {
 		Invoke()
 	checkIfError(t, err)
 
-	assert.Len(t, compose.Services, 2)
+	require.Len(t, compose.Services, 2)
 	assert.Contains(t, compose.Services, "local-nginx")
 	assert.Contains(t, compose.Services, "local-mysql")
 }
@@ -183,7 +183,7 @@ func TestLocalDockerComposeWithWaitForService(t *testing.T) {
 		Invoke()
 	checkIfError(t, err)
 
-	assert.Len(t, compose.Services, 1)
+	require.Len(t, compose.Services, 1)
 	assert.Contains(t, compose.Services, "local-nginx")
 }
 
@@ -207,7 +207,7 @@ func TestLocalDockerComposeWithWaitForShortLifespanService(t *testing.T) {
 		Invoke()
 	checkIfError(t, err)
 
-	assert.Len(t, compose.Services, 2)
+	require.Len(t, compose.Services, 2)
 	assert.Contains(t, compose.Services, "falafel")
 	assert.Contains(t, compose.Services, "tzatziki")
 }
@@ -233,7 +233,7 @@ func TestLocalDockerComposeWithWaitHTTPStrategy(t *testing.T) {
 		Invoke()
 	checkIfError(t, err)
 
-	assert.Len(t, compose.Services, 1)
+	require.Len(t, compose.Services, 1)
 	assert.Contains(t, compose.Services, "local-nginx")
 }
 
@@ -258,7 +258,7 @@ func TestLocalDockerComposeWithContainerName(t *testing.T) {
 		Invoke()
 	checkIfError(t, err)
 
-	assert.Len(t, compose.Services, 1)
+	require.Len(t, compose.Services, 1)
 	assert.Contains(t, compose.Services, "local-nginx")
 }
 
@@ -280,7 +280,7 @@ func TestLocalDockerComposeWithWaitStrategy_NoExposedPorts(t *testing.T) {
 		Invoke()
 	checkIfError(t, err)
 
-	assert.Len(t, compose.Services, 1)
+	require.Len(t, compose.Services, 1)
 	assert.Contains(t, compose.Services, "local-nginx")
 }
 
@@ -303,7 +303,7 @@ func TestLocalDockerComposeWithMultipleWaitStrategies(t *testing.T) {
 		Invoke()
 	checkIfError(t, err)
 
-	assert.Len(t, compose.Services, 2)
+	require.Len(t, compose.Services, 2)
 	assert.Contains(t, compose.Services, "local-nginx")
 	assert.Contains(t, compose.Services, "local-mysql")
 }
@@ -331,7 +331,7 @@ func TestLocalDockerComposeWithFailedStrategy(t *testing.T) {
 	// A specific error message matcher is not asserted since the docker library can change the return message, breaking this test
 	require.Error(t, err.Error, "Expected error to be thrown because of a wrong suplied wait strategy")
 
-	assert.Len(t, compose.Services, 1)
+	require.Len(t, compose.Services, 1)
 	assert.Contains(t, compose.Services, "local-nginx")
 }
 
@@ -352,7 +352,7 @@ func TestLocalDockerComposeComplex(t *testing.T) {
 		Invoke()
 	checkIfError(t, err)
 
-	assert.Len(t, compose.Services, 2)
+	require.Len(t, compose.Services, 2)
 	assert.Contains(t, compose.Services, "local-nginx")
 	assert.Contains(t, compose.Services, "local-mysql")
 }
@@ -377,7 +377,7 @@ func TestLocalDockerComposeWithEnvironment(t *testing.T) {
 		Invoke()
 	checkIfError(t, err)
 
-	assert.Len(t, compose.Services, 1)
+	require.Len(t, compose.Services, 1)
 	assert.Contains(t, compose.Services, "local-nginx")
 
 	present := map[string]string{
@@ -413,7 +413,7 @@ func TestLocalDockerComposeWithMultipleComposeFiles(t *testing.T) {
 		Invoke()
 	checkIfError(t, err)
 
-	assert.Len(t, compose.Services, 3)
+	require.Len(t, compose.Services, 3)
 	assert.Contains(t, compose.Services, "local-nginx")
 	assert.Contains(t, compose.Services, "local-mysql")
 	assert.Contains(t, compose.Services, "local-postgres")

--- a/modules/localstack/v1/s3_test.go
+++ b/modules/localstack/v1/s3_test.go
@@ -104,7 +104,7 @@ func TestS3(t *testing.T) {
 			require.NotNil(t, output)
 
 			buckets := output.Buckets
-			assert.Len(t, buckets, 1)
+			require.Len(t, buckets, 1)
 			assert.Equal(t, bucketName, *buckets[0].Name)
 		})
 
@@ -117,7 +117,7 @@ func TestS3(t *testing.T) {
 
 			objects := output.Contents
 
-			assert.Len(t, objects, 1)
+			require.Len(t, objects, 1)
 			assert.Equal(t, s3Key1, *objects[0].Key)
 			assert.Equal(t, int64(len(body1)), *objects[0].Size)
 		})

--- a/modules/localstack/v2/s3_test.go
+++ b/modules/localstack/v2/s3_test.go
@@ -110,7 +110,7 @@ func TestS3(t *testing.T) {
 			require.NotNil(t, output)
 
 			buckets := output.Buckets
-			assert.Len(t, buckets, 1)
+			require.Len(t, buckets, 1)
 			assert.Equal(t, bucketName, *buckets[0].Name)
 		})
 
@@ -123,7 +123,7 @@ func TestS3(t *testing.T) {
 
 			objects := output.Contents
 
-			assert.Len(t, objects, 1)
+			require.Len(t, objects, 1)
 			assert.Equal(t, s3Key1, *objects[0].Key)
 			assert.Equal(t, aws.Int64(int64(len(body1))), objects[0].Size)
 		})

--- a/options_test.go
+++ b/options_test.go
@@ -54,7 +54,7 @@ func TestOverrideContainerRequest(t *testing.T) {
 
 	// toBeMergedRequest should not be changed
 	assert.Equal(t, "", toBeMergedRequest.Env["BAR"])
-	assert.Len(t, toBeMergedRequest.ExposedPorts, 1)
+	require.Len(t, toBeMergedRequest.ExposedPorts, 1)
 	assert.Equal(t, "67890/tcp", toBeMergedRequest.ExposedPorts[0])
 
 	// req should be merged with toBeMergedRequest


### PR DESCRIPTION
## What does this PR do?

This uses `require.Len` instead of `assert.Len` calls when element is reused for tests.


## Why is it important?

When assert.Len is used, this is generally to check the length of a list that is generally used in at least one other test.

## Related issues
- Relates #2808 