### PR TITLE
chore: support for deciding when to auto-export the image ports in case no exposed ports are passed

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -85,6 +85,11 @@ type Config struct {
 	//
 	// Environment variable: TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE
 	TestcontainersHost string `properties:"tc.host,default="`
+
+	// AutoExposePorts is a flag to enable or disable the automatic exposure of ports when no ports are explicitly exposed.
+	//
+	// Environment variable: TESTCONTAINERS_AUTO_EXPOSE_PORTS
+	AutoExposePorts bool `properties:"tc.auto.expose.ports,default=true"`
 }
 
 // }
@@ -139,6 +144,11 @@ func read() Config {
 		ryukConnectionTimeoutEnv := readTestcontainersEnv("RYUK_CONNECTION_TIMEOUT")
 		if timeout, err := time.ParseDuration(ryukConnectionTimeoutEnv); err == nil {
 			config.RyukConnectionTimeout = timeout
+		}
+
+		autoExposePortsEnv := readTestcontainersEnv("TESTCONTAINERS_AUTO_EXPOSE_PORTS")
+		if parseBool(autoExposePortsEnv) {
+			config.AutoExposePorts = autoExposePortsEnv == "true"
 		}
 
 		return config

--- a/lifecycle.go
+++ b/lifecycle.go
@@ -14,6 +14,7 @@ import (
 	"github.com/docker/docker/api/types/network"
 	"github.com/docker/go-connections/nat"
 
+	"github.com/testcontainers/testcontainers-go/internal/config"
 	"github.com/testcontainers/testcontainers-go/log"
 )
 
@@ -581,12 +582,15 @@ func (p *DockerProvider) preCreateContainerHook(ctx context.Context, req Contain
 	exposedPorts := req.ExposedPorts
 	// this check must be done after the pre-creation Modifiers are called, so the network mode is already set
 	if len(exposedPorts) == 0 && !hostConfig.NetworkMode.IsContainer() {
-		image, err := p.client.ImageInspect(ctx, dockerInput.Image)
-		if err != nil {
-			return err
-		}
-		for p := range image.Config.ExposedPorts {
-			exposedPorts = append(exposedPorts, string(p))
+		// Only expose the ports defined in the image if configured in the Testcontainers properties file.
+		if config.Read().AutoExposePorts {
+			image, err := p.client.ImageInspect(ctx, dockerInput.Image)
+			if err != nil {
+				return err
+			}
+			for p := range image.Config.ExposedPorts {
+				exposedPorts = append(exposedPorts, string(p))
+			}
 		}
 	}
 

--- a/lifecycle.go
+++ b/lifecycle.go
@@ -584,13 +584,7 @@ func (p *DockerProvider) preCreateContainerHook(ctx context.Context, req Contain
 	if len(exposedPorts) == 0 && !hostConfig.NetworkMode.IsContainer() {
 		// Only expose the ports defined in the image if configured in the Testcontainers properties file.
 		if config.Read().AutoExposePorts {
-			image, err := p.client.ImageInspect(ctx, dockerInput.Image)
-			if err != nil {
-				return err
-			}
-			for p := range image.Config.ExposedPorts {
-				exposedPorts = append(exposedPorts, string(p))
-			}
+			hostConfig.PublishAllPorts = true
 		}
 	}
 


### PR DESCRIPTION
- **feat: add a new config to disable exposing image ports automatically**
- **chore: support for disabling auto-exposing ports from the image**

<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
This PR adds support for enabling/disabling auto-exposing the port from the container image (default is true: ports are automatically exposed).

This new setting can be configured at the properties level (using the `tc.auto.expose.ports` property) or with an env var (`TESTCONTAINERS_AUTO_EXPOSE_PORTS`).
When set to true, which is the default, the exposed ports in the image are automatically exposed to the container. When set to false, they are not.

This behavior was present in tc-java in the past (basically `-P` flag, publish all exposed ports), but we removed it, because it created bugs on Windows with running out of ports in a specific range over time. Given that bug is still open in Docker for Windows, we decided to not publish all ports, or at least let users configure it.

On the other hand, we are simplifying the auto-exposure of all the ports: instead of inspecting the image and merging the ports with the user request, we set the `PublishAllPorts` option to true in the hostConfig modifier.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
Simplify code, and also reduce the chances to get the bug described in https://github.com/docker/for-win/issues/11584

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Related to https://github.com/docker/for-win/issues/11584

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
