### PR TITLE
feat: use recommended cluster settings for cockroachdb

### DIFF
--- a/modules/cockroachdb/cockroachdb.go
+++ b/modules/cockroachdb/cockroachdb.go
@@ -244,17 +244,17 @@ func addTLS(ctx context.Context, container testcontainers.Container, opts option
 func setRecommendedSettings(ctx context.Context, container testcontainers.Container, opts options) error {
 	port, err := container.MappedPort(ctx, defaultSQLPort)
 	if err != nil {
-		return err
+		return fmt.Errorf("mapped port: %w", err)
 	}
 
 	host, err := container.Host(ctx)
 	if err != nil {
-		return err
+		return fmt.Errorf("host: %w", err)
 	}
 
 	db, err := sql.Open("pgx/v5", connString(opts, host, port))
 	if err != nil {
-		return err
+		return fmt.Errorf("sql.Open: %w", err)
 	}
 	defer db.Close()
 
@@ -272,7 +272,7 @@ func setRecommendedSettings(ctx context.Context, container testcontainers.Contai
 	for _, stmt := range stmts {
 		_, err = db.Exec(stmt)
 		if err != nil {
-			return err
+			return fmt.Errorf("db.Exec: %w", err)
 		}
 	}
 

--- a/modules/cockroachdb/cockroachdb.go
+++ b/modules/cockroachdb/cockroachdb.go
@@ -240,7 +240,7 @@ func addTLS(ctx context.Context, container testcontainers.Container, opts option
 }
 
 // runStatements runs the configured statements against the CockroachDB container.
-func runStatements(ctx context.Context, container testcontainers.Container, opts options) (err error) {
+func runStatements(ctx context.Context, container testcontainers.Container, opts options) (err error) { //nolint:nonamedreturns // Needed for error checking.
 	if len(opts.Statements) == 0 {
 		return nil
 	}

--- a/modules/cockroachdb/cockroachdb.go
+++ b/modules/cockroachdb/cockroachdb.go
@@ -240,7 +240,7 @@ func addTLS(ctx context.Context, container testcontainers.Container, opts option
 }
 
 // runStatements runs the configured statements against the CockroachDB container.
-func runStatements(ctx context.Context, container testcontainers.Container, opts options) (err error) { //nolint:nonamedreturns // Needed for error checking.
+func runStatements(ctx context.Context, container testcontainers.Container, opts options) (err error) {
 	if len(opts.Statements) == 0 {
 		return nil
 	}

--- a/modules/cockroachdb/cockroachdb.go
+++ b/modules/cockroachdb/cockroachdb.go
@@ -240,7 +240,7 @@ func addTLS(ctx context.Context, container testcontainers.Container, opts option
 }
 
 // runStatements runs the configured statements against the CockroachDB container.
-func runStatements(ctx context.Context, container testcontainers.Container, opts options) error {
+func runStatements(ctx context.Context, container testcontainers.Container, opts options) (err error) {
 	if len(opts.Statements) == 0 {
 		return nil
 	}
@@ -259,7 +259,12 @@ func runStatements(ctx context.Context, container testcontainers.Container, opts
 	if err != nil {
 		return fmt.Errorf("sql.Open: %w", err)
 	}
-	defer db.Close()
+	defer func() {
+		cerr := db.Close()
+		if err == nil {
+			err = cerr
+		}
+	}()
 
 	for _, stmt := range opts.Statements {
 		if _, err = db.Exec(stmt); err != nil {

--- a/modules/cockroachdb/cockroachdb.go
+++ b/modules/cockroachdb/cockroachdb.go
@@ -262,8 +262,7 @@ func runStatements(ctx context.Context, container testcontainers.Container, opts
 	defer db.Close()
 
 	for _, stmt := range opts.Statements {
-		_, err = db.Exec(stmt)
-		if err != nil {
+		if _, err = db.Exec(stmt); err != nil {
 			return fmt.Errorf("db.Exec: %w", err)
 		}
 	}

--- a/modules/cockroachdb/cockroachdb.go
+++ b/modules/cockroachdb/cockroachdb.go
@@ -93,7 +93,7 @@ func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustom
 					},
 					PostReadies: []testcontainers.ContainerHook{
 						func(ctx context.Context, container testcontainers.Container) error {
-							return setRecommendedSettings(ctx, container, o)
+							return runStatements(ctx, container, o)
 						},
 					},
 				},
@@ -239,9 +239,12 @@ func addTLS(ctx context.Context, container testcontainers.Container, opts option
 	return nil
 }
 
-// setRecommendedSettings applies the cluster settings recommended by cockroachlabs for testing clusters.
-// See https://www.cockroachlabs.com/docs/stable/local-testing for more information.
-func setRecommendedSettings(ctx context.Context, container testcontainers.Container, opts options) error {
+// runStatements runs the configured statements against the CockroachDB container.
+func runStatements(ctx context.Context, container testcontainers.Container, opts options) error {
+	if len(opts.Statements) == 0 {
+		return nil
+	}
+
 	port, err := container.MappedPort(ctx, defaultSQLPort)
 	if err != nil {
 		return fmt.Errorf("mapped port: %w", err)
@@ -258,18 +261,7 @@ func setRecommendedSettings(ctx context.Context, container testcontainers.Contai
 	}
 	defer db.Close()
 
-	stmts := []string{
-		"SET CLUSTER SETTING kv.range_merge.queue_interval = '50ms'",
-		"SET CLUSTER SETTING jobs.registry.interval.gc = '30s'",
-		"SET CLUSTER SETTING jobs.registry.interval.cancel = '180s'",
-		"SET CLUSTER SETTING jobs.retention_time = '15s'",
-		"SET CLUSTER SETTING sql.stats.automatic_collection.enabled = false",
-		"SET CLUSTER SETTING kv.range_split.by_load_merge_delay = '5s'",
-		`ALTER RANGE default CONFIGURE ZONE USING "gc.ttlseconds" = 600`,
-		`ALTER DATABASE system CONFIGURE ZONE USING "gc.ttlseconds" = 600`,
-	}
-
-	for _, stmt := range stmts {
+	for _, stmt := range opts.Statements {
 		_, err = db.Exec(stmt)
 		if err != nil {
 			return fmt.Errorf("db.Exec: %w", err)

--- a/modules/cockroachdb/cockroachdb_test.go
+++ b/modules/cockroachdb/cockroachdb_test.go
@@ -28,6 +28,9 @@ func TestCockroach_NotRoot(t *testing.T) {
 		url: "postgres://test@localhost:xxxxx/defaultdb?sslmode=disable",
 		opts: []testcontainers.ContainerCustomizer{
 			cockroachdb.WithUser("test"),
+			// Do not run the default statements as the user used on this test is
+			// lacking the needed MODIFYCLUSTERSETTING privilege to run them.
+			cockroachdb.WithStatements(),
 		},
 	})
 }
@@ -38,6 +41,9 @@ func TestCockroach_Password(t *testing.T) {
 		opts: []testcontainers.ContainerCustomizer{
 			cockroachdb.WithUser("foo"),
 			cockroachdb.WithPassword("bar"),
+			// Do not run the default statements as the user used on this test is
+			// lacking the needed MODIFYCLUSTERSETTING privilege to run them.
+			cockroachdb.WithStatements(),
 		},
 	})
 }
@@ -50,6 +56,9 @@ func TestCockroach_TLS(t *testing.T) {
 		url: "postgres://root@localhost:xxxxx/defaultdb?sslmode=verify-full",
 		opts: []testcontainers.ContainerCustomizer{
 			cockroachdb.WithTLS(tlsCfg),
+			// Do not run the default statements as the user used on this test is
+			// lacking the needed MODIFYCLUSTERSETTING privilege to run them.
+			cockroachdb.WithStatements(),
 		},
 	})
 }

--- a/modules/cockroachdb/examples_test.go
+++ b/modules/cockroachdb/examples_test.go
@@ -55,7 +55,7 @@ func ExampleRun() {
 func ExampleRun_withRecommendedSettings() {
 	ctx := context.Background()
 
-	cockroachdbContainer, err := cockroachdb.Run(ctx, "cockroachdb/cockroach:latest-v23.1", cockroachdb.WithStatements(cockroachdb.ClusterDefaults...))
+	cockroachdbContainer, err := cockroachdb.Run(ctx, "cockroachdb/cockroach:latest-v23.1", cockroachdb.WithStatements(cockroachdb.DefaultStatements...))
 	defer func() {
 		if err := testcontainers.TerminateContainer(cockroachdbContainer); err != nil {
 			log.Printf("failed to terminate container: %s", err)

--- a/modules/cockroachdb/examples_test.go
+++ b/modules/cockroachdb/examples_test.go
@@ -2,6 +2,7 @@ package cockroachdb_test
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 	"log"
 	"net/url"
@@ -49,4 +50,62 @@ func ExampleRun() {
 	// Output:
 	// true
 	// postgres://root@localhost:xxx/defaultdb?sslmode=disable
+}
+
+func ExampleRun_withRecommendedSettings() {
+	ctx := context.Background()
+
+	cockroachdbContainer, err := cockroachdb.Run(ctx, "cockroachdb/cockroach:latest-v23.1", cockroachdb.WithStatements(cockroachdb.ClusterDefaults...))
+	defer func() {
+		if err := testcontainers.TerminateContainer(cockroachdbContainer); err != nil {
+			log.Printf("failed to terminate container: %s", err)
+		}
+	}()
+	if err != nil {
+		log.Printf("failed to start container: %s", err)
+		return
+	}
+
+	state, err := cockroachdbContainer.State(ctx)
+	if err != nil {
+		log.Printf("failed to get container state: %s", err)
+		return
+	}
+	fmt.Println(state.Running)
+
+	addr, err := cockroachdbContainer.ConnectionString(ctx)
+	if err != nil {
+		log.Printf("failed to get connection string: %s", err)
+		return
+	}
+
+	db, err := sql.Open("pgx/v5", addr)
+	if err != nil {
+		log.Printf("failed to open connection: %s", err)
+		return
+	}
+	defer func() {
+		if err := db.Close(); err != nil {
+			log.Printf("failed to close connection: %s", err)
+		}
+	}()
+
+	var queueInterval string
+	if err := db.QueryRow("SHOW CLUSTER SETTING kv.range_merge.queue_interval").Scan(&queueInterval); err != nil {
+		log.Printf("failed to scan row: %s", err)
+		return
+	}
+	fmt.Println(queueInterval)
+
+	var statsCollectionEnabled bool
+	if err := db.QueryRow("SHOW CLUSTER SETTING sql.stats.automatic_collection.enabled").Scan(&statsCollectionEnabled); err != nil {
+		log.Printf("failed to scan row: %s", err)
+		return
+	}
+	fmt.Println(statsCollectionEnabled)
+
+	// Output:
+	// true
+	// 00:00:00.05
+	// false
 }

--- a/modules/cockroachdb/options.go
+++ b/modules/cockroachdb/options.go
@@ -17,7 +17,7 @@ func defaultOptions() options {
 		Password:   defaultPassword,
 		Database:   defaultDatabase,
 		StoreSize:  defaultStoreSize,
-		Statements: ClusterDefaults,
+		Statements: DefaultStatements,
 	}
 }
 
@@ -70,9 +70,9 @@ func WithTLS(cfg *TLSConfig) Option {
 	}
 }
 
-// ClusterDefaults are the settings recommended by Cockroach Labs for testing clusters.
+// DefaultStatements are the settings recommended by Cockroach Labs for testing clusters.
 // See https://www.cockroachlabs.com/docs/stable/local-testing for more information.
-var ClusterDefaults = []string{
+var DefaultStatements = []string{
 	"SET CLUSTER SETTING kv.range_merge.queue_interval = '50ms'",
 	"SET CLUSTER SETTING jobs.registry.interval.gc = '30s'",
 	"SET CLUSTER SETTING jobs.registry.interval.cancel = '180s'",
@@ -84,7 +84,7 @@ var ClusterDefaults = []string{
 }
 
 // WithStatements sets the statements to run on the CockroachDB cluster once the container is ready.
-// This, in combination with ClusterDefaults, can be used to configure the cluster with the settings
+// This, in combination with DefaultStatements, can be used to configure the cluster with the settings
 // recommended by Cockroach Labs.
 func WithStatements(statements ...string) Option {
 	return func(o *options) {

--- a/modules/cockroachdb/options.go
+++ b/modules/cockroachdb/options.go
@@ -3,11 +3,12 @@ package cockroachdb
 import "github.com/testcontainers/testcontainers-go"
 
 type options struct {
-	Database  string
-	User      string
-	Password  string
-	StoreSize string
-	TLS       *TLSConfig
+	Database   string
+	User       string
+	Password   string
+	StoreSize  string
+	TLS        *TLSConfig
+	Statements []string
 }
 
 func defaultOptions() options {
@@ -65,5 +66,25 @@ func WithStoreSize(size string) Option {
 func WithTLS(cfg *TLSConfig) Option {
 	return func(o *options) {
 		o.TLS = cfg
+	}
+}
+
+// ClusterDefaults are the settings recommended by Cockroach Labs for testing clusters.
+// See https://www.cockroachlabs.com/docs/stable/local-testing for more information.
+var ClusterDefaults []string = []string{
+	"SET CLUSTER SETTING kv.range_merge.queue_interval = '50ms'",
+	"SET CLUSTER SETTING jobs.registry.interval.gc = '30s'",
+	"SET CLUSTER SETTING jobs.registry.interval.cancel = '180s'",
+	"SET CLUSTER SETTING jobs.retention_time = '15s'",
+	"SET CLUSTER SETTING sql.stats.automatic_collection.enabled = false",
+	"SET CLUSTER SETTING kv.range_split.by_load_merge_delay = '5s'",
+	`ALTER RANGE default CONFIGURE ZONE USING "gc.ttlseconds" = 600`,
+	`ALTER DATABASE system CONFIGURE ZONE USING "gc.ttlseconds" = 600`,
+}
+
+// WithStatements sets the statements to run on the CockroachDB cluster once the container is ready.
+func WithStatements(statements ...string) Option {
+	return func(o *options) {
+		o.Statements = statements
 	}
 }

--- a/modules/cockroachdb/options.go
+++ b/modules/cockroachdb/options.go
@@ -13,10 +13,11 @@ type options struct {
 
 func defaultOptions() options {
 	return options{
-		User:      defaultUser,
-		Password:  defaultPassword,
-		Database:  defaultDatabase,
-		StoreSize: defaultStoreSize,
+		User:       defaultUser,
+		Password:   defaultPassword,
+		Database:   defaultDatabase,
+		StoreSize:  defaultStoreSize,
+		Statements: ClusterDefaults,
 	}
 }
 
@@ -83,6 +84,8 @@ var ClusterDefaults = []string{
 }
 
 // WithStatements sets the statements to run on the CockroachDB cluster once the container is ready.
+// This, in combination with ClusterDefaults, can be used to configure the cluster with the settings
+// recommended by Cockroach Labs.
 func WithStatements(statements ...string) Option {
 	return func(o *options) {
 		o.Statements = statements

--- a/modules/cockroachdb/options.go
+++ b/modules/cockroachdb/options.go
@@ -71,7 +71,7 @@ func WithTLS(cfg *TLSConfig) Option {
 
 // ClusterDefaults are the settings recommended by Cockroach Labs for testing clusters.
 // See https://www.cockroachlabs.com/docs/stable/local-testing for more information.
-var ClusterDefaults []string = []string{
+var ClusterDefaults = []string{
 	"SET CLUSTER SETTING kv.range_merge.queue_interval = '50ms'",
 	"SET CLUSTER SETTING jobs.registry.interval.gc = '30s'",
 	"SET CLUSTER SETTING jobs.registry.interval.cancel = '180s'",

--- a/modules/cockroachdb/options.go
+++ b/modules/cockroachdb/options.go
@@ -71,6 +71,7 @@ func WithTLS(cfg *TLSConfig) Option {
 }
 
 // DefaultStatements are the settings recommended by Cockroach Labs for testing clusters.
+// Note that to use these defaults the user needs to have MODIFYCLUSTERSETTING privilege.
 // See https://www.cockroachlabs.com/docs/stable/local-testing for more information.
 var DefaultStatements = []string{
 	"SET CLUSTER SETTING kv.range_merge.queue_interval = '50ms'",


### PR DESCRIPTION
## What does this PR do?

This PR configures the cockroachdb container with the [settings recommended by Cockroach Labs](https://www.cockroachlabs.com/docs/stable/local-testing#use-a-local-single-node-cluster-with-in-memory-storage) for testing clusters.

## Why is it important?

It seems reasonable to follow their advise but the why for each of these settings is explained in the link above.

## Related issues

None

## How to test this PR

I did some rather naive testing by running a test suite with and without these changes and it seemed like it did work in that the the tests took less time to finish with these settings than without them. It's not clear to me whether that improvement will be there in all possible scenarios but, as I said before, I think it's reasonable to follow Cockroach Labs advise on this.