### PR TITLE
fix(dockermcpgateway): use duckduckgo instead of brave

### DIFF
--- a/modules/dockermcpgateway/dockermcpgateway_test.go
+++ b/modules/dockermcpgateway/dockermcpgateway_test.go
@@ -27,7 +27,7 @@ func TestDockerMCPGateway_withServerAndTools(t *testing.T) {
 	ctr, err := dmcpg.Run(
 		ctx, "docker/mcp-gateway:latest",
 		dmcpg.WithTools("curl", []string{"curl"}),
-		dmcpg.WithTools("brave", []string{"brave_local_search", "brave_web_search"}),
+		dmcpg.WithTools("duckduckgo", []string{"fetch_content", "search"}),
 		dmcpg.WithTools("github-official", []string{"add_issue_comment"}),
 	)
 	testcontainers.CleanupContainer(t, ctr)
@@ -39,8 +39,8 @@ func TestDockerMCPGateway_withServerAndTools(t *testing.T) {
 		switch server {
 		case "curl":
 			require.Equal(t, []string{"curl"}, tools)
-		case "brave":
-			require.ElementsMatch(t, []string{"brave_local_search", "brave_web_search"}, tools)
+		case "duckduckgo":
+			require.ElementsMatch(t, []string{"fetch_content", "search"}, tools)
 		case "github-official":
 			require.Equal(t, []string{"add_issue_comment"}, tools)
 		default:

--- a/modules/dockermcpgateway/examples_test.go
+++ b/modules/dockermcpgateway/examples_test.go
@@ -17,7 +17,7 @@ func ExampleRun() {
 	ctr, err := dmcpg.Run(
 		ctx, "docker/mcp-gateway:latest",
 		dmcpg.WithTools("curl", []string{"curl"}),
-		dmcpg.WithTools("brave", []string{"brave_local_search", "brave_web_search"}),
+		dmcpg.WithTools("duckduckgo", []string{"fetch_content", "search"}),
 		dmcpg.WithTools("github-official", []string{"add_issue_comment"}),
 	)
 	defer func() {
@@ -51,7 +51,7 @@ func ExampleRun_connectMCPClient() {
 	ctr, err := dmcpg.Run(
 		ctx, "docker/mcp-gateway:latest",
 		dmcpg.WithTools("curl", []string{"curl"}),
-		dmcpg.WithTools("brave", []string{"brave_local_search", "brave_web_search"}),
+		dmcpg.WithTools("duckduckgo", []string{"fetch_content", "search"}),
 		dmcpg.WithTools("github-official", []string{"add_issue_comment"}),
 	)
 	defer func() {


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
In the tests, this PR replaces the Brave MCP server with the DuckDuckGo one
<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
Brave server was killed with this error:
"Can't start brave: context deadline exceeded"

making the testable examples to fail, as the tools retrieved by the MCP client were not detected.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->


<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


## Follow-ups
We probably need to ivestigate why the Brave MCP server is killed :thinking:
