### PR TITLE
golangci-lint: enable perfsprint linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,6 +8,7 @@ linters:
     - misspell
     - nolintlint
     - nakedret
+    - perfsprint
     - testifylint
     - thelper
     - usestdlibvars

--- a/docker.go
+++ b/docker.go
@@ -152,7 +152,7 @@ func (c *DockerContainer) PortEndpoint(ctx context.Context, port nat.Port, proto
 
 	protoFull := ""
 	if proto != "" {
-		protoFull = fmt.Sprintf("%s://", proto)
+		protoFull = proto + "://"
 	}
 
 	return fmt.Sprintf("%s%s:%s", protoFull, host, outerPort.Port()), nil

--- a/docker_auth_test.go
+++ b/docker_auth_test.go
@@ -284,11 +284,11 @@ func prepareLocalRegistryWithAuth(t *testing.T) string {
 		},
 		Files: []ContainerFile{
 			{
-				HostFilePath:      fmt.Sprintf("%s/testdata/auth", wd),
+				HostFilePath:      wd + "/testdata/auth",
 				ContainerFilePath: "/auth",
 			},
 			{
-				HostFilePath:      fmt.Sprintf("%s/testdata/data", wd),
+				HostFilePath:      wd + "/testdata/data",
 				ContainerFilePath: "/data",
 			},
 		},

--- a/file_test.go
+++ b/file_test.go
@@ -6,6 +6,7 @@ import (
 	"archive/tar"
 	"bytes"
 	"compress/gzip"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -37,7 +38,7 @@ func Test_IsDir(t *testing.T) {
 		{
 			filepath: "foobar.doc",
 			expected: false,
-			err:      fmt.Errorf("does not exist"),
+			err:      errors.New("does not exist"),
 		},
 	}
 

--- a/internal/core/bootstrap.go
+++ b/internal/core/bootstrap.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"os"
 
@@ -89,7 +90,7 @@ func init() {
 		return
 	}
 
-	sessionID = fmt.Sprintf("%x", hasher.Sum(nil))
+	sessionID = hex.EncodeToString(hasher.Sum(nil))
 }
 
 func ProcessID() string {

--- a/internal/core/docker_host_test.go
+++ b/internal/core/docker_host_test.go
@@ -2,7 +2,7 @@ package core
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -46,7 +46,7 @@ func testCallbackCheckPassing(_ context.Context, _ string) error {
 }
 
 func testCallbackCheckError(_ context.Context, _ string) error {
-	return fmt.Errorf("could not check the Docker host")
+	return errors.New("could not check the Docker host")
 }
 
 func mockCallbackCheck(t *testing.T, fn func(_ context.Context, _ string) error) {

--- a/internal/core/docker_rootless.go
+++ b/internal/core/docker_rootless.go
@@ -3,11 +3,11 @@ package core
 import (
 	"context"
 	"errors"
-	"fmt"
 	"net/url"
 	"os"
 	"path/filepath"
 	"runtime"
+	"strconv"
 )
 
 var (
@@ -144,7 +144,7 @@ func rootlessSocketPathFromHomeDesktopDir() (string, error) {
 // rootlessSocketPathFromRunDir returns the path to the rootless Docker socket from the /run/user/<uid>/docker.sock file.
 func rootlessSocketPathFromRunDir() (string, error) {
 	uid := os.Getuid()
-	f := filepath.Join(baseRunDir, "user", fmt.Sprintf("%d", uid), "docker.sock")
+	f := filepath.Join(baseRunDir, "user", strconv.Itoa(uid), "docker.sock")
 	if fileExists(f) {
 		return f, nil
 	}

--- a/internal/core/docker_rootless_test.go
+++ b/internal/core/docker_rootless_test.go
@@ -2,9 +2,9 @@ package core
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -161,7 +161,7 @@ func TestRootlessDockerSocketPath(t *testing.T) {
 		})
 
 		uid := os.Getuid()
-		runDir := filepath.Join(tmpDir, "user", fmt.Sprintf("%d", uid))
+		runDir := filepath.Join(tmpDir, "user", strconv.Itoa(uid))
 		err = createTmpDockerSocket(runDir)
 		require.NoError(t, err)
 
@@ -208,7 +208,7 @@ func setupRootlessNotFound(t *testing.T) {
 
 	baseRunDir = tmpDir
 	uid := os.Getuid()
-	runDir := filepath.Join(tmpDir, "run", "user", fmt.Sprintf("%d", uid))
+	runDir := filepath.Join(tmpDir, "run", "user", strconv.Itoa(uid))
 	err = createTmpDir(runDir)
 	require.NoError(t, err)
 }

--- a/modules/chroma/chroma.go
+++ b/modules/chroma/chroma.go
@@ -2,6 +2,7 @@ package chroma
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/testcontainers/testcontainers-go"
@@ -66,7 +67,7 @@ func (c *ChromaContainer) RESTEndpoint(ctx context.Context) (string, error) {
 
 	host, err := c.Host(ctx)
 	if err != nil {
-		return "", fmt.Errorf("failed to get container host")
+		return "", errors.New("failed to get container host")
 	}
 
 	return fmt.Sprintf("http://%s:%s", host, containerPort.Port()), nil

--- a/modules/cockroachdb/certs.go
+++ b/modules/cockroachdb/certs.go
@@ -2,7 +2,7 @@ package cockroachdb
 
 import (
 	"crypto/x509"
-	"fmt"
+	"errors"
 	"net"
 	"time"
 
@@ -28,7 +28,7 @@ func NewTLSConfig() (*TLSConfig, error) {
 		ValidFor:          time.Hour,
 	})
 	if caCert == nil {
-		return nil, fmt.Errorf("failed to generate CA certificate")
+		return nil, errors.New("failed to generate CA certificate")
 	}
 	// }
 
@@ -42,7 +42,7 @@ func NewTLSConfig() (*TLSConfig, error) {
 		Parent:            caCert, // using the CA certificate as parent
 	})
 	if nodeCert == nil {
-		return nil, fmt.Errorf("failed to generate node certificate")
+		return nil, errors.New("failed to generate node certificate")
 	}
 	// }
 
@@ -54,7 +54,7 @@ func NewTLSConfig() (*TLSConfig, error) {
 		Parent:            caCert, // using the CA certificate as parent
 	})
 	if clientCert == nil {
-		return nil, fmt.Errorf("failed to generate client certificate")
+		return nil, errors.New("failed to generate client certificate")
 	}
 
 	return &TLSConfig{

--- a/modules/cockroachdb/cockroachdb.go
+++ b/modules/cockroachdb/cockroachdb.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"net"
 	"net/url"
@@ -18,7 +19,7 @@ import (
 	"github.com/testcontainers/testcontainers-go/wait"
 )
 
-var ErrTLSNotEnabled = fmt.Errorf("tls not enabled")
+var ErrTLSNotEnabled = errors.New("tls not enabled")
 
 const (
 	certsDir = "/tmp"
@@ -144,7 +145,7 @@ func addCmd(req *testcontainers.GenericContainerRequest, opts options) error {
 			return fmt.Errorf("unsupported user %s with TLS, use %s", opts.User, defaultUser)
 		}
 		if opts.Password != "" {
-			return fmt.Errorf("cannot use password authentication with TLS")
+			return errors.New("cannot use password authentication with TLS")
 		}
 	}
 

--- a/modules/compose/compose_api_test.go
+++ b/modules/compose/compose_api_test.go
@@ -2,7 +2,7 @@ package compose
 
 import (
 	"context"
-	"fmt"
+	"encoding/hex"
 	"hash/fnv"
 	"os"
 	"path/filepath"
@@ -642,7 +642,7 @@ func TestDockerComposeAPIVolumesDeletedOnDown(t *testing.T) {
 
 	volumeListFilters := filters.NewArgs()
 	// the "mydata" identifier comes from the "testdata/docker-compose-volume.yml" file
-	volumeListFilters.Add("name", fmt.Sprintf("%s_mydata", identifier))
+	volumeListFilters.Add("name", identifier+"_mydata")
 	volumeList, err := compose.dockerClient.VolumeList(ctx, volume.ListOptions{Filters: volumeListFilters})
 	require.NoError(t, err, "compose.dockerClient.VolumeList()")
 
@@ -690,7 +690,7 @@ func TestDockerComposeApiWithWaitForShortLifespanService(t *testing.T) {
 }
 
 func testNameHash(name string) StackIdentifier {
-	return StackIdentifier(fmt.Sprintf("%x", fnv.New32a().Sum([]byte(name))))
+	return StackIdentifier(hex.EncodeToString(fnv.New32a().Sum([]byte(name))))
 }
 
 // cleanup is a helper function that schedules the compose stack to be stopped when the test ends.

--- a/modules/dolt/dolt.go
+++ b/modules/dolt/dolt.go
@@ -3,6 +3,7 @@ package dolt
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"path/filepath"
 	"strings"
@@ -84,7 +85,7 @@ func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustom
 	}
 
 	if len(password) == 0 && password == "" && !strings.EqualFold(rootUser, username) {
-		return nil, fmt.Errorf("empty password can be used only with the root user")
+		return nil, errors.New("empty password can be used only with the root user")
 	}
 
 	container, err := testcontainers.GenericContainer(ctx, genericContainerReq)

--- a/modules/elasticsearch/elasticsearch.go
+++ b/modules/elasticsearch/elasticsearch.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -212,7 +213,7 @@ func configurePassword(settings *Options, req *testcontainers.GenericContainerRe
 
 	if settings.Password != "" {
 		if isOSS(req.Image) {
-			return fmt.Errorf("it's not possible to activate security on Elastic OSS Image. Please switch to the default distribution.")
+			return errors.New("it's not possible to activate security on Elastic OSS Image. Please switch to the default distribution.")
 		}
 
 		if _, ok := req.Env["ELASTIC_PASSWORD"]; !ok {

--- a/modules/elasticsearch/version.go
+++ b/modules/elasticsearch/version.go
@@ -22,7 +22,7 @@ func isAtLeastVersion(image string, major int) bool {
 	}
 
 	if !strings.HasPrefix(version, "v") {
-		version = fmt.Sprintf("v%s", version)
+		version = "v" + version
 	}
 
 	if semver.IsValid(version) {

--- a/modules/gcloud/spanner_test.go
+++ b/modules/gcloud/spanner_test.go
@@ -63,7 +63,7 @@ func ExampleRunSpannerContainer() {
 	// }
 
 	instanceOp, err := instanceAdmin.CreateInstance(ctx, &instancepb.CreateInstanceRequest{
-		Parent:     fmt.Sprintf("projects/%s", projectId),
+		Parent:     "projects/" + projectId,
 		InstanceId: instanceId,
 		Instance: &instancepb.Instance{
 			DisplayName: instanceId,

--- a/modules/inbucket/inbucket.go
+++ b/modules/inbucket/inbucket.go
@@ -44,7 +44,7 @@ func (c *InbucketContainer) WebInterface(ctx context.Context) (string, error) {
 		return "", err
 	}
 
-	return fmt.Sprintf("http://%s", net.JoinHostPort(host, containerPort.Port())), nil
+	return "http://" + net.JoinHostPort(host, containerPort.Port()), nil
 }
 
 // Deprecated: use Run instead

--- a/modules/k3s/k3s.go
+++ b/modules/k3s/k3s.go
@@ -220,7 +220,7 @@ func (c *K3sContainer) LoadImages(ctx context.Context, images ...string) error {
 		return fmt.Errorf("saving images %w", err)
 	}
 
-	containerPath := fmt.Sprintf("/tmp/%s", filepath.Base(imagesTar.Name()))
+	containerPath := "/tmp/" + filepath.Base(imagesTar.Name())
 	err = c.Container.CopyFileToContainer(ctx, imagesTar.Name(), containerPath, 0x644)
 	if err != nil {
 		return fmt.Errorf("copying image to container %w", err)

--- a/modules/k6/k6.go
+++ b/modules/k6/k6.go
@@ -143,7 +143,7 @@ func WithCache() testcontainers.CustomizeRequestOption {
 	cacheVol := os.Getenv("TC_K6_BUILD_CACHE")
 	// if no volume is provided, create one and ensure add labels for garbage collection
 	if cacheVol == "" {
-		cacheVol = fmt.Sprintf("k6-cache-%s", testcontainers.SessionID())
+		cacheVol = "k6-cache-" + testcontainers.SessionID()
 		volOptions = &mount.VolumeOptions{
 			Labels: testcontainers.GenericLabels(),
 		}

--- a/modules/kafka/kafka.go
+++ b/modules/kafka/kafka.go
@@ -2,8 +2,10 @@ package kafka
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math"
+	"strconv"
 	"strings"
 
 	"github.com/docker/go-connections/nat"
@@ -58,7 +60,7 @@ func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustom
 			"KAFKA_OFFSETS_TOPIC_NUM_PARTITIONS":             "1",
 			"KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR": "1",
 			"KAFKA_TRANSACTION_STATE_LOG_MIN_ISR":            "1",
-			"KAFKA_LOG_FLUSH_INTERVAL_MESSAGES":              fmt.Sprintf("%d", math.MaxInt),
+			"KAFKA_LOG_FLUSH_INTERVAL_MESSAGES":              strconv.Itoa(math.MaxInt),
 			"KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS":         "0",
 			"KAFKA_NODE_ID":                                  "1",
 			"KAFKA_PROCESS_ROLES":                            "broker,controller",
@@ -203,7 +205,7 @@ func configureControllerQuorumVoters(req *testcontainers.GenericContainerRequest
 // which is available since version 7.0.0.
 func validateKRaftVersion(fqName string) error {
 	if fqName == "" {
-		return fmt.Errorf("image cannot be empty")
+		return errors.New("image cannot be empty")
 	}
 
 	image := fqName[:strings.LastIndex(fqName, ":")]
@@ -218,7 +220,7 @@ func validateKRaftVersion(fqName string) error {
 
 	// semver requires the version to start with a "v"
 	if !strings.HasPrefix(version, "v") {
-		version = fmt.Sprintf("v%s", version)
+		version = "v" + version
 	}
 
 	if semver.Compare(version, "v7.4.0") < 0 { // version < v7.4.0

--- a/modules/localstack/localstack.go
+++ b/modules/localstack/localstack.go
@@ -29,7 +29,7 @@ func isLegacyMode(image string) bool {
 	}
 
 	if !strings.HasPrefix(version, "v") {
-		version = fmt.Sprintf("v%s", version)
+		version = "v" + version
 	}
 
 	if semver.IsValid(version) {
@@ -48,7 +48,7 @@ func isVersion2(image string) bool {
 	}
 
 	if !strings.HasPrefix(version, "v") {
-		version = fmt.Sprintf("v%s", version)
+		version = "v" + version
 	}
 
 	if semver.IsValid(version) {
@@ -82,7 +82,7 @@ func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustom
 		ExposedPorts: []string{fmt.Sprintf("%d/tcp", defaultPort)},
 		Env:          map[string]string{},
 		HostConfigModifier: func(hostConfig *container.HostConfig) {
-			hostConfig.Binds = []string{fmt.Sprintf("%s:/var/run/docker.sock", dockerHost)}
+			hostConfig.Binds = []string{dockerHost + ":/var/run/docker.sock"}
 		},
 	}
 

--- a/modules/localstack/localstack_test.go
+++ b/modules/localstack/localstack_test.go
@@ -2,7 +2,6 @@ package localstack
 
 import (
 	"context"
-	"fmt"
 	"io"
 	"strings"
 	"testing"
@@ -100,7 +99,7 @@ func TestIsLegacyMode(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.version, func(t *testing.T) {
-			got := isLegacyMode(fmt.Sprintf("localstack/localstack:%s", tt.version))
+			got := isLegacyMode("localstack/localstack:" + tt.version)
 			require.Equal(t, tt.want, got, "runInLegacyMode() = %v, want %v", got, tt.want)
 		})
 	}
@@ -119,7 +118,7 @@ func TestRunContainer(t *testing.T) {
 
 		ctr, err := Run(
 			ctx,
-			fmt.Sprintf("localstack/localstack:%s", tt.version),
+			"localstack/localstack:"+tt.version,
 		)
 		testcontainers.CleanupContainer(t, ctr)
 

--- a/modules/mariadb/mariadb.go
+++ b/modules/mariadb/mariadb.go
@@ -2,6 +2,7 @@ package mariadb
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"path/filepath"
 	"strings"
@@ -165,7 +166,7 @@ func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustom
 	password := req.Env["MARIADB_PASSWORD"]
 
 	if len(password) == 0 && password == "" && !strings.EqualFold(rootUser, username) {
-		return nil, fmt.Errorf("empty password can be used only with the root user")
+		return nil, errors.New("empty password can be used only with the root user")
 	}
 
 	container, err := testcontainers.GenericContainer(ctx, genericContainerReq)

--- a/modules/meilisearch/meilisearch.go
+++ b/modules/meilisearch/meilisearch.go
@@ -64,7 +64,7 @@ func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustom
 				FileMode:          0o755,
 			},
 		}
-		genericContainerReq.Cmd = []string{"meilisearch", "--import-dump", fmt.Sprintf("/dumps/%s", settings.DumpDataFileName)}
+		genericContainerReq.Cmd = []string{"meilisearch", "--import-dump", "/dumps/" + settings.DumpDataFileName}
 	}
 
 	// the wait strategy does not support TLS at the moment,

--- a/modules/minio/minio.go
+++ b/modules/minio/minio.go
@@ -2,6 +2,7 @@ package minio
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/testcontainers/testcontainers-go"
@@ -89,7 +90,7 @@ func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustom
 	username := req.Env["MINIO_ROOT_USER"]
 	password := req.Env["MINIO_ROOT_PASSWORD"]
 	if username == "" || password == "" {
-		return nil, fmt.Errorf("username or password has not been set")
+		return nil, errors.New("username or password has not been set")
 	}
 
 	container, err := testcontainers.GenericContainer(ctx, genericContainerReq)

--- a/modules/mongodb/mongodb.go
+++ b/modules/mongodb/mongodb.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	_ "embed"
+	"errors"
 	"fmt"
 	"time"
 
@@ -59,7 +60,7 @@ func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustom
 	username := req.Env["MONGO_INITDB_ROOT_USERNAME"]
 	password := req.Env["MONGO_INITDB_ROOT_PASSWORD"]
 	if username != "" && password == "" || username == "" && password != "" {
-		return nil, fmt.Errorf("if you specify username or password, you must provide both of them")
+		return nil, errors.New("if you specify username or password, you must provide both of them")
 	}
 
 	replicaSet := req.Env[replicaSetOptEnvKey]

--- a/modules/mysql/mysql.go
+++ b/modules/mysql/mysql.go
@@ -2,6 +2,7 @@ package mysql
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"path/filepath"
 	"strings"
@@ -82,7 +83,7 @@ func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustom
 	password := req.Env["MYSQL_PASSWORD"]
 
 	if len(password) == 0 && password == "" && !strings.EqualFold(rootUser, username) {
-		return nil, fmt.Errorf("empty password can be used only with the root user")
+		return nil, errors.New("empty password can be used only with the root user")
 	}
 
 	container, err := testcontainers.GenericContainer(ctx, genericContainerReq)

--- a/modules/neo4j/config.go
+++ b/modules/neo4j/config.go
@@ -35,7 +35,7 @@ func WithAdminPassword(adminPassword string) testcontainers.CustomizeRequestOpti
 	return func(req *testcontainers.GenericContainerRequest) error {
 		pwd := "none"
 		if adminPassword != "" {
-			pwd = fmt.Sprintf("neo4j/%s", adminPassword)
+			pwd = "neo4j/" + adminPassword
 		}
 
 		req.Env["NEO4J_AUTH"] = pwd
@@ -127,7 +127,7 @@ func validate(req *testcontainers.GenericContainerRequest) error {
 func formatNeo4jConfig(name string) string {
 	result := strings.ReplaceAll(name, "_", "__")
 	result = strings.ReplaceAll(result, ".", "_")
-	return fmt.Sprintf("NEO4J_%s", result)
+	return "NEO4J_" + result
 }
 
 // WithAcceptCommercialLicenseAgreement sets the environment variable

--- a/modules/neo4j/neo4j.go
+++ b/modules/neo4j/neo4j.go
@@ -56,9 +56,9 @@ func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustom
 			"NEO4J_AUTH": "none",
 		},
 		ExposedPorts: []string{
-			fmt.Sprintf("%s/tcp", defaultBoltPort),
-			fmt.Sprintf("%s/tcp", defaultHttpPort),
-			fmt.Sprintf("%s/tcp", defaultHttpsPort),
+			defaultBoltPort + "/tcp",
+			defaultHttpPort + "/tcp",
+			defaultHttpsPort + "/tcp",
 		},
 		WaitingFor: &wait.MultiStrategy{
 			Strategies: []wait.Strategy{

--- a/modules/ollama/examples_test.go
+++ b/modules/ollama/examples_test.go
@@ -85,7 +85,7 @@ func ExampleRun_withModel_llama2_http() {
 	"prompt":"Why is the sky blue?"
 }`
 
-	req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("%s/api/generate", connectionStr), strings.NewReader(payload))
+	req, err := http.NewRequest(http.MethodPost, connectionStr+"/api/generate", strings.NewReader(payload))
 	if err != nil {
 		log.Printf("failed to create request: %s", err)
 		return

--- a/modules/openfga/openfga.go
+++ b/modules/openfga/openfga.go
@@ -36,7 +36,7 @@ func (c *OpenFGAContainer) PlaygroundEndpoint(ctx context.Context) (string, erro
 		return "", fmt.Errorf("failed to get playground endpoint: %w", err)
 	}
 
-	return fmt.Sprintf("%s/playground", endpoint), nil
+	return endpoint + "/playground", nil
 }
 
 // Deprecated: use Run instead

--- a/modules/openldap/openldap.go
+++ b/modules/openldap/openldap.go
@@ -38,7 +38,7 @@ func (c *OpenLDAPContainer) ConnectionString(ctx context.Context, args ...string
 		return "", err
 	}
 
-	connStr := fmt.Sprintf("ldap://%s", net.JoinHostPort(host, containerPort.Port()))
+	connStr := "ldap://" + net.JoinHostPort(host, containerPort.Port())
 	return connStr, nil
 }
 

--- a/modules/postgres/postgres.go
+++ b/modules/postgres/postgres.go
@@ -3,6 +3,7 @@ package postgres
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -262,7 +263,7 @@ func (c *PostgresContainer) checkSnapshotConfig(opts []SnapshotOption) (string, 
 	}
 
 	if c.dbName == "postgres" {
-		return "", fmt.Errorf("cannot restore the postgres system database as it cannot be dropped to be restored")
+		return "", errors.New("cannot restore the postgres system database as it cannot be dropped to be restored")
 	}
 	return snapshotName, nil
 }

--- a/modules/qdrant/qdrant.go
+++ b/modules/qdrant/qdrant.go
@@ -2,6 +2,7 @@ package qdrant
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -64,7 +65,7 @@ func (c *QdrantContainer) RESTEndpoint(ctx context.Context) (string, error) {
 
 	host, err := c.Host(ctx)
 	if err != nil {
-		return "", fmt.Errorf("failed to get container host")
+		return "", errors.New("failed to get container host")
 	}
 
 	return fmt.Sprintf("http://%s:%s", host, containerPort.Port()), nil
@@ -79,7 +80,7 @@ func (c *QdrantContainer) GRPCEndpoint(ctx context.Context) (string, error) {
 
 	host, err := c.Host(ctx)
 	if err != nil {
-		return "", fmt.Errorf("failed to get container host")
+		return "", errors.New("failed to get container host")
 	}
 
 	return fmt.Sprintf("%s:%s", host, containerPort.Port()), nil

--- a/modules/rabbitmq/types_test.go
+++ b/modules/rabbitmq/types_test.go
@@ -46,16 +46,16 @@ func (b Binding) AsCommand() []string {
 	cmd := []string{"rabbitmqadmin"}
 
 	if b.VHost != "" {
-		cmd = append(cmd, fmt.Sprintf("--vhost=%s", b.VHost))
+		cmd = append(cmd, "--vhost="+b.VHost)
 	}
 
-	cmd = append(cmd, "declare", "binding", fmt.Sprintf("source=%s", b.Source), fmt.Sprintf("destination=%s", b.Destination))
+	cmd = append(cmd, "declare", "binding", "source="+b.Source, "destination="+b.Destination)
 
 	if b.DestinationType != "" {
-		cmd = append(cmd, fmt.Sprintf("destination_type=%s", b.DestinationType))
+		cmd = append(cmd, "destination_type="+b.DestinationType)
 	}
 	if b.RoutingKey != "" {
-		cmd = append(cmd, fmt.Sprintf("routing_key=%s", b.RoutingKey))
+		cmd = append(cmd, "routing_key="+b.RoutingKey)
 	}
 
 	if len(b.Args) > 0 {
@@ -92,7 +92,7 @@ func (e Exchange) AsCommand() []string {
 		cmd = append(cmd, "--vhost="+e.VHost)
 	}
 
-	cmd = append(cmd, "declare", "exchange", fmt.Sprintf("name=%s", e.Name), fmt.Sprintf("type=%s", e.Type))
+	cmd = append(cmd, "declare", "exchange", "name="+e.Name, "type="+e.Type)
 
 	if e.AutoDelete {
 		cmd = append(cmd, "auto_delete=true")
@@ -130,13 +130,13 @@ type OperatorPolicy struct {
 }
 
 func (op OperatorPolicy) AsCommand() []string {
-	cmd := []string{"rabbitmqadmin", "declare", "operator_policy", fmt.Sprintf("name=%s", op.Name), fmt.Sprintf("pattern=%s", op.Pattern)}
+	cmd := []string{"rabbitmqadmin", "declare", "operator_policy", "name=" + op.Name, "pattern=" + op.Pattern}
 
 	if op.Priority > 0 {
 		cmd = append(cmd, fmt.Sprintf("priority=%d", op.Priority))
 	}
 	if op.ApplyTo != "" {
-		cmd = append(cmd, fmt.Sprintf("apply-to=%s", op.ApplyTo))
+		cmd = append(cmd, "apply-to="+op.ApplyTo)
 	}
 
 	if len(op.Definition) > 0 {
@@ -173,7 +173,7 @@ func NewParameter(component string, name string, value string) Parameter {
 func (p Parameter) AsCommand() []string {
 	return []string{
 		"rabbitmqadmin", "declare", "parameter",
-		fmt.Sprintf("component=%s", p.Component), fmt.Sprintf("name=%s", p.Name), fmt.Sprintf("value=%s", p.Value),
+		"component=" + p.Component, "name=" + p.Name, "value=" + p.Value,
 	}
 }
 
@@ -203,8 +203,8 @@ func NewPermission(vhost string, user string, configure string, write string, re
 func (p Permission) AsCommand() []string {
 	return []string{
 		"rabbitmqadmin", "declare", "permission",
-		fmt.Sprintf("vhost=%s", p.VHost), fmt.Sprintf("user=%s", p.User),
-		fmt.Sprintf("configure=%s", p.Configure), fmt.Sprintf("write=%s", p.Write), fmt.Sprintf("read=%s", p.Read),
+		"vhost=" + p.VHost, "user=" + p.User,
+		"configure=" + p.Configure, "write=" + p.Write, "read=" + p.Read,
 	}
 }
 
@@ -242,13 +242,13 @@ func (p Policy) AsCommand() []string {
 		cmd = append(cmd, "--vhost="+p.VHost)
 	}
 
-	cmd = append(cmd, "declare", "policy", fmt.Sprintf("name=%s", p.Name), fmt.Sprintf("pattern=%s", p.Pattern))
+	cmd = append(cmd, "declare", "policy", "name="+p.Name, "pattern="+p.Pattern)
 
 	if p.Priority > 0 {
 		cmd = append(cmd, fmt.Sprintf("priority=%d", p.Priority))
 	}
 	if p.ApplyTo != "" {
-		cmd = append(cmd, fmt.Sprintf("apply-to=%s", p.ApplyTo))
+		cmd = append(cmd, "apply-to="+p.ApplyTo)
 	}
 
 	if len(p.Definition) > 0 {
@@ -283,7 +283,7 @@ func (q Queue) AsCommand() []string {
 		cmd = append(cmd, "--vhost="+q.VHost)
 	}
 
-	cmd = append(cmd, "declare", "queue", fmt.Sprintf("name=%s", q.Name))
+	cmd = append(cmd, "declare", "queue", "name="+q.Name)
 
 	if q.AutoDelete {
 		cmd = append(cmd, "auto_delete=true")
@@ -328,8 +328,8 @@ func (u User) AsCommand() []string {
 
 	return []string{
 		"rabbitmqadmin", "declare", "user",
-		fmt.Sprintf("name=%s", u.Name), fmt.Sprintf("password=%s", u.Password),
-		fmt.Sprintf("tags=%s", strings.Join(uniqueTags, ",")),
+		"name=" + u.Name, "password=" + u.Password,
+		"tags=" + strings.Join(uniqueTags, ","),
 	}
 }
 
@@ -344,7 +344,7 @@ type VirtualHost struct {
 }
 
 func (v VirtualHost) AsCommand() []string {
-	cmd := []string{"rabbitmqadmin", "declare", "vhost", fmt.Sprintf("name=%s", v.Name)}
+	cmd := []string{"rabbitmqadmin", "declare", "vhost", "name=" + v.Name}
 
 	if v.Tracing {
 		cmd = append(cmd, "tracing=true")
@@ -361,7 +361,7 @@ type VirtualHostLimit struct {
 }
 
 func (v VirtualHostLimit) AsCommand() []string {
-	return []string{"rabbitmqadmin", "declare", "vhost_limit", fmt.Sprintf("vhost=%s", v.VHost), fmt.Sprintf("name=%s", v.Name), fmt.Sprintf("value=%d", v.Value)}
+	return []string{"rabbitmqadmin", "declare", "vhost_limit", "vhost=" + v.VHost, "name=" + v.Name, fmt.Sprintf("value=%d", v.Value)}
 }
 
 // --------- Virtual Hosts ---------

--- a/modules/redis/redis.go
+++ b/modules/redis/redis.go
@@ -3,6 +3,7 @@ package redis
 import (
 	"context"
 	"fmt"
+	"strconv"
 
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/wait"
@@ -135,7 +136,7 @@ func WithSnapshotting(seconds int, changedKeys int) testcontainers.CustomizeRequ
 	}
 
 	return func(req *testcontainers.GenericContainerRequest) error {
-		processRedisServerArgs(req, []string{"--save", fmt.Sprintf("%d", seconds), fmt.Sprintf("%d", changedKeys)})
+		processRedisServerArgs(req, []string{"--save", strconv.Itoa(seconds), strconv.Itoa(changedKeys)})
 		return nil
 	}
 }

--- a/modules/redpanda/redpanda.go
+++ b/modules/redpanda/redpanda.go
@@ -6,6 +6,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	_ "embed"
+	"errors"
 	"fmt"
 	"math"
 	"net/http"
@@ -329,7 +330,7 @@ func registerListeners(settings options, req testcontainers.GenericContainerRequ
 	}
 
 	if len(req.Networks) == 0 {
-		return fmt.Errorf("container must be attached to at least one network")
+		return errors.New("container must be attached to at least one network")
 	}
 
 	for _, listener := range settings.Listeners {
@@ -418,11 +419,11 @@ func isAtLeastVersion(image, major string) bool {
 	}
 
 	if !strings.HasPrefix(version, "v") {
-		version = fmt.Sprintf("v%s", version)
+		version = "v" + version
 	}
 
 	if semver.IsValid(version) {
-		return semver.Compare(version, fmt.Sprintf("v%s", major)) >= 0 // version >= v8.x
+		return semver.Compare(version, "v"+major) >= 0 // version >= v8.x
 	}
 
 	return false

--- a/modules/redpanda/redpanda_test.go
+++ b/modules/redpanda/redpanda_test.go
@@ -50,7 +50,7 @@ func TestRedpanda(t *testing.T) {
 	httpCl := &http.Client{Timeout: 5 * time.Second}
 	schemaRegistryURL, err := ctr.SchemaRegistryAddress(ctx)
 	require.NoError(t, err)
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("%s/subjects", schemaRegistryURL), nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, schemaRegistryURL+"/subjects", nil)
 	require.NoError(t, err)
 	resp, err := httpCl.Do(req)
 	require.NoError(t, err)
@@ -62,7 +62,7 @@ func TestRedpanda(t *testing.T) {
 	adminAPIURL, err := ctr.AdminAPIAddress(ctx)
 	// }
 	require.NoError(t, err)
-	req, err = http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("%s/v1/cluster/health_overview", adminAPIURL), nil)
+	req, err = http.NewRequestWithContext(ctx, http.MethodGet, adminAPIURL+"/v1/cluster/health_overview", nil)
 	require.NoError(t, err)
 	resp, err = httpCl.Do(req)
 	require.NoError(t, err)
@@ -162,7 +162,7 @@ func TestRedpandaWithAuthentication(t *testing.T) {
 	require.NoError(t, err)
 
 	// Failed authentication
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("%s/subjects", schemaRegistryURL), nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, schemaRegistryURL+"/subjects", nil)
 	require.NoError(t, err)
 	resp, err := httpCl.Do(req)
 	require.NoError(t, err)
@@ -285,7 +285,7 @@ func TestRedpandaWithOldVersionAndWasm(t *testing.T) {
 	require.NoError(t, err)
 
 	// Failed authentication
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("%s/subjects", schemaRegistryURL), nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, schemaRegistryURL+"/subjects", nil)
 	require.NoError(t, err)
 	resp, err := httpCl.Do(req)
 	require.NoError(t, err)
@@ -353,7 +353,7 @@ func TestRedpandaWithTLS(t *testing.T) {
 	adminAPIURL, err := ctr.AdminAPIAddress(ctx)
 	require.NoError(t, err)
 	require.True(t, strings.HasPrefix(adminAPIURL, "https://"), "AdminAPIAddress should return https url")
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("%s/v1/cluster/health_overview", adminAPIURL), nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, adminAPIURL+"/v1/cluster/health_overview", nil)
 	require.NoError(t, err)
 	resp, err := httpCl.Do(req)
 	require.NoError(t, err)
@@ -364,7 +364,7 @@ func TestRedpandaWithTLS(t *testing.T) {
 	schemaRegistryURL, err := ctr.SchemaRegistryAddress(ctx)
 	require.NoError(t, err)
 	require.True(t, strings.HasPrefix(adminAPIURL, "https://"), "SchemaRegistryAddress should return https url")
-	req, err = http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("%s/subjects", schemaRegistryURL), nil)
+	req, err = http.NewRequestWithContext(ctx, http.MethodGet, schemaRegistryURL+"/subjects", nil)
 	require.NoError(t, err)
 	resp, err = httpCl.Do(req)
 	require.NoError(t, err)
@@ -545,7 +545,7 @@ func TestRedpandaBootstrapConfig(t *testing.T) {
 
 	{
 		// Check that the configs reflect specified values
-		req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("%s/v1/cluster_config", adminAPIUrl), nil)
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, adminAPIUrl+"/v1/cluster_config", nil)
 		require.NoError(t, err)
 		resp, err := httpCl.Do(req)
 		require.NoError(t, err)
@@ -562,7 +562,7 @@ func TestRedpandaBootstrapConfig(t *testing.T) {
 
 	{
 		// Check that no restart is required. i.e. that the configs were applied via bootstrap config
-		req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("%s/v1/cluster_config/status", adminAPIUrl), nil)
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, adminAPIUrl+"/v1/cluster_config/status", nil)
 		require.NoError(t, err)
 		resp, err := httpCl.Do(req)
 		require.NoError(t, err)

--- a/modules/registry/registry.go
+++ b/modules/registry/registry.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -286,7 +287,7 @@ func SetDockerAuthConfig(host, username, password string, additional ...string) 
 // triples to add more auth configurations.
 func DockerAuthConfig(host, username, password string, additional ...string) (map[string]dockercfg.AuthConfig, error) {
 	if len(additional)%3 != 0 {
-		return nil, fmt.Errorf("additional must be a multiple of 3")
+		return nil, errors.New("additional must be a multiple of 3")
 	}
 
 	additional = append(additional, host, username, password)

--- a/modules/valkey/valkey.go
+++ b/modules/valkey/valkey.go
@@ -3,6 +3,7 @@ package valkey
 import (
 	"context"
 	"fmt"
+	"strconv"
 
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/wait"
@@ -137,7 +138,7 @@ func WithSnapshotting(seconds int, changedKeys int) testcontainers.CustomizeRequ
 	}
 
 	return func(req *testcontainers.GenericContainerRequest) error {
-		processValkeyServerArgs(req, []string{"--save", fmt.Sprintf("%d", seconds), fmt.Sprintf("%d", changedKeys)})
+		processValkeyServerArgs(req, []string{"--save", strconv.Itoa(seconds), strconv.Itoa(changedKeys)})
 		return nil
 	}
 }

--- a/modules/vearch/vearch.go
+++ b/modules/vearch/vearch.go
@@ -2,6 +2,7 @@ package vearch
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -73,7 +74,7 @@ func (c *VearchContainer) RESTEndpoint(ctx context.Context) (string, error) {
 
 	host, err := c.Host(ctx)
 	if err != nil {
-		return "", fmt.Errorf("failed to get container host")
+		return "", errors.New("failed to get container host")
 	}
 
 	return fmt.Sprintf("http://%s:%s", host, containerPort.Port()), nil

--- a/modules/weaviate/examples_test.go
+++ b/modules/weaviate/examples_test.go
@@ -73,7 +73,7 @@ func ExampleRun_connectWithClient() {
 	connectionClient := &http.Client{}
 	headers := map[string]string{
 		// put here the custom API key, e.g. for OpenAPI
-		"Authorization": fmt.Sprintf("Bearer %s", "custom-api-key"),
+		"Authorization": "Bearer custom-api-key",
 	}
 
 	cli := weaviate.New(weaviate.Config{
@@ -142,7 +142,7 @@ func ExampleRun_connectWithClientWithModules() {
 	connectionClient := &http.Client{}
 	headers := map[string]string{
 		// put here the custom API key, e.g. for OpenAPI
-		"Authorization": fmt.Sprintf("Bearer %s", "custom-api-key"),
+		"Authorization": "Bearer custom-api-key",
 	}
 
 	cli := weaviate.New(weaviate.Config{

--- a/modules/weaviate/weaviate.go
+++ b/modules/weaviate/weaviate.go
@@ -2,6 +2,7 @@ package weaviate
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -76,7 +77,7 @@ func (c *WeaviateContainer) HttpHostAddress(ctx context.Context) (string, string
 
 	host, err := c.Host(ctx)
 	if err != nil {
-		return "", "", fmt.Errorf("failed to get container host")
+		return "", "", errors.New("failed to get container host")
 	}
 
 	return "http", fmt.Sprintf("%s:%s", host, port.Port()), nil
@@ -92,7 +93,7 @@ func (c *WeaviateContainer) GrpcHostAddress(ctx context.Context) (string, error)
 
 	host, err := c.Host(ctx)
 	if err != nil {
-		return "", fmt.Errorf("failed to get container host")
+		return "", errors.New("failed to get container host")
 	}
 
 	return fmt.Sprintf("%s:%s", host, port.Port()), nil

--- a/port_forwarding.go
+++ b/port_forwarding.go
@@ -40,7 +40,7 @@ var sshPassword = uuid.NewString()
 // 3. Close the SSH sessions before killing the container.
 func exposeHostPorts(ctx context.Context, req *ContainerRequest, ports ...int) (sshdConnectHook ContainerLifecycleHooks, err error) {
 	if len(ports) == 0 {
-		return sshdConnectHook, fmt.Errorf("no ports to expose")
+		return sshdConnectHook, errors.New("no ports to expose")
 	}
 
 	// Use the first network of the container to connect to the SSHD container.
@@ -252,7 +252,7 @@ func configureSSHConfig(ctx context.Context, sshdC *sshdContainer) (*ssh.ClientC
 
 func (sshdC *sshdContainer) exposeHostPort(ctx context.Context, ports ...int) error {
 	for _, port := range ports {
-		pw := NewPortForwarder(fmt.Sprintf("localhost:%s", sshdC.port), sshdC.sshConfig, port, port)
+		pw := NewPortForwarder("localhost:"+sshdC.port, sshdC.sshConfig, port, port)
 		sshdC.portForwarders = append(sshdC.portForwarders, *pw)
 
 		go pw.Forward(ctx) //nolint:errcheck // Nothing we can usefully do with the error

--- a/reaper.go
+++ b/reaper.go
@@ -83,7 +83,7 @@ func NewReaper(ctx context.Context, sessionID string, provider ReaperProvider, r
 func reaperContainerNameFromSessionID(sessionID string) string {
 	// The session id is 64 characters, so we will not hit the limit of 128
 	// characters for container names.
-	return fmt.Sprintf("reaper_%s", sessionID)
+	return "reaper_" + sessionID
 }
 
 // reaperSpawner is a singleton that manages the reaper container.

--- a/wait/all.go
+++ b/wait/all.go
@@ -2,7 +2,7 @@ package wait
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"time"
 )
 
@@ -58,7 +58,7 @@ func (ms *MultiStrategy) WaitUntilReady(ctx context.Context, target StrategyTarg
 	}
 
 	if len(ms.Strategies) == 0 {
-		return fmt.Errorf("no wait strategy supplied")
+		return errors.New("no wait strategy supplied")
 	}
 
 	for _, strategy := range ms.Strategies {

--- a/wait/host_port.go
+++ b/wait/host_port.go
@@ -126,7 +126,7 @@ func (hp *HostPortStrategy) WaitUntilReady(ctx context.Context, target StrategyT
 	}
 
 	if internalPort == "" {
-		return fmt.Errorf("no port to wait for")
+		return errors.New("no port to wait for")
 	}
 
 	var port nat.Port


### PR DESCRIPTION
## What does this PR do?

[perfsprint](https://golangci-lint.run/usage/linters/#perfsprint) checks that fmt.Sprintf can be replaced with a faster alternative.