### PR TITLE
chore: use require instead of t.Fatal (part 2)

### DIFF
--- a/lifecycle_test.go
+++ b/lifecycle_test.go
@@ -3,7 +3,9 @@ package testcontainers
 import (
 	"bufio"
 	"context"
+	"errors"
 	"fmt"
+	"io"
 	"strings"
 	"testing"
 	"time"
@@ -914,13 +916,10 @@ func TestPrintContainerLogsOnError(t *testing.T) {
 	rd := bufio.NewReader(containerLogs)
 	for {
 		line, err := rd.ReadString('\n')
-		if err != nil {
-			if err.Error() == "EOF" {
-				break
-			}
-
-			t.Fatal("Read Error:", err)
+		if errors.Is(err, io.EOF) {
+			break
 		}
+		require.NoErrorf(t, err, "Read Error")
 
 		// the last line of the array should contain the line of interest,
 		// but we are checking all the lines to make sure that is present

--- a/logconsumer_test.go
+++ b/logconsumer_test.go
@@ -323,9 +323,8 @@ func TestContainerLogWithErrClosed(t *testing.T) {
 
 	hitNginx := func() {
 		i, _, err := dind.Exec(ctx, []string{"wget", "--spider", "localhost:" + port.Port()})
-		if err != nil || i > 0 {
-			t.Fatalf("Can't make request to nginx container from dind container")
-		}
+		require.NoError(t, err, "Can't make request to nginx container from dind container")
+		require.Zerof(t, i, "Can't make request to nginx container from dind container")
 	}
 
 	hitNginx()
@@ -340,13 +339,11 @@ func TestContainerLogWithErrClosed(t *testing.T) {
 	}
 	// Simulate a transient closed connection to the docker daemon
 	i, _, err := dind.Exec(ctx, append([]string{"iptables", "-A"}, iptableArgs...))
-	if err != nil || i > 0 {
-		t.Fatalf("Failed to close connection to dind daemon: i(%d), err %v", i, err)
-	}
+	require.NoErrorf(t, err, "Failed to close connection to dind daemon: i(%d), err %v", i, err)
+	require.Zerof(t, i, "Failed to close connection to dind daemon: i(%d), err %v", i, err)
 	i, _, err = dind.Exec(ctx, append([]string{"iptables", "-D"}, iptableArgs...))
-	if err != nil || i > 0 {
-		t.Fatalf("Failed to re-open connection to dind daemon: i(%d), err %v", i, err)
-	}
+	require.NoErrorf(t, err, "Failed to re-open connection to dind daemon: i(%d), err %v", i, err)
+	require.Zerof(t, i, "Failed to re-open connection to dind daemon: i(%d), err %v", i, err)
 	time.Sleep(time.Second * 3)
 
 	hitNginx()

--- a/modules/chroma/chroma_test.go
+++ b/modules/chroma/chroma_test.go
@@ -23,33 +23,23 @@ func TestChroma(t *testing.T) {
 		// restEndpoint {
 		restEndpoint, err := ctr.RESTEndpoint(ctx)
 		// }
-		if err != nil {
-			tt.Fatalf("failed to get REST endpoint: %s", err)
-		}
+		require.NoErrorf(tt, err, "failed to get REST endpoint")
 
 		cli := &http.Client{}
 		resp, err := cli.Get(restEndpoint + "/docs")
-		if err != nil {
-			tt.Fatalf("failed to perform GET request: %s", err)
-		}
+		require.NoErrorf(tt, err, "failed to perform GET request")
 		defer resp.Body.Close()
 
-		if resp.StatusCode != http.StatusOK {
-			tt.Fatalf("unexpected status code: %d", resp.StatusCode)
-		}
+		require.Equalf(tt, http.StatusOK, resp.StatusCode, "unexpected status code: %d", resp.StatusCode)
 	})
 
 	t.Run("GetClient", func(tt *testing.T) {
 		// restEndpoint {
 		endpoint, err := ctr.RESTEndpoint(context.Background())
-		if err != nil {
-			tt.Fatalf("failed to get REST endpoint: %s", err)
-		}
+		require.NoErrorf(tt, err, "failed to get REST endpoint")
 		chromaClient, err := chromago.NewClient(endpoint)
 		// }
-		if err != nil {
-			tt.Fatalf("failed to create client: %s", err)
-		}
+		require.NoErrorf(tt, err, "failed to create client")
 
 		hb, err := chromaClient.Heartbeat(context.TODO())
 		require.NoError(tt, err)

--- a/modules/compose/compose_test.go
+++ b/modules/compose/compose_test.go
@@ -448,22 +448,16 @@ func TestLocalDockerComposeWithVolume(t *testing.T) {
 func assertVolumeDoesNotExist(tb testing.TB, volumeName string) {
 	tb.Helper()
 	containerClient, err := testcontainers.NewDockerClientWithOpts(context.Background())
-	if err != nil {
-		tb.Fatalf("Failed to get provider: %v", err)
-	}
+	require.NoErrorf(tb, err, "Failed to get provider")
 
 	volumeList, err := containerClient.VolumeList(context.Background(), volume.ListOptions{Filters: filters.NewArgs(filters.Arg("name", volumeName))})
-	if err != nil {
-		tb.Fatalf("Failed to list volumes: %v", err)
-	}
+	require.NoErrorf(tb, err, "Failed to list volumes")
 
 	if len(volumeList.Warnings) > 0 {
 		tb.Logf("Volume list warnings: %v", volumeList.Warnings)
 	}
 
-	if len(volumeList.Volumes) > 0 {
-		tb.Fatalf("Volume list is not empty")
-	}
+	require.Emptyf(tb, volumeList.Volumes, "Volume list is not empty")
 }
 
 func assertContainerEnvironmentVariables(
@@ -474,16 +468,11 @@ func assertContainerEnvironmentVariables(
 ) {
 	tb.Helper()
 	containerClient, err := testcontainers.NewDockerClientWithOpts(context.Background())
-	if err != nil {
-		tb.Fatalf("Failed to get provider: %v", err)
-	}
+	require.NoErrorf(tb, err, "Failed to get provider")
 
 	containers, err := containerClient.ContainerList(context.Background(), container.ListOptions{})
-	if err != nil {
-		tb.Fatalf("Failed to list containers: %v", err)
-	} else if len(containers) == 0 {
-		tb.Fatalf("container list empty")
-	}
+	require.NoErrorf(tb, err, "Failed to list containers")
+	require.NotEmptyf(tb, containers, "container list empty")
 
 	containerNameRegexp := regexp.MustCompile(fmt.Sprintf(`^\/?%s(_|-)%s(_|-)\d$`, composeIdentifier, serviceName))
 	var containerID string
@@ -499,9 +488,7 @@ containerLoop:
 	}
 
 	details, err := containerClient.ContainerInspect(context.Background(), containerID)
-	if err != nil {
-		tb.Fatalf("Failed to inspect container: %v", err)
-	}
+	require.NoErrorf(tb, err, "Failed to inspect container")
 
 	for k, v := range present {
 		keyVal := k + "=" + v
@@ -516,17 +503,11 @@ containerLoop:
 
 func checkIfError(t *testing.T, err ExecError) {
 	t.Helper()
-	if err.Error != nil {
-		t.Fatalf("Failed when running %v: %v", err.Command, err.Error)
-	}
+	require.NoErrorf(t, err.Error, "Failed when running %v", err.Command)
 
-	if err.Stdout != nil {
-		t.Fatalf("An error in Stdout happened when running %v: %v", err.Command, err.Stdout)
-	}
+	require.NoErrorf(t, err.Stdout, "An error in Stdout happened when running %v", err.Command)
 
-	if err.Stderr != nil {
-		t.Fatalf("An error in Stderr happened when running %v: %v", err.Command, err.Stderr)
-	}
+	require.NoErrorf(t, err.Stderr, "An error in Stderr happened when running %v", err.Command)
 
 	assert.NotNil(t, err.StdoutOutput)
 	assert.NotNil(t, err.StderrOutput)

--- a/modules/couchbase/couchbase_test.go
+++ b/modules/couchbase/couchbase_test.go
@@ -115,29 +115,21 @@ func TestEventingServiceWithCommunityContainer(t *testing.T) {
 func testBucketUsage(t *testing.T, bucket *gocb.Bucket) {
 	t.Helper()
 	err := bucket.WaitUntilReady(5*time.Second, nil)
-	if err != nil {
-		t.Fatalf("could not connect bucket: %s", err)
-	}
+	require.NoErrorf(t, err, "could not connect bucket")
 
 	key := "foo"
 	data := map[string]string{"key": "value"}
 	collection := bucket.DefaultCollection()
 
 	_, err = collection.Upsert(key, data, nil)
-	if err != nil {
-		t.Fatalf("could not upsert data: %s", err)
-	}
+	require.NoErrorf(t, err, "could not upsert data")
 
 	result, err := collection.Get(key, nil)
-	if err != nil {
-		t.Fatalf("could not get data: %s", err)
-	}
+	require.NoErrorf(t, err, "could not get data")
 
 	var resultData map[string]string
 	err = result.Content(&resultData)
-	if err != nil {
-		t.Fatalf("could not assign content: %s", err)
-	}
+	require.NoErrorf(t, err, "could not assign content")
 
 	if resultData["key"] != "value" {
 		t.Errorf("Expected value to be [%s], got %s", "value", resultData["key"])

--- a/modules/influxdb/influxdb_test.go
+++ b/modules/influxdb/influxdb_test.go
@@ -24,9 +24,7 @@ func TestV1Container(t *testing.T) {
 	state, err := influxDbContainer.State(ctx)
 	require.NoError(t, err)
 
-	if !state.Running {
-		t.Fatal("InfluxDB container is not running")
-	}
+	require.Truef(t, state.Running, "InfluxDB container is not running")
 }
 
 func TestV2Container(t *testing.T) {

--- a/modules/rabbitmq/rabbitmq_test.go
+++ b/modules/rabbitmq/rabbitmq_test.go
@@ -72,9 +72,7 @@ func TestRunContainer_connectUsingAmqps(t *testing.T) {
 	amqpsURL, err := rabbitmqContainer.AmqpsURL(ctx)
 	require.NoError(t, err)
 
-	if !strings.HasPrefix(amqpsURL, "amqps") {
-		t.Fatal(fmt.Errorf("AMQPS Url should begin with `amqps`"))
-	}
+	require.Truef(t, strings.HasPrefix(amqpsURL, "amqps"), "AMQPS Url should begin with `amqps`")
 
 	certs := x509.NewCertPool()
 
@@ -85,9 +83,7 @@ func TestRunContainer_connectUsingAmqps(t *testing.T) {
 	amqpsConnection, err := amqp.DialTLS(amqpsURL, &tls.Config{InsecureSkipVerify: false, RootCAs: certs})
 	require.NoError(t, err)
 
-	if amqpsConnection.IsClosed() {
-		t.Fatal(fmt.Errorf("AMQPS Connection unexpectdely closed"))
-	}
+	require.Falsef(t, amqpsConnection.IsClosed(), "AMQPS Connection unexpectdely closed")
 	err = amqpsConnection.Close()
 	require.NoError(t, err)
 }

--- a/modules/weaviate/weaviate_test.go
+++ b/modules/weaviate/weaviate_test.go
@@ -66,8 +66,7 @@ func TestWeaviate(t *testing.T) {
 		meta, err := client.Misc().MetaGetter().Do(ctx)
 		require.NoError(tt, err)
 
-		if meta == nil || meta.Version == "" {
-			tt.Fatal("failed to get /v1/meta response")
-		}
+		require.NotNilf(tt, meta, "failed to get /v1/meta response")
+		require.NotEmptyf(tt, meta.Version, "failed to get /v1/meta response")
 	})
 }


### PR DESCRIPTION
## What does this PR do?

This uses `require` instead of `t.Fatal` calls


## Why is it important?

This reduce the number of lines required to make an assertion.
It also make the assertion easier to understand.

## Related issues
- Relates #2808 