### PR TITLE
fix: build artifact name properly

### DIFF
--- a/.github/workflows/ci-test-go.yml
+++ b/.github/workflows/ci-test-go.yml
@@ -119,11 +119,18 @@ jobs:
         timeout-minutes: 30
         run: make test-unit
 
+      - name: Set sonar artifact name
+        # For the core library, where the project directory is '.', we'll use "core" as artifact name.
+        # For the modules, we'll remove the slashes, keeping the name of the module
+        if: ${{ github.ref_name == 'main' && github.repository_owner == 'testcontainers' && inputs.run-tests && !inputs.rootless-docker && !inputs.ryuk-disabled }}
+        run: |
+          echo "ARTIFACT_NAME=$(basename ${{ inputs.project-directory == '.' && 'core' || inputs.project-directory }})-${{ inputs.go-version }}-${{ inputs.platform }}" >> $GITHUB_ENV
+
       - name: Upload SonarCloud files
         if: ${{ github.ref_name == 'main' && github.repository_owner == 'testcontainers' && inputs.run-tests && !inputs.rootless-docker && !inputs.ryuk-disabled }}
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
         with:
-          name: sonarcloud-${{ inputs.project-directory }}-${{ inputs.go-version }}-${{ inputs.platform }}
+          name: sonarcloud-${{ env.ARTIFACT_NAME }}
           path: |
             ./sonar-project.properties
             ${{ inputs.project-directory }}/TEST-unit.xml


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
It adds a step to build the artifact name as a shell step, in which it uses the basename of the project dir to build the name. 
For the core library, whose string representation is '.', we'll replace it with core.

Finally, the sonar step will read this new env var.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
Fix the build for modules, as sonar does not allow slashes in the name.
<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Caused by #2889

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
