### PR TITLE
fix(dind): use docker image load

### DIFF
--- a/modules/dind/dind.go
+++ b/modules/dind/dind.go
@@ -91,7 +91,7 @@ func (c *Container) LoadImage(ctx context.Context, image string) (err error) {
 		err = errors.Join(err, os.Remove(imagesTar.Name()))
 	}()
 
-	if err = provider.SaveImages(context.Background(), imagesTar.Name(), image); err != nil {
+	if err = provider.SaveImages(ctx, imagesTar.Name(), image); err != nil {
 		return fmt.Errorf("save images: %w", err)
 	}
 
@@ -100,7 +100,7 @@ func (c *Container) LoadImage(ctx context.Context, image string) (err error) {
 		return fmt.Errorf("copy image to container: %w", err)
 	}
 
-	if _, _, err = c.Container.Exec(ctx, []string{"docker", "image", "import", containerPath, image}); err != nil {
+	if _, _, err = c.Container.Exec(ctx, []string{"docker", "image", "load", "-i", containerPath}); err != nil {
 		return fmt.Errorf("import image: %w", err)
 	}
 

--- a/modules/dind/dind_test.go
+++ b/modules/dind/dind_test.go
@@ -32,7 +32,7 @@ func Test_LoadImages(t *testing.T) {
 	require.NoError(t, err)
 
 	// ensure nginx image is available locally
-	err = provider.PullImage(ctx, "nginx")
+	err = provider.PullImage(ctx, "nginx:1.27")
 	require.NoError(t, err)
 
 	t.Run("not-available", func(t *testing.T) {

--- a/modules/dind/dind_test.go
+++ b/modules/dind/dind_test.go
@@ -2,7 +2,6 @@ package dind_test
 
 import (
 	"context"
-	"slices"
 	"testing"
 	"time"
 
@@ -42,16 +41,21 @@ func Test_LoadImages(t *testing.T) {
 	})
 
 	t.Run("success", func(t *testing.T) {
-		err := dindContainer.LoadImage(ctx, "nginx")
+		err := dindContainer.LoadImage(ctx, "nginx:1.27")
 		require.NoError(t, err)
 
 		images, err := cli.ImageList(ctx, image.ListOptions{})
 		require.NoError(t, err)
 
-		found := slices.ContainsFunc(images, func(img image.Summary) bool {
-			return len(img.RepoTags) > 0 && img.RepoTags[0] == "nginx:latest"
-		})
+		if len(images) == 0 || len(images) > 1 {
+			t.Fatalf("got %d images, expected 1", len(images))
+		}
 
-		require.True(t, found)
+		img, err := cli.ImageInspect(ctx, images[0].ID)
+		require.NoError(t, err)
+
+		require.Equal(t, "nginx:1.27", img.RepoTags[0])
+		require.Equal(t, []string{"/docker-entrypoint.sh"}, []string(img.Config.Entrypoint))
+		require.Equal(t, []string{"nginx", "-g", "daemon off;"}, []string(img.Config.Cmd))
 	})
 }


### PR DESCRIPTION
Loading images with docker image import does not preserve metatdata such as entrypoint, cmd, labels and tags. This makes the loaded image unusable as is.

This replaces the command with docker image load which fully preserves the metadata.

## How to test this PR

Using the previous implementation will have the new test fail because the entrypoint and cmd are not preserved.