### PR TITLE
feat(ci): Test against the nightly master moby

### DIFF
--- a/.github/workflows/docker-moby-latest.yml
+++ b/.github/workflows/docker-moby-latest.yml
@@ -10,6 +10,12 @@ jobs:
     strategy:
       matrix:
         rootless-docker: [true, false]
+        containerd-integration: [true, false]
+        # ghaction-setup-docker doesn't work with rootless yet
+        exclude:
+          - rootless-docker: true
+            container-integration: true
+
     name: "Core tests using latest moby/moby"
     runs-on: 'ubuntu-latest'
     continue-on-error: true
@@ -42,7 +48,22 @@ jobs:
       - name: modTidy
         run: go mod tidy
 
-      - name: Install Latest Docker
+      - name: Install Nightly Docker
+        # rootless not supported with ghaction-setup-docker yet
+        if: ${{ matrix.rootless-docker == false }}
+        uses: crazy-max/ghaction-setup-docker@master
+        with:
+          daemon-config: |
+            {
+              "debug": true,
+              "features": {
+                "containerd-snapshotter": ${{ matrix.containerd-integration }}
+              }
+            }
+          version: type=image,tag=master
+
+      - name: Install test Docker
+        if: ${{ matrix.rootless-docker }}
         run: curl https://get.docker.com | CHANNEL=test sh
 
       - name: go test


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
Changes the Github actions workflow that ran the tests against a Docker Engine from the `test` channel of download.docker.com to get the nightly build off the `master` branch.

Currently it uses the `crazy-max/ghaction-setup-docker@master` action. We plan to move to to Docker org soon.

It also adds the containerd integration to the test matrix.
Rootless is not supported yet.

## Why is it important?
The `test` channel isn't updated that often as it requires us to run the whole release pipeline.
With this change, testcontainers tests will be ran against the master branch of moby and test the containerd image store integration.

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- 

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
