### PR TITLE
fix(localstack): more reliable legacy tag detection

### DIFF
--- a/modules/localstack/localstack_test.go
+++ b/modules/localstack/localstack_test.go
@@ -82,7 +82,7 @@ func TestConfigureDockerHost(t *testing.T) {
 	}
 }
 
-func TestIsLegacyMode(t *testing.T) {
+func TestIsLegacyVersion(t *testing.T) {
 	tests := []struct {
 		version string
 		want    bool
@@ -112,13 +112,13 @@ func TestIsLegacyMode(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.version, func(t *testing.T) {
-			got := isLegacyMode("localstack/localstack:" + tt.version)
+			got := !isMinimumVersion("localstack/localstack:"+tt.version, "v0.11")
 			require.Equal(t, tt.want, got, "runInLegacyMode() = %v, want %v", got, tt.want)
 		})
 	}
 }
 
-func TestIsVersion2(t *testing.T) {
+func TestIsMinimumVersion2(t *testing.T) {
 	tests := []struct {
 		version string
 		want    bool
@@ -152,7 +152,7 @@ func TestIsVersion2(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.version, func(t *testing.T) {
-			got := isVersion2("localstack/localstack:" + tt.version)
+			got := isMinimumVersion("localstack/localstack:"+tt.version, "v2")
 			require.Equal(t, tt.want, got, "runInLegacyMode() = %v, want %v", got, tt.want)
 		})
 	}

--- a/modules/localstack/localstack_test.go
+++ b/modules/localstack/localstack_test.go
@@ -89,17 +89,70 @@ func TestIsLegacyMode(t *testing.T) {
 	}{
 		{"foo", true},
 		{"latest", false},
+		{"latest-amd64", false},
+		{"s3-latest", false},
+		{"s3-latest-amd64", false},
+		{"stable", false},
+		{"stable-amd64", false},
 		{"0.10.0", true},
+		{"0.10.0-amd64", true},
 		{"0.10.999", true},
+		{"0.10.999-amd64", true},
 		{"0.11", false},
+		{"0.11-amd64", false},
 		{"0.11.2", false},
+		{"0.11.2-amd64", false},
 		{"0.12", false},
+		{"0.12-amd64", false},
+		{"1", false},
+		{"1-amd64", false},
 		{"1.0", false},
+		{"1.0-amd64", false},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.version, func(t *testing.T) {
 			got := isLegacyMode("localstack/localstack:" + tt.version)
+			require.Equal(t, tt.want, got, "runInLegacyMode() = %v, want %v", got, tt.want)
+		})
+	}
+}
+
+func TestIsVersion2(t *testing.T) {
+	tests := []struct {
+		version string
+		want    bool
+	}{
+		{"foo", false},
+		{"latest", true},
+		{"latest-amd64", true},
+		{"s3-latest", true},
+		{"s3-latest-amd64", true},
+		{"stable", true},
+		{"stable-amd64", true},
+		{"1", false},
+		{"1-amd64", false},
+		{"1.12", false},
+		{"1.12-amd64", false},
+		{"1.12.2", false},
+		{"1.12.2-amd64", false},
+		{"2", true},
+		{"2-amd64", true},
+		{"2.0", true},
+		{"2.0-amd64", true},
+		{"2.0.0", true},
+		{"2.0.0-amd64", true},
+		{"2.0.1", true},
+		{"2.0.1-amd64", true},
+		{"2.1", true},
+		{"2.1-amd64", true},
+		{"3", true},
+		{"3-amd64", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.version, func(t *testing.T) {
+			got := isVersion2("localstack/localstack:" + tt.version)
 			require.Equal(t, tt.want, got, "runInLegacyMode() = %v, want %v", got, tt.want)
 		})
 	}


### PR DESCRIPTION
## What does this PR do?

Improves the internal `isLegacyMode` function to handle all tag conventions used by localstack.

## Why is it important?

I'm currently unable to use the much smaller `localstack/localstack:s3-latest` image tag because it's incorrectly detected as a legacy version.

## How to test this PR

Unit test included.