### PR TITLE
deps: update go version from 1.22.0 to 1.23.0

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,7 +2,7 @@
 // README at: https://github.com/devcontainers/templates/tree/main/src/go
 {
 	"name": "Go",
-	"image": "mcr.microsoft.com/devcontainers/go:1.22-bookworm",
+	"image": "mcr.microsoft.com/devcontainers/go:1.23-bookworm",
 
 	// Features to add to the dev container. More info: https://containers.dev/features.
 	// "features": {},

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -183,7 +183,7 @@ branches:
         # Required. Require branches to be up to date before merging.
         strict: true
         # Required. The list of status checks to require in order to merge into this branch
-        contexts: ["test (1.x, ubuntu-latest) / ./ubuntu-latest/1.x"]
+        contexts: ["test (1.24.x) / test: /1.24.x"]
       # Required. Enforce all configured restrictions for administrators. Set to true to enforce required status checks for repository administrators. Set to null to disable.
       enforce_admins: false
       # Prevent merge commits from being pushed to matching branches

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
       # We don't want to fail the build the soonest but identify which modules passed and failed.
       fail-fast: false
       matrix:
-        go-version: [1.22.x, 1.x]
+        go-version: [1.23.x, 1.24.x]
         module: ${{ fromJSON(needs.detect-modules.outputs.modules) }}
     uses: ./.github/workflows/ci-test-go.yml
     with:
@@ -82,7 +82,7 @@ jobs:
     name: "Test with reaper off"
     strategy:
       matrix:
-        go-version: [1.22.x, 1.x]
+        go-version: [1.23.x, 1.24.x]
     uses: ./.github/workflows/ci-test-go.yml
     with:
       go-version: ${{ matrix.go-version }}
@@ -102,7 +102,7 @@ jobs:
     name: "Test with Rootless Docker"
     strategy:
       matrix:
-        go-version: [1.22.x, 1.x]
+        go-version: [1.23.x, 1.24.x]
     uses: ./.github/workflows/ci-test-go.yml
     with:
       go-version: ${{ matrix.go-version }}

--- a/docs/system_requirements/ci/aws_codebuild.md
+++ b/docs/system_requirements/ci/aws_codebuild.md
@@ -11,7 +11,7 @@ version: 0.2
 phases:
   install:
     runtime-versions:
-      golang: 1.22
+      golang: 1.23
   build:
     commands:
       - go test ./...

--- a/docs/system_requirements/ci/circle_ci.md
+++ b/docs/system_requirements/ci/circle_ci.md
@@ -57,7 +57,7 @@ workflows:
       - tests:
           matrix:
             parameters:
-              go-version: ["1.21.7", "1.22.3"]
+              go-version: ["1.23.6", "1.24.0"]
 
 ```
 

--- a/docs/system_requirements/ci/concourse_ci.md
+++ b/docs/system_requirements/ci/concourse_ci.md
@@ -36,7 +36,7 @@ jobs:
             start_docker
 
             cd repo
-            docker run -it --rm -v "$PWD:$PWD" -w "$PWD" -v /var/run/docker.sock:/var/run/docker.sock golang:1.22 go test ./...
+            docker run -it --rm -v "$PWD:$PWD" -w "$PWD" -v /var/run/docker.sock:/var/run/docker.sock golang:1.23 go test ./...
 ```
 
 Finally, you can use Concourse's [fly CLI](https://concourse-ci.org/fly.html) to set the pipeline and trigger the job:

--- a/docs/system_requirements/ci/dind_patterns.md
+++ b/docs/system_requirements/ci/dind_patterns.md
@@ -24,7 +24,7 @@ $ tree .
 └── platform
     └── integration_test.go
 
-$ docker run -it --rm -v $PWD:$PWD -w $PWD -v /var/run/docker.sock:/var/run/docker.sock golang:1.22 go test ./... -v
+$ docker run -it --rm -v $PWD:$PWD -w $PWD -v /var/run/docker.sock:/var/run/docker.sock golang:1.23 go test ./... -v
 ```
 
 Where:
@@ -45,7 +45,7 @@ The same can be achieved with Docker Compose:
 
 ```yaml
 tests:
-  image: golang:1.22
+  image: golang:1.23
   stop_signal: SIGKILL
   stdin_open: true
   tty: true

--- a/docs/system_requirements/ci/gitlab_ci.md
+++ b/docs/system_requirements/ci/gitlab_ci.md
@@ -57,7 +57,7 @@ variables:
   DOCKER_DRIVER: overlay2
 
 test:
- image: golang:1.22
+ image: golang:1.23
  stage: test
  script: go test ./... -v
 ```

--- a/docs/system_requirements/ci/tekton.md
+++ b/docs/system_requirements/ci/tekton.md
@@ -16,7 +16,7 @@ spec:
     - name: source
   steps:
     - name: read
-      image: golang:1.22
+      image: golang:1.23
       workingDir: $(workspaces.source.path)
       script: go test ./... -v
       volumeMounts:

--- a/docs/system_requirements/ci/travis.md
+++ b/docs/system_requirements/ci/travis.md
@@ -7,7 +7,7 @@ is the minimal required config.
 language: go
 go:
 - 1.x
-- "1.22"
+- "1.23"
 
 services:
 - docker

--- a/examples/nginx/go.mod
+++ b/examples/nginx/go.mod
@@ -1,6 +1,8 @@
 module github.com/testcontainers/testcontainers-go/examples/nginx
 
-go 1.22
+go 1.23.0
+
+toolchain go1.23.6
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/examples/toxiproxy/go.mod
+++ b/examples/toxiproxy/go.mod
@@ -1,6 +1,8 @@
 module github.com/testcontainers/testcontainers-go/examples/toxiproxy
 
-go 1.22
+go 1.23.0
+
+toolchain go1.23.6
 
 require (
 	github.com/Shopify/toxiproxy/v2 v2.8.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/testcontainers/testcontainers-go
 
-go 1.22
+go 1.23.0
+
+toolchain go1.23.6
 
 require (
 	dario.cat/mergo v1.0.0

--- a/modulegen/go.mod
+++ b/modulegen/go.mod
@@ -1,6 +1,8 @@
 module github.com/testcontainers/testcontainers-go/modulegen
 
-go 1.22
+go 1.23.0
+
+toolchain go1.23.6
 
 require (
 	github.com/spf13/cobra v1.8.0

--- a/modules/artemis/go.mod
+++ b/modules/artemis/go.mod
@@ -1,6 +1,8 @@
 module github.com/testcontainers/testcontainers-go/modules/artemis
 
-go 1.22
+go 1.23.0
+
+toolchain go1.23.6
 
 require (
 	github.com/docker/go-connections v0.5.0

--- a/modules/azurite/go.mod
+++ b/modules/azurite/go.mod
@@ -1,6 +1,8 @@
 module github.com/testcontainers/testcontainers-go/modules/azurite
 
-go 1.22
+go 1.23.0
+
+toolchain go1.23.6
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.11.1

--- a/modules/cassandra/go.mod
+++ b/modules/cassandra/go.mod
@@ -1,6 +1,8 @@
 module github.com/testcontainers/testcontainers-go/modules/cassandra
 
-go 1.22
+go 1.23.0
+
+toolchain go1.23.6
 
 require (
 	github.com/docker/go-connections v0.5.0

--- a/modules/chroma/go.mod
+++ b/modules/chroma/go.mod
@@ -1,6 +1,8 @@
 module github.com/testcontainers/testcontainers-go/modules/chroma
 
-go 1.22
+go 1.23.0
+
+toolchain go1.23.6
 
 require (
 	github.com/amikos-tech/chroma-go v0.1.2

--- a/modules/clickhouse/go.mod
+++ b/modules/clickhouse/go.mod
@@ -1,6 +1,8 @@
 module github.com/testcontainers/testcontainers-go/modules/clickhouse
 
-go 1.22
+go 1.23.0
+
+toolchain go1.23.6
 
 require (
 	github.com/ClickHouse/clickhouse-go/v2 v2.20.0

--- a/modules/cockroachdb/go.mod
+++ b/modules/cockroachdb/go.mod
@@ -1,6 +1,8 @@
 module github.com/testcontainers/testcontainers-go/modules/cockroachdb
 
-go 1.22
+go 1.23.0
+
+toolchain go1.23.6
 
 require (
 	github.com/docker/go-connections v0.5.0

--- a/modules/compose/go.mod
+++ b/modules/compose/go.mod
@@ -1,6 +1,8 @@
 module github.com/testcontainers/testcontainers-go/modules/compose
 
-go 1.22.10
+go 1.23.0
+
+toolchain go1.23.6
 
 replace github.com/testcontainers/testcontainers-go => ../..
 

--- a/modules/compose/testdata/echoserver.Dockerfile
+++ b/modules/compose/testdata/echoserver.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.13-alpine
+FROM golang:1.23-alpine@sha256:f8113c4b13e2a8b3a168dceaee88ac27743cc84e959f43b9dbd2291e9c3f57a0
 
 WORKDIR /app
 

--- a/modules/consul/go.mod
+++ b/modules/consul/go.mod
@@ -1,6 +1,8 @@
 module github.com/testcontainers/testcontainers-go/modules/consul
 
-go 1.22
+go 1.23.0
+
+toolchain go1.23.6
 
 require (
 	github.com/hashicorp/consul/api v1.27.0

--- a/modules/couchbase/go.mod
+++ b/modules/couchbase/go.mod
@@ -1,6 +1,8 @@
 module github.com/testcontainers/testcontainers-go/modules/couchbase
 
-go 1.22
+go 1.23.0
+
+toolchain go1.23.6
 
 require (
 	github.com/cenkalti/backoff/v4 v4.2.1

--- a/modules/databend/go.mod
+++ b/modules/databend/go.mod
@@ -1,6 +1,8 @@
 module github.com/testcontainers/testcontainers-go/modules/databend
 
-go 1.22.0
+go 1.23.0
+
+toolchain go1.23.6
 
 require (
 	github.com/datafuselabs/databend-go v0.7.0

--- a/modules/dolt/go.mod
+++ b/modules/dolt/go.mod
@@ -1,6 +1,8 @@
 module github.com/testcontainers/testcontainers-go/modules/dolt
 
-go 1.22
+go 1.23.0
+
+toolchain go1.23.6
 
 require (
 	github.com/go-sql-driver/mysql v1.7.1

--- a/modules/dynamodb/go.mod
+++ b/modules/dynamodb/go.mod
@@ -1,6 +1,8 @@
 module github.com/testcontainers/testcontainers-go/modules/dynamodb
 
-go 1.22
+go 1.23.0
+
+toolchain go1.23.6
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.31.0

--- a/modules/elasticsearch/go.mod
+++ b/modules/elasticsearch/go.mod
@@ -1,6 +1,8 @@
 module github.com/testcontainers/testcontainers-go/modules/elasticsearch
 
-go 1.22
+go 1.23.0
+
+toolchain go1.23.6
 
 require (
 	github.com/elastic/go-elasticsearch/v8 v8.12.1

--- a/modules/etcd/go.mod
+++ b/modules/etcd/go.mod
@@ -1,6 +1,8 @@
 module github.com/testcontainers/testcontainers-go/modules/etcd
 
-go 1.22
+go 1.23.0
+
+toolchain go1.23.6
 
 require (
 	github.com/docker/docker v27.1.1+incompatible

--- a/modules/gcloud/go.mod
+++ b/modules/gcloud/go.mod
@@ -1,6 +1,8 @@
 module github.com/testcontainers/testcontainers-go/modules/gcloud
 
-go 1.22
+go 1.23.0
+
+toolchain go1.23.6
 
 require (
 	cloud.google.com/go/bigquery v1.59.1

--- a/modules/grafana-lgtm/go.mod
+++ b/modules/grafana-lgtm/go.mod
@@ -1,6 +1,8 @@
 module github.com/testcontainers/testcontainers-go/modules/grafana-lgtm
 
-go 1.22
+go 1.23.0
+
+toolchain go1.23.6
 
 require (
 	github.com/docker/go-connections v0.5.0

--- a/modules/inbucket/go.mod
+++ b/modules/inbucket/go.mod
@@ -1,6 +1,8 @@
 module github.com/testcontainers/testcontainers-go/modules/inbucket
 
-go 1.22
+go 1.23.0
+
+toolchain go1.23.6
 
 require (
 	github.com/inbucket/inbucket v2.0.0+incompatible

--- a/modules/influxdb/go.mod
+++ b/modules/influxdb/go.mod
@@ -1,6 +1,8 @@
 module github.com/testcontainers/testcontainers-go/modules/influxdb
 
-go 1.22
+go 1.23.0
+
+toolchain go1.23.6
 
 require (
 	github.com/influxdata/influxdb1-client v0.0.0-20220302092344-a9ab5670611c

--- a/modules/k3s/go.mod
+++ b/modules/k3s/go.mod
@@ -1,6 +1,8 @@
 module github.com/testcontainers/testcontainers-go/modules/k3s
 
-go 1.22
+go 1.23.0
+
+toolchain go1.23.6
 
 require (
 	github.com/docker/docker v27.1.1+incompatible

--- a/modules/k6/go.mod
+++ b/modules/k6/go.mod
@@ -1,6 +1,8 @@
 module github.com/testcontainers/testcontainers-go/modules/k6
 
-go 1.22
+go 1.23.0
+
+toolchain go1.23.6
 
 require (
 	github.com/docker/docker v27.1.1+incompatible

--- a/modules/kafka/go.mod
+++ b/modules/kafka/go.mod
@@ -1,6 +1,8 @@
 module github.com/testcontainers/testcontainers-go/modules/kafka
 
-go 1.22
+go 1.23.0
+
+toolchain go1.23.6
 
 require (
 	github.com/IBM/sarama v1.42.1

--- a/modules/localstack/go.mod
+++ b/modules/localstack/go.mod
@@ -1,6 +1,8 @@
 module github.com/testcontainers/testcontainers-go/modules/localstack
 
-go 1.22
+go 1.23.0
+
+toolchain go1.23.6
 
 require (
 	github.com/aws/aws-sdk-go v1.50.31

--- a/modules/mariadb/go.mod
+++ b/modules/mariadb/go.mod
@@ -1,6 +1,8 @@
 module github.com/testcontainers/testcontainers-go/modules/mariadb
 
-go 1.22
+go 1.23.0
+
+toolchain go1.23.6
 
 require (
 	github.com/go-sql-driver/mysql v1.7.1

--- a/modules/meilisearch/go.mod
+++ b/modules/meilisearch/go.mod
@@ -1,6 +1,8 @@
 module github.com/testcontainers/testcontainers-go/modules/meilisearch
 
-go 1.22
+go 1.23.0
+
+toolchain go1.23.6
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/modules/milvus/go.mod
+++ b/modules/milvus/go.mod
@@ -1,6 +1,8 @@
 module github.com/testcontainers/testcontainers-go/modules/milvus
 
-go 1.22
+go 1.23.0
+
+toolchain go1.23.6
 
 require (
 	github.com/milvus-io/milvus-sdk-go/v2 v2.4.0

--- a/modules/minio/go.mod
+++ b/modules/minio/go.mod
@@ -1,6 +1,8 @@
 module github.com/testcontainers/testcontainers-go/modules/minio
 
-go 1.22
+go 1.23.0
+
+toolchain go1.23.6
 
 require (
 	github.com/minio/minio-go/v7 v7.0.68

--- a/modules/mockserver/go.mod
+++ b/modules/mockserver/go.mod
@@ -1,6 +1,8 @@
 module github.com/testcontainers/testcontainers-go/modules/mockserver
 
-go 1.22
+go 1.23.0
+
+toolchain go1.23.6
 
 require (
 	github.com/BraspagDevelopers/mock-server-client v0.2.2

--- a/modules/mongodb/go.mod
+++ b/modules/mongodb/go.mod
@@ -1,6 +1,8 @@
 module github.com/testcontainers/testcontainers-go/modules/mongodb
 
-go 1.22
+go 1.23.0
+
+toolchain go1.23.6
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/modules/mssql/go.mod
+++ b/modules/mssql/go.mod
@@ -1,6 +1,8 @@
 module github.com/testcontainers/testcontainers-go/modules/mssql
 
-go 1.22
+go 1.23.0
+
+toolchain go1.23.6
 
 require (
 	github.com/microsoft/go-mssqldb v1.7.0

--- a/modules/mysql/go.mod
+++ b/modules/mysql/go.mod
@@ -1,6 +1,8 @@
 module github.com/testcontainers/testcontainers-go/modules/mysql
 
-go 1.22
+go 1.23.0
+
+toolchain go1.23.6
 
 require (
 	github.com/go-sql-driver/mysql v1.7.1

--- a/modules/nats/go.mod
+++ b/modules/nats/go.mod
@@ -1,6 +1,8 @@
 module github.com/testcontainers/testcontainers-go/modules/nats
 
-go 1.22
+go 1.23.0
+
+toolchain go1.23.6
 
 require (
 	github.com/nats-io/nats.go v1.33.1

--- a/modules/neo4j/go.mod
+++ b/modules/neo4j/go.mod
@@ -1,6 +1,8 @@
 module github.com/testcontainers/testcontainers-go/modules/neo4j
 
-go 1.22
+go 1.23.0
+
+toolchain go1.23.6
 
 require (
 	github.com/docker/go-connections v0.5.0

--- a/modules/ollama/go.mod
+++ b/modules/ollama/go.mod
@@ -1,6 +1,8 @@
 module github.com/testcontainers/testcontainers-go/modules/ollama
 
-go 1.22
+go 1.23.0
+
+toolchain go1.23.6
 
 require (
 	github.com/docker/docker v27.1.1+incompatible

--- a/modules/openfga/go.mod
+++ b/modules/openfga/go.mod
@@ -1,6 +1,8 @@
 module github.com/testcontainers/testcontainers-go/modules/openfga
 
-go 1.22
+go 1.23.0
+
+toolchain go1.23.6
 
 require (
 	github.com/openfga/go-sdk v0.3.5

--- a/modules/openldap/go.mod
+++ b/modules/openldap/go.mod
@@ -1,6 +1,8 @@
 module github.com/testcontainers/testcontainers-go/modules/openldap
 
-go 1.22
+go 1.23.0
+
+toolchain go1.23.6
 
 require (
 	github.com/go-ldap/ldap/v3 v3.4.6

--- a/modules/opensearch/go.mod
+++ b/modules/opensearch/go.mod
@@ -1,6 +1,8 @@
 module github.com/testcontainers/testcontainers-go/modules/opensearch
 
-go 1.22
+go 1.23.0
+
+toolchain go1.23.6
 
 require (
 	github.com/docker/docker v27.1.1+incompatible

--- a/modules/pinecone/go.mod
+++ b/modules/pinecone/go.mod
@@ -1,6 +1,8 @@
 module github.com/testcontainers/testcontainers-go/modules/pinecone
 
-go 1.22
+go 1.23.0
+
+toolchain go1.23.6
 
 require (
 	github.com/pinecone-io/go-pinecone/v2 v2.2.0

--- a/modules/postgres/go.mod
+++ b/modules/postgres/go.mod
@@ -1,6 +1,8 @@
 module github.com/testcontainers/testcontainers-go/modules/postgres
 
-go 1.22
+go 1.23.0
+
+toolchain go1.23.6
 
 require (
 	github.com/docker/go-connections v0.5.0

--- a/modules/pulsar/go.mod
+++ b/modules/pulsar/go.mod
@@ -1,6 +1,8 @@
 module github.com/testcontainers/testcontainers-go/modules/pulsar
 
-go 1.22
+go 1.23.0
+
+toolchain go1.23.6
 
 require (
 	github.com/apache/pulsar-client-go v0.10.0

--- a/modules/qdrant/go.mod
+++ b/modules/qdrant/go.mod
@@ -1,6 +1,8 @@
 module github.com/testcontainers/testcontainers-go/modules/qdrant
 
-go 1.22
+go 1.23.0
+
+toolchain go1.23.6
 
 require (
 	github.com/qdrant/go-client v1.7.0

--- a/modules/rabbitmq/go.mod
+++ b/modules/rabbitmq/go.mod
@@ -1,6 +1,8 @@
 module github.com/testcontainers/testcontainers-go/modules/rabbitmq
 
-go 1.22
+go 1.23.0
+
+toolchain go1.23.6
 
 require (
 	github.com/docker/go-connections v0.5.0

--- a/modules/redis/go.mod
+++ b/modules/redis/go.mod
@@ -1,6 +1,8 @@
 module github.com/testcontainers/testcontainers-go/modules/redis
 
-go 1.22
+go 1.23.0
+
+toolchain go1.23.6
 
 require (
 	github.com/go-redis/redis/v8 v8.11.5

--- a/modules/redpanda/go.mod
+++ b/modules/redpanda/go.mod
@@ -1,6 +1,8 @@
 module github.com/testcontainers/testcontainers-go/modules/redpanda
 
-go 1.22
+go 1.23.0
+
+toolchain go1.23.6
 
 require (
 	github.com/docker/go-connections v0.5.0

--- a/modules/registry/go.mod
+++ b/modules/registry/go.mod
@@ -1,6 +1,8 @@
 module github.com/testcontainers/testcontainers-go/modules/registry
 
-go 1.22
+go 1.23.0
+
+toolchain go1.23.6
 
 require (
 	github.com/cpuguy83/dockercfg v0.3.2

--- a/modules/surrealdb/go.mod
+++ b/modules/surrealdb/go.mod
@@ -1,6 +1,8 @@
 module github.com/testcontainers/testcontainers-go/modules/surrealdb
 
-go 1.22
+go 1.23.0
+
+toolchain go1.23.6
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/modules/valkey/go.mod
+++ b/modules/valkey/go.mod
@@ -1,6 +1,8 @@
 module github.com/testcontainers/testcontainers-go/modules/valkey
 
-go 1.22
+go 1.23.0
+
+toolchain go1.23.6
 
 require (
 	github.com/google/uuid v1.6.0

--- a/modules/vault/go.mod
+++ b/modules/vault/go.mod
@@ -1,6 +1,8 @@
 module github.com/testcontainers/testcontainers-go/modules/vault
 
-go 1.22
+go 1.23.0
+
+toolchain go1.23.6
 
 require (
 	github.com/docker/docker v27.1.1+incompatible

--- a/modules/vearch/go.mod
+++ b/modules/vearch/go.mod
@@ -1,6 +1,8 @@
 module github.com/testcontainers/testcontainers-go/modules/vearch
 
-go 1.22.0
+go 1.23.0
+
+toolchain go1.23.6
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/modules/weaviate/go.mod
+++ b/modules/weaviate/go.mod
@@ -1,6 +1,8 @@
 module github.com/testcontainers/testcontainers-go/modules/weaviate
 
-go 1.22
+go 1.23.0
+
+toolchain go1.23.6
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/modules/yugabytedb/go.mod
+++ b/modules/yugabytedb/go.mod
@@ -1,6 +1,8 @@
 module github.com/testcontainers/testcontainers-go/modules/yugabytedb
 
-go 1.22
+go 1.23.0
+
+toolchain go1.23.6
 
 require (
 	github.com/lib/pq v1.10.9

--- a/testdata/args.Dockerfile
+++ b/testdata/args.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.13-alpine
+FROM golang:1.23-alpine@sha256:f8113c4b13e2a8b3a168dceaee88ac27743cc84e959f43b9dbd2291e9c3f57a0
 
 ARG FOO
 

--- a/testdata/echoserver.Dockerfile
+++ b/testdata/echoserver.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.13-alpine
+FROM golang:1.23-alpine@sha256:f8113c4b13e2a8b3a168dceaee88ac27743cc84e959f43b9dbd2291e9c3f57a0
 
 WORKDIR /app
 

--- a/wait/testdata/http/Dockerfile
+++ b/wait/testdata/http/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18-alpine@sha256:77f25981bd57e60a510165f3be89c901aec90453fd0f1c5a45691f6cb1528807 as builder
+FROM golang:1.23-alpine@sha256:f8113c4b13e2a8b3a168dceaee88ac27743cc84e959f43b9dbd2291e9c3f57a0 as builder
 WORKDIR /app
 COPY . .
 RUN mkdir -p dist

--- a/wait/testdata/http/go.mod
+++ b/wait/testdata/http/go.mod
@@ -1,3 +1,5 @@
 module httptest
 
-go 1.22
+go 1.23.0
+
+toolchain go1.23.6


### PR DESCRIPTION
## What does this PR do?

[Go 1.24.0](https://go.dev/blog/go1.24) has been released on since 11 February 2025

This update Go version from 1.22.0 to 1.23.0
