### PR TITLE
feat(redpanda): add bootstrap user account option

### DIFF
--- a/docs/modules/redpanda.md
+++ b/docs/modules/redpanda.md
@@ -182,3 +182,8 @@ is an HTTP-based API and thus the returned format will be: http://host:port.
 <!--codeinclude-->
 [Get admin API address](../../modules/redpanda/redpanda_test.go) inside_block:adminAPIAddress
 <!--/codeinclude-->
+
+#### WithAdminAPIAuthentication
+
+Enables Admin API Authentication by setting [`admin_api_require_auth`](https://docs.redpanda.com/current/reference/properties/cluster-properties/#admin_api_require_auth) cluster configuration property to `true`. 
+It also configures a bootstrap superuser account via [`RP_BOOTSTRAP_USER`](https://docs.redpanda.com/current/deploy/deployment-option/self-hosted/manual/production/production-deployment/#bootstrap-a-user-account) environment variable.

--- a/modules/redpanda/admin_api.go
+++ b/modules/redpanda/admin_api.go
@@ -12,7 +12,7 @@ import (
 
 // AdminAPIClient is a client for the Redpanda Admin API.
 type AdminAPIClient struct {
-	baseURL  string
+	BaseURL  string
 	username string
 	password string
 	client   *http.Client
@@ -21,7 +21,7 @@ type AdminAPIClient struct {
 // NewAdminAPIClient creates a new AdminAPIClient.
 func NewAdminAPIClient(baseURL string) *AdminAPIClient {
 	return &AdminAPIClient{
-		baseURL: baseURL,
+		BaseURL: baseURL,
 		client:  http.DefaultClient,
 	}
 }
@@ -37,11 +37,6 @@ func (cl *AdminAPIClient) WithAuthentication(username, password string) *AdminAP
 	cl.username = username
 	cl.password = password
 	return cl
-}
-
-// BaseURL returns the base URL of the AdminAPIClient.
-func (cl *AdminAPIClient) BaseURL() string {
-	return cl.baseURL
 }
 
 // Username returns the username of the AdminAPIClient.
@@ -72,7 +67,7 @@ func (cl *AdminAPIClient) CreateUser(ctx context.Context, username, password str
 		return fmt.Errorf("failed to marshal create user request: %w", err)
 	}
 
-	endpoint, err := url.JoinPath(cl.baseURL, "/v1/security/users")
+	endpoint, err := url.JoinPath(cl.BaseURL, "/v1/security/users")
 	if err != nil {
 		return fmt.Errorf("failed to join url path: %w", err)
 	}

--- a/modules/redpanda/admin_api.go
+++ b/modules/redpanda/admin_api.go
@@ -11,8 +11,10 @@ import (
 )
 
 type AdminAPIClient struct {
-	BaseURL string
-	client  *http.Client
+	BaseURL  string
+	Username string
+	Password string
+	client   *http.Client
 }
 
 func NewAdminAPIClient(baseURL string) *AdminAPIClient {
@@ -54,6 +56,10 @@ func (cl *AdminAPIClient) CreateUser(ctx context.Context, username, password str
 		return fmt.Errorf("failed to build http request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
+
+	if cl.Username != "" || cl.Password != "" {
+		req.SetBasicAuth(cl.Username, cl.Password)
+	}
 
 	resp, err := cl.client.Do(req)
 	if err != nil {

--- a/modules/redpanda/admin_api.go
+++ b/modules/redpanda/admin_api.go
@@ -10,23 +10,48 @@ import (
 	"net/url"
 )
 
+// AdminAPIClient is a client for the Redpanda Admin API.
 type AdminAPIClient struct {
-	BaseURL  string
-	Username string
-	Password string
+	baseURL  string
+	username string
+	password string
 	client   *http.Client
 }
 
+// NewAdminAPIClient creates a new AdminAPIClient.
 func NewAdminAPIClient(baseURL string) *AdminAPIClient {
 	return &AdminAPIClient{
-		BaseURL: baseURL,
+		baseURL: baseURL,
 		client:  http.DefaultClient,
 	}
 }
 
+// WithHTTPClient sets the HTTP client for the AdminAPIClient.
 func (cl *AdminAPIClient) WithHTTPClient(c *http.Client) *AdminAPIClient {
 	cl.client = c
 	return cl
+}
+
+// WithAuthentication sets the username and password for the AdminAPIClient.
+func (cl *AdminAPIClient) WithAuthentication(username, password string) *AdminAPIClient {
+	cl.username = username
+	cl.password = password
+	return cl
+}
+
+// BaseURL returns the base URL of the AdminAPIClient.
+func (cl *AdminAPIClient) BaseURL() string {
+	return cl.baseURL
+}
+
+// Username returns the username of the AdminAPIClient.
+func (cl *AdminAPIClient) Username() string {
+	return cl.username
+}
+
+// Password returns the password of the AdminAPIClient.
+func (cl *AdminAPIClient) Password() string {
+	return cl.password
 }
 
 type createUserRequest struct {
@@ -35,6 +60,7 @@ type createUserRequest struct {
 	Algorithm string `json:"algorithm"`
 }
 
+// CreateUser creates a new user in Redpanda using Admin API.
 func (cl *AdminAPIClient) CreateUser(ctx context.Context, username, password string) error {
 	userReq := createUserRequest{
 		User:      username,
@@ -46,7 +72,7 @@ func (cl *AdminAPIClient) CreateUser(ctx context.Context, username, password str
 		return fmt.Errorf("failed to marshal create user request: %w", err)
 	}
 
-	endpoint, err := url.JoinPath(cl.BaseURL, "/v1/security/users")
+	endpoint, err := url.JoinPath(cl.baseURL, "/v1/security/users")
 	if err != nil {
 		return fmt.Errorf("failed to join url path: %w", err)
 	}
@@ -57,8 +83,8 @@ func (cl *AdminAPIClient) CreateUser(ctx context.Context, username, password str
 	}
 	req.Header.Set("Content-Type", "application/json")
 
-	if cl.Username != "" || cl.Password != "" {
-		req.SetBasicAuth(cl.Username, cl.Password)
+	if cl.username != "" || cl.password != "" {
+		req.SetBasicAuth(cl.username, cl.password)
 	}
 
 	resp, err := cl.client.Do(req)

--- a/modules/redpanda/options.go
+++ b/modules/redpanda/options.go
@@ -47,6 +47,9 @@ type options struct {
 	// ExtraBootstrapConfig is a map of configs to be interpolated into the
 	// container's bootstrap.yml
 	ExtraBootstrapConfig map[string]any
+
+	// EnableAdminAPIAuthentication enables Admin API authentication
+	EnableAdminAPIAuthentication bool
 }
 
 func defaultOptions() options {
@@ -168,5 +171,14 @@ func WithListener(lis string) Option {
 func WithBootstrapConfig(cfg string, val any) Option {
 	return func(o *options) {
 		o.ExtraBootstrapConfig[cfg] = val
+	}
+}
+
+// WithEnableAdminAPIAuthentication enables Admin API Authentication.
+// It sets `admin_api_require_auth` configuration to true and configures a bootstrap user account.
+// See https://docs.redpanda.com/current/deploy/deployment-option/self-hosted/manual/production/production-deployment/#bootstrap-a-user-account
+func WithEnableAdminAPIAuthentication() Option {
+	return func(o *options) {
+		o.EnableAdminAPIAuthentication = true
 	}
 }

--- a/modules/redpanda/options.go
+++ b/modules/redpanda/options.go
@@ -174,10 +174,10 @@ func WithBootstrapConfig(cfg string, val any) Option {
 	}
 }
 
-// WithEnableAdminAPIAuthentication enables Admin API Authentication.
+// WithAdminAPIAuthentication enables Admin API Authentication.
 // It sets `admin_api_require_auth` configuration to true and configures a bootstrap user account.
 // See https://docs.redpanda.com/current/deploy/deployment-option/self-hosted/manual/production/production-deployment/#bootstrap-a-user-account
-func WithEnableAdminAPIAuthentication() Option {
+func WithAdminAPIAuthentication() Option {
 	return func(o *options) {
 		o.EnableAdminAPIAuthentication = true
 	}

--- a/modules/redpanda/options.go
+++ b/modules/redpanda/options.go
@@ -48,8 +48,8 @@ type options struct {
 	// container's bootstrap.yml
 	ExtraBootstrapConfig map[string]any
 
-	// EnableAdminAPIAuthentication enables Admin API authentication
-	EnableAdminAPIAuthentication bool
+	// enableAdminAPIAuthentication enables Admin API authentication
+	enableAdminAPIAuthentication bool
 }
 
 func defaultOptions() options {
@@ -179,6 +179,6 @@ func WithBootstrapConfig(cfg string, val any) Option {
 // See https://docs.redpanda.com/current/deploy/deployment-option/self-hosted/manual/production/production-deployment/#bootstrap-a-user-account
 func WithAdminAPIAuthentication() Option {
 	return func(o *options) {
-		o.EnableAdminAPIAuthentication = true
+		o.enableAdminAPIAuthentication = true
 	}
 }

--- a/modules/redpanda/redpanda.go
+++ b/modules/redpanda/redpanda.go
@@ -111,7 +111,7 @@ func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustom
 	}
 
 	// 2.2. If enabled, bootstrap user account
-	if settings.EnableAdminAPIAuthentication {
+	if settings.enableAdminAPIAuthentication {
 		// set the RP_BOOTSTRAP_USER env var
 		if req.Env == nil {
 			req.Env = map[string]string{}
@@ -253,7 +253,7 @@ func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustom
 
 		adminAPIUrl := fmt.Sprintf("%s://%v:%d", c.urlScheme, hostIP, adminAPIPort.Int())
 		adminCl := NewAdminAPIClient(adminAPIUrl)
-		if settings.EnableAdminAPIAuthentication {
+		if settings.enableAdminAPIAuthentication {
 			adminCl = adminCl.WithAuthentication(bootstrapAdminAPIUser, bootstrapAdminAPIPassword)
 		}
 

--- a/modules/redpanda/redpanda.go
+++ b/modules/redpanda/redpanda.go
@@ -254,8 +254,7 @@ func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustom
 		adminAPIUrl := fmt.Sprintf("%s://%v:%d", c.urlScheme, hostIP, adminAPIPort.Int())
 		adminCl := NewAdminAPIClient(adminAPIUrl)
 		if settings.EnableAdminAPIAuthentication {
-			adminCl.Username = bootstrapAdminAPIUser
-			adminCl.Password = bootstrapAdminAPIPassword
+			adminCl = adminCl.WithAuthentication(bootstrapAdminAPIUser, bootstrapAdminAPIPassword)
 		}
 
 		if settings.EnableTLS {

--- a/modules/redpanda/redpanda.go
+++ b/modules/redpanda/redpanda.go
@@ -44,6 +44,9 @@ const (
 	bootstrapConfigFile = ".bootstrap.yaml"
 	certFile            = "cert.pem"
 	keyFile             = "key.pem"
+
+	bootstrapAdminAPIUser     = "redpanda_bootstrap_admin_user"
+	bootstrapAdminAPIPassword = "redpanda_bootstrap_admin_password"
 )
 
 // Container represents the Redpanda container type used in the module.
@@ -105,6 +108,25 @@ func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustom
 	// 2.1. If the image is not at least v23.3, disable wasm transform
 	if !isAtLeastVersion(req.ContainerRequest.Image, "23.3") {
 		settings.EnableWasmTransform = false
+	}
+
+	// 2.2. If enabled, bootstrap user account
+	if settings.EnableAdminAPIAuthentication {
+		// set the RP_BOOTSTRAP_USER env var
+		if req.Env == nil {
+			req.Env = map[string]string{}
+		}
+		req.Env["RP_BOOTSTRAP_USER"] = bootstrapAdminAPIUser + ":" + bootstrapAdminAPIPassword
+
+		// add our internal bootstrap admin user to superusers
+		settings.Superusers = append(settings.Superusers, bootstrapAdminAPIUser)
+
+		// enable admin_api_require_auth
+		if settings.ExtraBootstrapConfig == nil {
+			settings.ExtraBootstrapConfig = map[string]any{}
+		}
+
+		settings.ExtraBootstrapConfig["admin_api_require_auth"] = true
 	}
 
 	// 3. Register extra kafka listeners if provided, network aliases will be
@@ -231,6 +253,11 @@ func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustom
 
 		adminAPIUrl := fmt.Sprintf("%s://%v:%d", c.urlScheme, hostIP, adminAPIPort.Int())
 		adminCl := NewAdminAPIClient(adminAPIUrl)
+		if settings.EnableAdminAPIAuthentication {
+			adminCl.Username = bootstrapAdminAPIUser
+			adminCl.Password = bootstrapAdminAPIPassword
+		}
+
 		if settings.EnableTLS {
 			adminCl = adminCl.WithHTTPClient(&http.Client{
 				Timeout: 5 * time.Second,

--- a/modules/redpanda/redpanda_test.go
+++ b/modules/redpanda/redpanda_test.go
@@ -274,7 +274,7 @@ func TestRedpandaWithBootstrapUserAuthentication(t *testing.T) {
 	})
 
 	// Test Schema Registry API
-	t.Run("schema registry", func(t *testing.T) {
+	t.Run("schema-registry", func(t *testing.T) {
 		t.Run("failed authentication", func(t *testing.T) {
 			// Failed authentication
 			req, err := http.NewRequestWithContext(ctx, http.MethodGet, schemaRegistryURL+"/subjects", nil)

--- a/modules/redpanda/redpanda_test.go
+++ b/modules/redpanda/redpanda_test.go
@@ -382,7 +382,7 @@ func TestRedpandaWithOldVersionAndWasm(t *testing.T) {
 	})
 
 	// Test wrong mechanism
-	t.Run("wrong mechanism", func(t *testing.T) {
+	t.Run("wrong-mechanism", func(t *testing.T) {
 		kafkaCl, err := kgo.NewClient(
 			kgo.SeedBrokers(seedBroker),
 			kgo.SASL(plain.Auth{

--- a/modules/redpanda/redpanda_test.go
+++ b/modules/redpanda/redpanda_test.go
@@ -347,7 +347,7 @@ func TestRedpandaWithOldVersionAndWasm(t *testing.T) {
 	}
 
 	// Test successful authentication, but failed authorization with a non-superuser account
-	t.Run("non-superuser account", func(t *testing.T) {
+	t.Run("non-superuser", func(t *testing.T) {
 		kafkaCl, err := kgo.NewClient(
 			kgo.SeedBrokers(seedBroker),
 			kgo.SASL(scram.Auth{

--- a/modules/redpanda/redpanda_test.go
+++ b/modules/redpanda/redpanda_test.go
@@ -400,7 +400,7 @@ func TestRedpandaWithOldVersionAndWasm(t *testing.T) {
 
 	// Test Schema Registry API
 	t.Run("schema-registry", func(t *testing.T) {
-		t.Run("failed authentication", func(t *testing.T) {
+		t.Run("failed-authentication", func(t *testing.T) {
 			req, err := http.NewRequestWithContext(ctx, http.MethodGet, schemaRegistryURL+"/subjects", nil)
 			require.NoError(t, err)
 			resp, err := httpCl.Do(req)

--- a/modules/redpanda/redpanda_test.go
+++ b/modules/redpanda/redpanda_test.go
@@ -257,7 +257,7 @@ func TestRedpandaWithBootstrapUserAuthentication(t *testing.T) {
 	})
 
 	// Test failed authentication
-	t.Run("invalid user", func(t *testing.T) {
+	t.Run("invalid-user", func(t *testing.T) {
 		kafkaCl, err := kgo.NewClient(
 			kgo.SeedBrokers(seedBroker),
 			kgo.SASL(scram.Auth{

--- a/modules/redpanda/redpanda_test.go
+++ b/modules/redpanda/redpanda_test.go
@@ -285,7 +285,7 @@ func TestRedpandaWithBootstrapUserAuthentication(t *testing.T) {
 			resp.Body.Close()
 		})
 
-		t.Run("successful authentication", func(t *testing.T) {
+		t.Run("successful-authentication", func(t *testing.T) {
 			for user, password := range serviceAccounts {
 				req, err := http.NewRequestWithContext(ctx, http.MethodGet, schemaRegistryURL+"/subjects", nil)
 				require.NoError(t, err)

--- a/modules/redpanda/redpanda_test.go
+++ b/modules/redpanda/redpanda_test.go
@@ -365,7 +365,7 @@ func TestRedpandaWithOldVersionAndWasm(t *testing.T) {
 	})
 
 	// Test failed authentication
-	t.Run("invalid user", func(t *testing.T) {
+	t.Run("invalid-user", func(t *testing.T) {
 		kafkaCl, err := kgo.NewClient(
 			kgo.SeedBrokers(seedBroker),
 			kgo.SASL(scram.Auth{

--- a/modules/redpanda/redpanda_test.go
+++ b/modules/redpanda/redpanda_test.go
@@ -410,7 +410,7 @@ func TestRedpandaWithOldVersionAndWasm(t *testing.T) {
 		})
 
 		// Successful authentication
-		t.Run("successful authentication", func(t *testing.T) {
+		t.Run("successful-authentication", func(t *testing.T) {
 			for user, password := range serviceAccounts {
 				req, err := http.NewRequestWithContext(ctx, http.MethodGet, schemaRegistryURL+"/subjects", nil)
 				require.NoError(t, err)

--- a/modules/redpanda/redpanda_test.go
+++ b/modules/redpanda/redpanda_test.go
@@ -399,7 +399,7 @@ func TestRedpandaWithOldVersionAndWasm(t *testing.T) {
 	})
 
 	// Test Schema Registry API
-	t.Run("schema registry", func(t *testing.T) {
+	t.Run("schema-registry", func(t *testing.T) {
 		t.Run("failed authentication", func(t *testing.T) {
 			req, err := http.NewRequestWithContext(ctx, http.MethodGet, schemaRegistryURL+"/subjects", nil)
 			require.NoError(t, err)

--- a/modules/redpanda/redpanda_test.go
+++ b/modules/redpanda/redpanda_test.go
@@ -110,7 +110,7 @@ func TestRedpandaWithAuthentication(t *testing.T) {
 	}
 
 	// Test successful authentication & authorization with all created superusers
-	t.Run("happy path", func(t *testing.T) {
+	t.Run("happy-path", func(t *testing.T) {
 		for user, password := range serviceAccounts {
 			kafkaCl, err := kgo.NewClient(
 				kgo.SeedBrokers(seedBroker),
@@ -147,7 +147,7 @@ func TestRedpandaWithAuthentication(t *testing.T) {
 	})
 
 	// Test failed authentication
-	t.Run("invalid user", func(t *testing.T) {
+	t.Run("invalid-user", func(t *testing.T) {
 		kafkaCl, err := kgo.NewClient(
 			kgo.SeedBrokers(seedBroker),
 			kgo.SASL(scram.Auth{
@@ -164,8 +164,8 @@ func TestRedpandaWithAuthentication(t *testing.T) {
 	})
 
 	// Test Schema Registry API
-	t.Run("schema registry", func(t *testing.T) {
-		t.Run("failed authentication", func(t *testing.T) {
+	t.Run("schema-registry", func(t *testing.T) {
+		t.Run("failed-authentication", func(t *testing.T) {
 			// Failed authentication
 			req, err := http.NewRequestWithContext(ctx, http.MethodGet, schemaRegistryURL+"/subjects", nil)
 			require.NoError(t, err)
@@ -175,7 +175,7 @@ func TestRedpandaWithAuthentication(t *testing.T) {
 			resp.Body.Close()
 		})
 
-		t.Run("successful authentication", func(t *testing.T) {
+		t.Run("successful-authentication", func(t *testing.T) {
 			for user, password := range serviceAccounts {
 				req, err := http.NewRequestWithContext(ctx, http.MethodGet, schemaRegistryURL+"/subjects", nil)
 				require.NoError(t, err)
@@ -220,7 +220,7 @@ func TestRedpandaWithBootstrapUserAuthentication(t *testing.T) {
 	require.NoError(t, err)
 
 	// Test successful authentication & authorization with all created superusers
-	t.Run("happy path", func(t *testing.T) {
+	t.Run("happy-path", func(t *testing.T) {
 		for user, password := range serviceAccounts {
 			kafkaCl, err := kgo.NewClient(
 				kgo.SeedBrokers(seedBroker),

--- a/modules/redpanda/redpanda_test.go
+++ b/modules/redpanda/redpanda_test.go
@@ -239,7 +239,7 @@ func TestRedpandaWithBootstrapUserAuthentication(t *testing.T) {
 	})
 
 	// Test successful authentication, but failed authorization with a non-superuser account
-	t.Run("non-superuser account", func(t *testing.T) {
+	t.Run("non-superuser", func(t *testing.T) {
 		kafkaCl, err := kgo.NewClient(
 			kgo.SeedBrokers(seedBroker),
 			kgo.SASL(scram.Auth{


### PR DESCRIPTION
## What does this PR do?

Adds an option to have a bootstrap user account when starting the container.

See https://docs.redpanda.com/current/deploy/deployment-option/self-hosted/manual/production/production-deployment/#bootstrap-a-user-account

## Why is it important?

Without this option and capability it is not possible to successfully start the Redpanda testcontainers module with Admin API authentication on (`admin_api_require_auth` config set to `true`). 


