### PR TITLE
chore: clarify image auth warning message for public images

### DIFF
--- a/docker.go
+++ b/docker.go
@@ -1428,7 +1428,7 @@ func (p *DockerProvider) ReuseOrCreateContainer(ctx context.Context, req Contain
 func (p *DockerProvider) attemptToPullImage(ctx context.Context, tag string, pullOpt image.PullOptions) error {
 	registry, imageAuth, err := DockerImageAuth(ctx, tag)
 	if err != nil {
-		p.Logger.Printf("Failed to get image auth for %s. Setting empty credentials for the image: %s. Error is: %s", registry, tag, err)
+		p.Logger.Printf("No image auth found for %s. Setting empty credentials for the image: %s. This is expected for public images. Details: %s", registry, tag, err)
 	} else {
 		// see https://github.com/docker/docs/blob/e8e1204f914767128814dca0ea008644709c117f/engine/api/sdk/examples.md?plain=1#L649-L657
 		encodedJSON, err := json.Marshal(imageAuth)


### PR DESCRIPTION
- chore: clarify image auth warning message for public images

## What does this PR do?

This PR updates the log message shown when Docker image authentication credentials are not found during an image pull.
The new message clarifies that missing credentials is expected for public images and is not a critical error.
No functional or behavioral changes are introduced; only the log output is improved for clarity.

## Why is it important?

The previous log message used the word "Failed", which could be interpreted as a critical error by users, even though missing credentials is normal for public images.
This change helps avoid confusion and reduces unnecessary concern for users pulling public images, improving the developer experience and log readability.

## Related issues

- Relates #2752 


