### PR TITLE
bug: fix leaking logs

### DIFF
--- a/wait/wait_test.go
+++ b/wait/wait_test.go
@@ -61,3 +61,17 @@ func (st MockStrategyTarget) State(ctx context.Context) (*types.ContainerState, 
 func (st MockStrategyTarget) CopyFileFromContainer(ctx context.Context, filePath string) (io.ReadCloser, error) {
 	return st.CopyFileFromContainerImpl(ctx, filePath)
 }
+
+type MockLogger struct {
+	PrintfImpl  func(format string, v ...interface{})
+	PrintlnImpl func(v ...interface{})
+}
+
+var _ Logging = MockLogger{}
+
+func (l MockLogger) Printf(format string, v ...interface{}) {
+	l.PrintfImpl(format, v...)
+}
+func (l MockLogger) Println(v ...interface{}) {
+	l.PrintlnImpl(v...)
+}


### PR DESCRIPTION
## What does this PR do?

Adds a new non-breaking option `func (hp *HostPortStrategy) WithLogger(logger Logging) *HostPortStrategy`.

## Why is it important?

The linked issue identified leaking logs when waiting for exposed/listening ports. The proposed implementation preserves the current behaviour when not providing the option.

## Related issues

- Closes #2909

## How to test this PR

New unit tests are included using mock implementations of the logger interface.


## Follow-ups

Consider if the proposed implementation aligns well with the current designs for a centralised logger. I could not import the `testcontainers.Logging` interface due to circular import dependencies, so I had to define a local targeted interface.
