### PR TITLE
fix: pass secret to the reusable workflow

### DIFF
--- a/.github/workflows/ci-test-go.yml
+++ b/.github/workflows/ci-test-go.yml
@@ -3,10 +3,6 @@ run-name: "${{ inputs.project-directory }} ${{ inputs.go-version }} ${{ inputs.p
 
 on:
   workflow_call:
-    secrets:
-      SONAR_TOKEN:
-        required: false
-        description: "Sonar token used to connect to SonarCloud"
     inputs:
       go-version:
         required: true
@@ -100,7 +96,7 @@ jobs:
         if: always()
 
       - name: Set Sonar Cloud environment variables
-        if: ${{ secrets.SONAR_TOKEN != '' && github.ref_name == 'main' && github.repository_owner == 'testcontainers' }}
+        if: ${{ !inputs.rootless-docker && !inputs.ryuk-disabled && github.ref_name == 'main' && github.repository_owner == 'testcontainers' }}
         run: |
           echo "PROJECT_VERSION=$(grep 'latest_version' mkdocs.yml | cut -d':' -f2 | tr -d ' ')" >> $GITHUB_ENV
           if [ "${{ inputs.project-directory }}" = "." ]; then
@@ -112,7 +108,7 @@ jobs:
           fi
 
       - name: SonarQube Scan
-        if: ${{ secrets.SONAR_TOKEN != '' && github.ref_name == 'main' && github.repository_owner == 'testcontainers' }}
+        if: ${{ !inputs.rootless-docker && !inputs.ryuk-disabled && github.ref_name == 'main' && github.repository_owner == 'testcontainers' }}
         uses: SonarSource/sonarqube-scan-action@0303d6b62e310685c0e34d0b9cde218036885c4d # v5.0.0
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/ci-test-go.yml
+++ b/.github/workflows/ci-test-go.yml
@@ -3,6 +3,10 @@ run-name: "${{ inputs.project-directory }} ${{ inputs.go-version }} ${{ inputs.p
 
 on:
   workflow_call:
+    secrets:
+      SONAR_TOKEN:
+        required: false
+        description: "Sonar token used to connect to SonarCloud"
     inputs:
       go-version:
         required: true
@@ -95,9 +99,8 @@ jobs:
             paths: "**/${{ inputs.project-directory }}/TEST-unit*.xml"
         if: always()
 
-
       - name: Set Sonar Cloud environment variables
-        if: ${{ !inputs.rootless-docker && !inputs.ryuk-disabled && github.ref_name == 'main' && github.repository_owner == 'testcontainers' }}
+        if: ${{ secrets.SONAR_TOKEN != "" && github.ref_name == 'main' && github.repository_owner == 'testcontainers' }}
         run: |
           echo "PROJECT_VERSION=$(grep 'latest_version' mkdocs.yml | cut -d':' -f2 | tr -d ' ')" >> $GITHUB_ENV
           if [ "${{ inputs.project-directory }}" = "." ]; then
@@ -109,7 +112,7 @@ jobs:
           fi
 
       - name: SonarQube Scan
-        if: ${{ !inputs.rootless-docker && !inputs.ryuk-disabled && github.ref_name == 'main' && github.repository_owner == 'testcontainers' }}
+        if: ${{ secrets.SONAR_TOKEN != "" && github.ref_name == 'main' && github.repository_owner == 'testcontainers' }}
         uses: SonarSource/sonarqube-scan-action@0303d6b62e310685c0e34d0b9cde218036885c4d # v5.0.0
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/ci-test-go.yml
+++ b/.github/workflows/ci-test-go.yml
@@ -100,7 +100,7 @@ jobs:
         if: always()
 
       - name: Set Sonar Cloud environment variables
-        if: ${{ secrets.SONAR_TOKEN != "" && github.ref_name == 'main' && github.repository_owner == 'testcontainers' }}
+        if: ${{ secrets.SONAR_TOKEN != '' && github.ref_name == 'main' && github.repository_owner == 'testcontainers' }}
         run: |
           echo "PROJECT_VERSION=$(grep 'latest_version' mkdocs.yml | cut -d':' -f2 | tr -d ' ')" >> $GITHUB_ENV
           if [ "${{ inputs.project-directory }}" = "." ]; then
@@ -112,7 +112,7 @@ jobs:
           fi
 
       - name: SonarQube Scan
-        if: ${{ secrets.SONAR_TOKEN != "" && github.ref_name == 'main' && github.repository_owner == 'testcontainers' }}
+        if: ${{ secrets.SONAR_TOKEN != '' && github.ref_name == 'main' && github.repository_owner == 'testcontainers' }}
         uses: SonarSource/sonarqube-scan-action@0303d6b62e310685c0e34d0b9cde218036885c4d # v5.0.0
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,9 +73,7 @@ jobs:
       project-directory: "${{ matrix.module }}"
       rootless-docker: false
       ryuk-disabled: false
-    secrets:
-      # Only pass the SONAR_TOKEN for the modules
-      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+    secrets: inherit
 
   # The job below is a copy of the job above, but with ryuk disabled.
   # It's executed in the first stage to avoid concurrency issues.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,13 +68,14 @@ jobs:
       pull-requests: read  # for sonarsource/sonarcloud-github-action to determine which PR to decorate
     uses: ./.github/workflows/ci-test-go.yml
     with:
-      # Only pass the SONAR_TOKEN for the modules
-      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
       go-version: ${{ matrix.go-version }}
       platforms: ${{ matrix.module == 'modulegen' && '["ubuntu-latest", "macos-latest", "windows-latest"]' || '["ubuntu-latest"]' }}
       project-directory: "${{ matrix.module }}"
       rootless-docker: false
       ryuk-disabled: false
+    secrets:
+      # Only pass the SONAR_TOKEN for the modules
+      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
   # The job below is a copy of the job above, but with ryuk disabled.
   # It's executed in the first stage to avoid concurrency issues.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,8 @@ jobs:
       pull-requests: read  # for sonarsource/sonarcloud-github-action to determine which PR to decorate
     uses: ./.github/workflows/ci-test-go.yml
     with:
+      # Only pass the SONAR_TOKEN for the modules
+      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
       go-version: ${{ matrix.go-version }}
       platforms: ${{ matrix.module == 'modulegen' && '["ubuntu-latest", "macos-latest", "windows-latest"]' || '["ubuntu-latest"]' }}
       project-directory: "${{ matrix.module }}"


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
Passes the secret to the reusable workflow.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
GH actions needs to explicitly pass the secrets to reusable workflows, else the value is empty, causing the sonar step to fail, breaking the build.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Completes #3007 

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
