### PR TITLE
chore(ci): run core tests on Testcontainers Cloud

### DIFF
--- a/.github/workflows/ci-test-go.yml
+++ b/.github/workflows/ci-test-go.yml
@@ -18,6 +18,11 @@ on:
         type: string
         default: "."
         description: "The directory where the Go project is located."
+      testcontainers-cloud:
+        required: false
+        type: boolean
+        default: false
+        description: "Run the tests on Testcontainers Cloud"
       rootless-docker:
         required: false
         type: boolean
@@ -81,6 +86,13 @@ jobs:
             echo "No dependencies script found at $SCRIPT_PATH - skipping installation"
           fi
 
+      # Setup Testcontainers Cloud Client right before your Testcontainers tests
+      - name: Setup Docker Cloud Client
+        if: ${{ inputs.testcontainers-cloud }}
+        uses: atomicjar/testcontainers-cloud-setup-action@c335bdbb570ec7c48f72c7d450c077f0a002293e # v1.3
+        with:
+          token: ${{ secrets.TCC_TOKEN }}
+
       - name: go test
         working-directory: ./${{ inputs.project-directory }}
         timeout-minutes: 30
@@ -89,6 +101,13 @@ jobs:
       - name: Run checker
         run: |
             ./scripts/check_environment.sh
+
+      # (Optionally) When you don't need Testcontainers Cloud anymore, you could terminate sessions eagerly
+      - name: Terminate Testcontainers Cloud Client active sessions
+        if: ${{ inputs.testcontainers-cloud }}
+        uses: atomicjar/testcontainers-cloud-setup-action@c335bdbb570ec7c48f72c7d450c077f0a002293e # v1.3
+        with:
+          action: terminate
 
       - name: Test Summary
         uses: test-summary/action@31493c76ec9e7aa675f1585d3ed6f1da69269a86 # v2.4

--- a/.github/workflows/ci-test-go.yml
+++ b/.github/workflows/ci-test-go.yml
@@ -87,7 +87,7 @@ jobs:
           fi
 
       # Setup Testcontainers Cloud Client right before your Testcontainers tests
-      - name: Setup Docker Cloud Client
+      - name: Setup Testcontainers Cloud Client
         if: ${{ inputs.testcontainers-cloud }}
         uses: atomicjar/testcontainers-cloud-setup-action@c335bdbb570ec7c48f72c7d450c077f0a002293e # v1.3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,9 +71,30 @@ jobs:
       go-version: ${{ matrix.go-version }}
       platforms: ${{ matrix.module == 'modulegen' && '["ubuntu-latest", "macos-latest", "windows-latest"]' || '["ubuntu-latest"]' }}
       project-directory: "${{ matrix.module }}"
+      testcontainers-cloud: false
       rootless-docker: false
       ryuk-disabled: false
     secrets: inherit
+
+  # The job below is a copy of the job above, but using Docker Cloud.
+  test-testcontainers-cloud:
+    # the core module is identified by the empty string (the root path)
+    if: ${{ contains(fromJSON(needs.detect-modules.outputs.modules), '') }}
+    needs:
+      - detect-modules
+      - lint
+    name: "Test using Docker Cloud"
+    strategy:
+      matrix:
+        go-version: [1.23.x, 1.24.x]
+    uses: ./.github/workflows/ci-test-go.yml
+    with:
+      go-version: ${{ matrix.go-version }}
+      platforms: '["ubuntu-latest"]'
+      project-directory: "."
+      testcontainers-cloud: true
+      rootless-docker: false
+      ryuk-disabled: false
 
   # The job below is a copy of the job above, but with ryuk disabled.
   # It's executed in the first stage to avoid concurrency issues.
@@ -92,6 +113,7 @@ jobs:
       go-version: ${{ matrix.go-version }}
       platforms: '["ubuntu-latest"]'
       project-directory: "."
+      testcontainers-cloud: false
       rootless-docker: false
       ryuk-disabled: true
 
@@ -112,6 +134,7 @@ jobs:
       go-version: ${{ matrix.go-version }}
       platforms: '["ubuntu-latest"]'
       project-directory: "."
+      testcontainers-cloud: false
       rootless-docker: true
       ryuk-disabled: false
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
     needs:
       - detect-modules
       - lint
-    name: "Test using Docker Cloud"
+    name: "Test using Testcontainers Cloud"
     strategy:
       matrix:
         go-version: [1.23.x, 1.24.x]


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
It runs the tests on Testcontainers Cloud, only when the core module is added to the build.

For that it extends the existing reusable workflow to accept one boolean argument, and if set to true, install the Testcontainers Cloud Client before running the tests.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
Dogfood Testcontainers Cloud.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->


<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
