### PR TITLE
docs(mysql|neo4j): remove default image codeblock

### DIFF
--- a/docs/modules/mysql.md
+++ b/docs/modules/mysql.md
@@ -52,12 +52,6 @@ When starting the MySQL container, you can pass options in a variadic way to con
 If you need to set a different MySQL Docker image, you can set a valid Docker image as the second argument in the `Run` function.
 E.g. `Run(context.Background(), "mysql:8.0.36")`.
 
-By default, the container will use the following Docker image:
-
-<!--codeinclude-->
-[Default Docker image](../../modules/mysql/mysql.go) inside_block:defaultImage
-<!--/codeinclude-->
-
 {% include "../features/common_functional_options.md" %}
 
 #### Set username, password and database name

--- a/docs/modules/neo4j.md
+++ b/docs/modules/neo4j.md
@@ -58,12 +58,6 @@ When starting the Neo4j container, you can pass options in a variadic way to con
 If you need to set a different Neo4j Docker image, you can set a valid Docker image as the second argument in the `Run` function.
 E.g. `Run(context.Background(), "neo4j:4.4")`.
 
-By default, the container will use the following Docker image:
-
-<!--codeinclude-->
-[Default Docker image](../../modules/neo4j/neo4j.go) inside_block:defaultImage
-<!--/codeinclude-->
-
 {% include "../features/common_functional_options.md" %}
 
 #### Logger


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
It removes the block referring to the default image used in the MySQL and Neo4J modules

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
There is no default image by default, as it's delegated to the end user through the Run function.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->


<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
