### PR TITLE
chore(deps): update go.mod in azure module

### DIFF
--- a/modules/azure/go.mod
+++ b/modules/azure/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/docker/go-connections v0.5.0
 	github.com/stretchr/testify v1.10.0
 	github.com/testcontainers/testcontainers-go v0.37.0
-	github.com/testcontainers/testcontainers-go/modules/mssql v0.35.0
+	github.com/testcontainers/testcontainers-go/modules/mssql v0.37.0
 )
 
 require (


### PR DESCRIPTION
## What does this PR do?

When trying to start service bus emulator via the services package I am getting:

`github.com/testcontainers/testcontainers-go/modules/azure/servicebus /Users/XXXX/go/pkg/mod/github.com/testcontainers/testcontainers-go/modules/azure@v0.37.0/servicebus/servicebus.go:137:65: mssqlContainer.Password undefined (type *mssql.MSSQLServerContainer has no field or method Password, but does have unexported field password)`

So the code cannot even be built.

My temporary fix was to change dependency of mssql to version 0.37 in the indirect dependencies of my go.mod.

Solution:
Instead of using mssql version 0.35 in the direct dependencies version 0.37 should be used.


## How to reproduce:

Start the container with:

```go
// Create a Service Bus container
container, err := servicebus.Run(
  ctx,
  "mcr.microsoft.com/azure-messaging/servicebus-emulator:1.1.2",
  servicebus.WithAcceptEULA(),
)
```


## Why is it important?

If this change is not done, running service bus via the service bus package is not possible

## Related issues

- Relates #3008