### PR TITLE
feature | Adding auth to couchbase initCluster functions to support container reuse

### DIFF
--- a/modules/couchbase/couchbase.go
+++ b/modules/couchbase/couchbase.go
@@ -218,11 +218,12 @@ func (c *CouchbaseContainer) waitUntilNodeIsOnline(ctx context.Context) error {
 		WithStatusCodeMatcher(func(status int) bool {
 			return status == http.StatusOK
 		}).
+		WithBasicAuth(c.config.username, c.config.password).
 		WaitUntilReady(ctx, c)
 }
 
 func (c *CouchbaseContainer) initializeIsEnterprise(ctx context.Context) error {
-	response, err := c.doHTTPRequest(ctx, MGMT_PORT, "/pools", http.MethodGet, nil, false)
+	response, err := c.doHTTPRequest(ctx, MGMT_PORT, "/pools", http.MethodGet, nil)
 	if err != nil {
 		return err
 	}
@@ -251,7 +252,7 @@ func (c *CouchbaseContainer) renameNode(ctx context.Context) error {
 		"hostname": hostname,
 	}
 
-	_, err = c.doHTTPRequest(ctx, MGMT_PORT, "/node/controller/rename", http.MethodPost, body, false)
+	_, err = c.doHTTPRequest(ctx, MGMT_PORT, "/node/controller/rename", http.MethodPost, body)
 
 	return err
 }
@@ -260,7 +261,7 @@ func (c *CouchbaseContainer) initializeServices(ctx context.Context) error {
 	body := map[string]string{
 		"services": c.getEnabledServices(),
 	}
-	_, err := c.doHTTPRequest(ctx, MGMT_PORT, "/node/controller/setupServices", http.MethodPost, body, false)
+	_, err := c.doHTTPRequest(ctx, MGMT_PORT, "/node/controller/setupServices", http.MethodPost, body)
 
 	return err
 }
@@ -281,7 +282,7 @@ func (c *CouchbaseContainer) setMemoryQuotas(ctx context.Context) error {
 		}
 	}
 
-	_, err := c.doHTTPRequest(ctx, MGMT_PORT, "/pools/default", http.MethodPost, body, false)
+	_, err := c.doHTTPRequest(ctx, MGMT_PORT, "/pools/default", http.MethodPost, body)
 
 	return err
 }
@@ -293,7 +294,7 @@ func (c *CouchbaseContainer) configureAdminUser(ctx context.Context) error {
 		"port":     "SAME",
 	}
 
-	_, err := c.doHTTPRequest(ctx, MGMT_PORT, "/settings/web", http.MethodPost, body, false)
+	_, err := c.doHTTPRequest(ctx, MGMT_PORT, "/settings/web", http.MethodPost, body)
 
 	return err
 }
@@ -352,7 +353,7 @@ func (c *CouchbaseContainer) configureExternalPorts(ctx context.Context) error {
 		body["eventingSSL"] = eventingSSL.Port()
 	}
 
-	_, err := c.doHTTPRequest(ctx, MGMT_PORT, "/node/controller/setupAlternateAddresses/external", http.MethodPut, body, true)
+	_, err := c.doHTTPRequest(ctx, MGMT_PORT, "/node/controller/setupAlternateAddresses/external", http.MethodPut, body)
 
 	return err
 }
@@ -370,7 +371,7 @@ func (c *CouchbaseContainer) configureIndexer(ctx context.Context) error {
 		"storageMode": string(c.config.indexStorageMode),
 	}
 
-	_, err := c.doHTTPRequest(ctx, MGMT_PORT, "/settings/indexes", http.MethodPost, body, true)
+	_, err := c.doHTTPRequest(ctx, MGMT_PORT, "/settings/indexes", http.MethodPost, body)
 
 	return err
 }
@@ -473,7 +474,7 @@ func (c *CouchbaseContainer) isPrimaryIndexOnline(ctx context.Context, bucket bu
 	}
 
 	err := backoff.Retry(func() error {
-		response, err := c.doHTTPRequest(ctx, QUERY_PORT, "/query/service", http.MethodPost, body, true)
+		response, err := c.doHTTPRequest(ctx, QUERY_PORT, "/query/service", http.MethodPost, body)
 		if err != nil {
 			return err
 		}
@@ -494,7 +495,7 @@ func (c *CouchbaseContainer) createPrimaryIndex(ctx context.Context, bucket buck
 		"statement": "CREATE PRIMARY INDEX on `" + bucket.name + "`",
 	}
 	err := backoff.Retry(func() error {
-		response, err := c.doHTTPRequest(ctx, QUERY_PORT, "/query/service", http.MethodPost, body, true)
+		response, err := c.doHTTPRequest(ctx, QUERY_PORT, "/query/service", http.MethodPost, body)
 		firstError := gjson.Get(string(response), "errors.0.code").Int()
 		if firstError != 0 {
 			return errors.New("index creation failed")
@@ -510,7 +511,7 @@ func (c *CouchbaseContainer) isQueryKeyspacePresent(ctx context.Context, bucket 
 	}
 
 	err := backoff.Retry(func() error {
-		response, err := c.doHTTPRequest(ctx, QUERY_PORT, "/query/service", http.MethodPost, body, true)
+		response, err := c.doHTTPRequest(ctx, QUERY_PORT, "/query/service", http.MethodPost, body)
 		if err != nil {
 			return err
 		}
@@ -556,12 +557,12 @@ func (c *CouchbaseContainer) createBucket(ctx context.Context, bucket bucket) er
 		"replicaNumber": strconv.Itoa(bucket.numReplicas),
 	}
 
-	_, err := c.doHTTPRequest(ctx, MGMT_PORT, "/pools/default/buckets", http.MethodPost, body, true)
+	_, err := c.doHTTPRequest(ctx, MGMT_PORT, "/pools/default/buckets", http.MethodPost, body)
 
 	return err
 }
 
-func (c *CouchbaseContainer) doHTTPRequest(ctx context.Context, port, path, method string, body map[string]string, auth bool) ([]byte, error) {
+func (c *CouchbaseContainer) doHTTPRequest(ctx context.Context, port, path, method string, body map[string]string) ([]byte, error) {
 	form := url.Values{}
 	for k, v := range body {
 		form.Set(k, v)
@@ -581,10 +582,7 @@ func (c *CouchbaseContainer) doHTTPRequest(ctx context.Context, port, path, meth
 		}
 
 		request.Header.Add("Content-Type", "application/x-www-form-urlencoded")
-
-		if auth {
-			request.SetBasicAuth(c.config.username, c.config.password)
-		}
+		request.SetBasicAuth(c.config.username, c.config.password)
 
 		response, err := http.DefaultClient.Do(request)
 		if err != nil {


### PR DESCRIPTION
## What does this PR do?
This PR aims to enable a created couchbase container to be reused between test packages, and accomplishes this by passing the basic auth header with every request made to the container's management ports.

## Why is it important?
Since Go's test context creates physically separated binaries between packages, re-using a created container directly using the testcontainer's framework is impossible; so to accomplish the same thing utilizing testcontainer's framework we can configure the GenericContainer with a fixed container name. This fixed container name then allows other test packages within an application to reference the already created container minimizing resource consumption and repeated start up cost.

Currently in applications with lots of tests/slow running tests this singleton couchbase container starts up and runs just fine when tests attempt to create their own container via `Run` but once the Admin user has been enabled by the first test, all subsequent tests fail with "init cluster: context deadline exceeded" because the http requests are failing with 401.


## Follow-ups
It is likely that other implementations of testcontainers for other common images will have a similar issue when the container is reused.
