### PR TITLE
fix(portforward): stop port-forward from the beforeStop container hook to the afterStop

### DIFF
--- a/port_forwarding.go
+++ b/port_forwarding.go
@@ -172,7 +172,7 @@ func exposeHostPorts(ctx context.Context, req *ContainerRequest, ports ...int) (
 				return sshdContainer.exposeHostPort(ctx, req.HostAccessPorts...)
 			},
 		},
-		PreStops:      stopHooks,
+		PostStops:     stopHooks,
 		PreTerminates: stopHooks,
 	}
 


### PR DESCRIPTION
## What does this PR do?

Changes host port-forwards to be stopped after the main container is stopped.

## Why is it important?

This allows the main container's shutdown process to use the host forwarded port.
(E.g., to flush data to the host-port before shutdown).

## Related issues

Closes #3046

## How to test this PR

Used the repro that originally discovered the issue in #3046:
 - start a fluentbit container with a HTTP output sent to the host forwarded port
 - trigger shutdown, and ensure that fluentbit can flush data successfully
