### PR TITLE
fix(mssql): reduce flakiness in tests

### DIFF
--- a/modules/mssql/Makefile
+++ b/modules/mssql/Makefile
@@ -1,5 +1,7 @@
 include ../../commons-test.mk
 
+export GODEBUG=x509negativeserial=1
+
 .PHONY: test
 test:
 	$(MAKE) test-mssql

--- a/modules/mssql/Makefile
+++ b/modules/mssql/Makefile
@@ -1,5 +1,9 @@
 include ../../commons-test.mk
 
+# Enforce x509negativeserial=1. This is required in case the tests
+# use certificates with negative serial numbers.
+# Go 1.23+ rejects these certificates without this flag.
+# Cf https://pkg.go.dev/crypto/x509#ParseCertificate
 export GODEBUG=x509negativeserial=1
 
 .PHONY: test


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
It adds a Go env var to the shell the tests are run in order to mitigate the recent flakiness we are seeing when parsing the TLS certs in the MSSQL server container:

> TLS Handshake failed: tls: failed to parse certificate from server: x509: negative serial number

The PR is setting the env var in the Makefile for MSSQL.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
Reduce flakiness

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Related to https://github.com/golang/go/issues/71606
- Related to https://github.com/influxdata/telegraf/issues/16309

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
