### PR TITLE
chore: enable var-naming from revive (private vars only)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -71,11 +71,18 @@ linters-settings:
       - name: use-any
       - name: var-declaration
       - name: var-naming
-        disabled: true
+        arguments:
+          - ["ID"] # AllowList
+          - ["VM"] # DenyList
+          - - upperCaseConst: true # Extra parameter (upperCaseConst|skipPackageNameChecks)
   testifylint:
     disable:
       - float-compare
       - go-require
     enable-all: true
+output:
+  formats:
+    - format: colored-line-number
+  path-prefix: "."
 run:
   timeout: 5m

--- a/commons-test.mk
+++ b/commons-test.mk
@@ -30,7 +30,7 @@ dependencies-scan:
 
 .PHONY: lint
 lint: $(GOBIN)/golangci-lint
-	golangci-lint run --out-format=colored-line-number --path-prefix=. --verbose -c $(ROOT_DIR)/.golangci.yml --fix
+	golangci-lint run --verbose -c $(ROOT_DIR)/.golangci.yml --fix
 
 .PHONY: generate
 generate: $(GOBIN)/mockery

--- a/docker_test.go
+++ b/docker_test.go
@@ -1325,13 +1325,13 @@ func TestContainerInspect_RawInspectIsCleanedOnStop(t *testing.T) {
 	require.NoError(t, ctr.Stop(context.Background(), nil))
 }
 
-func readHostname(tb testing.TB, containerId string) string {
+func readHostname(tb testing.TB, containerID string) string {
 	tb.Helper()
 	containerClient, err := NewDockerClientWithOpts(context.Background())
 	require.NoErrorf(tb, err, "Failed to create Docker client")
 	defer containerClient.Close()
 
-	containerDetails, err := containerClient.ContainerInspect(context.Background(), containerId)
+	containerDetails, err := containerClient.ContainerInspect(context.Background(), containerID)
 	require.NoErrorf(tb, err, "Failed to inspect container")
 
 	return containerDetails.Config.Hostname

--- a/examples/toxiproxy/toxiproxy_test.go
+++ b/examples/toxiproxy/toxiproxy_test.go
@@ -42,9 +42,9 @@ func TestToxiproxy(t *testing.T) {
 	toxiproxyProxyHostIP, err := toxiproxyContainer.Host(ctx)
 	require.NoError(t, err)
 
-	redisUri := fmt.Sprintf("redis://%s:%s?read_timeout=2s", toxiproxyProxyHostIP, toxiproxyProxyPort.Port())
+	redisURI := fmt.Sprintf("redis://%s:%s?read_timeout=2s", toxiproxyProxyHostIP, toxiproxyProxyPort.Port())
 
-	options, err := redis.ParseURL(redisUri)
+	options, err := redis.ParseURL(redisURI)
 	require.NoError(t, err)
 	redisClient := redis.NewClient(options)
 

--- a/modules/consul/consul.go
+++ b/modules/consul/consul.go
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	defaultHttpApiPort = "8500"
+	defaultHTTPAPIPort = "8500"
 	defaultBrokerPort  = "8600"
 )
 
@@ -24,8 +24,10 @@ type ConsulContainer struct {
 }
 
 // ApiEndpoint returns host:port for the HTTP API endpoint.
+//
+//nolint:revive //FIXME
 func (c *ConsulContainer) ApiEndpoint(ctx context.Context) (string, error) {
-	mappedPort, err := c.MappedPort(ctx, defaultHttpApiPort)
+	mappedPort, err := c.MappedPort(ctx, defaultHTTPAPIPort)
 	if err != nil {
 		return "", err
 	}
@@ -74,14 +76,14 @@ func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustom
 		ContainerRequest: testcontainers.ContainerRequest{
 			Image: img,
 			ExposedPorts: []string{
-				defaultHttpApiPort + "/tcp",
+				defaultHTTPAPIPort + "/tcp",
 				defaultBrokerPort + "/tcp",
 				defaultBrokerPort + "/udp",
 			},
 			Env: map[string]string{},
 			WaitingFor: wait.ForAll(
 				wait.ForLog("Consul agent running!"),
-				wait.ForListeningPort(defaultHttpApiPort+"/tcp"),
+				wait.ForListeningPort(defaultHTTPAPIPort+"/tcp"),
 			),
 		},
 		Started: true,

--- a/modules/consul/examples_test.go
+++ b/modules/consul/examples_test.go
@@ -69,12 +69,12 @@ func ExampleRun_connect() {
 	}
 	// }
 
-	node_name, err := client.Agent().NodeName()
+	nodeName, err := client.Agent().NodeName()
 	if err != nil {
 		log.Printf("failed to get node name: %s", err)
 		return
 	}
-	fmt.Println(len(node_name) > 0)
+	fmt.Println(len(nodeName) > 0)
 
 	// Output:
 	// true

--- a/modules/couchbase/couchbase.go
+++ b/modules/couchbase/couchbase.go
@@ -222,7 +222,7 @@ func (c *CouchbaseContainer) waitUntilNodeIsOnline(ctx context.Context) error {
 }
 
 func (c *CouchbaseContainer) initializeIsEnterprise(ctx context.Context) error {
-	response, err := c.doHttpRequest(ctx, MGMT_PORT, "/pools", http.MethodGet, nil, false)
+	response, err := c.doHTTPRequest(ctx, MGMT_PORT, "/pools", http.MethodGet, nil, false)
 	if err != nil {
 		return err
 	}
@@ -251,7 +251,7 @@ func (c *CouchbaseContainer) renameNode(ctx context.Context) error {
 		"hostname": hostname,
 	}
 
-	_, err = c.doHttpRequest(ctx, MGMT_PORT, "/node/controller/rename", http.MethodPost, body, false)
+	_, err = c.doHTTPRequest(ctx, MGMT_PORT, "/node/controller/rename", http.MethodPost, body, false)
 
 	return err
 }
@@ -260,7 +260,7 @@ func (c *CouchbaseContainer) initializeServices(ctx context.Context) error {
 	body := map[string]string{
 		"services": c.getEnabledServices(),
 	}
-	_, err := c.doHttpRequest(ctx, MGMT_PORT, "/node/controller/setupServices", http.MethodPost, body, false)
+	_, err := c.doHTTPRequest(ctx, MGMT_PORT, "/node/controller/setupServices", http.MethodPost, body, false)
 
 	return err
 }
@@ -281,7 +281,7 @@ func (c *CouchbaseContainer) setMemoryQuotas(ctx context.Context) error {
 		}
 	}
 
-	_, err := c.doHttpRequest(ctx, MGMT_PORT, "/pools/default", http.MethodPost, body, false)
+	_, err := c.doHTTPRequest(ctx, MGMT_PORT, "/pools/default", http.MethodPost, body, false)
 
 	return err
 }
@@ -293,7 +293,7 @@ func (c *CouchbaseContainer) configureAdminUser(ctx context.Context) error {
 		"port":     "SAME",
 	}
 
-	_, err := c.doHttpRequest(ctx, MGMT_PORT, "/settings/web", http.MethodPost, body, false)
+	_, err := c.doHTTPRequest(ctx, MGMT_PORT, "/settings/web", http.MethodPost, body, false)
 
 	return err
 }
@@ -352,7 +352,7 @@ func (c *CouchbaseContainer) configureExternalPorts(ctx context.Context) error {
 		body["eventingSSL"] = eventingSSL.Port()
 	}
 
-	_, err := c.doHttpRequest(ctx, MGMT_PORT, "/node/controller/setupAlternateAddresses/external", http.MethodPut, body, true)
+	_, err := c.doHTTPRequest(ctx, MGMT_PORT, "/node/controller/setupAlternateAddresses/external", http.MethodPut, body, true)
 
 	return err
 }
@@ -370,7 +370,7 @@ func (c *CouchbaseContainer) configureIndexer(ctx context.Context) error {
 		"storageMode": string(c.config.indexStorageMode),
 	}
 
-	_, err := c.doHttpRequest(ctx, MGMT_PORT, "/settings/indexes", http.MethodPost, body, true)
+	_, err := c.doHTTPRequest(ctx, MGMT_PORT, "/settings/indexes", http.MethodPost, body, true)
 
 	return err
 }
@@ -473,7 +473,7 @@ func (c *CouchbaseContainer) isPrimaryIndexOnline(ctx context.Context, bucket bu
 	}
 
 	err := backoff.Retry(func() error {
-		response, err := c.doHttpRequest(ctx, QUERY_PORT, "/query/service", http.MethodPost, body, true)
+		response, err := c.doHTTPRequest(ctx, QUERY_PORT, "/query/service", http.MethodPost, body, true)
 		if err != nil {
 			return err
 		}
@@ -494,7 +494,7 @@ func (c *CouchbaseContainer) createPrimaryIndex(ctx context.Context, bucket buck
 		"statement": "CREATE PRIMARY INDEX on `" + bucket.name + "`",
 	}
 	err := backoff.Retry(func() error {
-		response, err := c.doHttpRequest(ctx, QUERY_PORT, "/query/service", http.MethodPost, body, true)
+		response, err := c.doHTTPRequest(ctx, QUERY_PORT, "/query/service", http.MethodPost, body, true)
 		firstError := gjson.Get(string(response), "errors.0.code").Int()
 		if firstError != 0 {
 			return errors.New("index creation failed")
@@ -510,7 +510,7 @@ func (c *CouchbaseContainer) isQueryKeyspacePresent(ctx context.Context, bucket 
 	}
 
 	err := backoff.Retry(func() error {
-		response, err := c.doHttpRequest(ctx, QUERY_PORT, "/query/service", http.MethodPost, body, true)
+		response, err := c.doHTTPRequest(ctx, QUERY_PORT, "/query/service", http.MethodPost, body, true)
 		if err != nil {
 			return err
 		}
@@ -556,18 +556,18 @@ func (c *CouchbaseContainer) createBucket(ctx context.Context, bucket bucket) er
 		"replicaNumber": strconv.Itoa(bucket.numReplicas),
 	}
 
-	_, err := c.doHttpRequest(ctx, MGMT_PORT, "/pools/default/buckets", http.MethodPost, body, true)
+	_, err := c.doHTTPRequest(ctx, MGMT_PORT, "/pools/default/buckets", http.MethodPost, body, true)
 
 	return err
 }
 
-func (c *CouchbaseContainer) doHttpRequest(ctx context.Context, port, path, method string, body map[string]string, auth bool) ([]byte, error) {
+func (c *CouchbaseContainer) doHTTPRequest(ctx context.Context, port, path, method string, body map[string]string, auth bool) ([]byte, error) {
 	form := url.Values{}
 	for k, v := range body {
 		form.Set(k, v)
 	}
 
-	url, err := c.getUrl(ctx, port, path)
+	url, err := c.getURL(ctx, port, path)
 	if err != nil {
 		return nil, err
 	}
@@ -607,7 +607,7 @@ func (c *CouchbaseContainer) doHttpRequest(ctx context.Context, port, path, meth
 	return bytes, nil
 }
 
-func (c *CouchbaseContainer) getUrl(ctx context.Context, port, path string) (string, error) {
+func (c *CouchbaseContainer) getURL(ctx context.Context, port, path string) (string, error) {
 	host, err := c.Host(ctx)
 	if err != nil {
 		return "", err

--- a/modules/dolt/dolt.go
+++ b/modules/dolt/dolt.go
@@ -218,6 +218,7 @@ func WithDoltCredsPublicKey(key string) testcontainers.CustomizeRequestOption {
 	}
 }
 
+//nolint:revive //FIXME
 func WithDoltCloneRemoteUrl(url string) testcontainers.CustomizeRequestOption {
 	return func(req *testcontainers.GenericContainerRequest) error {
 		req.Env["DOLT_REMOTE_CLONE_URL"] = url

--- a/modules/grafana-lgtm/examples_test.go
+++ b/modules/grafana-lgtm/examples_test.go
@@ -134,14 +134,14 @@ func setupOTelSDK(ctx context.Context, ctr *grafanalgtm.GrafanaLGTMContainer) (s
 	)
 	otel.SetTextMapPropagator(prop)
 
-	otlpHttpEndpoint := ctr.MustOtlpHttpEndpoint(ctx)
+	otlpHTTPEndpoint := ctr.MustOtlpHttpEndpoint(ctx)
 
 	traceExporter, err := otlptrace.New(ctx,
 		otlptracehttp.NewClient(
 			// adding schema to avoid this error:
 			// 2024/07/19 13:16:30 internal_logging.go:50: "msg"="otlptrace: parse endpoint url" "error"="parse \"127.0.0.1:33007\": first path segment in URL cannot contain colon" "url"="127.0.0.1:33007"
 			// it does not happen with the logs and metrics exporters
-			otlptracehttp.WithEndpointURL("http://"+otlpHttpEndpoint),
+			otlptracehttp.WithEndpointURL("http://"+otlpHTTPEndpoint),
 			otlptracehttp.WithInsecure(),
 		),
 	)
@@ -158,7 +158,7 @@ func setupOTelSDK(ctx context.Context, ctr *grafanalgtm.GrafanaLGTMContainer) (s
 
 	metricExporter, err := otlpmetrichttp.New(ctx,
 		otlpmetrichttp.WithInsecure(),
-		otlpmetrichttp.WithEndpoint(otlpHttpEndpoint),
+		otlpmetrichttp.WithEndpoint(otlpHTTPEndpoint),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("new metric exporter: %w", err)
@@ -185,7 +185,7 @@ func setupOTelSDK(ctx context.Context, ctr *grafanalgtm.GrafanaLGTMContainer) (s
 
 	logExporter, err := otlploghttp.New(ctx,
 		otlploghttp.WithInsecure(),
-		otlploghttp.WithEndpoint(otlpHttpEndpoint),
+		otlploghttp.WithEndpoint(otlpHTTPEndpoint),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("new log exporter: %w", err)

--- a/modules/grafana-lgtm/grafana.go
+++ b/modules/grafana-lgtm/grafana.go
@@ -15,7 +15,7 @@ const (
 	LokiPort       = "3100/tcp"
 	TempoPort      = "3200/tcp"
 	OtlpGrpcPort   = "4317/tcp"
-	OtlpHttpPort   = "4318/tcp"
+	OtlpHttpPort   = "4318/tcp" //nolint:revive //FIXME
 	PrometheusPort = "9090/tcp"
 )
 
@@ -110,6 +110,8 @@ func (c *GrafanaLGTMContainer) MustTempoEndpoint(ctx context.Context) string {
 }
 
 // HttpEndpoint returns the HTTP URL
+//
+//nolint:revive //FIXME
 func (c *GrafanaLGTMContainer) HttpEndpoint(ctx context.Context) (string, error) {
 	url, err := baseEndpoint(ctx, c, GrafanaPort)
 	if err != nil {
@@ -120,6 +122,8 @@ func (c *GrafanaLGTMContainer) HttpEndpoint(ctx context.Context) (string, error)
 }
 
 // MustHttpEndpoint returns the HTTP endpoint or panics if an error occurs
+//
+//nolint:revive //FIXME
 func (c *GrafanaLGTMContainer) MustHttpEndpoint(ctx context.Context) string {
 	url, err := c.HttpEndpoint(ctx)
 	if err != nil {
@@ -130,6 +134,8 @@ func (c *GrafanaLGTMContainer) MustHttpEndpoint(ctx context.Context) string {
 }
 
 // OtlpHttpEndpoint returns the OTLP HTTP endpoint
+//
+//nolint:revive //FIXME
 func (c *GrafanaLGTMContainer) OtlpHttpEndpoint(ctx context.Context) (string, error) {
 	url, err := baseEndpoint(ctx, c, OtlpHttpPort)
 	if err != nil {
@@ -140,6 +146,8 @@ func (c *GrafanaLGTMContainer) OtlpHttpEndpoint(ctx context.Context) (string, er
 }
 
 // MustOtlpHttpEndpoint returns the OTLP HTTP endpoint or panics if an error occurs
+//
+//nolint:revive //FIXME
 func (c *GrafanaLGTMContainer) MustOtlpHttpEndpoint(ctx context.Context) string {
 	url, err := c.OtlpHttpEndpoint(ctx)
 	if err != nil {
@@ -170,6 +178,8 @@ func (c *GrafanaLGTMContainer) MustOtlpGrpcEndpoint(ctx context.Context) string 
 }
 
 // PrometheusHttpEndpoint returns the Prometheus HTTP endpoint
+//
+//nolint:revive //FIXME
 func (c *GrafanaLGTMContainer) PrometheusHttpEndpoint(ctx context.Context) (string, error) {
 	url, err := baseEndpoint(ctx, c, PrometheusPort)
 	if err != nil {
@@ -180,6 +190,8 @@ func (c *GrafanaLGTMContainer) PrometheusHttpEndpoint(ctx context.Context) (stri
 }
 
 // MustPrometheusHttpEndpoint returns the Prometheus HTTP endpoint or panics if an error occurs
+//
+//nolint:revive //FIXME
 func (c *GrafanaLGTMContainer) MustPrometheusHttpEndpoint(ctx context.Context) string {
 	url, err := c.PrometheusHttpEndpoint(ctx)
 	if err != nil {

--- a/modules/inbucket/inbucket.go
+++ b/modules/inbucket/inbucket.go
@@ -16,6 +16,8 @@ type InbucketContainer struct {
 
 // SmtpConnection returns the connection string for the smtp server, using the default
 // 2500 port, and obtaining the host and exposed port from the container.
+//
+//nolint:revive //FIXME
 func (c *InbucketContainer) SmtpConnection(ctx context.Context) (string, error) {
 	containerPort, err := c.MappedPort(ctx, "2500/tcp")
 	if err != nil {

--- a/modules/inbucket/inbucket_test.go
+++ b/modules/inbucket/inbucket_test.go
@@ -19,15 +19,15 @@ func TestInbucket(t *testing.T) {
 	require.NoError(t, err)
 
 	// smtpConnection {
-	smtpUrl, err := ctr.SmtpConnection(ctx)
+	smtpURL, err := ctr.SmtpConnection(ctx)
 	// }
 	require.NoError(t, err)
 
 	// webInterface {
-	webInterfaceUrl, err := ctr.WebInterface(ctx)
+	webInterfaceURL, err := ctr.WebInterface(ctx)
 	// }
 	require.NoError(t, err)
-	restClient, err := client.New(webInterfaceUrl)
+	restClient, err := client.New(webInterfaceURL)
 	require.NoError(t, err)
 
 	headers, err := restClient.ListMailbox("to@example.org")
@@ -38,7 +38,7 @@ func TestInbucket(t *testing.T) {
 		"Subject: Testcontainers test!\r\n" +
 		"\r\n" +
 		"This is a Testcontainers test.\r\n")
-	err = smtp.SendMail(smtpUrl, nil, "from@example.org", []string{"to@example.org"}, msg)
+	err = smtp.SendMail(smtpURL, nil, "from@example.org", []string{"to@example.org"}, msg)
 	require.NoError(t, err)
 
 	headers, err = restClient.ListMailbox("to@example.org")

--- a/modules/influxdb/influxdb.go
+++ b/modules/influxdb/influxdb.go
@@ -35,7 +35,7 @@ func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustom
 			"INFLUXDB_HTTP_HTTPS_ENABLED":    "false",
 			"INFLUXDB_HTTP_AUTH_ENABLED":     "false",
 		},
-		WaitingFor: waitForHttpHealth(),
+		WaitingFor: waitForHTTPHealth(),
 	}
 	genericContainerReq := testcontainers.GenericContainerRequest{
 		ContainerRequest: req,
@@ -61,6 +61,7 @@ func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustom
 	return c, nil
 }
 
+//nolint:revive //FIXME
 func (c *InfluxDbContainer) MustConnectionUrl(ctx context.Context) string {
 	connectionString, err := c.ConnectionUrl(ctx)
 	if err != nil {
@@ -69,6 +70,7 @@ func (c *InfluxDbContainer) MustConnectionUrl(ctx context.Context) string {
 	return connectionString
 }
 
+//nolint:revive //FIXME
 func (c *InfluxDbContainer) ConnectionUrl(ctx context.Context) (string, error) {
 	containerPort, err := c.MappedPort(ctx, "8086/tcp")
 	if err != nil {
@@ -129,13 +131,13 @@ func WithInitDb(srcPath string) testcontainers.CustomizeRequestOption {
 
 		req.WaitingFor = wait.ForAll(
 			wait.ForLog("Server shutdown completed"),
-			waitForHttpHealth(),
+			waitForHTTPHealth(),
 		)
 		return nil
 	}
 }
 
-func waitForHttpHealth() *wait.HTTPStrategy {
+func waitForHTTPHealth() *wait.HTTPStrategy {
 	return wait.ForHTTP("/health").
 		WithResponseMatcher(func(body io.Reader) bool {
 			decoder := json.NewDecoder(body)

--- a/modules/influxdb/influxdb_test.go
+++ b/modules/influxdb/influxdb_test.go
@@ -63,16 +63,16 @@ func TestWithInitDb(t *testing.T) {
 	require.NoError(t, err)
 	defer cli.Close()
 
-	expected_0 := `[{"statement_id":0,"Series":[{"name":"h2o_feet","tags":{"location":"coyote_creek"},"columns":["time","location","max"],"values":[[1566977040,"coyote_creek",9.964]]},{"name":"h2o_feet","tags":{"location":"santa_monica"},"columns":["time","location","max"],"values":[[1566964440,"santa_monica",7.205]]}],"Messages":null}]`
+	expected0 := `[{"statement_id":0,"Series":[{"name":"h2o_feet","tags":{"location":"coyote_creek"},"columns":["time","location","max"],"values":[[1566977040,"coyote_creek",9.964]]},{"name":"h2o_feet","tags":{"location":"santa_monica"},"columns":["time","location","max"],"values":[[1566964440,"santa_monica",7.205]]}],"Messages":null}]`
 	q := influxclient.NewQuery(`select "location", MAX("water_level") from "h2o_feet" group by "location"`, "NOAA_water_database", "s")
 	response, err := cli.Query(q)
 	require.NoError(t, err)
 
 	require.NoError(t, response.Error())
-	testJson, err := json.Marshal(response.Results)
+	testJSON, err := json.Marshal(response.Results)
 	require.NoError(t, err)
 
-	assert.JSONEq(t, expected_0, string(testJson))
+	assert.JSONEq(t, expected0, string(testJSON))
 }
 
 func TestWithConfigFile(t *testing.T) {

--- a/modules/k3s/k3s.go
+++ b/modules/k3s/k3s.go
@@ -159,7 +159,7 @@ func (c *K3sContainer) GetKubeConfig(ctx context.Context) ([]byte, error) {
 	}
 
 	server := "https://" + fmt.Sprintf("%v:%d", hostIP, mappedPort.Int())
-	newKubeConfig, err := kubeConfigWithServerUrl(string(kubeConfigYaml), server)
+	newKubeConfig, err := kubeConfigWithServerURL(string(kubeConfigYaml), server)
 	if err != nil {
 		return nil, fmt.Errorf("failed to modify kubeconfig with server url: %w", err)
 	}
@@ -167,7 +167,7 @@ func (c *K3sContainer) GetKubeConfig(ctx context.Context) ([]byte, error) {
 	return newKubeConfig, nil
 }
 
-func kubeConfigWithServerUrl(kubeConfigYaml, server string) ([]byte, error) {
+func kubeConfigWithServerURL(kubeConfigYaml, server string) ([]byte, error) {
 	kubeConfig, err := unmarshal([]byte(kubeConfigYaml))
 	if err != nil {
 		return nil, fmt.Errorf("failed to unmarshal kubeconfig: %w", err)

--- a/modules/k6/k6.go
+++ b/modules/k6/k6.go
@@ -26,7 +26,7 @@ type K6Container struct {
 }
 
 type DownloadableFile struct {
-	Uri         url.URL
+	Uri         url.URL //nolint:revive //FIXME
 	DownloadDir string
 	User        string
 	Password    string

--- a/modules/nats/nats_test.go
+++ b/modules/nats/nats_test.go
@@ -28,8 +28,8 @@ func TestNATS(t *testing.T) {
 	// }
 	require.NoError(t, err)
 
-	mustUri := ctr.MustConnectionString(ctx)
-	require.Equal(t, mustUri, uri)
+	mustURI := ctr.MustConnectionString(ctx)
+	require.Equal(t, mustURI, uri)
 
 	// perform assertions
 	nc, err := nats.Connect(uri)

--- a/modules/neo4j/neo4j.go
+++ b/modules/neo4j/neo4j.go
@@ -14,8 +14,8 @@ import (
 const (
 	// containerPorts {
 	defaultBoltPort  = "7687"
-	defaultHttpPort  = "7474"
-	defaultHttpsPort = "7473"
+	defaultHTTPPort  = "7474"
+	defaultHTTPSPort = "7473"
 	// }
 )
 
@@ -25,6 +25,8 @@ type Neo4jContainer struct {
 }
 
 // BoltUrl returns the bolt url for the Neo4j container, using the bolt port, in the format of neo4j://host:port
+//
+//nolint:revive //FIXME
 func (c Neo4jContainer) BoltUrl(ctx context.Context) (string, error) {
 	host, err := c.Host(ctx)
 	if err != nil {
@@ -49,7 +51,7 @@ func RunContainer(ctx context.Context, opts ...testcontainers.ContainerCustomize
 
 // Run creates an instance of the Neo4j container type
 func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustomizer) (*Neo4jContainer, error) {
-	httpPort, _ := nat.NewPort("tcp", defaultHttpPort)
+	httpPort, _ := nat.NewPort("tcp", defaultHTTPPort)
 	request := testcontainers.ContainerRequest{
 		Image: img,
 		Env: map[string]string{
@@ -57,15 +59,15 @@ func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustom
 		},
 		ExposedPorts: []string{
 			defaultBoltPort + "/tcp",
-			defaultHttpPort + "/tcp",
-			defaultHttpsPort + "/tcp",
+			defaultHTTPPort + "/tcp",
+			defaultHTTPSPort + "/tcp",
 		},
 		WaitingFor: &wait.MultiStrategy{
 			Strategies: []wait.Strategy{
 				wait.NewLogStrategy("Bolt enabled on"),
 				&wait.HTTPStrategy{
 					Port:              httpPort,
-					StatusCodeMatcher: isHttpOk(),
+					StatusCodeMatcher: isHTTPOk(),
 				},
 			},
 		},
@@ -105,7 +107,7 @@ func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustom
 	return c, nil
 }
 
-func isHttpOk() func(status int) bool {
+func isHTTPOk() func(status int) bool {
 	return func(status int) bool {
 		return status == http.StatusOK
 	}

--- a/modules/neo4j/neo4j_test.go
+++ b/modules/neo4j/neo4j_test.go
@@ -144,10 +144,10 @@ func setupNeo4j(ctx context.Context) (*neo4j.Neo4jContainer, error) {
 func createDriver(t *testing.T, ctx context.Context, container *neo4j.Neo4jContainer) neo.DriverWithContext {
 	t.Helper()
 	// boltURL {
-	boltUrl, err := container.BoltUrl(ctx)
+	boltURL, err := container.BoltUrl(ctx)
 	// }
 	require.NoError(t, err)
-	driver, err := neo.NewDriverWithContext(boltUrl, neo.BasicAuth("neo4j", testPassword, ""))
+	driver, err := neo.NewDriverWithContext(boltURL, neo.BasicAuth("neo4j", testPassword, ""))
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		err := driver.Close(ctx)

--- a/modules/ollama/local_test.go
+++ b/modules/ollama/local_test.go
@@ -362,7 +362,7 @@ func TestRun_localWithCustomHost(t *testing.T) {
 		testcontainers.CleanupContainer(t, ollamaContainer)
 		require.NoError(t, err)
 
-		testRun_localWithCustomHost(ctx, t, ollamaContainer)
+		testRunLocalWithCustomHost(ctx, t, ollamaContainer)
 	})
 
 	t.Run("local-env", func(t *testing.T) {
@@ -370,11 +370,11 @@ func TestRun_localWithCustomHost(t *testing.T) {
 		testcontainers.CleanupContainer(t, ollamaContainer)
 		require.NoError(t, err)
 
-		testRun_localWithCustomHost(ctx, t, ollamaContainer)
+		testRunLocalWithCustomHost(ctx, t, ollamaContainer)
 	})
 }
 
-func testRun_localWithCustomHost(ctx context.Context, t *testing.T, ollamaContainer *ollama.OllamaContainer) {
+func testRunLocalWithCustomHost(ctx context.Context, t *testing.T, ollamaContainer *ollama.OllamaContainer) {
 	t.Helper()
 
 	t.Run("connection-string", func(t *testing.T) {

--- a/modules/openfga/openfga.go
+++ b/modules/openfga/openfga.go
@@ -24,6 +24,8 @@ func (c *OpenFGAContainer) GrpcEndpoint(ctx context.Context) (string, error) {
 
 // HttpEndpoint returns the HTTP endpoint for the OpenFGA container,
 // which uses the 8080/tcp port.
+//
+//nolint:revive //FIXME
 func (c *OpenFGAContainer) HttpEndpoint(ctx context.Context) (string, error) {
 	return c.PortEndpoint(ctx, "8080/tcp", "http")
 }

--- a/modules/pinecone/pinecone.go
+++ b/modules/pinecone/pinecone.go
@@ -44,6 +44,8 @@ func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustom
 }
 
 // HttpEndpoint returns the http endpoint for the pinecone container
+//
+//nolint:revive //FIXME
 func (c *Container) HttpEndpoint() (string, error) {
 	return c.PortEndpoint(context.Background(), "5080/tcp", "http")
 }

--- a/modules/qdrant/examples_test.go
+++ b/modules/qdrant/examples_test.go
@@ -69,7 +69,7 @@ func ExampleRun_createPoints() {
 	}
 	defer conn.Close()
 
-	collections_client := pb.NewCollectionsClient(conn)
+	collectionsClient := pb.NewCollectionsClient(conn)
 
 	const (
 		collectionName        = "test_collection"
@@ -79,7 +79,7 @@ func ExampleRun_createPoints() {
 
 	// 1. create the collection
 	var defaultSegmentNumber uint64 = 2
-	_, err = collections_client.Create(context.Background(), &pb.CreateCollection{
+	_, err = collectionsClient.Create(context.Background(), &pb.CreateCollection{
 		CollectionName: collectionName,
 		VectorsConfig: &pb.VectorsConfig{Config: &pb.VectorsConfig_Params{
 			Params: &pb.VectorParams{
@@ -99,7 +99,7 @@ func ExampleRun_createPoints() {
 	// 2. Contact the server and print out its response.
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
-	r, err := collections_client.List(ctx, &pb.ListCollectionsRequest{})
+	r, err := collectionsClient.List(ctx, &pb.ListCollectionsRequest{})
 	if err != nil {
 		log.Printf("could not get collections: %v", err)
 		return
@@ -270,7 +270,7 @@ func ExampleRun_createPoints() {
 	}
 
 	// 7. Retrieve points by ids
-	pointsById, err := pointsClient.Get(context.Background(), &pb.GetPoints{
+	pointsByID, err := pointsClient.Get(context.Background(), &pb.GetPoints{
 		CollectionName: collectionName,
 		Ids: []*pb.PointId{
 			{PointIdOptions: &pb.PointId_Num{Num: 1}},
@@ -282,7 +282,7 @@ func ExampleRun_createPoints() {
 		return
 	}
 
-	fmt.Printf("Retrieved points: %d\n", len(pointsById.GetResult()))
+	fmt.Printf("Retrieved points: %d\n", len(pointsByID.GetResult()))
 
 	// 8. Unfiltered search
 	unfilteredSearchResult, err := pointsClient.Search(context.Background(), &pb.SearchPoints{

--- a/modules/rabbitmq/rabbitmq.go
+++ b/modules/rabbitmq/rabbitmq.go
@@ -57,11 +57,15 @@ func (c *RabbitMQContainer) AmqpsURL(ctx context.Context) (string, error) {
 }
 
 // HttpURL returns the URL for HTTP management.
+//
+//nolint:revive //FIXME
 func (c *RabbitMQContainer) HttpURL(ctx context.Context) (string, error) {
 	return c.PortEndpoint(ctx, nat.Port(DefaultHTTPPort), "http")
 }
 
 // HttpsURL returns the URL for HTTPS management.
+//
+//nolint:revive //FIXME
 func (c *RabbitMQContainer) HttpsURL(ctx context.Context) (string, error) {
 	return c.PortEndpoint(ctx, nat.Port(DefaultHTTPSPort), "https")
 }

--- a/modules/redpanda/redpanda.go
+++ b/modules/redpanda/redpanda.go
@@ -37,7 +37,7 @@ const (
 	defaultKafkaAPIPort       = "9092/tcp"
 	defaultAdminAPIPort       = "9644/tcp"
 	defaultSchemaRegistryPort = "8081/tcp"
-	defaultDockerKafkaApiPort = "29092"
+	defaultDockerKafkaAPIPort = "29092"
 
 	redpandaDir         = "/etc/redpanda"
 	entrypointFile      = "/entrypoint-tc.sh"

--- a/modules/redpanda/redpanda_test.go
+++ b/modules/redpanda/redpanda_test.go
@@ -556,8 +556,8 @@ func TestRedpandaBootstrapConfig(t *testing.T) {
 		require.NoError(t, err)
 		reservation := int(data["data_transforms_per_core_memory_reservation"].(float64))
 		require.Equal(t, 33554432, reservation)
-		pf_limit := int(data["data_transforms_per_function_memory_limit"].(float64))
-		require.Equal(t, 16777216, pf_limit)
+		pfLimit := int(data["data_transforms_per_function_memory_limit"].(float64))
+		require.Equal(t, 16777216, pfLimit)
 	}
 
 	{
@@ -572,7 +572,7 @@ func TestRedpandaBootstrapConfig(t *testing.T) {
 		err = json.NewDecoder(resp.Body).Decode(&data)
 		require.NoError(t, err)
 		require.Len(t, data, 1)
-		needs_restart := data[0]["restart"].(bool)
-		require.False(t, needs_restart)
+		needsRestart := data[0]["restart"].(bool)
+		require.False(t, needsRestart)
 	}
 }

--- a/modules/vault/vault.go
+++ b/modules/vault/vault.go
@@ -91,6 +91,8 @@ func WithInitCommand(commands ...string) testcontainers.CustomizeRequestOption {
 
 // HttpHostAddress returns the http host address of Vault.
 // It returns a string with the format http://<host>:<port>
+//
+//nolint:revive //FIXME
 func (v *VaultContainer) HttpHostAddress(ctx context.Context) (string, error) {
 	host, err := v.Host(ctx)
 	if err != nil {

--- a/modules/weaviate/weaviate.go
+++ b/modules/weaviate/weaviate.go
@@ -69,6 +69,8 @@ func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustom
 
 // HttpHostAddress returns the schema and host of the Weaviate container.
 // At the moment, it only supports the http scheme.
+//
+//nolint:revive //FIXME
 func (c *WeaviateContainer) HttpHostAddress(ctx context.Context) (string, string, error) {
 	port, err := c.MappedPort(ctx, httpPort)
 	if err != nil {

--- a/network/network_test.go
+++ b/network/network_test.go
@@ -190,13 +190,13 @@ func TestContainerWithReaperNetwork(t *testing.T) {
 	testcontainers.CleanupContainer(t, nginx)
 	require.NoError(t, err)
 
-	containerId := nginx.GetContainerID()
+	containerID := nginx.GetContainerID()
 
 	cli, err := testcontainers.NewDockerClientWithOpts(ctx)
 	require.NoError(t, err)
 	defer cli.Close()
 
-	cnt, err := cli.ContainerInspect(ctx, containerId)
+	cnt, err := cli.ContainerInspect(ctx, containerID)
 	require.NoError(t, err)
 	require.Len(t, cnt.NetworkSettings.Networks, maxNetworksCount)
 	require.NotNil(t, cnt.NetworkSettings.Networks[networks[0]])

--- a/wait/sql.go
+++ b/wait/sql.go
@@ -10,25 +10,25 @@ import (
 )
 
 var (
-	_ Strategy        = (*waitForSql)(nil)
-	_ StrategyTimeout = (*waitForSql)(nil)
+	_ Strategy        = (*waitForSQL)(nil)
+	_ StrategyTimeout = (*waitForSQL)(nil)
 )
 
-const defaultForSqlQuery = "SELECT 1"
+const defaultForSQLQuery = "SELECT 1"
 
 // ForSQL constructs a new waitForSql strategy for the given driver
-func ForSQL(port nat.Port, driver string, url func(host string, port nat.Port) string) *waitForSql {
-	return &waitForSql{
+func ForSQL(port nat.Port, driver string, url func(host string, port nat.Port) string) *waitForSQL {
+	return &waitForSQL{
 		Port:           port,
 		URL:            url,
 		Driver:         driver,
 		startupTimeout: defaultStartupTimeout(),
 		PollInterval:   defaultPollInterval(),
-		query:          defaultForSqlQuery,
+		query:          defaultForSQLQuery,
 	}
 }
 
-type waitForSql struct {
+type waitForSQL struct {
 	timeout *time.Duration
 
 	URL            func(host string, port nat.Port) string
@@ -40,31 +40,31 @@ type waitForSql struct {
 }
 
 // WithStartupTimeout can be used to change the default startup timeout
-func (w *waitForSql) WithStartupTimeout(timeout time.Duration) *waitForSql {
+func (w *waitForSQL) WithStartupTimeout(timeout time.Duration) *waitForSQL {
 	w.timeout = &timeout
 	return w
 }
 
 // WithPollInterval can be used to override the default polling interval of 100 milliseconds
-func (w *waitForSql) WithPollInterval(pollInterval time.Duration) *waitForSql {
+func (w *waitForSQL) WithPollInterval(pollInterval time.Duration) *waitForSQL {
 	w.PollInterval = pollInterval
 	return w
 }
 
 // WithQuery can be used to override the default query used in the strategy.
-func (w *waitForSql) WithQuery(query string) *waitForSql {
+func (w *waitForSQL) WithQuery(query string) *waitForSQL {
 	w.query = query
 	return w
 }
 
-func (w *waitForSql) Timeout() *time.Duration {
+func (w *waitForSQL) Timeout() *time.Duration {
 	return w.timeout
 }
 
 // WaitUntilReady repeatedly tries to run "SELECT 1" or user defined query on the given port using sql and driver.
 //
 // If it doesn't succeed until the timeout value which defaults to 60 seconds, it will return an error.
-func (w *waitForSql) WaitUntilReady(ctx context.Context, target StrategyTarget) error {
+func (w *waitForSQL) WaitUntilReady(ctx context.Context, target StrategyTarget) error {
 	timeout := defaultStartupTimeout()
 	if w.timeout != nil {
 		timeout = *w.timeout

--- a/wait/sql_test.go
+++ b/wait/sql_test.go
@@ -18,7 +18,7 @@ func Test_waitForSql_WithQuery(t *testing.T) {
 			return "fake-url"
 		})
 
-		require.Equal(t, defaultForSqlQuery, w.query)
+		require.Equal(t, defaultForSQLQuery, w.query)
 	})
 	t.Run("custom query", func(t *testing.T) {
 		const q = "SELECT 100;"


### PR DESCRIPTION
#### What does this PR do?

enable [var-naming](https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#var-naming) rule from revive

This also moves output configuration from Makefile to golangci-lint config

⚠️ Only private fields are fixed, the other are annotated with `//nolint:revive //FIXME` to be fixed later as agreed on https://github.com/testcontainers/testcontainers-go/pull/2960#issuecomment-2640515755