### PR TITLE
chore!: rename EnpointSettingsModifier to EndpointSettingsModifier

### DIFF
--- a/container.go
+++ b/container.go
@@ -128,44 +128,44 @@ func (c *ContainerFile) validate() error {
 // ContainerRequest represents the parameters used to get a running container
 type ContainerRequest struct {
 	FromDockerfile
-	HostAccessPorts         []int
-	Image                   string
-	ImageSubstitutors       []ImageSubstitutor
-	Entrypoint              []string
-	Env                     map[string]string
-	ExposedPorts            []string // allow specifying protocol info
-	Cmd                     []string
-	Labels                  map[string]string
-	Mounts                  ContainerMounts
-	Tmpfs                   map[string]string
-	RegistryCred            string // Deprecated: Testcontainers will detect registry credentials automatically
-	WaitingFor              wait.Strategy
-	Name                    string // for specifying container name
-	Hostname                string
-	WorkingDir              string                                     // specify the working directory of the container
-	ExtraHosts              []string                                   // Deprecated: Use HostConfigModifier instead
-	Privileged              bool                                       // For starting privileged container
-	Networks                []string                                   // for specifying network names
-	NetworkAliases          map[string][]string                        // for specifying network aliases
-	NetworkMode             container.NetworkMode                      // Deprecated: Use HostConfigModifier instead
-	Resources               container.Resources                        // Deprecated: Use HostConfigModifier instead
-	Files                   []ContainerFile                            // files which will be copied when container starts
-	User                    string                                     // for specifying uid:gid
-	SkipReaper              bool                                       // Deprecated: The reaper is globally controlled by the .testcontainers.properties file or the TESTCONTAINERS_RYUK_DISABLED environment variable
-	ReaperImage             string                                     // Deprecated: use WithImageName ContainerOption instead. Alternative reaper image
-	ReaperOptions           []ContainerOption                          // Deprecated: the reaper is configured at the properties level, for an entire test session
-	AutoRemove              bool                                       // Deprecated: Use HostConfigModifier instead. If set to true, the container will be removed from the host when stopped
-	AlwaysPullImage         bool                                       // Always pull image
-	ImagePlatform           string                                     // ImagePlatform describes the platform which the image runs on.
-	Binds                   []string                                   // Deprecated: Use HostConfigModifier instead
-	ShmSize                 int64                                      // Amount of memory shared with the host (in bytes)
-	CapAdd                  []string                                   // Deprecated: Use HostConfigModifier instead. Add Linux capabilities
-	CapDrop                 []string                                   // Deprecated: Use HostConfigModifier instead. Drop Linux capabilities
-	ConfigModifier          func(*container.Config)                    // Modifier for the config before container creation
-	HostConfigModifier      func(*container.HostConfig)                // Modifier for the host config before container creation
-	EnpointSettingsModifier func(map[string]*network.EndpointSettings) // Modifier for the network settings before container creation
-	LifecycleHooks          []ContainerLifecycleHooks                  // define hooks to be executed during container lifecycle
-	LogConsumerCfg          *LogConsumerConfig                         // define the configuration for the log producer and its log consumers to follow the logs
+	HostAccessPorts          []int
+	Image                    string
+	ImageSubstitutors        []ImageSubstitutor
+	Entrypoint               []string
+	Env                      map[string]string
+	ExposedPorts             []string // allow specifying protocol info
+	Cmd                      []string
+	Labels                   map[string]string
+	Mounts                   ContainerMounts
+	Tmpfs                    map[string]string
+	RegistryCred             string // Deprecated: Testcontainers will detect registry credentials automatically
+	WaitingFor               wait.Strategy
+	Name                     string // for specifying container name
+	Hostname                 string
+	WorkingDir               string                                     // specify the working directory of the container
+	ExtraHosts               []string                                   // Deprecated: Use HostConfigModifier instead
+	Privileged               bool                                       // For starting privileged container
+	Networks                 []string                                   // for specifying network names
+	NetworkAliases           map[string][]string                        // for specifying network aliases
+	NetworkMode              container.NetworkMode                      // Deprecated: Use HostConfigModifier instead
+	Resources                container.Resources                        // Deprecated: Use HostConfigModifier instead
+	Files                    []ContainerFile                            // files which will be copied when container starts
+	User                     string                                     // for specifying uid:gid
+	SkipReaper               bool                                       // Deprecated: The reaper is globally controlled by the .testcontainers.properties file or the TESTCONTAINERS_RYUK_DISABLED environment variable
+	ReaperImage              string                                     // Deprecated: use WithImageName ContainerOption instead. Alternative reaper image
+	ReaperOptions            []ContainerOption                          // Deprecated: the reaper is configured at the properties level, for an entire test session
+	AutoRemove               bool                                       // Deprecated: Use HostConfigModifier instead. If set to true, the container will be removed from the host when stopped
+	AlwaysPullImage          bool                                       // Always pull image
+	ImagePlatform            string                                     // ImagePlatform describes the platform which the image runs on.
+	Binds                    []string                                   // Deprecated: Use HostConfigModifier instead
+	ShmSize                  int64                                      // Amount of memory shared with the host (in bytes)
+	CapAdd                   []string                                   // Deprecated: Use HostConfigModifier instead. Add Linux capabilities
+	CapDrop                  []string                                   // Deprecated: Use HostConfigModifier instead. Drop Linux capabilities
+	ConfigModifier           func(*container.Config)                    // Modifier for the config before container creation
+	HostConfigModifier       func(*container.HostConfig)                // Modifier for the host config before container creation
+	EndpointSettingsModifier func(map[string]*network.EndpointSettings) // Modifier for the network settings before container creation
+	LifecycleHooks           []ContainerLifecycleHooks                  // define hooks to be executed during container lifecycle
+	LogConsumerCfg           *LogConsumerConfig                         // define the configuration for the log producer and its log consumers to follow the logs
 }
 
 // sessionID returns the session ID for the container request.

--- a/lifecycle.go
+++ b/lifecycle.go
@@ -555,8 +555,8 @@ func (p *DockerProvider) preCreateContainerHook(ctx context.Context, req Contain
 	}
 	req.HostConfigModifier(hostConfig)
 
-	if req.EnpointSettingsModifier != nil {
-		req.EnpointSettingsModifier(endpointSettings)
+	if req.EndpointSettingsModifier != nil {
+		req.EndpointSettingsModifier(endpointSettings)
 	}
 
 	networkingConfig.EndpointsConfig = endpointSettings

--- a/lifecycle_test.go
+++ b/lifecycle_test.go
@@ -57,7 +57,7 @@ func TestPreCreateModifierHook(t *testing.T) {
 					},
 				}
 			},
-			EnpointSettingsModifier: func(endpointSettings map[string]*network.EndpointSettings) {
+			EndpointSettingsModifier: func(endpointSettings map[string]*network.EndpointSettings) {
 				endpointSettings["a"] = &network.EndpointSettings{
 					Aliases: []string{"b"},
 					Links:   []string{"link1", "link2"},

--- a/options.go
+++ b/options.go
@@ -53,7 +53,7 @@ func WithConfigModifier(modifier func(config *container.Config)) CustomizeReques
 // WithEndpointSettingsModifier allows to override the default endpoint settings
 func WithEndpointSettingsModifier(modifier func(settings map[string]*network.EndpointSettings)) CustomizeRequestOption {
 	return func(req *GenericContainerRequest) error {
-		req.EnpointSettingsModifier = modifier
+		req.EndpointSettingsModifier = modifier
 
 		return nil
 	}

--- a/reaper_test.go
+++ b/reaper_test.go
@@ -53,8 +53,8 @@ func (m *mockReaperProvider) RunContainer(ctx context.Context, req ContainerRequ
 	}
 	req.HostConfigModifier(m.hostConfig)
 
-	if req.EnpointSettingsModifier != nil {
-		req.EnpointSettingsModifier(m.endpointSettings)
+	if req.EndpointSettingsModifier != nil {
+		req.EndpointSettingsModifier(m.endpointSettings)
 	}
 
 	// we're only interested in the request, so instead of mocking the Docker client


### PR DESCRIPTION
Rename `EnpointSettingsModifier` to `EndpointSettingsModifier`, as discussed in #2940.