### PR TITLE
feat: support assigning custom StartupTimeout within the elasticsearch module

### DIFF
--- a/modules/elasticsearch/elasticsearch.go
+++ b/modules/elasticsearch/elasticsearch.go
@@ -129,8 +129,8 @@ func setWaitFor(options *Options, req *testcontainers.ContainerRequest) {
 	}
 
 	waitHTTP := wait.ForHTTP("/").WithPort(defaultHTTPPort)
-	if options.StartupTimeout > 0 {
-		waitHTTP.WithStartupTimeout(options.StartupTimeout)
+	if options.startupTimeout > 0 {
+		waitHTTP.WithStartupTimeout(options.startupTimeout)
 	}
 	if sslRequired(req) {
 		waitHTTP = waitHTTP.WithTLS(true).WithAllowInsecure(true)
@@ -143,8 +143,8 @@ func setWaitFor(options *Options, req *testcontainers.ContainerRequest) {
 			WithTLS(true, &tls.Config{RootCAs: cw.certPool})
 
 		waitFile := wait.ForFile(defaultCaCertPath).WithMatcher(cw.Read)
-		if options.StartupTimeout > 0 {
-			waitFile.WithStartupTimeout(options.StartupTimeout)
+		if options.startupTimeout > 0 {
+			waitFile.WithStartupTimeout(options.startupTimeout)
 		}
 
 		strategies = append(strategies, waitFile)

--- a/modules/elasticsearch/elasticsearch_internal_test.go
+++ b/modules/elasticsearch/elasticsearch_internal_test.go
@@ -1,0 +1,93 @@
+package elasticsearch
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/wait"
+)
+
+func Test_setWaitFor(t *testing.T) {
+
+	sampleTimeout := 42 * time.Second
+	tests := []struct {
+		name     string
+		options  *Options
+		expected *time.Duration
+	}{
+		{
+			name:     "when no StartupTimeout, timeout is nil",
+			options:  &Options{},
+			expected: nil,
+		},
+		{
+			name:     "when no StartupTimeout is set, timeout is the same",
+			options:  &Options{StartupTimeout: sampleTimeout},
+			expected: &sampleTimeout,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			request := &testcontainers.ContainerRequest{}
+
+			setWaitFor(tt.options, request)
+
+			actual, ok := request.WaitingFor.(*wait.HTTPStrategy)
+			require.True(t, ok, "strategy should be HTTPStrategy")
+			assert.Equal(t, tt.expected, actual.Timeout())
+		})
+	}
+
+	t.Run("when StartupTimeout and SSL are setup, they work together", func(t *testing.T) {
+		timeout := 12 * time.Millisecond
+		options := &Options{StartupTimeout: timeout}
+		request := &testcontainers.ContainerRequest{
+			Image: "docker.elastic.co/elasticsearch/elasticsearch:8.9.0",
+		}
+
+		setWaitFor(options, request)
+
+		actual, ok := request.WaitingFor.(*wait.MultiStrategy)
+		require.True(t, ok, "strategy should be HTTPStrategy, was %T", request.WaitingFor)
+		require.Len(t, actual.Strategies, 2)
+		for i := range actual.Strategies {
+			t.Logf("strategy: %T", actual.Strategies[i])
+		}
+
+		actualFileStrategy, ok := actual.Strategies[0].(*wait.FileStrategy)
+		require.True(t, ok, "strategy should be FileStrategy, was: %T", actual.Strategies[0])
+		assert.Equal(t, &timeout, actualFileStrategy.Timeout())
+
+		actualHTTPStrategy, ok := actual.Strategies[1].(*wait.HTTPStrategy)
+		require.True(t, ok, "strategy should be HTTPStrategy, was: %T", actual.Strategies[1])
+		assert.Equal(t, &timeout, actualHTTPStrategy.Timeout())
+	})
+	t.Run("when request already has a strategy, it is first", func(t *testing.T) {
+		timeout := 12 * time.Second
+		options := &Options{
+			StartupTimeout: timeout,
+		}
+		request := &testcontainers.ContainerRequest{
+			WaitingFor: wait.ForExit(),
+		}
+
+		setWaitFor(options, request)
+
+		actual, ok := request.WaitingFor.(*wait.MultiStrategy)
+		require.True(t, ok, "strategy should be HTTPStrategy, was %T", request.WaitingFor)
+		require.Len(t, actual.Strategies, 2)
+		for i := range actual.Strategies {
+			t.Logf("strategy: %T", actual.Strategies[i])
+		}
+
+		_, ok = actual.Strategies[0].(*wait.ExitStrategy)
+		require.True(t, ok, "strategy should be ExitStrategy, was: %T", actual.Strategies[0])
+
+		actualHTTPStrategy, ok := actual.Strategies[1].(*wait.HTTPStrategy)
+		require.True(t, ok, "strategy should be HTTPStrategy, was: %T", actual.Strategies[1])
+		assert.Equal(t, &timeout, actualHTTPStrategy.Timeout())
+	})
+}

--- a/modules/elasticsearch/elasticsearch_internal_test.go
+++ b/modules/elasticsearch/elasticsearch_internal_test.go
@@ -19,13 +19,13 @@ func Test_setWaitFor(t *testing.T) {
 		expected *time.Duration
 	}{
 		{
-			name:     "when no StartupTimeout, timeout is nil",
+			name:     "when_no_startupTimeout_timeout_is_nil",
 			options:  &Options{},
 			expected: nil,
 		},
 		{
-			name:     "when no StartupTimeout is set, timeout is the same",
-			options:  &Options{StartupTimeout: sampleTimeout},
+			name:     "when_no_startupTimeout_is_set_timeout_is_the_same",
+			options:  &Options{startupTimeout: sampleTimeout},
 			expected: &sampleTimeout,
 		},
 	}
@@ -41,9 +41,9 @@ func Test_setWaitFor(t *testing.T) {
 		})
 	}
 
-	t.Run("when StartupTimeout and SSL are setup, they work together", func(t *testing.T) {
+	t.Run("when_startupTimeout_and_SSL_are_setup_they_work_together", func(t *testing.T) {
 		timeout := 12 * time.Millisecond
-		options := &Options{StartupTimeout: timeout}
+		options := &Options{startupTimeout: timeout}
 		request := &testcontainers.ContainerRequest{
 			Image: "docker.elastic.co/elasticsearch/elasticsearch:8.9.0",
 		}
@@ -65,10 +65,10 @@ func Test_setWaitFor(t *testing.T) {
 		require.True(t, ok, "strategy should be HTTPStrategy, was: %T", actual.Strategies[1])
 		assert.Equal(t, &timeout, actualHTTPStrategy.Timeout())
 	})
-	t.Run("when request already has a strategy, it is first", func(t *testing.T) {
+	t.Run("when_request_already_has_a_strategy_it_is_first", func(t *testing.T) {
 		timeout := 12 * time.Second
 		options := &Options{
-			StartupTimeout: timeout,
+			startupTimeout: timeout,
 		}
 		request := &testcontainers.ContainerRequest{
 			WaitingFor: wait.ForExit(),

--- a/modules/elasticsearch/elasticsearch_test.go
+++ b/modules/elasticsearch/elasticsearch_test.go
@@ -40,32 +40,32 @@ func TestElasticsearch(t *testing.T) {
 		passwordCustomiser testcontainers.ContainerCustomizer
 	}{
 		{
-			name:               "Elasticsearch 6 without password should allow access using unauthenticated HTTP requests",
+			name:               "Elasticsearch_6_without_password_should_allow_access_using_unauthenticated_HTTP_requests",
 			image:              baseImage6,
 			passwordCustomiser: nil,
 		},
 		{
-			name:               "Elasticsearch 6 with password should allow access using authenticated HTTP requests",
+			name:               "Elasticsearch_6_with_password_should_allow_access_using_authenticated_HTTP_requests",
 			image:              baseImage6,
 			passwordCustomiser: elasticsearch.WithPassword(password),
 		},
 		{
-			name:               "Elasticsearch 7 without password should allow access using unauthenticated HTTP requests",
+			name:               "Elasticsearch_7_without_password_should_allow_access_using_unauthenticated_HTTP_requests",
 			image:              baseImage7,
 			passwordCustomiser: nil,
 		},
 		{
-			name:               "Elasticsearch 7 with password should allow access using authenticated HTTP requests",
+			name:               "Elasticsearch_7_with_password_should_allow_access_using_authenticated_HTTP_requests",
 			image:              baseImage7,
 			passwordCustomiser: elasticsearch.WithPassword(password),
 		},
 		{
-			name:               "Elasticsearch 8 without password should not allow access with unauthenticated HTTPS requests",
+			name:               "Elasticsearch_8_without_password_should_not_allow_access_with_unauthenticated_HTTPS_requests",
 			image:              baseImage8,
 			passwordCustomiser: nil,
 		},
 		{
-			name:               "Elasticsearch 8 with password should allow access using authenticated HTTPS requests",
+			name:               "Elasticsearch_8_with_password_should_allow_access_using_authenticated_HTTPS_requests",
 			image:              baseImage8,
 			passwordCustomiser: elasticsearch.WithPassword(password),
 		},
@@ -137,15 +137,15 @@ func TestElasticsearch8WithoutSSL(t *testing.T) {
 		configKey string
 	}{
 		{
-			name:      "security disabled",
+			name:      "security_disabled",
 			configKey: "xpack.security.enabled",
 		},
 		{
-			name:      "transport ssl disabled",
+			name:      "transport_ssl_disabled",
 			configKey: "xpack.security.transport.ssl.enabled",
 		},
 		{
-			name:      "http ssl disabled",
+			name:      "http_ssl_disabled",
 			configKey: "xpack.security.http.ssl.enabled",
 		},
 	}

--- a/modules/elasticsearch/examples_test.go
+++ b/modules/elasticsearch/examples_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"strings"
+	"time"
 
 	es "github.com/elastic/go-elasticsearch/v8"
 
@@ -65,6 +66,33 @@ func ExampleRun_withUsingPassword() {
 	// Output:
 	// true
 	// foo
+}
+
+func ExampleRun_withStartupTimeout() {
+	// usingPassword {
+	ctx := context.Background()
+	elasticsearchContainer, err := elasticsearch.Run(
+		ctx,
+		"docker.elastic.co/elasticsearch/elasticsearch:7.9.2",
+		elasticsearch.WithStartupTimeout(2*time.Minute),
+	)
+	defer func() {
+		if err := testcontainers.TerminateContainer(elasticsearchContainer); err != nil {
+			log.Printf("failed to terminate container: %s", err)
+		}
+	}()
+	if err != nil {
+		log.Printf("failed to start container: %s", err)
+		return
+	}
+	// }
+
+	fmt.Println(strings.HasPrefix(elasticsearchContainer.Settings.Address, "http://"))
+	fmt.Println(elasticsearchContainer.Settings.StartupTimeout)
+
+	// Output:
+	// true
+	// 2m0s
 }
 
 func ExampleRun_connectUsingElasticsearchClient() {

--- a/modules/elasticsearch/examples_test.go
+++ b/modules/elasticsearch/examples_test.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"log"
 	"strings"
-	"time"
 
 	es "github.com/elastic/go-elasticsearch/v8"
 
@@ -66,33 +65,6 @@ func ExampleRun_withUsingPassword() {
 	// Output:
 	// true
 	// foo
-}
-
-func ExampleRun_withStartupTimeout() {
-	// usingPassword {
-	ctx := context.Background()
-	elasticsearchContainer, err := elasticsearch.Run(
-		ctx,
-		"docker.elastic.co/elasticsearch/elasticsearch:7.9.2",
-		elasticsearch.WithStartupTimeout(2*time.Minute),
-	)
-	defer func() {
-		if err := testcontainers.TerminateContainer(elasticsearchContainer); err != nil {
-			log.Printf("failed to terminate container: %s", err)
-		}
-	}()
-	if err != nil {
-		log.Printf("failed to start container: %s", err)
-		return
-	}
-	// }
-
-	fmt.Println(strings.HasPrefix(elasticsearchContainer.Settings.Address, "http://"))
-	fmt.Println(elasticsearchContainer.Settings.StartupTimeout)
-
-	// Output:
-	// true
-	// 2m0s
 }
 
 func ExampleRun_connectUsingElasticsearchClient() {

--- a/modules/elasticsearch/options.go
+++ b/modules/elasticsearch/options.go
@@ -1,6 +1,8 @@
 package elasticsearch
 
 import (
+	"time"
+
 	"github.com/testcontainers/testcontainers-go"
 )
 
@@ -8,10 +10,11 @@ import (
 // It could be used to build an HTTP client for the Elasticsearch container, as it will
 // hold information on how to connect to the container.
 type Options struct {
-	Address  string
-	CACert   []byte
-	Password string
-	Username string
+	Address        string
+	CACert         []byte
+	Password       string
+	Username       string
+	StartupTimeout time.Duration
 }
 
 func defaultOptions() *Options {
@@ -36,5 +39,12 @@ func (o Option) Customize(*testcontainers.GenericContainerRequest) error {
 func WithPassword(password string) Option {
 	return func(o *Options) {
 		o.Password = password
+	}
+}
+
+// WithStartupTimeout sets the timeout duration used when waiting for the Elasticsearch container to start.
+func WithStartupTimeout(timeout time.Duration) Option {
+	return func(o *Options) {
+		o.StartupTimeout = timeout
 	}
 }

--- a/modules/elasticsearch/options.go
+++ b/modules/elasticsearch/options.go
@@ -14,7 +14,7 @@ type Options struct {
 	CACert         []byte
 	Password       string
 	Username       string
-	StartupTimeout time.Duration
+	startupTimeout time.Duration
 }
 
 func defaultOptions() *Options {
@@ -45,6 +45,6 @@ func WithPassword(password string) Option {
 // WithStartupTimeout sets the timeout duration used when waiting for the Elasticsearch container to start.
 func WithStartupTimeout(timeout time.Duration) Option {
 	return func(o *Options) {
-		o.StartupTimeout = timeout
+		o.startupTimeout = timeout
 	}
 }


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->


## What does this PR do?

Adds an Option function to support configuring the timeout used for the internal WaitFor Strategies. I did my best to follow the example laid down by the existing [WithPassword](https://github.com/testcontainers/testcontainers-go/blob/f09b3af2cb985a17bd2b2eaaa5d384882ded8e28/modules/elasticsearch/options.go#L36) Option.

Because this is an internal concern that was is not exposed for assertions by the existing `elasticsearch_test.go`, I added the `elasticsearch_internal_test`. I saw no existing _internal_ test, so went with this naming pattern. Adding this test allowed me to extend the test coverage across the scenario when the incoming `request` [already has a WaitFor Strategy](https://github.com/testcontainers/testcontainers-go/blob/f09b3af2cb985a17bd2b2eaaa5d384882ded8e28/modules/elasticsearch/elasticsearch.go#L127-L128).

## Why is it important?

We were seeing intermittent timeout while running integration tests in Github PR Actions. The StartupTimeout needed to be applied to the internally controlled Strategies.

## Related issues

- Closes #2982 

## How to test this PR

I tested the PR by configuring a testcontainer that uses the option.  Not only did my Github actions pass, but also, by adding a logger, I can see the timeout is applied to the WaitFor Strategy:
```go
...
elasticsearchContainer, err := elasticsearch.Run(
	ctx,
	"docker.elastic.co/elasticsearch/elasticsearch:8.17.2",
	testcontainers.WithLogger(logger{}), //a custom fmt.Printf logger, or the supported TestLogger
	elasticsearch.WithStartupTimeout(2*time.Minute), // adding the feature from this PR
)
closer := func(ctx context.Context) error {
	return elasticsearchContainer.Terminate(ctx)
}
...
``` 

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
