### PR TITLE
fix(ci): exclude mkdocs.yml file and sonar.properties from the changed-modules script

### DIFF
--- a/scripts/changed-modules.sh
+++ b/scripts/changed-modules.sh
@@ -52,9 +52,9 @@ set -euxo pipefail
 #    ALL_CHANGED_FILES="go.mod a.go b.go" ./scripts/changed-modules.sh
 #    The output should be: all modules but the build-excluded ones.
 #
-# 13. A module is modified with a file that is excluded:
+# 13. A excluded module is modified with a file that is excluded:
 #    ALL_CHANGED_FILES="modules/k6/a.go mkdocs.yml" ./scripts/changed-modules.sh
-#    The output should be: the modules/k6 module.
+#    The output should be: no modules.
 #
 # 14. A excluded file and a file from the core module are modified:
 #    ALL_CHANGED_FILES="mkdocs.yml sonar-project.properties go.mod" ./scripts/changed-modules.sh

--- a/scripts/changed-modules.sh
+++ b/scripts/changed-modules.sh
@@ -52,6 +52,18 @@ set -euxo pipefail
 #    ALL_CHANGED_FILES="go.mod a.go b.go" ./scripts/changed-modules.sh
 #    The output should be: all modules but the build-excluded ones.
 #
+# 13. A module is modified with a file that is excluded:
+#    ALL_CHANGED_FILES="modules/k6/a.go mkdocs.yml" ./scripts/changed-modules.sh
+#    The output should be: the modules/k6 module.
+#
+# 14. A excluded file and a file from the core module are modified:
+#    ALL_CHANGED_FILES="mkdocs.yml sonar-project.properties go.mod" ./scripts/changed-modules.sh
+#    The output should be: all modules.
+#
+# 15. Only excluded files are modified:
+#    ALL_CHANGED_FILES="mkdocs.yml sonar-project.properties" ./scripts/changed-modules.sh
+#    The output should be: no modules.
+#
 # There is room for improvement in this script. For example, it could detect if the changes applied to the docs or the .github dirs, and then do not include any module in the list.
 # But then we would need to verify the CI scripts to ensure that the job receives the correct modules to build.
 
@@ -60,6 +72,9 @@ readonly ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
 
 # define an array of modules that won't be included in the list
 readonly excluded_modules=(".devcontainer" ".vscode" "docs")
+
+# define an array of files that won't be included in the list
+readonly excluded_files=("mkdocs.yml" "sonar-project.properties")
 
 # define an array of modules that won't be part of the build
 readonly no_build_modules=("modules/k6")
@@ -105,6 +120,15 @@ modified_modules=()
 # - if the modified files only contain files in one of the examples, include that example in the list
 # - if the modified files only contain files in the modulegen module, include only the modulegen module in the list
 for file in $modified_files; do
+    # check if the file is in one of the excluded files
+    for exclude_file in ${excluded_files[@]}; do
+        if [[ $file == $exclude_file ]]; then
+            # if the file is in the excluded files, skip the rest of the loop.
+            # Execution continues at the loop control of the 2nd enclosing loop.
+            continue 2
+        fi
+    done
+
     if [[ $file == modules/* ]]; then
         module_name=$(echo $file | cut -d'/' -f2)
         if [[ ! " ${modified_modules[@]} " =~ " ${module_name} " ]]; then


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
It adds an exclusion list of files that won't add all the modules to the changed modules list.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
A PR adding a new module, i.e. scyllaDB, will include changes in the mkdocs.yml file (for the website) and in the sonar.properties file (for sonar).

Before these changes, it would cause all modules to be added to the build, which is not desired.


<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->


<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->

## How to test this PR
Execute the script:

- A module is modified with a file that is excluded:
```shell
    ALL_CHANGED_FILES="modules/kafka/a.go mkdocs.yml" ./scripts/changed-modules.sh
    The output should be: the modules/kafka module.
```

-  A excluded file and a file from the core module are modified:
```shell
   ALL_CHANGED_FILES="mkdocs.yml sonar-project.properties go.mod" ./scripts/changed-modules.sh
    The output should be: all modules.
```

- Only excluded files are modified:
```shell
    ALL_CHANGED_FILES="mkdocs.yml sonar-project.properties" ./scripts/changed-modules.sh
    The output should be: no modules.
```
<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
