### PR TITLE
fix: strip headers from logs using log stream specification 

### DIFF
--- a/docker.go
+++ b/docker.go
@@ -368,7 +368,6 @@ func (c *DockerContainer) inspectRawContainer(ctx context.Context) (*container.I
 // Logs will fetch both STDOUT and STDERR from the current container. Returns a
 // ReadCloser and leaves it up to the caller to extract what it wants.
 func (c *DockerContainer) Logs(ctx context.Context) (io.ReadCloser, error) {
-
 	options := container.LogsOptions{
 		ShowStdout: true,
 		ShowStderr: true,

--- a/docker.go
+++ b/docker.go
@@ -5,6 +5,7 @@ import (
 	"bufio"
 	"context"
 	"encoding/base64"
+	"encoding/binary"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -367,7 +368,6 @@ func (c *DockerContainer) inspectRawContainer(ctx context.Context) (*container.I
 // Logs will fetch both STDOUT and STDERR from the current container. Returns a
 // ReadCloser and leaves it up to the caller to extract what it wants.
 func (c *DockerContainer) Logs(ctx context.Context) (io.ReadCloser, error) {
-	const streamHeaderSize = 8
 
 	options := container.LogsOptions{
 		ShowStdout: true,
@@ -380,42 +380,43 @@ func (c *DockerContainer) Logs(ctx context.Context) (io.ReadCloser, error) {
 	}
 	defer c.provider.Close()
 
+	resp, err := c.Inspect(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.Config.Tty {
+		return rc, nil
+	}
+
+	return c.parseMultiplexedLogs(rc), nil
+}
+
+// parseMultiplexedLogs handles the multiplexed log format used when TTY is disabled
+func (c *DockerContainer) parseMultiplexedLogs(rc io.ReadCloser) io.ReadCloser {
+	const streamHeaderSize = 8
+
 	pr, pw := io.Pipe()
 	r := bufio.NewReader(rc)
 
 	go func() {
-		lineStarted := true
-		for err == nil {
-			line, isPrefix, err := r.ReadLine()
-
-			if lineStarted && len(line) >= streamHeaderSize {
-				line = line[streamHeaderSize:] // trim stream header
-				lineStarted = false
-			}
-			if !isPrefix {
-				lineStarted = true
-			}
-
-			_, errW := pw.Write(line)
-			if errW != nil {
+		header := make([]byte, streamHeaderSize)
+		for {
+			_, errH := io.ReadFull(r, header)
+			if errH != nil {
+				_ = pw.CloseWithError(errH)
 				return
 			}
 
-			if !isPrefix {
-				_, errW := pw.Write([]byte("\n"))
-				if errW != nil {
-					return
-				}
-			}
-
-			if err != nil {
-				_ = pw.CloseWithError(err)
+			frameSize := binary.BigEndian.Uint32(header[4:])
+			if _, err := io.CopyN(pw, r, int64(frameSize)); err != nil {
+				pw.CloseWithError(err)
 				return
 			}
 		}
 	}()
 
-	return pr, nil
+	return pr
 }
 
 // Deprecated: use the ContainerRequest.LogConsumerConfig field instead.

--- a/from_dockerfile_test.go
+++ b/from_dockerfile_test.go
@@ -159,7 +159,7 @@ func TestBuildImageFromDockerfile_Target(t *testing.T) {
 
 		logs, err := io.ReadAll(r)
 		require.NoError(t, err)
-		require.Equal(t, fmt.Sprintf("target%d\n\n", i), string(logs))
+		require.Equal(t, fmt.Sprintf("target%d\n", i), string(logs))
 	}
 }
 

--- a/logconsumer_test.go
+++ b/logconsumer_test.go
@@ -363,7 +363,7 @@ func TestContainerLogsShouldBeWithoutStreamHeader(t *testing.T) {
 	ctx := context.Background()
 	req := ContainerRequest{
 		Image:      "alpine:latest",
-		Cmd:        []string{"sh", "-c", "id -u"},
+		Cmd:        []string{"sh", "-c", "echo 'abcdefghi' && echo 'foo'"},
 		WaitingFor: wait.ForExit(),
 	}
 	ctr, err := GenericContainer(ctx, GenericContainerRequest{
@@ -378,7 +378,7 @@ func TestContainerLogsShouldBeWithoutStreamHeader(t *testing.T) {
 	defer r.Close()
 	b, err := io.ReadAll(r)
 	require.NoError(t, err)
-	assert.Equal(t, "0", strings.TrimSpace(string(b)))
+	assert.Equal(t, "abcdefghi\nfoo", strings.TrimSpace(string(b)))
 }
 
 func TestContainerLogsEnableAtStart(t *testing.T) {

--- a/logconsumer_test.go
+++ b/logconsumer_test.go
@@ -378,7 +378,7 @@ func TestContainerLogsShouldBeWithoutStreamHeader(t *testing.T) {
 	defer r.Close()
 	b, err := io.ReadAll(r)
 	require.NoError(t, err)
-	assert.Equal(t, "abcdefghi\nfoo", strings.TrimSpace(string(b)))
+	require.Equal(t, "abcdefghi\nfoo", strings.TrimSpace(string(b)))
 }
 
 func TestContainerLogsTty(t *testing.T) {
@@ -403,7 +403,7 @@ func TestContainerLogsTty(t *testing.T) {
 	defer r.Close()
 	b, err := io.ReadAll(r)
 	require.NoError(t, err)
-	assert.Equal(t, "abcdefghi\r\nfoo", strings.TrimSpace(string(b)))
+	require.Equal(t, "abcdefghi\r\nfoo", strings.TrimSpace(string(b)))
 }
 
 func TestContainerLogsEnableAtStart(t *testing.T) {


### PR DESCRIPTION
## What does this PR do?

According to the log stream specification, the last 4 bytes of the header indicate the length of the log frame. There is an issue when a log message is exactly 10 character long, the header ends with `\00\00\00\10`. The current implementation uses `ReadLine` so it doesn't correctly read the header which results in the header being output. This is what the it looks like with the new test:

```
Error:      	Not equal: 
				expected: "abcdefghi\nfoo"
				actual  : "\x01\x00\x00\x00\x00\x00\x00\ni\nfoo"
				
				Diff:
				--- Expected
				+++ Actual
				@@ -1,2 +1,3 @@
				-abcdefghi
				+      
				+i
					foo
Test:       	TestContainerLogsShouldBeWithoutStreamHeader
```

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Related issues

Relates to #454
