### PR TITLE
fix: return unique modified modules

### DIFF
--- a/scripts/changed-modules.sh
+++ b/scripts/changed-modules.sh
@@ -36,6 +36,10 @@ set -euxo pipefail
 #    ALL_CHANGED_FILES="modules/nginx/go.mod modules/nginx/a.txt modules/nginx/b.txt" ./scripts/changed-modules.sh
 #    The output should be: the modules/nginx module.
 #
+# 9. Several files in the core module are modified:
+#    ALL_CHANGED_FILES="go.mod a.go b.go" ./scripts/changed-modules.sh
+#    The output should be: all modules.
+#
 # There is room for improvement in this script. For example, it could detect if the changes applied to the docs or the .github dirs, and then do not include any module in the list.
 # But then we would need to verify the CI scripts to ensure that the job receives the correct modules to build.
 

--- a/scripts/changed-modules.sh
+++ b/scripts/changed-modules.sh
@@ -32,6 +32,10 @@ set -euxo pipefail
 #    ALL_CHANGED_FILES="docs/a.md .vscode/a.json .devcontainer/a.json" ./scripts/changed-modules.sh
 #    The output should be: no modules.
 #
+# 8. Several files in the same module are modified:
+#    ALL_CHANGED_FILES="modules/nginx/go.mod modules/nginx/a.txt modules/nginx/b.txt" ./scripts/changed-modules.sh
+#    The output should be: the modules/nginx module.
+#
 # There is room for improvement in this script. For example, it could detect if the changes applied to the docs or the .github dirs, and then do not include any module in the list.
 # But then we would need to verify the CI scripts to ensure that the job receives the correct modules to build.
 
@@ -114,4 +118,6 @@ done
 # each module will be enclosed in double quotes
 # each module will be separated by a comma
 # the entire list will be enclosed in square brackets
-echo "["$(IFS=,; echo "${modified_modules[*]}" | sed 's/ /,/g')"]"
+# the list will be sorted and unique
+sorted_unique_modules=($(echo "${modified_modules[@]}" | tr ' ' '\n' | sort -u | tr '\n' ' '))
+echo "["$(IFS=,; echo "${sorted_unique_modules[*]}" | sed 's/ /,/g')"]"


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
It gets the modified modules list, sorts it and removes duplicates.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
A PR modifiying multiple files in the same module will trigger the build as many times as modified files where found in the module.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Caused by #2876
- Fixes #2972

## How to test this PR

```shell
ALL_CHANGED_FILES="modules/nginx/go.mod modules/nginx/a.txt modules/nginx/b.txt" ./scripts/changed-modules.sh
```

It should return just the `modules/nginx` entry in the array.


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
