### PR TITLE
chore(ci): enforce conventional commits syntax in PR titles

### DIFF
--- a/.github/workflows/conventions.yml
+++ b/.github/workflows/conventions.yml
@@ -1,0 +1,21 @@
+name: "Enforce conventions"
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+      - reopened
+
+permissions:
+  pull-requests: read
+
+jobs:
+  lint-pr:
+    name: Validate PR title follows Conventional Commits
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@0723387faaf9b38adef4775cd42cfd5155ed6017 # v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/conventions.yml
+++ b/.github/workflows/conventions.yml
@@ -19,3 +19,31 @@ jobs:
       - uses: amannn/action-semantic-pull-request@0723387faaf9b38adef4775cd42cfd5155ed6017 # v5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          # We may not need a scope on every commit (i.e. repo-level change).
+          #
+          # feat(redis): support for clustering
+          # chore(redis): update tests
+          # fix(redis): trim connection string
+          # ^    ^    ^
+          # |    |    |__ Subject
+          # |    |_______ Scope
+          # |____________ Type
+          requireScope: false
+          # Scope should be lowercase.
+          disallowScopes: |
+            [A-Z]+
+          # ensures the subject doesn't start with an uppercase character.
+          subjectPattern: ^(?![A-Z]).+$
+          subjectPatternError: |
+            The subject "{subject}" found in the pull request title "{title}"
+            didn't match the configured pattern. Please ensure that the subject
+            doesn't start with an uppercase character.
+          types: |
+            break
+            fix
+            feat
+            bug
+            docs
+            chore
+            deps

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -32,6 +32,7 @@ Please just be sure to:
 
 !!!important
     There is a GitHub Actions workflow that will check if your PR title follows the conventional commits convention. If not, it contributes a failed check to your PR.
+    To know more about the conventions, please refer to the [workflow file](https://github.com/testcontainers/testcontainers-go/blob/main/.github/workflows/conventions.yml).
 
 * use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for your commit messages, as it improves the readability of the commit history, and the review process.
 * unless necessary, please try to **avoid pushing --force** to the published branch you submitted a PR from, as it makes it harder to review the changes from a given previous state.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -29,6 +29,10 @@ Please just be sure to:
 * follow the style, naming and structure conventions of the rest of the project.
 * make commits atomic and easy to merge.
 * use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title. This will help us to understand the nature of the changes, and to generate the changelog after all the commits in the PR are squashed.
+
+!!!important
+    There is a GitHub Actions workflow that will check if your PR title follows the conventional commits convention. If not, it contributes a failed check to your PR.
+
 * use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for your commit messages, as it improves the readability of the commit history, and the review process.
 * unless necessary, please try to **avoid pushing --force** to the published branch you submitted a PR from, as it makes it harder to review the changes from a given previous state.
 * apply format running `make lint-all`. It will run `golangci-lint` for the core and modules with the configuration set in the root directory of the project. Please be aware that the lint stage on CI could fail if this is not done.


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
This PR adds a GH workflow to enforce that PRs follow conventional commits in their titles, including that info in the contributing guides.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
Enforce a consistent format that supports an easier-to-read changelog when the project is released.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes #2910

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
