### PR TITLE
feat: Add `WithReuse` and `WithContainerName` for modifying Generic Container Requests

### DIFF
--- a/options.go
+++ b/options.go
@@ -96,6 +96,25 @@ func WithHostPortAccess(ports ...int) CustomizeRequestOption {
 	}
 }
 
+// WithReuse will mark a container to be reused if it exists or create a new one if it doesn't.
+// It is used in conjunction with WithContainerName to ensure that the container is reused.
+func WithReuse() CustomizeRequestOption {
+	return func(req *GenericContainerRequest) error {
+		req.Reuse = true
+		return nil
+	}
+}
+
+// WithContainerName sets the name for the container request.
+func WithContainerName(name string) CustomizeRequestOption {
+	return func(req *GenericContainerRequest) error {
+		if name != "" {
+			req.Name = name
+		}
+		return nil
+	}
+}
+
 // Deprecated: the modules API forces passing the image as part of the signature of the Run function.
 // WithImage sets the image for a container
 func WithImage(image string) CustomizeRequestOption {

--- a/options_test.go
+++ b/options_test.go
@@ -238,3 +238,17 @@ func TestWithHostPortAccess(t *testing.T) {
 		})
 	}
 }
+
+func TestWithReuse(t *testing.T) {
+	req := &testcontainers.GenericContainerRequest{}
+	opt := testcontainers.WithReuse()
+	require.NoError(t, opt.Customize(req))
+	require.True(t, req.Reuse)
+}
+
+func TestWithName(t *testing.T) {
+	req := &testcontainers.GenericContainerRequest{}
+	opt := testcontainers.WithContainerName("cname")
+	require.NoError(t, opt.Customize(req))
+	require.Equal(t, "cname", req.Name)
+}


### PR DESCRIPTION
## What does this PR do?

This adds two functional options `WithReuse` and `WithContainerName`

## Why is it important?

When creating a `GenericContainerRequest` you can easily set these fields, but when using something like the `postgres.Run` function you cannot set these fields.

## Related issues

Closes #2726 


## How to test this PR

- Run the tests
- You can use the following gist: https://gist.github.com/jm96441n/74b6fa9b621cdd0c8d6548a6d2abd6d0
    - Clone down the gist
    - run `go mod tidy`
    - in one terminal window run `watch -n 1 docker ps`
    - in one terminal window run `go test ./...`, the test will sleep for 10 seconds to see the container is reused)
    - in the terminal running the `watch` command see only one container `pg-test` come up and then go away when ryuk cleans it up (alternatively you can just run `docker ps` repeatedly to see)
