### PR TITLE
feat: allow saving specific platforms for an image

### DIFF
--- a/docker.go
+++ b/docker.go
@@ -1786,11 +1786,11 @@ func (p *DockerProvider) ListImages(ctx context.Context) ([]ImageInfo, error) {
 
 // SaveImages exports a list of images as an uncompressed tar
 func (p *DockerProvider) SaveImages(ctx context.Context, output string, images ...string) error {
-	return p.SaveImagesWithOps(ctx, output, images)
+	return p.SaveImagesWithOpts(ctx, output, images)
 }
 
-// SaveImagesWithOpts exports a list of images as an uncompressed tar, passiong options to the provider
-func (p *DockerProvider) SaveImagesWithOps(ctx context.Context, output string, images []string, opts ...SaveImageOption) error {
+// SaveImagesWithOpts exports a list of images as an uncompressed tar, passing options to the provider
+func (p *DockerProvider) SaveImagesWithOpts(ctx context.Context, output string, images []string, opts ...SaveImageOption) error {
 	saveOpts := saveImageOptions{}
 
 	for _, opt := range opts {

--- a/image.go
+++ b/image.go
@@ -22,6 +22,6 @@ type SaveImageOption func(*saveImageOptions) error
 type ImageProvider interface {
 	ListImages(context.Context) ([]ImageInfo, error)
 	SaveImages(context.Context, string, ...string) error
-	SaveImagesWithOps(context.Context, string, []string, ...SaveImageOption) error
+	SaveImagesWithOpts(context.Context, string, []string, ...SaveImageOption) error
 	PullImage(context.Context, string) error
 }

--- a/image_test.go
+++ b/image_test.go
@@ -99,7 +99,7 @@ func TestSaveImagesWithOpts(t *testing.T) {
 	require.NoErrorf(t, err, "creating test container")
 
 	output := filepath.Join(t.TempDir(), "images.tar")
-	err = provider.SaveImagesWithOps(
+	err = provider.SaveImagesWithOpts(
 		context.Background(), output, []string{req.Image}, SaveDockerImageWithPlatforms(p...),
 	)
 	require.NoErrorf(t, err, "saving image %q", req.Image)

--- a/modules/k3s/k3s.go
+++ b/modules/k3s/k3s.go
@@ -213,7 +213,7 @@ func (c *K3sContainer) LoadImagesWithOpts(ctx context.Context, images []string, 
 		_ = os.Remove(imagesTar.Name())
 	}()
 
-	err = provider.SaveImagesWithOps(context.Background(), imagesTar.Name(), images, opts...)
+	err = provider.SaveImagesWithOpts(context.Background(), imagesTar.Name(), images, opts...)
 	if err != nil {
 		return fmt.Errorf("saving images %w", err)
 	}


### PR DESCRIPTION
## What does this PR do?

This introduces a way to pass image save options (like platform) to the image client. This allows saving a specific architecture for an image.

## Why is it important?

With OCI multi-arch images, it is sometimes needed to save image for a different architecture than the current one. This changes allows to control the behavior instead of defaulting to the current platform.
