### PR TITLE
reaper: change default reaper port to avoid contention

### DIFF
--- a/reaper.go
+++ b/reaper.go
@@ -41,7 +41,7 @@ var (
 
 	// defaultReaperPort is the default port that the reaper listens on if not
 	// overridden by the RYUK_PORT environment variable.
-	defaultReaperPort = nat.Port("8080/tcp")
+	defaultReaperPort = nat.Port("9095/tcp")
 
 	// errReaperNotFound is returned when no reaper container is found.
 	errReaperNotFound = errors.New("reaper not found")


### PR DESCRIPTION
A default port of 8080 is in appropriate as it is often contended for in many environments. This sets the default port to a less commonly used port (9095).

Fixes #3172 