### PR TITLE
fix(nats): use wait for listening port instead of wait for log

### DIFF
--- a/modules/nats/nats.go
+++ b/modules/nats/nats.go
@@ -33,10 +33,7 @@ func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustom
 		Image:        img,
 		ExposedPorts: []string{defaultClientPort, defaultRoutingPort, defaultMonitoringPort},
 		Cmd:          []string{"-DV", "-js"},
-		WaitingFor: wait.ForAll(
-			wait.ForListeningPort(defaultClientPort),
-			wait.ForLog("Server is ready"),
-		),
+		WaitingFor:   wait.ForListeningPort(defaultClientPort),
 	}
 
 	genericContainerReq := testcontainers.GenericContainerRequest{


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?

Updates the WaitingFor condition in test containers from

```
wait.ForLog("Listening for client connections on 0.0.0.0:4222")
```

to

```
wait.ForListeningPort(defaultClientPort),
```

## Why is it important?

The previous log message indicated only that the server had started, which might occur before the listener is ready to handle all operations.
`wait.ForListeningPort(defaultClientPort),` is a clearer signal that the nats server startup process has completed, providing a more accurate readiness check.
