### PR TITLE
chore: enable early-return, indent-error-flow and superfluous-else from revive linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,13 +9,12 @@ linters:
     - nolintlint
     - nakedret
     - perfsprint
+    - revive
     - testifylint
     - thelper
     - usestdlibvars
 
 linters-settings:
-  nakedret:
-    max-func-lines: 0
   errorlint:
     # Check whether fmt.Errorf uses the %w verb for formatting errors.
     # See the https://github.com/polyfloyd/go-errorlint for caveats.
@@ -31,6 +30,52 @@ linters-settings:
       - standard
       - default
       - prefix(github.com/testcontainers)
+  nakedret:
+    max-func-lines: 0
+  revive:
+    min-confidence: 0.8
+    rules:
+      - name: blank-imports
+      - name: context-as-argument
+        disabled: true
+        arguments:
+          - allowTypesBefore: "*testing.T"
+      - name: context-keys-type
+      - name: dot-imports
+      - name: early-return
+        arguments:
+          - "preserveScope"
+      - name: empty-block
+        disabled: true
+      - name: error-naming
+        disabled: true
+      - name: error-return
+      - name: error-strings
+        disabled: true
+      - name: errorf
+      - name: increment-decrement
+      - name: indent-error-flow
+        arguments:
+          - "preserveScope"
+      - name: range
+      - name: receiver-naming
+      - name: redefines-builtin-id
+        disabled: true
+      - name: superfluous-else
+        arguments:
+          - "preserveScope"
+      - name: time-naming
+      - name: unexported-return
+        disabled: true
+      - name: unreachable-code
+      - name: unused-parameter
+        disabled: true
+      - name: use-any
+        disabled: true
+      - name: var-declaration
+        disabled: true
+      - name: var-naming
+        disabled: true
   testifylint:
     disable:
       - float-compare

--- a/container.go
+++ b/container.go
@@ -529,9 +529,8 @@ func (c *ContainerRequest) validateMounts() error {
 		targetPath := m.Target.Target()
 		if targets[targetPath] {
 			return fmt.Errorf("%w: %s", ErrDuplicateMountTarget, targetPath)
-		} else {
-			targets[targetPath] = true
 		}
+		targets[targetPath] = true
 	}
 
 	if c.HostConfigModifier == nil {
@@ -551,9 +550,8 @@ func (c *ContainerRequest) validateMounts() error {
 			targetPath := parts[1]
 			if targets[targetPath] {
 				return fmt.Errorf("%w: %s", ErrDuplicateMountTarget, targetPath)
-			} else {
-				targets[targetPath] = true
 			}
+			targets[targetPath] = true
 		}
 	}
 

--- a/docker.go
+++ b/docker.go
@@ -1120,11 +1120,10 @@ func (p *DockerProvider) CreateContainer(ctx context.Context, req ContainerReque
 		} else {
 			img, _, err := p.client.ImageInspectWithRaw(ctx, imageName)
 			if err != nil {
-				if client.IsErrNotFound(err) {
-					shouldPullImage = true
-				} else {
+				if !client.IsErrNotFound(err) {
 					return nil, err
 				}
+				shouldPullImage = true
 			}
 			if platform != nil && (img.Architecture != platform.Architecture || img.Os != platform.OS) {
 				shouldPullImage = true

--- a/internal/core/docker_rootless.go
+++ b/internal/core/docker_rootless.go
@@ -79,11 +79,9 @@ func fileExists(f string) bool {
 }
 
 func parseURL(s string) (string, error) {
-	var hostURL *url.URL
-	if u, err := url.Parse(s); err != nil {
+	hostURL, err := url.Parse(s)
+	if err != nil {
 		return "", err
-	} else {
-		hostURL = u
 	}
 
 	switch hostURL.Scheme {

--- a/modules/compose/compose_api.go
+++ b/modules/compose/compose_api.go
@@ -592,9 +592,8 @@ func withEnv(env map[string]string) func(*cli.ProjectOptions) error {
 		for k, v := range env {
 			if _, ok := options.Environment[k]; ok {
 				return fmt.Errorf("environment with key %s already set", k)
-			} else {
-				options.Environment[k] = v
 			}
+			options.Environment[k] = v
 		}
 
 		return nil

--- a/modules/registry/registry.go
+++ b/modules/registry/registry.go
@@ -194,9 +194,8 @@ func (c *RegistryContainer) PushImage(ctx context.Context, ref string) error {
 	encodedJSON, err := json.Marshal(imageAuth)
 	if err != nil {
 		return fmt.Errorf("failed to encode image auth: %w", err)
-	} else {
-		pushOpts.RegistryAuth = base64.URLEncoding.EncodeToString(encodedJSON)
 	}
+	pushOpts.RegistryAuth = base64.URLEncoding.EncodeToString(encodedJSON)
 
 	_, err = dockerCli.ImagePush(ctx, ref, pushOpts)
 	if err != nil {

--- a/wait/exit.go
+++ b/wait/exit.go
@@ -76,9 +76,8 @@ func (ws *ExitStrategy) WaitUntilReady(ctx context.Context, target StrategyTarge
 			if err != nil {
 				if !strings.Contains(err.Error(), "No such container") {
 					return err
-				} else {
-					return nil
 				}
+				return nil
 			}
 			if state.Running {
 				time.Sleep(ws.PollInterval)


### PR DESCRIPTION
## What does this PR do?

[revive](https://golangci-lint.run/usage/linters/#revive) is a linter for Go. Drop-in replacement of golint.

This PR list default rules and focus on applying  early-return, indent-error-flow and superfluous-else rules.