### PR TITLE
feat: allow overriding the session ID

### DIFF
--- a/container.go
+++ b/container.go
@@ -22,6 +22,7 @@ import (
 	"github.com/moby/patternmatcher/ignorefile"
 
 	tcexec "github.com/testcontainers/testcontainers-go/exec"
+	"github.com/testcontainers/testcontainers-go/internal/config"
 	"github.com/testcontainers/testcontainers-go/internal/core"
 	"github.com/testcontainers/testcontainers-go/log"
 	"github.com/testcontainers/testcontainers-go/wait"
@@ -176,7 +177,7 @@ func (c *ContainerRequest) sessionID() string {
 		return sessionID
 	}
 
-	return core.SessionID()
+	return config.Read().SessionID
 }
 
 // containerOptions functional options for a container

--- a/docker.go
+++ b/docker.go
@@ -1010,7 +1010,7 @@ func (c *DockerContainer) connectReaper(ctx context.Context) error {
 		return nil
 	}
 
-	reaper, err := spawner.reaper(context.WithValue(ctx, core.DockerHostContextKey, c.provider.host), core.SessionID(), c.provider)
+	reaper, err := spawner.reaper(context.WithValue(ctx, core.DockerHostContextKey, c.provider.host), c.provider.config.SessionID, c.provider)
 	if err != nil {
 		return fmt.Errorf("reaper: %w", err)
 	}

--- a/docker_client.go
+++ b/docker_client.go
@@ -9,7 +9,9 @@ import (
 	"github.com/moby/moby/client"
 
 	"github.com/testcontainers/testcontainers-go/internal"
+	"github.com/testcontainers/testcontainers-go/internal/config"
 	"github.com/testcontainers/testcontainers-go/internal/core"
+	"github.com/testcontainers/testcontainers-go/internal/core/bootstrap"
 	"github.com/testcontainers/testcontainers-go/log"
 )
 
@@ -17,6 +19,8 @@ import (
 // It implements the SystemAPIClient interface in order to cache the docker info and reuse it.
 type DockerClient struct {
 	*client.Client // client is embedded into our own client
+
+	config config.Config
 }
 
 var (
@@ -85,8 +89,8 @@ func (c *DockerClient) Info(ctx context.Context, options client.InfoOptions) (cl
 		internal.Version,
 		host,
 		core.MustExtractDockerSocket(ctx),
-		core.SessionID(),
-		core.ProcessID(),
+		c.config.SessionID,
+		bootstrap.ProcessID(),
 	)
 
 	return dockerInfo, nil
@@ -123,8 +127,11 @@ func NewDockerClientWithOpts(ctx context.Context, opt ...client.Opt) (*DockerCli
 		return nil, err
 	}
 
+	tcConfig := config.Read()
+
 	tcClient := DockerClient{
 		Client: dockerClient,
+		config: tcConfig,
 	}
 
 	if _, err = tcClient.Info(ctx, client.InfoOptions{}); err != nil {

--- a/docker_client.go
+++ b/docker_client.go
@@ -127,11 +127,9 @@ func NewDockerClientWithOpts(ctx context.Context, opt ...client.Opt) (*DockerCli
 		return nil, err
 	}
 
-	tcConfig := config.Read()
-
 	tcClient := DockerClient{
 		Client: dockerClient,
-		config: tcConfig,
+		config: config.Read(),
 	}
 
 	if _, err = tcClient.Info(ctx, client.InfoOptions{}); err != nil {

--- a/generic.go
+++ b/generic.go
@@ -7,6 +7,7 @@ import (
 	"maps"
 	"sync"
 
+	"github.com/testcontainers/testcontainers-go/internal/config"
 	"github.com/testcontainers/testcontainers-go/internal/core"
 	"github.com/testcontainers/testcontainers-go/log"
 )
@@ -100,7 +101,7 @@ type GenericProvider interface {
 // reaper is enabled, otherwise this is excluded to prevent resources being
 // incorrectly reaped.
 func GenericLabels() map[string]string {
-	return core.DefaultLabels(core.SessionID())
+	return core.DefaultLabels(config.Read().SessionID)
 }
 
 // AddGenericLabels adds the generic labels to target.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -52,6 +52,13 @@ type Config struct {
 	// Environment variable: TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX
 	HubImageNamePrefix string `properties:"hub.image.name.prefix,default="`
 
+	// SessionID is the ID of the testing session.
+	// Setting this value will preclude runs from creating more than one reaper. Therefore,
+	// changes to ryuk settings past its creation will be ignored.
+	//
+	// Environment variable: TESTCONTAINERS_SESSION_ID
+	SessionID string `properties:"session.id,default="`
+
 	// RyukDisabled is a flag to enable or disable the Garbage Collector.
 	// Setting this to true will prevent testcontainers from automatically cleaning up
 	// resources, which is particularly important in tests which timeout as they
@@ -119,6 +126,11 @@ func read() Config {
 		hubImageNamePrefix := os.Getenv("TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX")
 		if hubImageNamePrefix != "" {
 			config.HubImageNamePrefix = hubImageNamePrefix
+		}
+
+		sessionID := os.Getenv("TESTCONTAINERS_SESSION_ID")
+		if sessionID != "" {
+			config.SessionID = sessionID
 		}
 
 		ryukPrivilegedEnv := os.Getenv("TESTCONTAINERS_RYUK_CONTAINER_PRIVILEGED")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/magiconair/properties"
+
 	"github.com/testcontainers/testcontainers-go/internal/core/bootstrap"
 )
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/magiconair/properties"
+	"github.com/testcontainers/testcontainers-go/internal/core/bootstrap"
 )
 
 const ReaperDefaultImage = "testcontainers/ryuk:0.14.0"
@@ -131,6 +132,8 @@ func read() Config {
 		sessionID := os.Getenv("TESTCONTAINERS_SESSION_ID")
 		if sessionID != "" {
 			config.SessionID = sessionID
+		} else if config.SessionID == "" {
+			config.SessionID = bootstrap.SessionID()
 		}
 
 		ryukPrivilegedEnv := os.Getenv("TESTCONTAINERS_RYUK_CONTAINER_PRIVILEGED")

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -569,7 +569,7 @@ func TestReadTCConfig(t *testing.T) {
 				},
 			},
 			{
-				"With Ryuk disabled using an env var and properties. Env var wins",
+				"With Session ID set using an env var and properties. Env var wins",
 				`session.id=bar`,
 				map[string]string{
 					"TESTCONTAINERS_SESSION_ID": "foo",

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"github.com/testcontainers/testcontainers-go/internal/core/bootstrap"
 )
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go/internal/core/bootstrap"
 )
 
 const (
@@ -43,6 +44,7 @@ func TestReadConfig(t *testing.T) {
 		config := Read()
 
 		expected := Config{
+			SessionID:    bootstrap.SessionID(),
 			RyukDisabled: true,
 			Host:         "", // docker socket is empty at the properties file
 		}
@@ -67,7 +69,9 @@ func TestReadTCConfig(t *testing.T) {
 
 		config := read()
 
-		expected := Config{}
+		expected := Config{
+			SessionID: bootstrap.SessionID(),
+		}
 
 		assert.Equal(t, expected, config)
 	})
@@ -104,7 +108,9 @@ func TestReadTCConfig(t *testing.T) {
 
 		config := read()
 
-		expected := Config{}
+		expected := Config{
+			SessionID: bootstrap.SessionID(),
+		}
 
 		assert.Equal(t, expected, config)
 	})
@@ -116,7 +122,10 @@ func TestReadTCConfig(t *testing.T) {
 		t.Setenv("DOCKER_HOST", tcpDockerHost33293)
 
 		config := read()
-		expected := Config{} // the config does not read DOCKER_HOST, that's why it's empty
+		expected := Config{
+			Host:      "", // the config does not read env var `DOCKER_HOST`, that's why `Host` it's empty
+			SessionID: bootstrap.SessionID(),
+		}
 
 		assert.Equal(t, expected, config)
 	})
@@ -151,6 +160,7 @@ func TestReadTCConfig(t *testing.T) {
 		defaultRyukConnectionTimeout := 60 * time.Second
 		defaultRyukReconnectionTimeout := 10 * time.Second
 		defaultConfig := Config{
+			SessionID:               bootstrap.SessionID(),
 			RyukConnectionTimeout:   defaultRyukConnectionTimeout,
 			RyukReconnectionTimeout: defaultRyukReconnectionTimeout,
 		}
@@ -166,6 +176,7 @@ func TestReadTCConfig(t *testing.T) {
 				"docker.host = " + tcpDockerHost33293,
 				map[string]string{},
 				Config{
+					SessionID:               bootstrap.SessionID(),
 					Host:                    tcpDockerHost33293,
 					RyukConnectionTimeout:   defaultRyukConnectionTimeout,
 					RyukReconnectionTimeout: defaultRyukReconnectionTimeout,
@@ -178,6 +189,7 @@ func TestReadTCConfig(t *testing.T) {
 	`,
 				map[string]string{},
 				Config{
+					SessionID:               bootstrap.SessionID(),
 					Host:                    tcpDockerHost4711,
 					RyukConnectionTimeout:   defaultRyukConnectionTimeout,
 					RyukReconnectionTimeout: defaultRyukReconnectionTimeout,
@@ -192,6 +204,7 @@ func TestReadTCConfig(t *testing.T) {
 	`,
 				map[string]string{},
 				Config{
+					SessionID:               bootstrap.SessionID(),
 					Host:                    tcpDockerHost1234,
 					TLSVerify:               1,
 					RyukConnectionTimeout:   defaultRyukConnectionTimeout,
@@ -203,6 +216,7 @@ func TestReadTCConfig(t *testing.T) {
 				"",
 				map[string]string{},
 				Config{
+					SessionID:               bootstrap.SessionID(),
 					RyukConnectionTimeout:   defaultRyukConnectionTimeout,
 					RyukReconnectionTimeout: defaultRyukReconnectionTimeout,
 				},
@@ -214,6 +228,7 @@ func TestReadTCConfig(t *testing.T) {
 			`,
 				map[string]string{},
 				Config{
+					SessionID:               bootstrap.SessionID(),
 					Host:                    tcpDockerHost1234,
 					RyukConnectionTimeout:   defaultRyukConnectionTimeout,
 					RyukReconnectionTimeout: defaultRyukReconnectionTimeout,
@@ -224,6 +239,7 @@ func TestReadTCConfig(t *testing.T) {
 				"docker.host=" + tcpDockerHost33293,
 				map[string]string{},
 				Config{
+					SessionID:               bootstrap.SessionID(),
 					Host:                    tcpDockerHost33293,
 					RyukConnectionTimeout:   defaultRyukConnectionTimeout,
 					RyukReconnectionTimeout: defaultRyukReconnectionTimeout,
@@ -243,6 +259,7 @@ func TestReadTCConfig(t *testing.T) {
 	docker.cert.path=/tmp/certs`,
 				map[string]string{},
 				Config{
+					SessionID:               bootstrap.SessionID(),
 					Host:                    tcpDockerHost1234,
 					CertPath:                "/tmp/certs",
 					RyukConnectionTimeout:   defaultRyukConnectionTimeout,
@@ -254,6 +271,7 @@ func TestReadTCConfig(t *testing.T) {
 				`ryuk.disabled=true`,
 				map[string]string{},
 				Config{
+					SessionID:               bootstrap.SessionID(),
 					RyukDisabled:            true,
 					RyukConnectionTimeout:   defaultRyukConnectionTimeout,
 					RyukReconnectionTimeout: defaultRyukReconnectionTimeout,
@@ -264,6 +282,7 @@ func TestReadTCConfig(t *testing.T) {
 				`ryuk.container.privileged=true`,
 				map[string]string{},
 				Config{
+					SessionID:               bootstrap.SessionID(),
 					RyukPrivileged:          true,
 					RyukConnectionTimeout:   defaultRyukConnectionTimeout,
 					RyukReconnectionTimeout: defaultRyukReconnectionTimeout,
@@ -275,6 +294,7 @@ func TestReadTCConfig(t *testing.T) {
 	ryuk.reconnection.timeout=13s`,
 				map[string]string{},
 				Config{
+					SessionID:               bootstrap.SessionID(),
 					RyukReconnectionTimeout: 13 * time.Second,
 					RyukConnectionTimeout:   12 * time.Second,
 				},
@@ -287,6 +307,7 @@ func TestReadTCConfig(t *testing.T) {
 					"RYUK_CONNECTION_TIMEOUT":   "12s",
 				},
 				Config{
+					SessionID:               bootstrap.SessionID(),
 					RyukReconnectionTimeout: 13 * time.Second,
 					RyukConnectionTimeout:   12 * time.Second,
 				},
@@ -300,6 +321,7 @@ func TestReadTCConfig(t *testing.T) {
 					"RYUK_CONNECTION_TIMEOUT":   "12s",
 				},
 				Config{
+					SessionID:               bootstrap.SessionID(),
 					RyukReconnectionTimeout: 13 * time.Second,
 					RyukConnectionTimeout:   12 * time.Second,
 				},
@@ -309,6 +331,7 @@ func TestReadTCConfig(t *testing.T) {
 				`ryuk.verbose=true`,
 				map[string]string{},
 				Config{
+					SessionID:               bootstrap.SessionID(),
 					RyukVerbose:             true,
 					RyukConnectionTimeout:   defaultRyukConnectionTimeout,
 					RyukReconnectionTimeout: defaultRyukReconnectionTimeout,
@@ -321,6 +344,7 @@ func TestReadTCConfig(t *testing.T) {
 					"TESTCONTAINERS_RYUK_DISABLED": "true",
 				},
 				Config{
+					SessionID:               bootstrap.SessionID(),
 					RyukDisabled:            true,
 					RyukConnectionTimeout:   defaultRyukConnectionTimeout,
 					RyukReconnectionTimeout: defaultRyukReconnectionTimeout,
@@ -333,6 +357,7 @@ func TestReadTCConfig(t *testing.T) {
 					"TESTCONTAINERS_RYUK_CONTAINER_PRIVILEGED": "true",
 				},
 				Config{
+					SessionID:               bootstrap.SessionID(),
 					RyukPrivileged:          true,
 					RyukConnectionTimeout:   defaultRyukConnectionTimeout,
 					RyukReconnectionTimeout: defaultRyukReconnectionTimeout,
@@ -345,6 +370,7 @@ func TestReadTCConfig(t *testing.T) {
 					"TESTCONTAINERS_RYUK_DISABLED": "true",
 				},
 				Config{
+					SessionID:               bootstrap.SessionID(),
 					RyukDisabled:            true,
 					RyukConnectionTimeout:   defaultRyukConnectionTimeout,
 					RyukReconnectionTimeout: defaultRyukReconnectionTimeout,
@@ -357,6 +383,7 @@ func TestReadTCConfig(t *testing.T) {
 					"TESTCONTAINERS_RYUK_DISABLED": "true",
 				},
 				Config{
+					SessionID:               bootstrap.SessionID(),
 					RyukDisabled:            true,
 					RyukConnectionTimeout:   defaultRyukConnectionTimeout,
 					RyukReconnectionTimeout: defaultRyukReconnectionTimeout,
@@ -385,6 +412,7 @@ func TestReadTCConfig(t *testing.T) {
 					"RYUK_VERBOSE": "true",
 				},
 				Config{
+					SessionID:               bootstrap.SessionID(),
 					RyukVerbose:             true,
 					RyukConnectionTimeout:   defaultRyukConnectionTimeout,
 					RyukReconnectionTimeout: defaultRyukReconnectionTimeout,
@@ -397,6 +425,7 @@ func TestReadTCConfig(t *testing.T) {
 					"RYUK_VERBOSE": "true",
 				},
 				Config{
+					SessionID:               bootstrap.SessionID(),
 					RyukVerbose:             true,
 					RyukConnectionTimeout:   defaultRyukConnectionTimeout,
 					RyukReconnectionTimeout: defaultRyukReconnectionTimeout,
@@ -425,6 +454,7 @@ func TestReadTCConfig(t *testing.T) {
 					"TESTCONTAINERS_RYUK_CONTAINER_PRIVILEGED": "true",
 				},
 				Config{
+					SessionID:               bootstrap.SessionID(),
 					RyukPrivileged:          true,
 					RyukConnectionTimeout:   defaultRyukConnectionTimeout,
 					RyukReconnectionTimeout: defaultRyukReconnectionTimeout,
@@ -437,6 +467,7 @@ func TestReadTCConfig(t *testing.T) {
 					"TESTCONTAINERS_RYUK_CONTAINER_PRIVILEGED": "true",
 				},
 				Config{
+					SessionID:               bootstrap.SessionID(),
 					RyukPrivileged:          true,
 					RyukConnectionTimeout:   defaultRyukConnectionTimeout,
 					RyukReconnectionTimeout: defaultRyukReconnectionTimeout,
@@ -467,6 +498,7 @@ func TestReadTCConfig(t *testing.T) {
 					"TESTCONTAINERS_RYUK_CONTAINER_PRIVILEGED": "true",
 				},
 				Config{
+					SessionID:      bootstrap.SessionID(),
 					RyukDisabled:   true,
 					RyukPrivileged: true,
 				},
@@ -492,6 +524,7 @@ func TestReadTCConfig(t *testing.T) {
 				`hub.image.name.prefix=` + defaultHubPrefix + `/props/`,
 				map[string]string{},
 				Config{
+					SessionID:               bootstrap.SessionID(),
 					HubImageNamePrefix:      defaultHubPrefix + "/props/",
 					RyukConnectionTimeout:   defaultRyukConnectionTimeout,
 					RyukReconnectionTimeout: defaultRyukReconnectionTimeout,
@@ -504,6 +537,7 @@ func TestReadTCConfig(t *testing.T) {
 					"TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX": defaultHubPrefix + "/env/",
 				},
 				Config{
+					SessionID:               bootstrap.SessionID(),
 					HubImageNamePrefix:      defaultHubPrefix + "/env/",
 					RyukConnectionTimeout:   defaultRyukConnectionTimeout,
 					RyukReconnectionTimeout: defaultRyukReconnectionTimeout,
@@ -516,7 +550,31 @@ func TestReadTCConfig(t *testing.T) {
 					"TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX": defaultHubPrefix + "/env/",
 				},
 				Config{
+					SessionID:               bootstrap.SessionID(),
 					HubImageNamePrefix:      defaultHubPrefix + "/env/",
+					RyukConnectionTimeout:   defaultRyukConnectionTimeout,
+					RyukReconnectionTimeout: defaultRyukReconnectionTimeout,
+				},
+			},
+			//
+			{
+				"With Session ID set as a property",
+				`session.id=foo`,
+				map[string]string{},
+				Config{
+					SessionID:               "foo",
+					RyukConnectionTimeout:   defaultRyukConnectionTimeout,
+					RyukReconnectionTimeout: defaultRyukReconnectionTimeout,
+				},
+			},
+			{
+				"With Ryuk disabled using an env var and properties. Env var wins",
+				`session.id=bar`,
+				map[string]string{
+					"TESTCONTAINERS_SESSION_ID": "foo",
+				},
+				Config{
+					SessionID:               "foo",
 					RyukConnectionTimeout:   defaultRyukConnectionTimeout,
 					RyukReconnectionTimeout: defaultRyukReconnectionTimeout,
 				},

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -21,6 +21,7 @@ const (
 func resetTestEnv(t *testing.T) {
 	t.Helper()
 	t.Setenv("TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX", "")
+	t.Setenv("TESTCONTAINERS_SESSION_ID", "")
 	t.Setenv("TESTCONTAINERS_RYUK_DISABLED", "")
 	t.Setenv("TESTCONTAINERS_RYUK_CONTAINER_PRIVILEGED", "")
 	t.Setenv("RYUK_VERBOSE", "")
@@ -76,6 +77,7 @@ func TestReadTCConfig(t *testing.T) {
 		t.Setenv("USERPROFILE", "") // Windows support
 		t.Setenv("TESTCONTAINERS_RYUK_DISABLED", "true")
 		t.Setenv("TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX", defaultHubPrefix)
+		t.Setenv("TESTCONTAINERS_SESSION_ID", "foo")
 		t.Setenv("TESTCONTAINERS_RYUK_CONTAINER_PRIVILEGED", "true")
 		t.Setenv("RYUK_RECONNECTION_TIMEOUT", "13s")
 		t.Setenv("RYUK_CONNECTION_TIMEOUT", "12s")
@@ -84,6 +86,7 @@ func TestReadTCConfig(t *testing.T) {
 
 		expected := Config{
 			HubImageNamePrefix:      defaultHubPrefix,
+			SessionID:               "foo",
 			RyukDisabled:            true,
 			RyukPrivileged:          true,
 			Host:                    "", // docker socket is empty at the properties file
@@ -124,6 +127,7 @@ func TestReadTCConfig(t *testing.T) {
 		t.Setenv("USERPROFILE", tmpDir) // Windows support
 		t.Setenv("TESTCONTAINERS_RYUK_DISABLED", "true")
 		t.Setenv("TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX", defaultHubPrefix)
+		t.Setenv("TESTCONTAINERS_SESSION_ID", "foo")
 		t.Setenv("TESTCONTAINERS_RYUK_CONTAINER_PRIVILEGED", "true")
 		t.Setenv("RYUK_VERBOSE", "true")
 		t.Setenv("RYUK_RECONNECTION_TIMEOUT", "13s")
@@ -132,6 +136,7 @@ func TestReadTCConfig(t *testing.T) {
 		config := read()
 		expected := Config{
 			HubImageNamePrefix:      defaultHubPrefix,
+			SessionID:               "foo",
 			RyukDisabled:            true,
 			RyukPrivileged:          true,
 			RyukVerbose:             true,

--- a/internal/core/bootstrap.go
+++ b/internal/core/bootstrap.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/shirou/gopsutil/v4/process"
+
 	"github.com/testcontainers/testcontainers-go/internal/config"
 )
 

--- a/internal/core/bootstrap/bootstrap.go
+++ b/internal/core/bootstrap/bootstrap.go
@@ -1,4 +1,4 @@
-package core
+package bootstrap
 
 import (
 	"crypto/sha256"
@@ -8,8 +8,6 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/shirou/gopsutil/v4/process"
-
-	"github.com/testcontainers/testcontainers-go/internal/config"
 )
 
 // sessionID returns a unique session ID for the current test session. Because each Go package
@@ -47,11 +45,6 @@ var processID string
 const sessionIDPlaceholder = "testcontainers-go:%d:%d"
 
 func init() {
-	cfg := config.Read()
-	if cfg.SessionID != "" {
-		sessionID = cfg.SessionID
-	}
-
 	processID = uuid.New().String()
 
 	parentPid := os.Getppid()
@@ -64,9 +57,7 @@ func init() {
 
 	processes, err := process.Processes()
 	if err != nil {
-		if sessionID == "" {
-			sessionID = uuid.New().String()
-		}
+		sessionID = uuid.New().String()
 		projectPath = fallbackCwd
 		return
 	}
@@ -84,9 +75,7 @@ func init() {
 
 		t, err := p.CreateTime()
 		if err != nil {
-			if sessionID == "" {
-				sessionID = uuid.New().String()
-			}
+			sessionID = uuid.New().String()
 			return
 		}
 
@@ -94,16 +83,14 @@ func init() {
 		break
 	}
 
-	if sessionID == "" {
-		hasher := sha256.New()
-		_, err = fmt.Fprintf(hasher, sessionIDPlaceholder, parentPid, createTime)
-		if err != nil {
-			sessionID = uuid.New().String()
-			return
-		}
-
-		sessionID = hex.EncodeToString(hasher.Sum(nil))
+	hasher := sha256.New()
+	_, err = fmt.Fprintf(hasher, sessionIDPlaceholder, parentPid, createTime)
+	if err != nil {
+		sessionID = uuid.New().String()
+		return
 	}
+
+	sessionID = hex.EncodeToString(hasher.Sum(nil))
 }
 
 func ProcessID() string {

--- a/internal/core/client.go
+++ b/internal/core/client.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/testcontainers/testcontainers-go/internal"
 	"github.com/testcontainers/testcontainers-go/internal/config"
+	"github.com/testcontainers/testcontainers-go/internal/core/bootstrap"
 )
 
 // NewClient returns a new docker client extracting the docker host from the different alternatives
@@ -35,8 +36,8 @@ func NewClient(ctx context.Context, ops ...client.Opt) (*client.Client, error) {
 
 	opts = append(opts, client.WithHTTPHeaders(
 		map[string]string{
-			"x-tc-pp":    ProjectPath(),
-			"x-tc-sid":   SessionID(),
+			"x-tc-pp":    bootstrap.ProjectPath(),
+			"x-tc-sid":   tcConfig.SessionID,
 			"User-Agent": "tc-go/" + internal.Version,
 		}),
 	)

--- a/network.go
+++ b/network.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/moby/moby/api/types/network"
 
+	"github.com/testcontainers/testcontainers-go/internal/config"
 	"github.com/testcontainers/testcontainers-go/internal/core"
 )
 
@@ -56,5 +57,5 @@ func (r NetworkRequest) sessionID() string {
 		return sessionID
 	}
 
-	return core.SessionID()
+	return config.Read().SessionID
 }

--- a/reaper_test.go
+++ b/reaper_test.go
@@ -119,7 +119,7 @@ func testReaperRunning(t *testing.T) {
 	t.Helper()
 
 	ctx := context.Background()
-	sessionID := core.SessionID()
+	sessionID := config.Read().SessionID
 	reaperContainer, err := spawner.lookupContainer(ctx, sessionID)
 	require.NoError(t, err)
 	require.NotNil(t, reaperContainer)

--- a/testcontainers.go
+++ b/testcontainers.go
@@ -3,6 +3,7 @@ package testcontainers
 import (
 	"context"
 
+	"github.com/testcontainers/testcontainers-go/internal/config"
 	"github.com/testcontainers/testcontainers-go/internal/core"
 )
 
@@ -50,5 +51,5 @@ func MustExtractDockerSocket(ctx context.Context) string {
 //   - identify the test session, aggregating the test execution of multiple packages in the same test session.
 //   - tag the containers created by testcontainers-go, adding a label to the container with the session ID.
 func SessionID() string {
-	return core.SessionID()
+	return config.Read().SessionID
 }


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
Makes the session ID configurable, allowing for long-running sessions.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
Speaking of my use-case, Apache Pulsar takes a long time to boot, so I wanted testcontainers to boot it up, eventually take it down, but allow me to use the same container across several runs. This wasn't the case, since I was getting a new reaper running on every test run. I wanted a rolling-window behavior, hence this change.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes #2804

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Follow-ups

Update the documentation.
