### PR TITLE
chore!: enable var-naming from revive

### DIFF
--- a/docs/modules/grafana-lgtm.md
+++ b/docs/modules/grafana-lgtm.md
@@ -67,7 +67,7 @@ The Grafana LGTM container exposes the following methods:
 
 - Since testcontainers-go <a href="https://github.com/testcontainers/testcontainers-go/releases/tag/v0.33.0"><span class="tc-version">:material-tag: v0.33.0</span></a>
 
-The `HttpEndpoint(ctx)` method returns the HTTP endpoint to connect to Grafana, using the default `3000` port. The same method with the `Must` prefix returns just the endpoint, and panics if an error occurs.
+The `HTTPEndpoint(ctx)` method returns the HTTP endpoint to connect to Grafana, using the default `3000` port. The same method with the `Must` prefix returns just the endpoint, and panics if an error occurs.
 
 #### Loki Endpoint
 
@@ -97,7 +97,7 @@ The `OtelGRPCEndpoint(ctx)` method returns the endpoint to connect to Otel using
 
 - Since testcontainers-go <a href="https://github.com/testcontainers/testcontainers-go/releases/tag/v0.33.0"><span class="tc-version">:material-tag: v0.33.0</span></a>
 
-The `PrometheusHttpEndpoint(ctx)` method returns the endpoint to connect to Prometheus, using the default `9090` port. The same method with the `Must` prefix returns just the endpoint, and panics if an error occurs.
+The `PrometheusHTTPEndpoint(ctx)` method returns the endpoint to connect to Prometheus, using the default `9090` port. The same method with the `Must` prefix returns just the endpoint, and panics if an error occurs.
 
 ## Examples
 

--- a/docs/modules/openfga.md
+++ b/docs/modules/openfga.md
@@ -54,7 +54,7 @@ E.g. `Run(context.Background(), "openfga/openfga:v1.5.0")`.
 
 The OpenFGA container exposes the following methods:
 
-#### HttpEndpoint
+#### HTTPEndpoint
 
 This method returns the HTTP endpoint to connect to the OpenFGA container, using the `8080` port.
 

--- a/docs/modules/pinecone.md
+++ b/docs/modules/pinecone.md
@@ -54,11 +54,11 @@ E.g. `Run(context.Background(), "ghcr.io/pinecone-io/pinecone-local:latest")`.
 
 The Pinecone container exposes the following methods:
 
-#### HttpEndpoint
+#### HTTPEndpoint
 
 - Not available until the next release of testcontainers-go <a href="https://github.com/testcontainers/testcontainers-go"><span class="tc-version">:material-tag: main</span></a>
 
-The `HttpEndpoint` method returns the location where the Pinecone container is listening.
+The `HTTPEndpoint` method returns the location where the Pinecone container is listening.
 It returns a string with the format `http://<host>:<port>`.
 
 <!--codeinclude-->

--- a/docs/modules/vault.md
+++ b/docs/modules/vault.md
@@ -92,7 +92,7 @@ If you need to run a vault command in the container, you can use the `WithInitCo
 
 ### Container Methods
 
-#### HttpHostAddress
+#### HTTPHostAddress
 
 This method returns the http host address of Vault, in the `http://<host>:<port>` format.
 

--- a/modules/clickhouse/clickhouse_test.go
+++ b/modules/clickhouse/clickhouse_test.go
@@ -24,7 +24,7 @@ const (
 )
 
 type Test struct {
-	Id uint64
+	ID uint64
 }
 
 func TestClickHouseDefaultConfig(t *testing.T) {
@@ -276,7 +276,7 @@ func performReplicatedCRUD(t *testing.T, conn driver.Conn) ([]Test, error) {
 			for rows.Next() {
 				var r Test
 
-				err := rows.Scan(&r.Id)
+				err := rows.Scan(&r.ID)
 				if err != nil {
 					return nil, err
 				}
@@ -325,7 +325,7 @@ func getAllRows(conn driver.Conn) ([]Test, error) {
 	for rows.Next() {
 		var r Test
 
-		err := rows.Scan(&r.Id)
+		err := rows.Scan(&r.ID)
 		if err != nil {
 			return nil, err
 		}

--- a/modules/consul/consul.go
+++ b/modules/consul/consul.go
@@ -23,10 +23,8 @@ type ConsulContainer struct {
 	testcontainers.Container
 }
 
-// ApiEndpoint returns host:port for the HTTP API endpoint.
-//
-//nolint:revive //FIXME
-func (c *ConsulContainer) ApiEndpoint(ctx context.Context) (string, error) {
+// APIEndpoint returns host:port for the HTTP API endpoint.
+func (c *ConsulContainer) APIEndpoint(ctx context.Context) (string, error) {
 	mappedPort, err := c.MappedPort(ctx, defaultHTTPAPIPort)
 	if err != nil {
 		return "", err

--- a/modules/consul/consul_test.go
+++ b/modules/consul/consul_test.go
@@ -44,7 +44,7 @@ func TestConsul(t *testing.T) {
 			require.NoError(t, err)
 
 			// Check if API is up
-			host, err := ctr.ApiEndpoint(ctx)
+			host, err := ctr.APIEndpoint(ctx)
 			require.NoError(t, err)
 			require.NotEmpty(t, host)
 

--- a/modules/consul/examples_test.go
+++ b/modules/consul/examples_test.go
@@ -54,7 +54,7 @@ func ExampleRun_connect() {
 		return
 	}
 
-	endpoint, err := consulContainer.ApiEndpoint(ctx)
+	endpoint, err := consulContainer.APIEndpoint(ctx)
 	if err != nil {
 		log.Printf("failed to get endpoint: %s", err)
 		return

--- a/modules/dolt/dolt.go
+++ b/modules/dolt/dolt.go
@@ -218,8 +218,7 @@ func WithDoltCredsPublicKey(key string) testcontainers.CustomizeRequestOption {
 	}
 }
 
-//nolint:revive //FIXME
-func WithDoltCloneRemoteUrl(url string) testcontainers.CustomizeRequestOption {
+func WithDoltCloneRemoteURL(url string) testcontainers.CustomizeRequestOption {
 	return func(req *testcontainers.GenericContainerRequest) error {
 		req.Env["DOLT_REMOTE_CLONE_URL"] = url
 		return nil

--- a/modules/dolt/dolt_test.go
+++ b/modules/dolt/dolt_test.go
@@ -64,7 +64,7 @@ func TestDoltWithPublicRemoteCloneUrl(t *testing.T) {
 		dolt.WithUsername("test"),
 		dolt.WithPassword("test"),
 		dolt.WithScripts(filepath.Join("testdata", "check_clone_public.sh")),
-		dolt.WithDoltCloneRemoteUrl("fake-remote-url"))
+		dolt.WithDoltCloneRemoteURL("fake-remote-url"))
 	testcontainers.CleanupContainer(t, ctr)
 	require.NoError(t, err)
 }
@@ -89,7 +89,7 @@ func TestDoltWithPrivateRemoteCloneUrl(t *testing.T) {
 		dolt.WithUsername("test"),
 		dolt.WithPassword("test"),
 		dolt.WithScripts(filepath.Join("testdata", "check_clone_private.sh")),
-		dolt.WithDoltCloneRemoteUrl("fake-remote-url"),
+		dolt.WithDoltCloneRemoteURL("fake-remote-url"),
 		dolt.WithDoltCredsPublicKey("fake-public-key"),
 		dolt.WithCredsFile(filename))
 	testcontainers.CleanupContainer(t, ctr)

--- a/modules/grafana-lgtm/examples_test.go
+++ b/modules/grafana-lgtm/examples_test.go
@@ -134,7 +134,7 @@ func setupOTelSDK(ctx context.Context, ctr *grafanalgtm.GrafanaLGTMContainer) (s
 	)
 	otel.SetTextMapPropagator(prop)
 
-	otlpHTTPEndpoint := ctr.MustOtlpHttpEndpoint(ctx)
+	otlpHTTPEndpoint := ctr.MustOtlpHTTPEndpoint(ctx)
 
 	traceExporter, err := otlptrace.New(ctx,
 		otlptracehttp.NewClient(

--- a/modules/grafana-lgtm/grafana.go
+++ b/modules/grafana-lgtm/grafana.go
@@ -16,7 +16,7 @@ const (
 	LokiPort       = "3100/tcp"
 	TempoPort      = "3200/tcp"
 	OtlpGrpcPort   = "4317/tcp"
-	OtlpHttpPort   = "4318/tcp" //nolint:revive //FIXME
+	OtlpHTTPPort   = "4318/tcp"
 	PrometheusPort = "9090/tcp"
 )
 
@@ -29,7 +29,7 @@ type GrafanaLGTMContainer struct {
 func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustomizer) (*GrafanaLGTMContainer, error) {
 	req := testcontainers.ContainerRequest{
 		Image:        img,
-		ExposedPorts: []string{GrafanaPort, LokiPort, TempoPort, OtlpGrpcPort, OtlpHttpPort, PrometheusPort},
+		ExposedPorts: []string{GrafanaPort, LokiPort, TempoPort, OtlpGrpcPort, OtlpHTTPPort, PrometheusPort},
 		WaitingFor:   wait.ForLog(".*The OpenTelemetry collector and the Grafana LGTM stack are up and running.*\\s").AsRegexp().WithOccurrence(1),
 	}
 
@@ -51,7 +51,7 @@ func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustom
 
 	c := &GrafanaLGTMContainer{Container: container}
 
-	url, err := c.OtlpHttpEndpoint(ctx)
+	url, err := c.OtlpHTTPEndpoint(ctx)
 	if err != nil {
 		// return the container instance to allow the caller to clean up
 		return c, fmt.Errorf("otlp http endpoint: %w", err)
@@ -110,10 +110,8 @@ func (c *GrafanaLGTMContainer) MustTempoEndpoint(ctx context.Context) string {
 	return url
 }
 
-// HttpEndpoint returns the HTTP URL
-//
-//nolint:revive //FIXME
-func (c *GrafanaLGTMContainer) HttpEndpoint(ctx context.Context) (string, error) {
+// HTTPEndpoint returns the HTTP URL
+func (c *GrafanaLGTMContainer) HTTPEndpoint(ctx context.Context) (string, error) {
 	url, err := baseEndpoint(ctx, c, GrafanaPort)
 	if err != nil {
 		return "", err
@@ -122,11 +120,9 @@ func (c *GrafanaLGTMContainer) HttpEndpoint(ctx context.Context) (string, error)
 	return url, nil
 }
 
-// MustHttpEndpoint returns the HTTP endpoint or panics if an error occurs
-//
-//nolint:revive //FIXME
-func (c *GrafanaLGTMContainer) MustHttpEndpoint(ctx context.Context) string {
-	url, err := c.HttpEndpoint(ctx)
+// MustHTTPEndpoint returns the HTTP endpoint or panics if an error occurs
+func (c *GrafanaLGTMContainer) MustHTTPEndpoint(ctx context.Context) string {
+	url, err := c.HTTPEndpoint(ctx)
 	if err != nil {
 		panic(err)
 	}
@@ -134,11 +130,9 @@ func (c *GrafanaLGTMContainer) MustHttpEndpoint(ctx context.Context) string {
 	return url
 }
 
-// OtlpHttpEndpoint returns the OTLP HTTP endpoint
-//
-//nolint:revive //FIXME
-func (c *GrafanaLGTMContainer) OtlpHttpEndpoint(ctx context.Context) (string, error) {
-	url, err := baseEndpoint(ctx, c, OtlpHttpPort)
+// OtlpHTTPEndpoint returns the OTLP HTTP endpoint
+func (c *GrafanaLGTMContainer) OtlpHTTPEndpoint(ctx context.Context) (string, error) {
+	url, err := baseEndpoint(ctx, c, OtlpHTTPPort)
 	if err != nil {
 		return "", err
 	}
@@ -146,11 +140,9 @@ func (c *GrafanaLGTMContainer) OtlpHttpEndpoint(ctx context.Context) (string, er
 	return url, nil
 }
 
-// MustOtlpHttpEndpoint returns the OTLP HTTP endpoint or panics if an error occurs
-//
-//nolint:revive //FIXME
-func (c *GrafanaLGTMContainer) MustOtlpHttpEndpoint(ctx context.Context) string {
-	url, err := c.OtlpHttpEndpoint(ctx)
+// MustOtlpHTTPEndpoint returns the OTLP HTTP endpoint or panics if an error occurs
+func (c *GrafanaLGTMContainer) MustOtlpHTTPEndpoint(ctx context.Context) string {
+	url, err := c.OtlpHTTPEndpoint(ctx)
 	if err != nil {
 		panic(err)
 	}
@@ -178,10 +170,8 @@ func (c *GrafanaLGTMContainer) MustOtlpGrpcEndpoint(ctx context.Context) string 
 	return url
 }
 
-// PrometheusHttpEndpoint returns the Prometheus HTTP endpoint
-//
-//nolint:revive //FIXME
-func (c *GrafanaLGTMContainer) PrometheusHttpEndpoint(ctx context.Context) (string, error) {
+// PrometheusHTTPEndpoint returns the Prometheus HTTP endpoint
+func (c *GrafanaLGTMContainer) PrometheusHTTPEndpoint(ctx context.Context) (string, error) {
 	url, err := baseEndpoint(ctx, c, PrometheusPort)
 	if err != nil {
 		return "", err
@@ -190,11 +180,9 @@ func (c *GrafanaLGTMContainer) PrometheusHttpEndpoint(ctx context.Context) (stri
 	return url, nil
 }
 
-// MustPrometheusHttpEndpoint returns the Prometheus HTTP endpoint or panics if an error occurs
-//
-//nolint:revive //FIXME
-func (c *GrafanaLGTMContainer) MustPrometheusHttpEndpoint(ctx context.Context) string {
-	url, err := c.PrometheusHttpEndpoint(ctx)
+// MustPrometheusHTTPEndpoint returns the Prometheus HTTP endpoint or panics if an error occurs
+func (c *GrafanaLGTMContainer) MustPrometheusHTTPEndpoint(ctx context.Context) string {
+	url, err := c.PrometheusHTTPEndpoint(ctx)
 	if err != nil {
 		panic(err)
 	}

--- a/modules/grafana-lgtm/grafana_test.go
+++ b/modules/grafana-lgtm/grafana_test.go
@@ -24,7 +24,7 @@ func TestGrafanaLGTM(t *testing.T) {
 	// perform assertions
 
 	t.Run("container is running with right version", func(t *testing.T) {
-		healthURL, err := url.Parse(fmt.Sprintf("http://%s/api/health", grafanaLgtmContainer.MustHttpEndpoint(ctx)))
+		healthURL, err := url.Parse(fmt.Sprintf("http://%s/api/health", grafanaLgtmContainer.MustHTTPEndpoint(ctx)))
 		require.NoError(t, err)
 
 		httpReq := http.Request{

--- a/modules/inbucket/inbucket.go
+++ b/modules/inbucket/inbucket.go
@@ -14,11 +14,9 @@ type InbucketContainer struct {
 	testcontainers.Container
 }
 
-// SmtpConnection returns the connection string for the smtp server, using the default
+// SMTPConnection returns the connection string for the smtp server, using the default
 // 2500 port, and obtaining the host and exposed port from the container.
-//
-//nolint:revive //FIXME
-func (c *InbucketContainer) SmtpConnection(ctx context.Context) (string, error) {
+func (c *InbucketContainer) SMTPConnection(ctx context.Context) (string, error) {
 	containerPort, err := c.MappedPort(ctx, "2500/tcp")
 	if err != nil {
 		return "", err

--- a/modules/inbucket/inbucket_test.go
+++ b/modules/inbucket/inbucket_test.go
@@ -19,7 +19,7 @@ func TestInbucket(t *testing.T) {
 	require.NoError(t, err)
 
 	// smtpConnection {
-	smtpURL, err := ctr.SmtpConnection(ctx)
+	smtpURL, err := ctr.SMTPConnection(ctx)
 	// }
 	require.NoError(t, err)
 

--- a/modules/influxdb/influxdb.go
+++ b/modules/influxdb/influxdb.go
@@ -61,17 +61,15 @@ func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustom
 	return c, nil
 }
 
-//nolint:revive //FIXME
-func (c *InfluxDbContainer) MustConnectionUrl(ctx context.Context) string {
-	connectionString, err := c.ConnectionUrl(ctx)
+func (c *InfluxDbContainer) MustConnectionURL(ctx context.Context) string {
+	connectionString, err := c.ConnectionURL(ctx)
 	if err != nil {
 		panic(err)
 	}
 	return connectionString
 }
 
-//nolint:revive //FIXME
-func (c *InfluxDbContainer) ConnectionUrl(ctx context.Context) (string, error) {
+func (c *InfluxDbContainer) ConnectionURL(ctx context.Context) (string, error) {
 	containerPort, err := c.MappedPort(ctx, "8086/tcp")
 	if err != nil {
 		return "", err

--- a/modules/influxdb/influxdb_test.go
+++ b/modules/influxdb/influxdb_test.go
@@ -58,7 +58,7 @@ func TestWithInitDb(t *testing.T) {
 	}
 
 	cli, err := influxclient.NewHTTPClient(influxclient.HTTPConfig{
-		Addr: influxDbContainer.MustConnectionUrl(ctx),
+		Addr: influxDbContainer.MustConnectionURL(ctx),
 	})
 	require.NoError(t, err)
 	defer cli.Close()
@@ -91,7 +91,7 @@ func TestWithConfigFile(t *testing.T) {
 
 	/// influxConnectionUrl {
 	cli, err := influxclient.NewHTTPClient(influxclient.HTTPConfig{
-		Addr: influxDbContainer.MustConnectionUrl(context.Background()),
+		Addr: influxDbContainer.MustConnectionURL(context.Background()),
 	})
 	// }
 	require.NoError(t, err)

--- a/modules/k6/k6.go
+++ b/modules/k6/k6.go
@@ -26,20 +26,20 @@ type K6Container struct {
 }
 
 type DownloadableFile struct {
-	Uri         url.URL //nolint:revive //FIXME
+	URI         url.URL
 	DownloadDir string
 	User        string
 	Password    string
 }
 
 func (d *DownloadableFile) getDownloadPath() string {
-	baseName := path.Base(d.Uri.Path)
+	baseName := path.Base(d.URI.Path)
 	return path.Join(d.DownloadDir, baseName)
 }
 
 func downloadFileFromDescription(d DownloadableFile) error {
 	client := http.Client{Timeout: time.Second * 60}
-	req, err := http.NewRequest(http.MethodGet, d.Uri.String(), nil)
+	req, err := http.NewRequest(http.MethodGet, d.URI.String(), nil)
 	if err != nil {
 		return err
 	}

--- a/modules/k6/k6_test.go
+++ b/modules/k6/k6_test.go
@@ -70,7 +70,7 @@ func TestK6(t *testing.T) {
 				uri, err := url.Parse(tc.script)
 				require.NoError(t, err)
 
-				desc := k6.DownloadableFile{Uri: *uri, DownloadDir: t.TempDir()}
+				desc := k6.DownloadableFile{URI: *uri, DownloadDir: t.TempDir()}
 				options = k6.WithRemoteTestScript(desc)
 			}
 

--- a/modules/neo4j/neo4j.go
+++ b/modules/neo4j/neo4j.go
@@ -24,10 +24,8 @@ type Neo4jContainer struct {
 	testcontainers.Container
 }
 
-// BoltUrl returns the bolt url for the Neo4j container, using the bolt port, in the format of neo4j://host:port
-//
-//nolint:revive //FIXME
-func (c Neo4jContainer) BoltUrl(ctx context.Context) (string, error) {
+// BoltURL returns the bolt url for the Neo4j container, using the bolt port, in the format of neo4j://host:port
+func (c Neo4jContainer) BoltURL(ctx context.Context) (string, error) {
 	host, err := c.Host(ctx)
 	if err != nil {
 		return "", err

--- a/modules/neo4j/neo4j_test.go
+++ b/modules/neo4j/neo4j_test.go
@@ -137,7 +137,7 @@ func setupNeo4j(ctx context.Context) (*neo4j.Neo4jContainer, error) {
 func createDriver(t *testing.T, ctx context.Context, container *neo4j.Neo4jContainer) neo.DriverWithContext {
 	t.Helper()
 	// boltURL {
-	boltURL, err := container.BoltUrl(ctx)
+	boltURL, err := container.BoltURL(ctx)
 	// }
 	require.NoError(t, err)
 	driver, err := neo.NewDriverWithContext(boltURL, neo.BasicAuth("neo4j", testPassword, ""))

--- a/modules/openfga/examples_test.go
+++ b/modules/openfga/examples_test.go
@@ -92,7 +92,7 @@ func ExampleRun_connectWithSDKClient() {
 	}
 
 	// httpEndpoint {
-	httpEndpoint, err := openfgaContainer.HttpEndpoint(context.Background())
+	httpEndpoint, err := openfgaContainer.HTTPEndpoint(context.Background())
 	if err != nil {
 		log.Printf("failed to get HTTP endpoint: %s", err)
 		return
@@ -160,7 +160,7 @@ func ExampleRun_writeModel() {
 		return
 	}
 
-	httpEndpoint, err := openfgaContainer.HttpEndpoint(context.Background())
+	httpEndpoint, err := openfgaContainer.HTTPEndpoint(context.Background())
 	if err != nil {
 		log.Printf("failed to get HTTP endpoint: %s", err)
 		return

--- a/modules/openfga/openfga.go
+++ b/modules/openfga/openfga.go
@@ -22,11 +22,9 @@ func (c *OpenFGAContainer) GrpcEndpoint(ctx context.Context) (string, error) {
 	return c.PortEndpoint(ctx, "8081/tcp", "http")
 }
 
-// HttpEndpoint returns the HTTP endpoint for the OpenFGA container,
+// HTTPEndpoint returns the HTTP endpoint for the OpenFGA container,
 // which uses the 8080/tcp port.
-//
-//nolint:revive //FIXME
-func (c *OpenFGAContainer) HttpEndpoint(ctx context.Context) (string, error) {
+func (c *OpenFGAContainer) HTTPEndpoint(ctx context.Context) (string, error) {
 	return c.PortEndpoint(ctx, "8080/tcp", "http")
 }
 

--- a/modules/pinecone/examples_test.go
+++ b/modules/pinecone/examples_test.go
@@ -34,7 +34,7 @@ func ExampleRun() {
 	fmt.Println(state.Running)
 
 	// httpConnection {
-	host, err := pineconeContainer.HttpEndpoint()
+	host, err := pineconeContainer.HTTPEndpoint()
 	if err != nil {
 		log.Printf("failed to get container state: %s", err)
 		return

--- a/modules/pinecone/pinecone.go
+++ b/modules/pinecone/pinecone.go
@@ -43,9 +43,7 @@ func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustom
 	return c, nil
 }
 
-// HttpEndpoint returns the http endpoint for the pinecone container
-//
-//nolint:revive //FIXME
-func (c *Container) HttpEndpoint() (string, error) {
+// HTTPEndpoint returns the http endpoint for the pinecone container
+func (c *Container) HTTPEndpoint() (string, error) {
 	return c.PortEndpoint(context.Background(), "5080/tcp", "http")
 }

--- a/modules/pinecone/pinecone_test.go
+++ b/modules/pinecone/pinecone_test.go
@@ -18,7 +18,7 @@ func TestPinecone(t *testing.T) {
 	testcontainers.CleanupContainer(t, ctr)
 	require.NoError(t, err)
 
-	host, err := ctr.HttpEndpoint()
+	host, err := ctr.HTTPEndpoint()
 	require.NoError(t, err)
 
 	pc, err := pinecone.NewClient(pinecone.NewClientParams{
@@ -39,7 +39,7 @@ func TestPinecone_index(t *testing.T) {
 	testcontainers.CleanupContainer(t, ctr)
 	require.NoError(t, err)
 
-	host, err := ctr.HttpEndpoint()
+	host, err := ctr.HTTPEndpoint()
 	require.NoError(t, err)
 
 	pc, err := pinecone.NewClient(pinecone.NewClientParams{

--- a/modules/rabbitmq/rabbitmq.go
+++ b/modules/rabbitmq/rabbitmq.go
@@ -56,17 +56,13 @@ func (c *RabbitMQContainer) AmqpsURL(ctx context.Context) (string, error) {
 	return fmt.Sprintf("amqps://%s:%s@%s", c.AdminUsername, c.AdminPassword, endpoint), nil
 }
 
-// HttpURL returns the URL for HTTP management.
-//
-//nolint:revive //FIXME
-func (c *RabbitMQContainer) HttpURL(ctx context.Context) (string, error) {
+// HTTPURL returns the URL for HTTP management.
+func (c *RabbitMQContainer) HTTPURL(ctx context.Context) (string, error) {
 	return c.PortEndpoint(ctx, nat.Port(DefaultHTTPPort), "http")
 }
 
-// HttpsURL returns the URL for HTTPS management.
-//
-//nolint:revive //FIXME
-func (c *RabbitMQContainer) HttpsURL(ctx context.Context) (string, error) {
+// HTTPSURL returns the URL for HTTPS management.
+func (c *RabbitMQContainer) HTTPSURL(ctx context.Context) (string, error) {
 	return c.PortEndpoint(ctx, nat.Port(DefaultHTTPSPort), "https")
 }
 

--- a/modules/vault/vault.go
+++ b/modules/vault/vault.go
@@ -89,11 +89,9 @@ func WithInitCommand(commands ...string) testcontainers.CustomizeRequestOption {
 	}
 }
 
-// HttpHostAddress returns the http host address of Vault.
+// HTTPHostAddress returns the http host address of Vault.
 // It returns a string with the format http://<host>:<port>
-//
-//nolint:revive //FIXME
-func (v *VaultContainer) HttpHostAddress(ctx context.Context) (string, error) {
+func (v *VaultContainer) HTTPHostAddress(ctx context.Context) (string, error) {
 	host, err := v.Host(ctx)
 	if err != nil {
 		return "", err

--- a/modules/vault/vault_test.go
+++ b/modules/vault/vault_test.go
@@ -38,7 +38,7 @@ func TestVault(t *testing.T) {
 	require.NoError(t, err)
 
 	// httpHostAddress {
-	hostAddress, err := vaultContainer.HttpHostAddress(ctx)
+	hostAddress, err := vaultContainer.HTTPHostAddress(ctx)
 	// }
 	require.NoError(t, err)
 

--- a/modules/weaviate/examples_test.go
+++ b/modules/weaviate/examples_test.go
@@ -58,7 +58,7 @@ func ExampleRun_connectWithClient() {
 		return
 	}
 
-	scheme, host, err := weaviateContainer.HttpHostAddress(ctx)
+	scheme, host, err := weaviateContainer.HTTPHostAddress(ctx)
 	if err != nil {
 		log.Printf("failed to get http schema and host: %s", err)
 		return
@@ -127,7 +127,7 @@ func ExampleRun_connectWithClientWithModules() {
 		return
 	}
 
-	scheme, host, err := weaviateContainer.HttpHostAddress(ctx)
+	scheme, host, err := weaviateContainer.HTTPHostAddress(ctx)
 	if err != nil {
 		log.Printf("failed to get http schema and host: %s", err)
 		return

--- a/modules/weaviate/weaviate.go
+++ b/modules/weaviate/weaviate.go
@@ -67,11 +67,9 @@ func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustom
 	return c, nil
 }
 
-// HttpHostAddress returns the schema and host of the Weaviate container.
+// HTTPHostAddress returns the schema and host of the Weaviate container.
 // At the moment, it only supports the http scheme.
-//
-//nolint:revive //FIXME
-func (c *WeaviateContainer) HttpHostAddress(ctx context.Context) (string, string, error) {
+func (c *WeaviateContainer) HTTPHostAddress(ctx context.Context) (string, string, error) {
 	port, err := c.MappedPort(ctx, httpPort)
 	if err != nil {
 		return "", "", fmt.Errorf("failed to get container port: %w", err)

--- a/modules/weaviate/weaviate_test.go
+++ b/modules/weaviate/weaviate_test.go
@@ -24,9 +24,9 @@ func TestWeaviate(t *testing.T) {
 	testcontainers.CleanupContainer(t, ctr)
 	require.NoError(t, err)
 
-	t.Run("HttpHostAddress", func(t *testing.T) {
+	t.Run("HTTPHostAddress", func(t *testing.T) {
 		// httpHostAddress {
-		schema, host, err := ctr.HttpHostAddress(ctx)
+		schema, host, err := ctr.HTTPHostAddress(ctx)
 		// }
 		require.NoError(t, err)
 
@@ -56,7 +56,7 @@ func TestWeaviate(t *testing.T) {
 	})
 
 	t.Run("Weaviate client", func(tt *testing.T) {
-		httpScheme, httpHost, err := ctr.HttpHostAddress(ctx)
+		httpScheme, httpHost, err := ctr.HTTPHostAddress(ctx)
 		require.NoError(tt, err)
 		grpcHost, err := ctr.GrpcHostAddress(ctx)
 		require.NoError(tt, err)


### PR DESCRIPTION
#### What does this PR do?

enable [var-naming](https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#var-naming) rule from revive

This also moves output configuration from Makefile to golangci-lint config

#### BREAKING CHANGES
⚠️ There are naming changes for constants and functions