### PR TITLE
Set correct version of azure in azurite

### DIFF
--- a/modules/azurite/go.mod
+++ b/modules/azurite/go.mod
@@ -7,7 +7,7 @@ toolchain go1.23.6
 require (
 	github.com/stretchr/testify v1.10.0
 	github.com/testcontainers/testcontainers-go v0.38.0
-	github.com/testcontainers/testcontainers-go/modules/azure v0.35.0
+	github.com/testcontainers/testcontainers-go/modules/azure v0.38.0
 )
 
 require (


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

It fixes the version of azure module in azurite module

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

Right now is not working the command
```
go get github.com/testcontainers/testcontainers-go/modules/azurite@v0.38.0 

> go: github.com/testcontainers/testcontainers-go/modules/azurite imports
        github.com/testcontainers/testcontainers-go/modules/azure/azurite: reading github.com/testcontainers/testcontainers-go/modules/azure/go.mod at revision modules/azure/v0.35.0: unknown revision modules/azure/v0.35.0
```

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- 

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
