### PR TITLE
fix(etcd): expose ports for the etcd nodes

### DIFF
--- a/modules/etcd/etcd.go
+++ b/modules/etcd/etcd.go
@@ -60,8 +60,9 @@ func (c *EtcdContainer) Terminate(ctx context.Context, opts ...testcontainers.Te
 // Run creates an instance of the etcd container type
 func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustomizer) (*EtcdContainer, error) {
 	req := testcontainers.ContainerRequest{
-		Image: img,
-		Cmd:   []string{},
+		Image:        img,
+		ExposedPorts: []string{clientPort, peerPort},
+		Cmd:          []string{},
 	}
 
 	genericContainerReq := testcontainers.GenericContainerRequest{


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
It adds the client and peer ports to the exposed ports of the etcd container, so that they are available for discovery.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
In #3159 we are adding the ability to auto-expose the image ports, and with that change we exposed this bug: if the ports are not automatically exposed, the etcd module is not able to connect to the client endpoints.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Discovered while testing #3159 

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
