### PR TITLE
fix: update GH actions for uploading/downloading artifacts

### DIFF
--- a/.github/workflows/ci-test-go.yml
+++ b/.github/workflows/ci-test-go.yml
@@ -123,7 +123,7 @@ jobs:
         if: ${{ github.ref_name == 'main' && github.repository_owner == 'testcontainers' && inputs.run-tests && !inputs.rootless-docker }}
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v3
         with:
-          name: sonarcloud
+          name: sonarcloud-${{ inputs.project-directory }}
           path: |
             ./sonar-project.properties
             ${{ inputs.project-directory }}/TEST-unit.xml

--- a/.github/workflows/ci-test-go.yml
+++ b/.github/workflows/ci-test-go.yml
@@ -123,7 +123,7 @@ jobs:
         if: ${{ github.ref_name == 'main' && github.repository_owner == 'testcontainers' && inputs.run-tests && !inputs.rootless-docker }}
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
         with:
-          name: sonarcloud-${{ inputs.project-directory }}
+          name: sonarcloud-${{ inputs.project-directory }}-${{ inputs.go-version }}-${{ inputs.platform }}
           path: |
             ./sonar-project.properties
             ${{ inputs.project-directory }}/TEST-unit.xml

--- a/.github/workflows/ci-test-go.yml
+++ b/.github/workflows/ci-test-go.yml
@@ -121,7 +121,7 @@ jobs:
 
       - name: Upload SonarCloud files
         if: ${{ github.ref_name == 'main' && github.repository_owner == 'testcontainers' && inputs.run-tests && !inputs.rootless-docker }}
-        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v3
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
         with:
           name: sonarcloud-${{ inputs.project-directory }}
           path: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,7 +136,8 @@ jobs:
       
       - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:
-          name: sonarcloud
+          pattern: sonarcloud-*
+          merge-multiple: true
             
       - name: Analyze with SonarCloud
         uses: sonarsource/sonarcloud-github-action@49e6cd3b187936a73b8280d59ffd9da69df63ec9 # v2.1.1


### PR DESCRIPTION
- **fix: breaking change in upload/download artifact github action**
- **fix: update version in comment**

<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
This PR changes the artifact name to be unique so that the GH action `actions/upload-artifact` in v4 does not fail because of unique names.

> Error: Failed to CreateArtifact: Received non-retryable error: Failed request: (409) Conflict: an artifact with this name already exists on the workflow run

According to the docs for the migration path: https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md

> In v3, Artifacts are mutable so it's possible to write workflow scenarios where multiple jobs upload to the same Artifact (...).
> In v4, Artifacts are immutable (unless deleted). So you must change each of the uploaded Artifacts to have a different name and filter the downloads by name to achieve the same effect.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
Fix the build and upload the artifacts to sonarcloud properly.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Caused by #2676 and #2885

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


## Follow-ups
We could follow the merge strategy, see https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md#merging-multiple-artifacts

