### PR TITLE
fix: handle nil value in CleanupNetwork

### DIFF
--- a/network/network_test.go
+++ b/network/network_test.go
@@ -440,3 +440,8 @@ func TestWithNewNetworkContextTimeout(t *testing.T) {
 	require.Empty(t, req.Networks)
 	require.Empty(t, req.NetworkAliases)
 }
+
+func TestCleanupWithNil(t *testing.T) {
+	var network *testcontainers.DockerNetwork
+	testcontainers.CleanupNetwork(t, network)
+}

--- a/testing.go
+++ b/testing.go
@@ -83,7 +83,9 @@ func CleanupNetwork(tb testing.TB, network Network) {
 	tb.Helper()
 
 	tb.Cleanup(func() {
-		noErrorOrIgnored(tb, network.Remove(context.Background()))
+		if !isNil(network) {
+			noErrorOrIgnored(tb, network.Remove(context.Background()))
+		}
 	})
 }
 


### PR DESCRIPTION
The godoc of `CleanupNetwork` states that a `nil` network will result in a no-op.

<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?

Fix `ClenaupNetwork` behavior to match with its godoc.

## Why is it important?

Function behaves differently than documented in godoc.

## Related issues

Closes #2927

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
