### PR TITLE
chore(ci): add Github labels based on PR title

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -29,22 +29,22 @@ categories:
 autolabeler:
   - label: 'breaking change'
     title:
-      - '/^[a-z]+(\(.+\))?!\:/i'
+      - '/^[a-z]+(\(.+\))?!\:/'
   - label: 'security'
     title:
-      - '/^security(\(.+\))?!?\:/i'
+      - '/^security(\(.+\))?!?\:/'
   - label: 'feature'
     title:
-      - '/^feat(\(.+\))?!?\:/i'
+      - '/^feat(\(.+\))?!?\:/'
   - label: 'bug'
     title:
-      - '/^(fix|bug)(\(.+\))?!?\:/i'
+      - '/^(fix|bug)(\(.+\))?!?\:/'
   - label: 'documentation'
     title:
-      - '/^docs(\(.+\))?!?\:/i'
+      - '/^docs(\(.+\))?!?\:/'
   - label: 'chore'
     title:
-      - '/^chore(\(.+\))?!?\:/i'
+      - '/^chore(\(.+\))?!?\:/'
   - label: 'dependencies'
     title:
-      - '/^deps(\(.+\))?!?\:/i'
+      - '/^deps(\(.+\))?!?\:/'

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -26,3 +26,25 @@ categories:
       - 'test flakiness'
   - title: 📦 Dependency updates
     label: 'dependencies'
+autolabeler:
+  - label: 'breaking change'
+    title:
+      - '/^break(\(.+\))?\:/i'
+  - label: 'security'
+    title:
+      - '/^security(\(.+\))?\:/i'
+  - label: 'feature'
+    title:
+      - '/^feat(\(.+\))?\:/i'
+  - label: 'bug'
+    title:
+      - '/^(fix|bug)(\(.+\))?\:/i'
+  - label: 'documentation'
+    title:
+      - '/^docs(\(.+\))?\:/i'
+  - label: 'chore'
+    title:
+      - '/^chore(\(.+\))?\:/i'
+  - label: 'dependencies'
+    title:
+      - '/^deps(\(.+\))?\:/i'

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -29,7 +29,7 @@ categories:
 autolabeler:
   - label: 'breaking change'
     title:
-      - '/^break(\(.+\))?\:/i'
+      - '/^[a-z]+(\(.+\))?!\:/i'
   - label: 'security'
     title:
       - '/^security(\(.+\))?\:/i'

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -38,7 +38,7 @@ autolabeler:
       - '/^feat(\(.+\))?!?\:/'
   - label: 'bug'
     title:
-      - '/^(fix|bug)(\(.+\))?!?\:/'
+      - '/^(fix)(\(.+\))?!?\:/'
   - label: 'documentation'
     title:
       - '/^docs(\(.+\))?!?\:/'

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -32,19 +32,19 @@ autolabeler:
       - '/^[a-z]+(\(.+\))?!\:/i'
   - label: 'security'
     title:
-      - '/^security(\(.+\))?\:/i'
+      - '/^security(\(.+\))?!?\:/i'
   - label: 'feature'
     title:
-      - '/^feat(\(.+\))?\:/i'
+      - '/^feat(\(.+\))?!?\:/i'
   - label: 'bug'
     title:
-      - '/^(fix|bug)(\(.+\))?\:/i'
+      - '/^(fix|bug)(\(.+\))?!?\:/i'
   - label: 'documentation'
     title:
-      - '/^docs(\(.+\))?\:/i'
+      - '/^docs(\(.+\))?!?\:/i'
   - label: 'chore'
     title:
-      - '/^chore(\(.+\))?\:/i'
+      - '/^chore(\(.+\))?!?\:/i'
   - label: 'dependencies'
     title:
-      - '/^deps(\(.+\))?\:/i'
+      - '/^deps(\(.+\))?!?\:/i'

--- a/.github/workflows/conventions.yml
+++ b/.github/workflows/conventions.yml
@@ -22,13 +22,14 @@ jobs:
         with:
           # We may not need a scope on every commit (i.e. repo-level change).
           #
+          # feat!: read config consistenly
           # feat(redis): support for clustering
           # chore(redis): update tests
           # fix(redis): trim connection string
           # ^    ^    ^
           # |    |    |__ Subject
           # |    |_______ Scope
-          # |____________ Type
+          # |____________ Type: it can end with a ! to denote a breaking change.
           requireScope: false
           # Scope should be lowercase.
           disallowScopes: |
@@ -40,7 +41,6 @@ jobs:
             didn't match the configured pattern. Please ensure that the subject
             doesn't start with an uppercase character.
           types: |
-            break
             security
             fix
             feat

--- a/.github/workflows/conventions.yml
+++ b/.github/workflows/conventions.yml
@@ -41,6 +41,7 @@ jobs:
             doesn't start with an uppercase character.
           types: |
             break
+            security
             fix
             feat
             bug

--- a/.github/workflows/conventions.yml
+++ b/.github/workflows/conventions.yml
@@ -44,7 +44,6 @@ jobs:
             security
             fix
             feat
-            bug
             docs
             chore
             deps

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -5,6 +5,10 @@ on:
   push:
     branches:
       - main
+  # pull_request event is required only for autolabeler
+  pull_request:
+    # Only following types are handled by the action, but one can default to all as well
+    types: [opened, reopened, synchronize]
 
 permissions:
   contents: read
@@ -17,5 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: release-drafter/release-drafter@3f0f87098bd6b5c5b9a36d49c41d998ea58f9348 # v5.19.0
+        with:
+          disable-autolabeler: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -29,12 +29,19 @@ Please just be sure to:
 * follow the style, naming and structure conventions of the rest of the project.
 * make commits atomic and easy to merge.
 * use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title. This will help us to understand the nature of the changes, and to generate the changelog after all the commits in the PR are squashed.
+    * Please use the `break` type for breaking changes, as these categories are considered as `breaking change` in the changelog.
+    * Please use the `security` type for security fixes, as these categories are considered as `security` in the changelog.
+    * Please use the `feat` type for new features, as these categories are considered as `feature` in the changelog.
+    * Please use the `fix` type for bug fixes, as these categories are considered as `bug` in the changelog.
+    * Please use the `docs` type for documentation updates, as these categories are considered as `documentation` in the changelog.
+    * Please use the `chore` type for housekeeping commits, including `build`, `ci`, `style`, `refactor`, `test`, `perf` and so on, as these categories are considered as `chore` in the changelog.
+    * Please use the `deps` type for dependency updates, as these categories are considered as `dependencies` in the changelog.
 
 !!!important
     There is a GitHub Actions workflow that will check if your PR title follows the conventional commits convention. If not, it contributes a failed check to your PR.
     To know more about the conventions, please refer to the [workflow file](https://github.com/testcontainers/testcontainers-go/blob/main/.github/workflows/conventions.yml).
 
-* use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for your commit messages, as it improves the readability of the commit history, and the review process.
+* use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for your commit messages, as it improves the readability of the commit history, and the review process. Please follow the above conventions for the PR title.
 * unless necessary, please try to **avoid pushing --force** to the published branch you submitted a PR from, as it makes it harder to review the changes from a given previous state.
 * apply format running `make lint-all`. It will run `golangci-lint` for the core and modules with the configuration set in the root directory of the project. Please be aware that the lint stage on CI could fail if this is not done.
     * For linting just the modules: `make -C modules lint-modules`

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -29,7 +29,7 @@ Please just be sure to:
 * follow the style, naming and structure conventions of the rest of the project.
 * make commits atomic and easy to merge.
 * use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for the PR title. This will help us to understand the nature of the changes, and to generate the changelog after all the commits in the PR are squashed.
-    * Please use the `break` type for breaking changes, as these categories are considered as `breaking change` in the changelog.
+    * Please use the `feat!`, `chore!`, `fix!`... types for breaking changes, as these categories are considered as `breaking change` in the changelog. Please use the `!` to denote a breaking change.
     * Please use the `security` type for security fixes, as these categories are considered as `security` in the changelog.
     * Please use the `feat` type for new features, as these categories are considered as `feature` in the changelog.
     * Please use the `fix` type for bug fixes, as these categories are considered as `bug` in the changelog.


### PR DESCRIPTION
- **chore: add security as valid convention PR title**
- **chore: add labels based on PR title**

<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
It activates the autolabeler feature from the release-drafter Github Action, adding labels based on the PR title.

This is now possible thanks to the enforcement of conventional commits in the PR title.
 
<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
It will simplify the burden of adding labels to PRs, making the creation of the release notes easier: as PRs will be automatically labelled, they will land into the right release notes section properly.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Follows up #2911

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
