### PR TITLE
fix: container binds syntax

### DIFF
--- a/container.go
+++ b/container.go
@@ -532,7 +532,7 @@ func (c *ContainerRequest) validateMounts() error {
 	if len(hostConfig.Binds) > 0 {
 		for _, bind := range hostConfig.Binds {
 			parts := strings.Split(bind, ":")
-			if len(parts) != 2 {
+			if len(parts) != 2 && len(parts) != 3 {
 				return fmt.Errorf("%w: %s", ErrInvalidBindMount, bind)
 			}
 			targetPath := parts[1]

--- a/container_test.go
+++ b/container_test.go
@@ -73,11 +73,33 @@ func Test_ContainerValidation(t *testing.T) {
 		},
 		{
 			Name:          "Invalid bind mount",
-			ExpectedError: "invalid bind mount: /data:/data:/data",
+			ExpectedError: "invalid bind mount: /data:/data:a:b",
 			ContainerRequest: testcontainers.ContainerRequest{
 				Image: "redis:latest",
 				HostConfigModifier: func(hc *container.HostConfig) {
-					hc.Binds = []string{"/data:/data:/data"}
+					hc.Binds = []string{"/data:/data:a:b"}
+				},
+			},
+		},
+		{
+			Name: "bind-options/provided",
+			ContainerRequest: testcontainers.ContainerRequest{
+				Image: "redis:latest",
+				HostConfigModifier: func(hc *container.HostConfig) {
+					hc.Binds = []string{
+						"/a:/a:nocopy",
+						"/b:/b:ro",
+						"/c:/c:rw",
+						"/d:/d:z",
+						"/e:/e:Z",
+						"/f:/f:shared",
+						"/g:/g:rshared",
+						"/h:/h:slave",
+						"/i:/i:rslave",
+						"/j:/j:private",
+						"/k:/k:rprivate",
+						"/l:/l:ro,z,shared",
+					}
 				},
 			},
 		},


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?

The container binds syntax is `host-src:container-dest[:options]` or `volume-name:container-dest[:options]` where `options` is a comma separated list of: `nocopy` `[ro|rw]`, `[z|Z]` or `[[r]shared|[r]slave|[r]private]`. See `HostConfig.Binds` of the Create a container request[1]

[1] https://docs.docker.com/reference/api/engine/version/v1.47/#tag/Container/operation/ContainerCreate

## Why is it important?

It is not possible to set some of these options (e.g. SELinux labels) otherwise.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- 

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
