### PR TITLE
feat(postgres): add WithOrderedInitScripts for Postgres testcontainers

### DIFF
--- a/modules/postgres/postgres.go
+++ b/modules/postgres/postgres.go
@@ -95,13 +95,12 @@ func WithDatabase(dbName string) testcontainers.CustomizeRequestOption {
 }
 
 // WithInitScripts sets the init scripts to be run when the container starts.
-// These init scripts will be executed in sorted name order as defined by the current locale, which defaults to en_US.utf8.
+// These init scripts will be executed in sorted name order as defined by the container's current locale, which defaults to en_US.utf8.
 // If you need to run your scripts in a specific order, consider using `WithOrderedInitScripts` instead.
 func WithInitScripts(scripts ...string) testcontainers.CustomizeRequestOption {
 	return func(req *testcontainers.GenericContainerRequest) error {
 		for _, script := range scripts {
-			filename := filepath.Base(script)
-			appendInitScript(req, script, filename)
+			appendInitScript(req, script, filepath.Base(script))
 		}
 		return nil
 	}
@@ -112,8 +111,7 @@ func WithInitScripts(scripts ...string) testcontainers.CustomizeRequestOption {
 func WithOrderedInitScripts(scripts ...string) testcontainers.CustomizeRequestOption {
 	return func(req *testcontainers.GenericContainerRequest) error {
 		for idx, script := range scripts {
-			filename := filepath.Base(script)
-			containerFilePath := fmt.Sprintf("%06d-%s", idx, filename)
+			containerFilePath := fmt.Sprintf("%03d-%s", idx, filepath.Base(script))
 			appendInitScript(req, script, containerFilePath)
 		}
 		return nil

--- a/modules/postgres/postgres_test.go
+++ b/modules/postgres/postgres_test.go
@@ -5,8 +5,10 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -19,6 +21,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/testcontainers/testcontainers-go"
+	tcexec "github.com/testcontainers/testcontainers-go/exec"
 	"github.com/testcontainers/testcontainers-go/modules/postgres"
 	"github.com/testcontainers/testcontainers-go/wait"
 )
@@ -286,6 +289,59 @@ func TestWithInitScript(t *testing.T) {
 	result, err := db.Exec("SELECT * FROM testdb;")
 	require.NoError(t, err)
 	require.NotNil(t, result)
+}
+
+func TestWithOrderedInitScript(t *testing.T) {
+	ctx := context.Background()
+
+	ctr, err := postgres.Run(ctx,
+		"postgres:15.2-alpine",
+		// Executes first the init-user-db shell-script, then the do-insert-user SQL script
+		// Using WithInitScripts, this would not work as
+		postgres.WithOrderedInitScripts(
+			filepath.Join("testdata", "init-user-db.sh"),
+			filepath.Join("testdata", "aaaa-insert-user.sql"),
+		),
+		postgres.WithDatabase(dbname),
+		postgres.WithUsername(user),
+		postgres.WithPassword(password),
+		postgres.BasicWaitStrategies(),
+	)
+	testcontainers.CleanupContainer(t, ctr)
+	require.NoError(t, err)
+
+	// Test that init scripts have been correctly renamed
+	c, reader, err := ctr.Exec(ctx, []string{"ls", "-l", "/docker-entrypoint-initdb.d"}, tcexec.Multiplexed())
+	require.NoError(t, err)
+	require.Equal(t, 0, c, "Expected to read init scripts from the container")
+
+	buf := new(strings.Builder)
+	_, err = io.Copy(buf, reader)
+	require.NoError(t, err)
+
+	initScripts := buf.String()
+	strings.Contains(initScripts, "000000-init-user-db.sh")
+	strings.Contains(initScripts, "000001-aaaa-insert-user.sql")
+
+	// explicitly set sslmode=disable because the container is not configured to use TLS
+	connStr, err := ctr.ConnectionString(ctx, "sslmode=disable")
+	require.NoError(t, err)
+
+	db, err := sql.Open("postgres", connStr)
+	require.NoError(t, err)
+	require.NotNil(t, db)
+	defer db.Close()
+
+	// database created in init script. See testdata/init-user-db.sh
+	rows, err := db.Query("SELECT COUNT(*) FROM testdb;")
+	require.NoError(t, err)
+	require.NotNil(t, rows)
+	for rows.Next() {
+		var count int
+		err := rows.Scan(&count)
+		require.NoError(t, err)
+		require.Equal(t, 2, count)
+	}
 }
 
 func TestSnapshot(t *testing.T) {

--- a/modules/postgres/postgres_test.go
+++ b/modules/postgres/postgres_test.go
@@ -297,7 +297,8 @@ func TestWithOrderedInitScript(t *testing.T) {
 	ctr, err := postgres.Run(ctx,
 		"postgres:15.2-alpine",
 		// Executes first the init-user-db shell-script, then the do-insert-user SQL script
-		// Using WithInitScripts, this would not work as
+		// Using WithInitScripts, this would not work.
+		// This is because aaaa-insert-user would get executed first, but requires init-user-db to be executed before.
 		postgres.WithOrderedInitScripts(
 			filepath.Join("testdata", "init-user-db.sh"),
 			filepath.Join("testdata", "aaaa-insert-user.sql"),
@@ -320,8 +321,8 @@ func TestWithOrderedInitScript(t *testing.T) {
 	require.NoError(t, err)
 
 	initScripts := buf.String()
-	strings.Contains(initScripts, "000000-init-user-db.sh")
-	strings.Contains(initScripts, "000001-aaaa-insert-user.sql")
+	strings.Contains(initScripts, "000-init-user-db.sh")
+	strings.Contains(initScripts, "001-aaaa-insert-user.sql")
 
 	// explicitly set sslmode=disable because the container is not configured to use TLS
 	connStr, err := ctr.ConnectionString(ctx, "sslmode=disable")

--- a/modules/postgres/testdata/aaaa-insert-user.sql
+++ b/modules/postgres/testdata/aaaa-insert-user.sql
@@ -1,0 +1,5 @@
+-- Do not rename this file, it is named like this
+-- to test correct ordering behavior.
+--
+-- See TestWithOrderedInitScripts.
+INSERT INTO testdb (id, name) VALUES (2, 'second user')


### PR DESCRIPTION
Type of change: Enhancement

## What does this PR do?

As suggested in the discussion, this adds a brand new option to add init scripts to your Postgres testcontainer, and run them in the order that the user provides them to the function.

It also further documents `WithInitScripts` to clarify in what order the scripts are executed. 

## Why is it important?

The files that are passed to `WithInitScripts` are copied inside the container, then run in alphanumerical order. I believe this is surprising behavior, as I expect the init scripts to be run in the order I passed them to testcontainers.

Someone ran into this behavior before and raised an issue : https://github.com/testcontainers/testcontainers-go/issues/2542

## Related issues

- Closes #3090

## How to test this PR

Try using the newly-added function `WithOrderedInitScripts` for the postgres container.
Any setup using `WithInitScripts` should work just like before.
