### PR TITLE
fix(localstack): remove checksum from image name before parsing version

### DIFF
--- a/modules/localstack/localstack.go
+++ b/modules/localstack/localstack.go
@@ -30,7 +30,7 @@ var recentVersionTags = []string{
 }
 
 func isMinimumVersion(image string, minVersion string) bool {
-	parts := strings.Split(image, ":")
+	parts := strings.Split(strings.Split(image, "@")[0], ":")
 	version := parts[len(parts)-1]
 
 	if pos := strings.LastIndexByte(version, '-'); pos >= 0 {

--- a/modules/localstack/localstack_test.go
+++ b/modules/localstack/localstack_test.go
@@ -108,6 +108,7 @@ func TestIsLegacyVersion(t *testing.T) {
 		{"1-amd64", false},
 		{"1.0", false},
 		{"1.0-amd64", false},
+		{"4.3.0@sha256:f3cb1a79f3add997575e859c3a2808e6dae4b0de836661de255baa2b576868f8", false},
 	}
 
 	for _, tt := range tests {
@@ -148,6 +149,7 @@ func TestIsMinimumVersion2(t *testing.T) {
 		{"2.1-amd64", true},
 		{"3", true},
 		{"3-amd64", true},
+		{"4.3.0@sha256:f3cb1a79f3add997575e859c3a2808e6dae4b0de836661de255baa2b576868f8", true},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## What does this PR do?

Adjusts `isMinimumVersion` to remove potential checksum from image name before extracting the version.

## Why is it important?

Else in case of image name with checksum the version is incorrectly extracted leading to incorrect errors about minimum version not being met etc.

For example, with following image name, the image name is extracted incorrectly:

```
docker.io/localstack/localstack:4.3.0@sha256:f3cb1a79f3add997575e859c3a2808e6dae4b0de836661de255baa2b576868f8
```

## Related issues

- closes #3128
