### PR TITLE
chore: enable var-declaration from revive linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -73,7 +73,6 @@ linters-settings:
       - name: use-any
         disabled: true
       - name: var-declaration
-        disabled: true
       - name: var-naming
         disabled: true
   testifylint:

--- a/container.go
+++ b/container.go
@@ -226,7 +226,7 @@ func (c *ContainerRequest) Validate() error {
 // GetContext retrieve the build context for the request
 // Must be closed when no longer needed.
 func (c *ContainerRequest) GetContext() (io.Reader, error) {
-	var includes []string = []string{"."}
+	includes := []string{"."}
 
 	if c.ContextArchive != nil {
 		return c.ContextArchive, nil

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -15,7 +15,7 @@ const ReaperDefaultImage = "testcontainers/ryuk:0.11.0"
 
 var (
 	tcConfig     Config
-	tcConfigOnce *sync.Once = new(sync.Once)
+	tcConfigOnce = new(sync.Once)
 )
 
 // testcontainersConfig {

--- a/internal/core/images_test.go
+++ b/internal/core/images_test.go
@@ -17,10 +17,10 @@ const (
 )
 
 func TestExtractImagesFromDockerfile(t *testing.T) {
-	var baseImage string = "scratch"
-	var registryHost string = "localhost"
-	var registryPort string = "5000"
-	var nginxImage string = "nginx:latest"
+	baseImage := "scratch"
+	registryHost := "localhost"
+	registryPort := "5000"
+	nginxImage := "nginx:latest"
 
 	tests := []struct {
 		name          string

--- a/modules/dynamodb/dynamodb_test.go
+++ b/modules/dynamodb/dynamodb_test.go
@@ -25,7 +25,7 @@ const (
 	baseImage    string = "amazon/dynamodb-local:"
 )
 
-var image2_2_1 string = baseImage + "2.2.1"
+var image2_2_1 = baseImage + "2.2.1"
 
 func TestRun(t *testing.T) {
 	ctx := context.Background()


### PR DESCRIPTION
## What does this PR do?

[revive](https://golangci-lint.run/usage/linters/#revive) is a linter for Go. Drop-in replacement of golint.

This PR list default rules and focus on applying var-declaration rule at first