### PR TITLE
fix: reuse testcontainers.RequireContainerExec

### DIFF
--- a/modules/kafka/kafka_test.go
+++ b/modules/kafka/kafka_test.go
@@ -2,7 +2,6 @@ package kafka_test
 
 import (
 	"context"
-	"io"
 	"strings"
 	"testing"
 
@@ -82,15 +81,11 @@ func assertAdvertisedListeners(t *testing.T, container testcontainers.Container)
 	inspect, err := container.Inspect(context.Background())
 	require.NoError(t, err)
 
-	hostname := inspect.Config.Hostname
+	brokerURL := "BROKER://" + inspect.Config.Hostname + ":9092"
 
-	code, r, err := container.Exec(context.Background(), []string{"cat", "/usr/sbin/testcontainers_start.sh"})
-	require.NoError(t, err)
+	ctx := context.Background()
 
-	require.Zero(t, code)
+	bs := testcontainers.RequireContainerExec(ctx, t, container, []string{"cat", "/usr/sbin/testcontainers_start.sh"})
 
-	bs, err := io.ReadAll(r)
-	require.NoError(t, err)
-
-	require.Containsf(t, string(bs), "BROKER://"+hostname+":9092", "expected advertised listeners to contain %s, got %s", "BROKER://"+hostname+":9092", string(bs))
+	require.Containsf(t, bs, brokerURL, "expected advertised listeners to contain %s, got %s", brokerURL, bs)
 }

--- a/modules/neo4j/neo4j_test.go
+++ b/modules/neo4j/neo4j_test.go
@@ -3,7 +3,6 @@ package neo4j_test
 import (
 	"context"
 	"fmt"
-	"io"
 	"strings"
 	"testing"
 
@@ -159,12 +158,7 @@ func createDriver(t *testing.T, ctx context.Context, container *neo4j.Neo4jConta
 
 func getContainerEnv(t *testing.T, ctx context.Context, container *neo4j.Neo4jContainer) string {
 	t.Helper()
-	exec, reader, err := container.Exec(ctx, []string{"env"})
-	require.NoErrorf(t, err, "expected env to successfully run but did not")
-	require.Zerof(t, exec, "expected env to exit with status 0 but exited with: %d", exec)
-	envVars, err := io.ReadAll(reader)
-	require.NoErrorf(t, err, "expected to read all bytes from env output but did not")
-	return string(envVars)
+	return testcontainers.RequireContainerExec(ctx, t, container, []string{"env"})
 }
 
 const logSeparator = "---$$$---"


### PR DESCRIPTION
## What does this PR do?

This uses testcontainers.RequireContainerExec where it is appropriate