### PR TITLE
chore(ci): run compose module tests against the upstream compose projects

### DIFF
--- a/.github/workflows/docker-moby-latest.yml
+++ b/.github/workflows/docker-moby-latest.yml
@@ -73,3 +73,63 @@ jobs:
           payload-file-path: "./payload-slack-content.json"
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_DOCKER_LATEST_WEBHOOK }}
+
+  test_latest_compose:
+    strategy:
+      matrix:
+        latest_compose_version: [true, false]
+        latest_compose-spec_version: [true, false]
+        exclude:
+          - latest_compose_version: false
+            latest_compose-spec_version: false
+
+    name: "Compose tests using a local copy of the compose and compose-spec projects"
+    runs-on: 'ubuntu-latest'
+    continue-on-error: true
+    steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Set up Go
+        uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
+        with:
+            go-version-file: 'modules/compose/go.mod'
+            cache-dependency-path: 'modules/compose/go.sum'
+        id: go
+
+      - name: Decide which make goal to use
+        run: |
+          if [ "${{ matrix.latest_compose_version }}" = "true" ] && [ "${{ matrix.latest_compose-spec_version }}" = "true" ]; then
+            echo "make_goal=compose-test-all-latest" >> $GITHUB_ENV
+          elif [ "${{ matrix.latest_compose_version }}" = "true" ] && [ "${{ matrix.latest_compose-spec_version }}" = "false" ]; then
+            echo "make_goal=compose-test-latest" >> $GITHUB_ENV
+          elif [ "${{ matrix.latest_compose_version }}" = "false" ] && [ "${{ matrix.latest_compose-spec_version }}" = "true" ]; then
+            echo "make_goal=compose-test-spec-latest" >> $GITHUB_ENV
+          fi
+
+      - name: "Run the tests"
+        timeout-minutes: 30
+        run: make ${make_goal}
+
+      - name: Create slack payload file
+        if: failure()
+        run: |
+          cat <<EOF > ./payload-slack-content.json
+          {
+              "tc_project": "testcontainers-go",
+              "compose_version": "${latest_compose_version}",
+              "compose-spec_version": "${latest_compose-spec_version}",
+              "tc_github_action_url": "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/attempts/${GITHUB_RUN_ATTEMPT}",
+              "tc_github_action_status": "FAILED",
+              "tc_slack_channel_id": "${{ secrets.SLACK_DOCKER_LATEST_CHANNEL_ID }}"
+          }
+
+      - name: Notify to Slack on failures
+        if: failure()
+        id: slack
+        uses: slackapi/slack-github-action@v2.0.0
+        with:
+          payload-templated: true
+          payload-file-path: "./payload-slack-content.json"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_COMPOSE_LATEST_WEBHOOK }}

--- a/.github/workflows/docker-projects-latest.yml
+++ b/.github/workflows/docker-projects-latest.yml
@@ -1,4 +1,4 @@
-name: Tests against Latest Docker Moby
+name: Tests against Latest Docker Projects
 
 on:
   schedule:

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ site/
 src/mkdocs-codeinclude-plugin
 src/pip-delete-this-directory.txt
 .idea/
+.build/
 .DS_Store
 
 TEST-*.xml

--- a/Makefile
+++ b/Makefile
@@ -42,3 +42,57 @@ clean-docs:
 .PHONY: serve-docs
 serve-docs: tcvenv
 	. $(PYTHONBIN)/activate; $(PYTHONBIN)/mkdocs serve
+
+## --------------------------------------
+
+# Compose tests: Make goals to test the compose module against the latest versions of the compose and compose-go repositories.
+#
+# The following goals are available:
+#
+# - compose-clean: Clean the .build directory, and clean the go.mod and go.sum files in the testcontainers-go compose module.
+# - compose-clone: Clone the compose and compose-go repositories into the .build directory.
+# - compose-replace: Replace the docker/compose/v2 dependency in the testcontainers-go compose module with the local copy.
+# - compose-spec-replace: Replace the compose-spec/compose-go/v2 dependency in the testcontainers-go compose module with the local copy.
+# - compose-tidy: Run "go mod tidy" in the testcontainers-go compose module.
+# - compose-test-all-latest: Test the testcontainers-go compose module against the latest versions of the compose and compose-go repositories.
+# - compose-test-latest: Test the testcontainers-go compose module against the latest version of the compose repository, using current version of the compose-spec repository.
+# - compose-test-spec-latest: Test the testcontainers-go compose module against the latest version of the compose-spec repository, using current version of the compose repository.
+
+.PHONY: compose-clean
+compose-clean:
+	rm -rf .build
+	cd modules/compose && git checkout -- go.mod go.sum
+
+.PHONY: compose-clone
+compose-clone: compose-clean
+	mkdir .build
+	git clone https://github.com/compose-spec/compose-go.git .build/compose-go & \
+	git clone https://github.com/docker/compose.git .build/compose
+	wait
+
+.PHONY: compose-replace
+compose-replace:
+	cd modules/compose && echo "replace github.com/docker/compose/v2 => ../../.build/compose" >> go.mod
+
+.PHONY: compose-spec-replace
+compose-spec-replace:
+	cd modules/compose && echo "replace github.com/compose-spec/compose-go/v2 => ../../.build/compose-go" >> go.mod
+
+.PHONY: compose-tidy
+compose-tidy:
+	cd modules/compose && go mod tidy
+
+# The following three goals are used in the GitHub Actions workflow to test the compose module against the latest versions of the compose and compose-spec repositories.
+# Please update the 'docker-moby-latest' workflow if you are making any changes to these goals.
+
+.PHONY: compose-test-all-latest
+compose-test-all-latest: compose-clone compose-replace compose-spec-replace compose-tidy
+	make -C modules/compose test-compose
+
+.PHONY: compose-test-latest
+compose-test-latest: compose-clone compose-replace compose-tidy
+	make -C modules/compose test-compose
+
+.PHONY: compose-test-spec-latest
+compose-test-spec-latest: compose-clone compose-spec-replace compose-tidy
+	make -C modules/compose test-compose

--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,7 @@ compose-tidy:
 	cd modules/compose && go mod tidy
 
 # The following three goals are used in the GitHub Actions workflow to test the compose module against the latest versions of the compose and compose-spec repositories.
-# Please update the 'docker-moby-latest' workflow if you are making any changes to these goals.
+# Please update the 'docker-projects-latest' workflow if you are making any changes to these goals.
 
 .PHONY: compose-test-all-latest
 compose-test-all-latest: compose-clone compose-replace compose-spec-replace compose-tidy


### PR DESCRIPTION
- **chore(compose): automate the execution of compose tests with Make**
- **chore(ci): run compose tests using upstream on a nightly basis**
- **chore: rename GHA file**

<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
This PR adds some Make goals to clone the compose and compose-spec Go packages to a git-ignored `.build` directory.

The, the different make goals will update the go.mod file of our compose module in order to replace the upstream compose packages with the local copies of them.
The automation allows to replace both, or just one of them, making it possible create a matrix with the different combinations:

| testcontainers-go compose module | docker/compose module | compose-spec/compose-go module | test it? |
|----------------------------------|-----------------------|--------------------------------|----------|
| current state | main:HEAD | main:HEAD | :white_check_mark: |
| current state | main:HEAD | current dependency | :white_check_mark: |
| current state | current dependency | main:HEAD | :white_check_mark: |
| current state | current dependency | current dependency | No, it's tested with every change in the compose module |

Finally, this automation will take place in a nightly build, and will send errors to our Slack, to be notified on errors and be ware that the upstream Compose could break our module.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
Shift left and detect changes in the upstream that could break our compose module.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->


<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->

## How to test this PR
The automation has been designed to be run by developers and by the CI in the same manner: run a Make goal. So, to test this:

1. Run testcontainers-go compose module's tests with all the upstream dependencies as latest (main:HEAD):
```shell
make compose-test-all-latest
```

2. Run testcontainers-go compose module's tests with docker/compose upstream dependency as latest, only:
```shell
make compose-test-latest
```

3. Run testcontainers-go compose module's tests with compose-spec/compose-go upstream dependency as latest, only:
```shell
make compose-test-spec-latest
```

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
