### PR TITLE
chore(postgres): use require.NotNil instead of assert.NotNil

### DIFF
--- a/modules/postgres/postgres_test.go
+++ b/modules/postgres/postgres_test.go
@@ -237,7 +237,7 @@ func TestWithSSL(t *testing.T) {
 
 	db, err := sql.Open("postgres", connStr)
 	require.NoError(t, err)
-	assert.NotNil(t, db)
+	require.NotNil(t, db)
 	defer db.Close()
 
 	result, err := db.Exec("SELECT * FROM testdb;")

--- a/modules/postgres/postgres_test.go
+++ b/modules/postgres/postgres_test.go
@@ -17,7 +17,6 @@ import (
 	_ "github.com/jackc/pgx/v5/stdlib"
 	_ "github.com/lib/pq"
 	"github.com/mdelapenya/tlscert"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/testcontainers/testcontainers-go"
@@ -242,7 +241,7 @@ func TestWithSSL(t *testing.T) {
 
 	result, err := db.Exec("SELECT * FROM testdb;")
 	require.NoError(t, err)
-	assert.NotNil(t, result)
+	require.NotNil(t, result)
 }
 
 func TestSSLValidatesKeyMaterialPath(t *testing.T) {


### PR DESCRIPTION

## What does this PR do?

This uses `require.NotNil` instead of `assert.NotNil` when the db variable will be used in the remainder of the test.

## Why is it important?

If the db variable were nil the next line that calls defer db.Close would panic and the following call to db.Exec that we are setting up could panic too.

## Related issues

- Relates #2808 
