### PR TITLE
feat: support adding wait strategies as functional option

### DIFF
--- a/docs/features/common_functional_options.md
+++ b/docs/features/common_functional_options.md
@@ -249,6 +249,8 @@ If you need to set a different wait strategy for the container, you can use `tes
 
 At the same time, it's possible to set a wait strategy and a custom deadline with `testcontainers.WithWaitStrategyAndDeadline`.
 
+Finally, you can also append a wait strategy to the existing wait strategy, using `testcontainers.WithAdditionalWaitStrategy` and `testcontainers.WithAdditionalWaitStrategyAndDeadline`.
+
 #### Startup Commands
 
 - Since testcontainers-go <a href="https://github.com/testcontainers/testcontainers-go/releases/tag/v0.25.0"><span class="tc-version">:material-tag: v0.25.0</span></a>

--- a/docs/features/common_functional_options.md
+++ b/docs/features/common_functional_options.md
@@ -242,12 +242,12 @@ You can also use `testcontainers.WithAdditionalLifecycleHooks`, which appends th
 
 #### Wait Strategies
 
-If you need to set a different wait strategy for the container, you can use `testcontainers.WithWaitStrategy` with a valid wait strategy.
+If you need to set a different wait strategy for the container, replacing the existing one, you can use `testcontainers.WithWaitStrategy` with a valid wait strategy.
 
 !!!info
     The default deadline for the wait strategy is 60 seconds.
 
-At the same time, it's possible to set a wait strategy and a custom deadline with `testcontainers.WithWaitStrategyAndDeadline`.
+At the same time, it's possible to replace the wait strategy with a new one and a custom deadline, using `testcontainers.WithWaitStrategyAndDeadline`.
 
 Finally, you can also append a wait strategy to the existing wait strategy, using `testcontainers.WithAdditionalWaitStrategy` and `testcontainers.WithAdditionalWaitStrategyAndDeadline`.
 

--- a/docs/modules/index.md
+++ b/docs/modules/index.md
@@ -211,7 +211,9 @@ In order to simplify the creation of the container for a given module, `Testcont
 - `testcontainers.WithAlwaysPull`: a function that pulls the image before starting the container.
 - `testcontainers.WithImagePlatform`: a function that sets the image platform for the container request.
 - `testcontainers.WithWaitStrategy`: a function that sets the wait strategy for the container request.
+- `testcontainers.WithAdditionalWaitStrategy`: a function that appends the wait strategy for the container request.
 - `testcontainers.WithWaitStrategyAndDeadline`: a function that sets the wait strategy for the container request with a deadline.
+- `testcontainers.WithAdditionalWaitStrategyAndDeadline`: a function that appends the wait strategy for the container request with a deadline.
 - `testcontainers.WithStartupCommand`: a function that sets the execution of a command when the container starts.
 - `testcontainers.WithAfterReadyCommand`: a function that sets the execution of a command right after the container is ready (its wait strategy is satisfied).
 - `testcontainers.WithDockerfile`: a function that sets the build from a Dockerfile for the container request.

--- a/docs/modules/index.md
+++ b/docs/modules/index.md
@@ -210,9 +210,9 @@ In order to simplify the creation of the container for a given module, `Testcont
 - `testcontainers.WithAdditionalLifecycleHooks`: a function that appends lifecycle hooks to the existing ones for the container request.
 - `testcontainers.WithAlwaysPull`: a function that pulls the image before starting the container.
 - `testcontainers.WithImagePlatform`: a function that sets the image platform for the container request.
-- `testcontainers.WithWaitStrategy`: a function that sets the wait strategy for the container request.
+- `testcontainers.WithWaitStrategy`: a function that replaces the wait strategy for the container request.
 - `testcontainers.WithAdditionalWaitStrategy`: a function that appends the wait strategy for the container request.
-- `testcontainers.WithWaitStrategyAndDeadline`: a function that sets the wait strategy for the container request with a deadline.
+- `testcontainers.WithWaitStrategyAndDeadline`: a function that replaces the wait strategy for the container request with a deadline.
 - `testcontainers.WithAdditionalWaitStrategyAndDeadline`: a function that appends the wait strategy for the container request with a deadline.
 - `testcontainers.WithStartupCommand`: a function that sets the execution of a command when the container starts.
 - `testcontainers.WithAfterReadyCommand`: a function that sets the execution of a command right after the container is ready (its wait strategy is satisfied).

--- a/modules/k3s/k3s_test.go
+++ b/modules/k3s/k3s_test.go
@@ -146,7 +146,7 @@ func Test_WithManifestOption(t *testing.T) {
 	k3sContainer, err := k3s.Run(ctx,
 		"rancher/k3s:v1.27.1-k3s1",
 		k3s.WithManifest("nginx-manifest.yaml"),
-		testcontainers.WithWaitStrategy(wait.ForExec([]string{"kubectl", "wait", "pod", "nginx", "--for=condition=Ready"})),
+		testcontainers.WithAdditionalWaitStrategy(wait.ForExec([]string{"kubectl", "wait", "pod", "nginx", "--for=condition=Ready"})),
 	)
 	testcontainers.CleanupContainer(t, k3sContainer)
 	require.NoError(t, err)

--- a/modules/localstack/examples_test.go
+++ b/modules/localstack/examples_test.go
@@ -101,7 +101,7 @@ func ExampleRun_legacyMode() {
 		ctx,
 		"localstack/localstack:0.10.0",
 		testcontainers.WithEnv(map[string]string{"SERVICES": "s3,sqs"}),
-		testcontainers.WithWaitStrategy(wait.ForLog("Ready.").WithStartupTimeout(5*time.Minute).WithOccurrence(1)),
+		testcontainers.WithAdditionalWaitStrategy(wait.ForLog("Ready.").WithStartupTimeout(5*time.Minute).WithOccurrence(1)),
 	)
 	defer func() {
 		if err := testcontainers.TerminateContainer(ctr); err != nil {

--- a/modules/mongodb/examples_test.go
+++ b/modules/mongodb/examples_test.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/modules/mongodb"
-	"github.com/testcontainers/testcontainers-go/wait"
 )
 
 func ExampleRun() {
@@ -89,7 +88,6 @@ func ExampleRun_withCredentials() {
 		"mongo:6",
 		mongodb.WithUsername("root"),
 		mongodb.WithPassword("password"),
-		testcontainers.WithWaitStrategy(wait.ForLog("Waiting for connections")),
 	)
 	defer func() {
 		if err := testcontainers.TerminateContainer(ctr); err != nil {

--- a/modules/mssql/mssql_test.go
+++ b/modules/mssql/mssql_test.go
@@ -50,7 +50,7 @@ func TestMSSQLServerWithMissingEulaOption(t *testing.T) {
 	t.Run("empty", func(t *testing.T) {
 		ctr, err := mssql.Run(ctx,
 			"mcr.microsoft.com/mssql/server:2022-CU14-ubuntu-22.04",
-			testcontainers.WithWaitStrategy(
+			testcontainers.WithAdditionalWaitStrategy(
 				wait.ForLog("The SQL Server End-User License Agreement (EULA) must be accepted")),
 		)
 		testcontainers.CleanupContainer(t, ctr)
@@ -61,7 +61,7 @@ func TestMSSQLServerWithMissingEulaOption(t *testing.T) {
 		ctr, err := mssql.Run(ctx,
 			"mcr.microsoft.com/mssql/server:2022-CU14-ubuntu-22.04",
 			testcontainers.WithEnv(map[string]string{"ACCEPT_EULA": "yes"}),
-			testcontainers.WithWaitStrategy(
+			testcontainers.WithAdditionalWaitStrategy(
 				wait.ForLog("The SQL Server End-User License Agreement (EULA) must be accepted")),
 		)
 		testcontainers.CleanupContainer(t, ctr)

--- a/modules/postgres/examples_test.go
+++ b/modules/postgres/examples_test.go
@@ -5,11 +5,9 @@ import (
 	"fmt"
 	"log"
 	"path/filepath"
-	"time"
 
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/modules/postgres"
-	"github.com/testcontainers/testcontainers-go/wait"
 )
 
 func ExampleRun() {
@@ -27,10 +25,7 @@ func ExampleRun() {
 		postgres.WithDatabase(dbName),
 		postgres.WithUsername(dbUser),
 		postgres.WithPassword(dbPassword),
-		testcontainers.WithWaitStrategy(
-			wait.ForLog("database system is ready to accept connections").
-				WithOccurrence(2).
-				WithStartupTimeout(5*time.Second)),
+		postgres.BasicWaitStrategies(),
 	)
 	defer func() {
 		if err := testcontainers.TerminateContainer(postgresContainer); err != nil {

--- a/modules/postgres/postgres_test.go
+++ b/modules/postgres/postgres_test.go
@@ -155,7 +155,7 @@ func TestContainerWithWaitForSQL(t *testing.T) {
 			postgres.WithDatabase(dbname),
 			postgres.WithUsername(user),
 			postgres.WithPassword(password),
-			testcontainers.WithWaitStrategy(wait.ForSQL(nat.Port(port), "postgres", dbURL)),
+			testcontainers.WithAdditionalWaitStrategy(wait.ForSQL(nat.Port(port), "postgres", dbURL)),
 		)
 		testcontainers.CleanupContainer(t, ctr)
 		require.NoError(t, err)
@@ -168,7 +168,7 @@ func TestContainerWithWaitForSQL(t *testing.T) {
 			postgres.WithDatabase(dbname),
 			postgres.WithUsername(user),
 			postgres.WithPassword(password),
-			testcontainers.WithWaitStrategy(wait.ForSQL(nat.Port(port), "postgres", dbURL).WithStartupTimeout(time.Second*5).WithQuery("SELECT 10")),
+			testcontainers.WithAdditionalWaitStrategy(wait.ForSQL(nat.Port(port), "postgres", dbURL).WithStartupTimeout(time.Second*5).WithQuery("SELECT 10")),
 		)
 		testcontainers.CleanupContainer(t, ctr)
 		require.NoError(t, err)
@@ -181,7 +181,7 @@ func TestContainerWithWaitForSQL(t *testing.T) {
 			postgres.WithDatabase(dbname),
 			postgres.WithUsername(user),
 			postgres.WithPassword(password),
-			testcontainers.WithWaitStrategy(wait.ForSQL(nat.Port(port), "postgres", dbURL).WithStartupTimeout(time.Second*5).WithQuery("SELECT 'a' from b")),
+			testcontainers.WithAdditionalWaitStrategy(wait.ForSQL(nat.Port(port), "postgres", dbURL).WithStartupTimeout(time.Second*5).WithQuery("SELECT 'a' from b")),
 		)
 		testcontainers.CleanupContainer(t, ctr)
 		require.Error(t, err)
@@ -225,7 +225,7 @@ func TestWithSSL(t *testing.T) {
 		postgres.WithDatabase(dbname),
 		postgres.WithUsername(user),
 		postgres.WithPassword(password),
-		testcontainers.WithWaitStrategy(wait.ForLog("database system is ready to accept connections").WithOccurrence(2).WithStartupTimeout(5*time.Second)),
+		testcontainers.WithAdditionalWaitStrategy(wait.ForLog("database system is ready to accept connections").WithOccurrence(2).WithStartupTimeout(5*time.Second)),
 		postgres.WithSSLCert(caCert.CertPath, serverCerts.CertPath, serverCerts.KeyPath),
 	)
 
@@ -255,7 +255,7 @@ func TestSSLValidatesKeyMaterialPath(t *testing.T) {
 		postgres.WithDatabase(dbname),
 		postgres.WithUsername(user),
 		postgres.WithPassword(password),
-		testcontainers.WithWaitStrategy(wait.ForLog("database system is ready to accept connections").WithOccurrence(2).WithStartupTimeout(5*time.Second)),
+		testcontainers.WithAdditionalWaitStrategy(wait.ForLog("database system is ready to accept connections").WithOccurrence(2).WithStartupTimeout(5*time.Second)),
 		postgres.WithSSLCert("", "", ""),
 	)
 

--- a/modules/postgres/wait_strategies.go
+++ b/modules/postgres/wait_strategies.go
@@ -14,7 +14,7 @@ import (
 //     Without this, the tests will be flaky on those OSes!
 func BasicWaitStrategies() testcontainers.CustomizeRequestOption {
 	// waitStrategy {
-	return testcontainers.WithWaitStrategy(
+	return testcontainers.WithAdditionalWaitStrategy(
 		// First, we wait for the container to log readiness twice.
 		// This is because it will restart itself after the first startup.
 		wait.ForLog("database system is ready to accept connections").WithOccurrence(2),

--- a/options.go
+++ b/options.go
@@ -373,7 +373,7 @@ func WithAfterReadyCommand(execs ...Executable) CustomizeRequestOption {
 	}
 }
 
-// WithWaitStrategy sets the wait strategy for a container, using 60 seconds as deadline
+// WithWaitStrategy replaces the wait strategy for a container, using 60 seconds as deadline
 func WithWaitStrategy(strategies ...wait.Strategy) CustomizeRequestOption {
 	return WithWaitStrategyAndDeadline(60*time.Second, strategies...)
 }
@@ -383,7 +383,7 @@ func WithAdditionalWaitStrategy(strategies ...wait.Strategy) CustomizeRequestOpt
 	return WithAdditionalWaitStrategyAndDeadline(60*time.Second, strategies...)
 }
 
-// WithWaitStrategyAndDeadline sets the wait strategy for a container, including deadline
+// WithWaitStrategyAndDeadline replaces the wait strategy for a container, including deadline
 func WithWaitStrategyAndDeadline(deadline time.Duration, strategies ...wait.Strategy) CustomizeRequestOption {
 	return func(req *GenericContainerRequest) error {
 		req.WaitingFor = wait.ForAll(strategies...).WithDeadline(deadline)

--- a/options.go
+++ b/options.go
@@ -378,10 +378,33 @@ func WithWaitStrategy(strategies ...wait.Strategy) CustomizeRequestOption {
 	return WithWaitStrategyAndDeadline(60*time.Second, strategies...)
 }
 
+// WithAdditionalWaitStrategy appends the wait strategy for a container, using 60 seconds as deadline
+func WithAdditionalWaitStrategy(strategies ...wait.Strategy) CustomizeRequestOption {
+	return WithAdditionalWaitStrategyAndDeadline(60*time.Second, strategies...)
+}
+
 // WithWaitStrategyAndDeadline sets the wait strategy for a container, including deadline
 func WithWaitStrategyAndDeadline(deadline time.Duration, strategies ...wait.Strategy) CustomizeRequestOption {
 	return func(req *GenericContainerRequest) error {
 		req.WaitingFor = wait.ForAll(strategies...).WithDeadline(deadline)
+
+		return nil
+	}
+}
+
+// WithAdditionalWaitStrategyAndDeadline appends the wait strategy for a container, including deadline
+func WithAdditionalWaitStrategyAndDeadline(deadline time.Duration, strategies ...wait.Strategy) CustomizeRequestOption {
+	return func(req *GenericContainerRequest) error {
+		if req.WaitingFor == nil {
+			req.WaitingFor = wait.ForAll(strategies...).WithDeadline(deadline)
+			return nil
+		}
+
+		wss := make([]wait.Strategy, 0, len(strategies)+1)
+		wss = append(wss, req.WaitingFor)
+		wss = append(wss, strategies...)
+
+		req.WaitingFor = wait.ForAll(wss...).WithDeadline(deadline)
 
 		return nil
 	}


### PR DESCRIPTION
- **feat: add a new functional option to append wait strategies to modules**
- **chore: update modules**

<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
It adds a new functional option to add additional wait strategies to the container.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
It's needed to allow users to append new wait strategies instead of replacing them all. At the moment a user used a module, and customised it with `WithWaitStrategy` the module strategies were overriden.

With this change, users can choose if overriding or appending.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->


<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
