### PR TITLE
chore: exclude "modules/k6" from the build

### DIFF
--- a/scripts/changed-modules.sh
+++ b/scripts/changed-modules.sh
@@ -40,6 +40,18 @@ set -euxo pipefail
 #    ALL_CHANGED_FILES="go.mod a.go b.go" ./scripts/changed-modules.sh
 #    The output should be: all modules.
 #
+# 10. Several files in a build-excluded module are modified:
+#    ALL_CHANGED_FILES="modules/k6/a.go" ./scripts/changed-modules.sh
+#    The output should be: no modules.
+#
+# 11. Several files in different modules, including a build-excluded one, are modified:
+#    ALL_CHANGED_FILES="modules/k6/a.go modules/clickhouse/a.txt" ./scripts/changed-modules.sh
+#    The output should be: the modules/clickhouse module.
+#
+# 12. Several files in the core module are modified:
+#    ALL_CHANGED_FILES="go.mod a.go b.go" ./scripts/changed-modules.sh
+#    The output should be: all modules but the build-excluded ones.
+#
 # There is room for improvement in this script. For example, it could detect if the changes applied to the docs or the .github dirs, and then do not include any module in the list.
 # But then we would need to verify the CI scripts to ensure that the job receives the correct modules to build.
 
@@ -48,6 +60,9 @@ readonly ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
 
 # define an array of modules that won't be included in the list
 readonly excluded_modules=(".devcontainer" ".vscode" "docs")
+
+# define an array of modules that won't be part of the build
+readonly no_build_modules=("modules/k6")
 
 # modules is an array that will store the paths of all the modules in the repository.
 modules=()
@@ -124,4 +139,21 @@ done
 # the entire list will be enclosed in square brackets
 # the list will be sorted and unique
 sorted_unique_modules=($(echo "${modified_modules[@]}" | tr ' ' '\n' | sort -u | tr '\n' ' '))
+
+# remove modules that won't be part of the build from the list
+filtered_modules=()
+for module in "${sorted_unique_modules[@]}"; do
+    skip=false
+    for no_build_module in "${no_build_modules[@]}"; do
+        if [[ ${module} == \"${no_build_module}\" ]]; then
+            skip=true
+            break
+        fi
+    done
+    if [[ $skip == false ]]; then
+        filtered_modules+=(${module})
+    fi
+done
+sorted_unique_modules=("${filtered_modules[@]}")
+
 echo "["$(IFS=,; echo "${sorted_unique_modules[*]}" | sed 's/ /,/g')"]"


### PR DESCRIPTION

<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
This PR adds a new condition in the changed-modules script to skip modules from the build, including the `k6` module at this time.

See #2986 for more info
<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
The k6 module relies on the `szkiba/k6x` Docker image, which at the same time relies in a folder structure on the Grafana's k6-docs repository in order to download an `extensions.json` file.

The docs repository has been refactored in https://github.com/grafana/k6-docs/pull/1832, and the Docker image repository, https://github.com/grafana/k6x, has been archived.

We could mark this module as deprecated, but even for that we would need a Docker image that works, probably getting the JSON file from the Git history of the docs repo at a point before the refactor (i.e. `572cce3fb675cb936f5772a4104b59a26c1e18e3`, using the `ref` query parameter in https://docs.github.com/en/rest/repos/contents?apiVersion=2022-11-28#get-repository-content). Because this is something out of our control, we are retiring the build for the k6 module, to avoid adding noise in our own PRs, at least until a docker image is released.

It's also important to notice that any release of the k6 module is broken, because all the k6x Docker images rely on the current folder structure in the k6-docs Github repo (see https://github.com/grafana/k6x/blob/1157a4180816a68fd218bccf03234ab9fe888a65/internal/resolver/gh.go#L68), so we would need to have that Docker image updated in the code using the module, on the image value passed to the `Run` function.



<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes #2986

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
