### PR TITLE
fix(etcd): single node etcd cluster access

### DIFF
--- a/modules/etcd/cmd_test.go
+++ b/modules/etcd/cmd_test.go
@@ -9,7 +9,7 @@ import (
 func Test_configureCMD(t *testing.T) {
 	t.Run("default", func(t *testing.T) {
 		got := configureCMD(options{})
-		want := []string{"etcd", "--name=default"}
+		want := []string{"etcd", "--name=default", "--listen-client-urls=http://0.0.0.0:2379", "--advertise-client-urls=http://0.0.0.0:2379"}
 		require.Equal(t, want, got)
 	})
 

--- a/modules/etcd/etcd.go
+++ b/modules/etcd/etcd.go
@@ -166,7 +166,10 @@ func configureCMD(settings options) []string {
 	cmds := []string{"etcd"}
 
 	if len(settings.nodeNames) == 0 {
-		cmds = append(cmds, "--name=default")
+		cmds = append(cmds, "--name=default",
+			"--listen-client-urls="+scheme+"://0.0.0.0:"+clientPort,
+			"--advertise-client-urls="+scheme+"://0.0.0.0:"+clientPort,
+		)
 	} else {
 		clusterCmds := []string{
 			"--name=" + settings.nodeNames[settings.currentNode],

--- a/modules/etcd/etcd_test.go
+++ b/modules/etcd/etcd_test.go
@@ -33,18 +33,20 @@ func TestRun(t *testing.T) {
 func TestPutGet(t *testing.T) {
 	t.Run("single_node", func(t *testing.T) {
 		ctr, err := etcd.Run(context.Background(), "gcr.io/etcd-development/etcd:v3.5.14")
-		require.NoError(t, err)
-		testPutGet(t, ctr)
+		testPutGet(t, ctr, err)
 	})
 	t.Run("multiple_nodes", func(t *testing.T) {
 		ctr, err := etcd.Run(context.Background(), "gcr.io/etcd-development/etcd:v3.5.14", etcd.WithNodes("etcd-1", "etcd-2", "etcd-3"))
-		require.NoError(t, err)
-		testPutGet(t, ctr)
+		testPutGet(t, ctr, err)
 	})
 }
 
-func testPutGet(t *testing.T, ctr *etcd.EtcdContainer) {
+func testPutGet(t *testing.T, ctr *etcd.EtcdContainer, err error) {
+	t.Helper()
+
 	testcontainers.CleanupContainer(t, ctr)
+
+	require.NoError(t, err)
 
 	ctx := context.Background()
 
@@ -56,9 +58,9 @@ func testPutGet(t *testing.T, ctr *etcd.EtcdContainer) {
 		DialTimeout: 5 * time.Second,
 	})
 	require.NoError(t, err)
-	defer func(cli *clientv3.Client) {
+	defer func() {
 		require.NoError(t, cli.Close())
-	}(cli)
+	}()
 
 	ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
 	defer cancel()

--- a/modules/etcd/etcd_test.go
+++ b/modules/etcd/etcd_test.go
@@ -30,57 +30,44 @@ func TestRun(t *testing.T) {
 	require.Contains(t, string(output), "default")
 }
 
-func TestRun_PutGet(t *testing.T) {
+func TestPutGet(t *testing.T) {
+	t.Run("single_node", func(t *testing.T) {
+		ctr, err := etcd.Run(context.Background(), "gcr.io/etcd-development/etcd:v3.5.14")
+		require.NoError(t, err)
+		testPutGet(t, ctr)
+	})
+	t.Run("multiple_nodes", func(t *testing.T) {
+		ctr, err := etcd.Run(context.Background(), "gcr.io/etcd-development/etcd:v3.5.14", etcd.WithNodes("etcd-1", "etcd-2", "etcd-3"))
+		require.NoError(t, err)
+		testPutGet(t, ctr)
+	})
+}
+
+func testPutGet(t *testing.T, ctr *etcd.EtcdContainer) {
+	testcontainers.CleanupContainer(t, ctr)
+
 	ctx := context.Background()
 
-	for _, tc := range []struct {
-		name    string
-		builder func(t *testing.T) *etcd.EtcdContainer
-	}{
-		{
-			name: "single_node",
-			builder: func(t *testing.T) *etcd.EtcdContainer {
-				ctr, err := etcd.Run(ctx, "gcr.io/etcd-development/etcd:v3.5.14")
-				require.NoError(t, err)
-				return ctr
-			},
-		},
-		{
-			name: "multiple_nodes",
-			builder: func(t *testing.T) *etcd.EtcdContainer {
-				ctr, err := etcd.Run(ctx, "gcr.io/etcd-development/etcd:v3.5.14", etcd.WithNodes("etcd-1", "etcd-2", "etcd-3"))
-				require.NoError(t, err)
-				return ctr
-			},
-		},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			ctr := tc.builder(t)
-			require.NoError(t, testcontainers.TerminateContainer(ctr))
+	clientEndpoints, err := ctr.ClientEndpoints(ctx)
+	require.NoError(t, err)
 
-			clientEndpoints, err := ctr.ClientEndpoints(ctx)
-			require.NoError(t, err)
+	cli, err := clientv3.New(clientv3.Config{
+		Endpoints:   clientEndpoints,
+		DialTimeout: 5 * time.Second,
+	})
+	require.NoError(t, err)
+	defer func(cli *clientv3.Client) {
+		require.NoError(t, cli.Close())
+	}(cli)
 
-			cli, err := clientv3.New(clientv3.Config{
-				Endpoints:   clientEndpoints,
-				DialTimeout: 5 * time.Second,
-			})
-			require.NoError(t, err)
-			defer func(cli *clientv3.Client) {
-				require.NoError(t, cli.Close())
-			}(cli)
+	ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	defer cancel()
+	_, err = cli.Put(ctx, "sample_key", "sample_value")
+	require.NoError(t, err)
 
-			ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
-			defer cancel()
-			_, err = cli.Put(ctx, "sample_key", "sample_value")
-			require.NoError(t, err)
+	resp, err := cli.Get(ctx, "sample_key")
+	require.NoError(t, err)
 
-			resp, err := cli.Get(ctx, "sample_key")
-			require.NoError(t, err)
-
-			require.Len(t, resp.Kvs, 1)
-			require.Equal(t, "sample_value", string(resp.Kvs[0].Value))
-		})
-
-	}
+	require.Len(t, resp.Kvs, 1)
+	require.Equal(t, "sample_value", string(resp.Kvs[0].Value))
 }

--- a/modules/etcd/etcd_test.go
+++ b/modules/etcd/etcd_test.go
@@ -33,28 +33,54 @@ func TestRun(t *testing.T) {
 func TestRun_PutGet(t *testing.T) {
 	ctx := context.Background()
 
-	ctr, err := etcd.Run(ctx, "gcr.io/etcd-development/etcd:v3.5.14", etcd.WithNodes("etcd-1", "etcd-2", "etcd-3"))
-	testcontainers.CleanupContainer(t, ctr)
-	require.NoError(t, err)
+	for _, tc := range []struct {
+		name    string
+		builder func(t *testing.T) *etcd.EtcdContainer
+	}{
+		{
+			name: "single_node",
+			builder: func(t *testing.T) *etcd.EtcdContainer {
+				ctr, err := etcd.Run(ctx, "gcr.io/etcd-development/etcd:v3.5.14")
+				require.NoError(t, err)
+				return ctr
+			},
+		},
+		{
+			name: "multiple_nodes",
+			builder: func(t *testing.T) *etcd.EtcdContainer {
+				ctr, err := etcd.Run(ctx, "gcr.io/etcd-development/etcd:v3.5.14", etcd.WithNodes("etcd-1", "etcd-2", "etcd-3"))
+				require.NoError(t, err)
+				return ctr
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctr := tc.builder(t)
+			require.NoError(t, testcontainers.TerminateContainer(ctr))
 
-	clientEndpoints, err := ctr.ClientEndpoints(ctx)
-	require.NoError(t, err)
+			clientEndpoints, err := ctr.ClientEndpoints(ctx)
+			require.NoError(t, err)
 
-	cli, err := clientv3.New(clientv3.Config{
-		Endpoints:   clientEndpoints,
-		DialTimeout: 5 * time.Second,
-	})
-	require.NoError(t, err)
-	defer cli.Close()
+			cli, err := clientv3.New(clientv3.Config{
+				Endpoints:   clientEndpoints,
+				DialTimeout: 5 * time.Second,
+			})
+			require.NoError(t, err)
+			defer func(cli *clientv3.Client) {
+				require.NoError(t, cli.Close())
+			}(cli)
 
-	ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
-	defer cancel()
-	_, err = cli.Put(ctx, "sample_key", "sample_value")
-	require.NoError(t, err)
+			ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
+			defer cancel()
+			_, err = cli.Put(ctx, "sample_key", "sample_value")
+			require.NoError(t, err)
 
-	resp, err := cli.Get(ctx, "sample_key")
-	require.NoError(t, err)
+			resp, err := cli.Get(ctx, "sample_key")
+			require.NoError(t, err)
 
-	require.Len(t, resp.Kvs, 1)
-	require.Equal(t, "sample_value", string(resp.Kvs[0].Value))
+			require.Len(t, resp.Kvs, 1)
+			require.Equal(t, "sample_value", string(resp.Kvs[0].Value))
+		})
+
+	}
 }


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
Added options listen-client-urls and advertise-client-urls for single etcd cluster execution.
<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
Without this options server cannot handle incoming requests since be default it listens only 127.0.0.1 network interface.
<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Related issues
<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes #3150

<!-- Recommended
## How to test this PR
Added a unit test for single node PutGet
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
