### PR TITLE
chore(deps): bump golangci-lint to v1.63.4

### DIFF
--- a/commons-test.mk
+++ b/commons-test.mk
@@ -6,7 +6,7 @@ define go_install
 endef
 
 $(GOBIN)/golangci-lint:
-	$(call go_install,github.com/golangci/golangci-lint/cmd/golangci-lint@v1.61.0)
+	$(call go_install,github.com/golangci/golangci-lint/cmd/golangci-lint@v1.63.4)
 
 $(GOBIN)/gotestsum:
 	$(call go_install,gotest.tools/gotestsum@latest)

--- a/modules/ollama/local_test.go
+++ b/modules/ollama/local_test.go
@@ -199,11 +199,11 @@ func TestRun_local(t *testing.T) {
 	t.Run("port-endpoint", func(t *testing.T) {
 		endpoint, err := ollamaContainer.PortEndpoint(ctx, testNatPort, "")
 		require.NoError(t, err)
-		require.Regexp(t, regexp.MustCompile(`^127.0.0.1:\d+$`), endpoint)
+		require.Regexp(t, `^127.0.0.1:\d+$`, endpoint)
 
 		endpoint, err = ollamaContainer.PortEndpoint(ctx, testNatPort, "http")
 		require.NoError(t, err)
-		require.Regexp(t, regexp.MustCompile(`^http://127.0.0.1:\d+$`), endpoint)
+		require.Regexp(t, `^http://127.0.0.1:\d+$`, endpoint)
 	})
 
 	t.Run("session-id", func(t *testing.T) {
@@ -392,7 +392,7 @@ func testRun_localWithCustomHost(ctx context.Context, t *testing.T, ollamaContai
 	t.Run("inspect", func(t *testing.T) {
 		inspect, err := ollamaContainer.Inspect(ctx)
 		require.NoError(t, err)
-		require.Regexp(t, regexp.MustCompile(`^local-ollama:\d+\.\d+\.\d+$`), inspect.Config.Image)
+		require.Regexp(t, `^local-ollama:\d+\.\d+\.\d+$`, inspect.Config.Image)
 
 		_, exists := inspect.Config.ExposedPorts[testNatPort]
 		require.True(t, exists)


### PR DESCRIPTION
#### What does this PR do?


Update golangci-lint to v1.63.4 and fixes newly raised issues