### PR TITLE
fix: preserve unix socket schema in testcontainersHostFromProperties

### DIFF
--- a/internal/core/docker_host.go
+++ b/internal/core/docker_host.go
@@ -298,12 +298,14 @@ func testcontainersHostFromProperties(_ context.Context) (string, error) {
 	cfg := config.Read()
 	testcontainersHost := cfg.TestcontainersHost
 	if testcontainersHost != "" {
-		parsed, err := parseURL(testcontainersHost)
+		// Validate the URL format
+		_, err := parseURL(testcontainersHost)
 		if err != nil {
 			return "", err
 		}
 
-		return parsed, nil
+		// Return the original URL to preserve schema for Docker client
+		return testcontainersHost, nil
 	}
 
 	return "", ErrTestcontainersHostNotSetInProperties

--- a/internal/core/docker_host_test.go
+++ b/internal/core/docker_host_test.go
@@ -177,13 +177,26 @@ func TestExtractDockerHost(t *testing.T) {
 		t.Cleanup(resetSocketOverrideFn)
 
 		t.Run("Testcontainers host is defined in properties", func(t *testing.T) {
-			content := "tc.host=" + testRemoteHost
+			t.Run("TCP host", func(t *testing.T) {
+				content := "tc.host=" + testRemoteHost
 
-			setupTestcontainersProperties(t, content)
+				setupTestcontainersProperties(t, content)
 
-			socket, err := testcontainersHostFromProperties(context.Background())
-			require.NoError(t, err)
-			require.Equal(t, testRemoteHost, socket)
+				socket, err := testcontainersHostFromProperties(context.Background())
+				require.NoError(t, err)
+				require.Equal(t, testRemoteHost, socket)
+			})
+
+			t.Run("Unix socket host preserves schema", func(t *testing.T) {
+				unixSocket := "unix:///var/run/docker.sock"
+				content := "tc.host=" + unixSocket
+
+				setupTestcontainersProperties(t, content)
+
+				socket, err := testcontainersHostFromProperties(context.Background())
+				require.NoError(t, err)
+				require.Equal(t, unixSocket, socket)
+			})
 		})
 
 		t.Run("Testcontainers host is not defined in properties", func(t *testing.T) {


### PR DESCRIPTION
## What does this PR do?

This PR fixes an issue where UNIX domain socket URLs configured in the `tc.host` property in `~/.testcontainers.properties` would have their schema stripped, causing Docker client initialization to fail.

**Changes made:**
- Modified [`testcontainersHostFromProperties`](https://github.com/testcontainers/testcontainers-go/blob/321f4f98ac821702ec5db20f970ba3a21c0dd9ce/internal/core/docker_host.go#L296-L310) function to preserve the original URL with schema after validation
- Added test coverage for UNIX socket schema preservation in the properties file
- Ensured backward compatibility for TCP hosts and other existing functionality

**Technical details:**
The function now validates the URL format using [`parseURL()`](https://github.com/testcontainers/testcontainers-go/blob/321f4f98ac821702ec5db20f970ba3a21c0dd9ce/internal/core/docker_rootless.go#L81-L96) but returns the original URL instead of the parsed result, ensuring the Docker client receives the full URL with schema (e.g., `unix:///var/run/docker.sock` instead of just `/var/run/docker.sock`).

## Why is it important?

When users configure UNIX domain sockets in `~/.testcontainers.properties` using `tc.host=unix:///var/run/docker.sock`, the application would panic with:

```
panic: check host "/var/run/docker.sock": new client: unable to parse docker host `/var/run/docker.sock`
```

This occurs because:
1. [`testcontainersHostFromProperties`](https://github.com/testcontainers/testcontainers-go/blob/321f4f98ac821702ec5db20f970ba3a21c0dd9ce/internal/core/docker_host.go#L296-L310) calls [`parseURL()`](https://github.com/testcontainers/testcontainers-go/blob/321f4f98ac821702ec5db20f970ba3a21c0dd9ce/internal/core/docker_rootless.go#L81-L96) which strips the `unix://` schema
2. The stripped path is passed to [`dockerHostCheck`](https://github.com/testcontainers/testcontainers-go/blob/321f4f98ac821702ec5db20f970ba3a21c0dd9ce/internal/core/docker_host.go#L61-L74) 
3. Docker client's ParseHostURL expects `protocol://address` format but receives only the path
4. Client initialization fails with parsing error

This fix ensures UNIX socket configurations in `~/.testcontainers.properties` work correctly while maintaining compatibility with existing TCP host configurations.

## Related issues

- This addresses a clear bug in UNIX socket handling for `tc.host` property in `~/.testcontainers.properties`
- If an issue should be created first, I'm happy to create one before merging this PR