### PR TITLE
fix(dockermodelrunner): wait for the model to be pulled

### DIFF
--- a/docs/modules/dockermodelrunner.md
+++ b/docs/modules/dockermodelrunner.md
@@ -76,7 +76,7 @@ The Docker Model Runner container exposes the following methods:
 
 - Since testcontainers-go <a href="https://github.com/testcontainers/testcontainers-go/releases/tag/v0.37.0"><span class="tc-version">:material-tag: v0.37.0</span></a>
 
-Use the `PullModel` method to pull a model from the Docker Model Runner.
+Use the `PullModel` method to pull a model from the Docker Model Runner. Make sure the passed context is not done before the pull operation is completed, so that the pull operation is cancelled.
 
 <!--codeinclude-->
 [Pulling a model at runtime](../../modules/dockermodelrunner/examples_test.go) inside_block:runPullModel

--- a/modules/dockermodelrunner/dockermodelrunner_test.go
+++ b/modules/dockermodelrunner/dockermodelrunner_test.go
@@ -3,6 +3,7 @@ package dockermodelrunner_test
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -60,6 +61,13 @@ func TestRun_client(t *testing.T) {
 
 		t.Run("failure", func(t *testing.T) {
 			err := ctr.PullModel(ctx, testNonExistentFQMN)
+			require.Error(t, err)
+		})
+
+		t.Run("failure/timeout", func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(ctx, 1*time.Millisecond)
+			defer cancel()
+			err := ctr.PullModel(ctx, testModelFQMN)
 			require.Error(t, err)
 		})
 	})

--- a/modules/dockermodelrunner/examples_test.go
+++ b/modules/dockermodelrunner/examples_test.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"slices"
 	"strings"
+	"time"
 
 	"github.com/openai/openai-go"
 	"github.com/openai/openai-go/option"
@@ -104,6 +105,9 @@ func ExampleRun_pullModel() {
 		modelTag       = "360M-Q4_K_M"
 		fqModelName    = modelNamespace + "/" + modelName + ":" + modelTag
 	)
+
+	ctx, cancel := context.WithTimeout(ctx, 60*time.Second)
+	defer cancel()
 
 	err = dmrCtr.PullModel(ctx, fqModelName)
 	if err != nil {

--- a/modules/dockermodelrunner/go.mod
+++ b/modules/dockermodelrunner/go.mod
@@ -3,6 +3,7 @@ module github.com/testcontainers/testcontainers-go/modules/dockermodelrunner
 go 1.23.0
 
 require (
+	github.com/cenkalti/backoff/v4 v4.2.1
 	github.com/openai/openai-go v0.1.0-beta.9
 	github.com/stretchr/testify v1.10.0
 	github.com/testcontainers/testcontainers-go v0.37.0
@@ -14,7 +15,6 @@ require (
 	dario.cat/mergo v1.0.1 // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
-	github.com/cenkalti/backoff/v4 v4.2.1 // indirect
 	github.com/containerd/log v0.1.0 // indirect
 	github.com/containerd/platforms v0.2.1 // indirect
 	github.com/cpuguy83/dockercfg v0.3.2 // indirect

--- a/modules/dockermodelrunner/go.mod
+++ b/modules/dockermodelrunner/go.mod
@@ -3,7 +3,6 @@ module github.com/testcontainers/testcontainers-go/modules/dockermodelrunner
 go 1.23.0
 
 require (
-	github.com/cenkalti/backoff/v4 v4.2.1
 	github.com/openai/openai-go v0.1.0-beta.9
 	github.com/stretchr/testify v1.10.0
 	github.com/testcontainers/testcontainers-go v0.37.0
@@ -15,6 +14,7 @@ require (
 	dario.cat/mergo v1.0.1 // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
+	github.com/cenkalti/backoff/v4 v4.2.1 // indirect
 	github.com/containerd/log v0.1.0 // indirect
 	github.com/containerd/platforms v0.2.1 // indirect
 	github.com/cpuguy83/dockercfg v0.3.2 // indirect

--- a/modules/dockermodelrunner/internal/sdk/client/pull.go
+++ b/modules/dockermodelrunner/internal/sdk/client/pull.go
@@ -2,10 +2,14 @@ package client
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"net/http"
 	"strings"
+	"time"
+
+	"github.com/cenkalti/backoff/v4"
 )
 
 // PullModel creates a model in the Docker Model Runner, by pulling the model from Docker Hub.
@@ -29,6 +33,35 @@ func (c *Client) PullModel(ctx context.Context, fullyQualifiedModelName string) 
 	// The Docker Model Runner returns a 200 status code for a successful pulls
 	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+	}
+
+	namespace := strings.Split(fullyQualifiedModelName, "/")[0]
+	modelName := strings.Split(fullyQualifiedModelName, "/")[1]
+
+	// Verify that the model is pulled successfully, honoring the parent context
+	// This is because the pull cancels when the connection is closed.
+	err = backoff.RetryNotify(
+		func() error {
+			if ctx.Err() != nil {
+				return backoff.Permanent(ctx.Err())
+			}
+
+			model, err := c.InspectModel(ctx, namespace, modelName)
+			if err != nil {
+				return err
+			}
+			if model == nil {
+				return errors.New("model not found")
+			}
+			return nil
+		},
+		backoff.WithContext(backoff.NewExponentialBackOff(), ctx),
+		func(err error, _ time.Duration) {
+			log.Default().Printf("🙏 Pulling model %s. Please be patient, no progress bar yet!", fullyQualifiedModelName)
+		},
+	)
+	if err != nil {
+		return fmt.Errorf("pull model: %w", err)
 	}
 
 	log.Default().Printf("✅ Model %s pulled successfully!", fullyQualifiedModelName)

--- a/modules/dockermodelrunner/internal/sdk/client/pull.go
+++ b/modules/dockermodelrunner/internal/sdk/client/pull.go
@@ -30,11 +30,6 @@ func (c *Client) PullModel(ctx context.Context, fullyQualifiedModelName string) 
 	}
 	defer resp.Body.Close()
 
-	// Check context after getting response
-	if err := ctx.Err(); err != nil {
-		return fmt.Errorf("context done after response: %w", err)
-	}
-
 	// The Docker Model Runner returns a 200 status code for a successful pulls
 	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("unexpected status code: %d", resp.StatusCode)

--- a/modules/dockermodelrunner/internal/sdk/client/pull.go
+++ b/modules/dockermodelrunner/internal/sdk/client/pull.go
@@ -4,12 +4,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
 	"net/http"
 	"strings"
 	"time"
 
 	"github.com/cenkalti/backoff/v4"
+
+	"github.com/testcontainers/testcontainers-go/log"
 )
 
 // PullModel creates a model in the Docker Model Runner, by pulling the model from Docker Hub.
@@ -57,7 +58,7 @@ func (c *Client) PullModel(ctx context.Context, fullyQualifiedModelName string) 
 		},
 		backoff.WithContext(backoff.NewExponentialBackOff(), ctx),
 		func(err error, _ time.Duration) {
-			log.Default().Printf("🙏 Pulling model %s. Please be patient, no progress bar yet!", fullyQualifiedModelName)
+			log.Default().Printf("🙏 Pulling model %s. Please be patient, no progress bar yet! %w", fullyQualifiedModelName, err)
 		},
 	)
 	if err != nil {


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
It adds a backoff-retry strategy after pulling a model in order to verify the model was actually pulled.

The retry uses the passed context to determine the exit.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
When the HTTP connection is closed, the pull cancels, but the code continues its execution, resulting in a not pulled model.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Caused by #3106

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
