### PR TITLE
add(docs): using gitlab-ci with kubernetes through kubedock guide

### DIFF
--- a/docs/system_requirements/ci/gitlab_ci.md
+++ b/docs/system_requirements/ci/gitlab_ci.md
@@ -39,7 +39,7 @@ So edit your `.gitlab-ci.yml` to include the [Docker-In-Docker service](https://
 
 Caveat: Current Docker releases (verified for 20.10.9) intentionally delay the startup, if the Docker API is bound to a network address but not TLS protected. To avoid this delay, the Docker process needs to be started with the argument `--tls=false`.  Otherwise jobs which access the Docker API at the very beginning might fail.
 
-Here is a sample `.gitlab-ci.yml` that executes test with gradle:
+Here is a sample `.gitlab-ci.yml` that executes go test:
 
 ```yml
 # DinD service is required for Testcontainers
@@ -60,4 +60,125 @@ test:
  image: golang:1.22
  stage: test
  script: go test ./... -v
+```
+
+## Example using Kubedock
+
+This applies if your executor is `kubernetes` and you don't want to use DinD. One option is to use [kubedock](https://github.com/joyrex2001/kubedock). This library is a minimal implementation of the Docker API that will orchestrate containers on a Kubernetes cluster.
+
+Here is the example Kubernetes configuration you must create:
+
+```yml
+# ServiceAccount for Kubedock
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kubedock
+  namespace: gitlab-runner
+
+# Role for Kubedock
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: kubedock-role
+  namespace: gitlab-runner
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["create", "get", "list", "delete", "watch"]
+  - apiGroups: [""]
+    resources: ["pods/log"]
+    verbs: ["list", "get"]
+  - apiGroups: [""]
+    resources: ["pods/exec"]
+    verbs: ["create"]
+  - apiGroups: [""]
+    resources: ["services"]
+    verbs: ["create", "get", "list", "delete"]
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["create", "get", "list", "delete"]
+
+# RoleBinding for Kubedock
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: kubedock-rolebinding
+  namespace: gitlab-runner
+subjects:
+  - kind: User
+    name: system:serviceaccount:gitlab-runner:kubedock
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: Role
+  name: kubedock-role
+  apiGroup: rbac.authorization.k8s.io
+
+# Deployment for Kubedock Server
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kubedock-server
+  namespace: gitlab-runner
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: kubedock-server
+  template:
+    metadata:
+      labels:
+        app: kubedock-server
+    spec:
+      serviceAccountName: kubedock
+      containers:
+        - name: kubedock-server
+          image: joyrex2001/kubedock:0.17.0
+          resources:
+            limits:
+              memory: "4Gi"
+              cpu: "1000m"
+            requests:
+              memory: "2Gi"
+              cpu: "200m"
+          ports:
+            - containerPort: 2475
+          args: [
+              # Configuration options described here:
+              # https://github.com/joyrex2001/kubedock/blob/master/config.md
+              "server",
+              "--namespace=gitlab-runner",
+              "--service-account=kubedock",
+              "--timeout=20m0s",
+              "--request-cpu=1",
+              "--request-memory=2Gi",
+              "--disable-dind",
+              "--reverse-proxy",
+              "--reapmax=60m",
+            ]
+
+# Service for Kubedock
+apiVersion: v1
+kind: Service
+metadata:
+  name: kubedock-service
+  namespace: gitlab-runner
+spec:
+  selector:
+    app: kubedock-server
+  type: ClusterIP
+  clusterIP: None
+```
+
+
+Here is a sample `.gitlab-ci.yml` that executes go test:
+
+```yml
+variables:
+  # Instruct Testcontainers to use the daemon of kubedock to create containers in kubernetes
+  DOCKER_HOST: "tcp://kubedock-service:2475"
+test:
+  image: golang:1.22
+  stage: test
+  script: go test ./... -v
 ```

--- a/docs/system_requirements/ci/gitlab_ci.md
+++ b/docs/system_requirements/ci/gitlab_ci.md
@@ -27,7 +27,7 @@ See below for an example runner configuration:
 
 Please also include the following in your GitlabCI pipeline definitions (`.gitlab-ci.yml`) that use Testcontainers:
 
-```yml
+```yaml
 variables:
   TESTCONTAINERS_HOST_OVERRIDE: "host.docker.internal"
 ```
@@ -41,7 +41,7 @@ Caveat: Current Docker releases (verified for 20.10.9) intentionally delay the s
 
 Here is a sample `.gitlab-ci.yml` that executes go test:
 
-```yml
+```yaml
 # DinD service is required for Testcontainers
 services:
   - name: docker:dind
@@ -68,7 +68,7 @@ This applies if your executor is `kubernetes` and you don't want to use DinD. On
 
 Here is the example Kubernetes configuration you must create:
 
-```yml
+```yaml
 # ServiceAccount for Kubedock
 apiVersion: v1
 kind: ServiceAccount
@@ -173,7 +173,7 @@ spec:
 
 Here is a sample `.gitlab-ci.yml` that executes go test:
 
-```yml
+```yaml
 variables:
   # Instruct Testcontainers to use the daemon of kubedock to create containers in kubernetes
   DOCKER_HOST: "tcp://kubedock-service:2475"


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
Adds guide for how to use testcontainers on a gitlab-ci configuration with kubernetes.
I also fixed the code blocks language issue where yamls were specified as ymls, resulting in syntax highlighting being disabled.

## Why is it important?
I had a hell of time configuring testcontainers on our kubernetes runners and I think  this can help other users.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- 

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
