### PR TITLE
chore(ci): add an end job to verify the pipeline finished with success

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -182,8 +182,8 @@ branches:
       required_status_checks:
         # Required. Require branches to be up to date before merging.
         strict: true
-        # Required. The list of status checks to require in order to merge into this branch
-        contexts: ["test (1.24.x) / test: /1.24.x"]
+        # Required. The list of status checks to require in order to merge into this branch. Please see ci.yml for then "end" job that runs after the tests jobs.
+        contexts: ["end"]
       # Required. Enforce all configured restrictions for administrators. Set to true to enforce required status checks for repository administrators. Set to null to disable.
       enforce_admins: false
       # Prevent merge commits from being pushed to matching branches

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -182,7 +182,7 @@ branches:
       required_status_checks:
         # Required. Require branches to be up to date before merging.
         strict: true
-        # Required. The list of status checks to require in order to merge into this branch. Please see ci.yml for then "end" job that runs after the tests jobs.
+        # Required. The list of status checks to require in order to merge into this branch. Please see ci.yml for the "end" job that runs after the tests jobs.
         contexts: ["end"]
       # Required. Enforce all configured restrictions for administrators. Set to true to enforce required status checks for repository administrators. Set to null to disable.
       enforce_admins: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,6 +119,10 @@ jobs:
       - test
     runs-on: ubuntu-latest
     steps:
+      - name: Check if any jobs failed
+        if: ${{ failure() || cancelled() }}
+        run: exit 1
+
       - run: echo "All tests completed successfully!"
 
   sonarcloud:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,6 +111,16 @@ jobs:
       rootless-docker: true
       ryuk-disabled: false
 
+  # This job serves as confirmation that all test jobs finished
+  end:
+    if: ${{ needs.detect-modules.outputs.modules_count > 0 }}
+    needs:
+      - detect-modules
+      - test
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "All tests completed successfully!"
+
   sonarcloud:
     permissions:
       contents: read  # for actions/checkout to fetch code


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
It adds an end job after the tests, if and only if there are modules to be tested. Also updates the GH repo settings to use this end job as GitHub check as the only required check for merging PRs.

The end job needs the `detect-modules` and the `test` jobs in order to be run, so it will always run at the end of the pipeline. The job will check if previous jobs failed or were cancelled, failing the job in those cases. Else, it prints out a success message, finishing the job successfully, creating a passed GH check.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
After the refactor of the pipeline to run the modified modules, the GH check was not updated (on purpose). This PR allows maintainers to see if a PR satisfies the required GH checks when reviewing and eventually merging a PR.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Related Issues
<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Resolves #2968 

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
