### PR TITLE
Redpanda: add support for http proxy

### DIFF
--- a/modules/redpanda/mounts/redpanda.yaml.tpl
+++ b/modules/redpanda/mounts/redpanda.yaml.tpl
@@ -72,4 +72,24 @@ schema_registry_client:
     - address: localhost
       port: 9093
 
+pandaproxy:
+  pandaproxy_api:
+    - address: 0.0.0.0
+      port: 8082
+      name: main
+      authentication_method: {{ .HTTPProxy.AuthenticationMethod }}
+
+{{ if .EnableTLS }}
+  pandaproxy_api_tls:
+    - name: main
+      enabled: true
+      cert_file: /etc/redpanda/cert.pem
+      key_file: /etc/redpanda/key.pem
+{{ end }}
+
+pandaproxy_client:
+  brokers:
+    - address: localhost
+      port: 9093
+
 auto_create_topics_enabled: {{ .AutoCreateTopics }}

--- a/modules/redpanda/options.go
+++ b/modules/redpanda/options.go
@@ -22,6 +22,10 @@ type options struct {
 	// or "http_basic" for HTTP basic authentication.
 	SchemaRegistryAuthenticationMethod string
 
+	// HTTPProxyAuthenticationMethod is the authentication method for HTTP Proxy (pandaproxy).
+	// Valid values are "none", "http_basic", or "oidc".
+	HTTPProxyAuthenticationMethod string
+
 	// EnableWasmTransform is a flag to enable wasm transform.
 	EnableWasmTransform bool
 
@@ -58,6 +62,7 @@ func defaultOptions() options {
 		KafkaEnableAuthorization:           false,
 		KafkaAuthenticationMethod:          "none",
 		SchemaRegistryAuthenticationMethod: "none",
+		HTTPProxyAuthenticationMethod:      "none",
 		ServiceAccounts:                    make(map[string]string, 0),
 		AutoCreateTopics:                   false,
 		EnableTLS:                          false,
@@ -125,6 +130,21 @@ func WithEnableWasmTransform() Option {
 func WithEnableSchemaRegistryHTTPBasicAuth() Option {
 	return func(o *options) {
 		o.SchemaRegistryAuthenticationMethod = "http_basic"
+	}
+}
+
+// WithEnableHTTPProxyBasicAuth enables HTTP basic authentication for
+// HTTP Proxy (pandaproxy).
+func WithEnableHTTPProxyBasicAuth() Option {
+	return func(o *options) {
+		o.HTTPProxyAuthenticationMethod = "http_basic"
+	}
+}
+
+// WithHTTPProxyOIDCAuth enables OIDC authentication for HTTP Proxy (pandaproxy).
+func WithHTTPProxyOIDCAuth() Option {
+	return func(o *options) {
+		o.HTTPProxyAuthenticationMethod = "oidc"
 	}
 }
 

--- a/modules/redpanda/redpanda.go
+++ b/modules/redpanda/redpanda.go
@@ -38,6 +38,7 @@ const (
 	defaultKafkaAPIPort       = "9092/tcp"
 	defaultAdminAPIPort       = "9644/tcp"
 	defaultSchemaRegistryPort = "8081/tcp"
+	defaultHTTPProxyPort      = "8082/tcp"
 
 	redpandaDir         = "/etc/redpanda"
 	entrypointFile      = "/entrypoint-tc.sh"
@@ -76,6 +77,7 @@ func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustom
 				defaultKafkaAPIPort,
 				defaultAdminAPIPort,
 				defaultSchemaRegistryPort,
+				defaultHTTPProxyPort,
 			},
 			Entrypoint: []string{entrypointFile},
 			Cmd: []string{
@@ -92,6 +94,7 @@ func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustom
 				wait.ForMappedPort(defaultKafkaAPIPort),
 				wait.ForMappedPort(defaultAdminAPIPort),
 				wait.ForMappedPort(defaultSchemaRegistryPort),
+				wait.ForMappedPort(defaultHTTPProxyPort),
 			),
 		},
 		Started: true,
@@ -236,6 +239,7 @@ func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustom
 		wait.ForListeningPort(defaultKafkaAPIPort),
 		waitHTTP,
 		wait.ForListeningPort(defaultSchemaRegistryPort),
+		wait.ForListeningPort(defaultHTTPProxyPort),
 		wait.ForLog("Successfully started Redpanda!"),
 	).WaitUntilReady(ctx, ctr)
 	if err != nil {
@@ -297,6 +301,12 @@ func (c *Container) AdminAPIAddress(ctx context.Context) (string, error) {
 // is an HTTP-based API and thus the returned format will be: http://host:port.
 func (c *Container) SchemaRegistryAddress(ctx context.Context) (string, error) {
 	return c.PortEndpoint(ctx, nat.Port(defaultSchemaRegistryPort), c.urlScheme)
+}
+
+// HTTPProxyAddress returns the address to the HTTP Proxy API (pandaproxy). This
+// is an HTTP-based API and thus the returned format will be: http://host:port.
+func (c *Container) HTTPProxyAddress(ctx context.Context) (string, error) {
+	return c.PortEndpoint(ctx, nat.Port(defaultHTTPProxyPort), c.urlScheme)
 }
 
 // renderBootstrapConfig renders the config template for the .bootstrap.yaml config,
@@ -362,6 +372,9 @@ func renderNodeConfig(settings options, hostIP string, advertisedKafkaPort int) 
 		SchemaRegistry: redpandaConfigTplParamsSchemaRegistry{
 			AuthenticationMethod: settings.SchemaRegistryAuthenticationMethod,
 		},
+		HTTPProxy: redpandaConfigTplParamsHTTPProxy{
+			AuthenticationMethod: settings.HTTPProxyAuthenticationMethod,
+		},
 		EnableTLS: settings.EnableTLS,
 	}
 
@@ -389,6 +402,7 @@ type redpandaBootstrapConfigTplParams struct {
 type redpandaConfigTplParams struct {
 	KafkaAPI         redpandaConfigTplParamsKafkaAPI
 	SchemaRegistry   redpandaConfigTplParamsSchemaRegistry
+	HTTPProxy        redpandaConfigTplParamsHTTPProxy
 	AutoCreateTopics bool
 	EnableTLS        bool
 }
@@ -402,6 +416,10 @@ type redpandaConfigTplParamsKafkaAPI struct {
 }
 
 type redpandaConfigTplParamsSchemaRegistry struct {
+	AuthenticationMethod string
+}
+
+type redpandaConfigTplParamsHTTPProxy struct {
 	AuthenticationMethod string
 }
 

--- a/modules/redpanda/redpanda_test.go
+++ b/modules/redpanda/redpanda_test.go
@@ -72,6 +72,16 @@ func TestRedpanda(t *testing.T) {
 	defer resp.Body.Close()
 	require.Equal(t, http.StatusOK, resp.StatusCode)
 
+	// Test HTTP Proxy API
+	httpProxyURL, err := ctr.HTTPProxyAddress(ctx)
+	require.NoError(t, err)
+	req, err = http.NewRequestWithContext(ctx, http.MethodGet, httpProxyURL+"/topics", nil)
+	require.NoError(t, err)
+	resp, err = httpCl.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
 	// Test produce to unknown topic
 	results := kafkaCl.ProduceSync(ctx, &kgo.Record{Topic: "test", Value: []byte("test message")})
 	require.Error(t, results.FirstErr(), kerr.UnknownTopicOrPartition)
@@ -699,6 +709,86 @@ func TestRedpandaBootstrapConfig(t *testing.T) {
 		needsRestart := data[0]["restart"].(bool)
 		require.False(t, needsRestart)
 	}
+}
+
+func TestRedpandaHTTPProxy(t *testing.T) {
+	ctx := context.Background()
+
+	ctr, err := redpanda.Run(ctx, testImage)
+	testcontainers.CleanupContainer(t, ctr)
+	require.NoError(t, err)
+
+	httpCl := &http.Client{Timeout: 10 * time.Second}
+
+	// Get HTTP Proxy URL
+	httpProxyURL, err := ctr.HTTPProxyAddress(ctx)
+	require.NoError(t, err)
+
+	// Test getting list of topics
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, httpProxyURL+"/topics", nil)
+	require.NoError(t, err)
+	resp, err := httpCl.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var topics []string
+	err = json.NewDecoder(resp.Body).Decode(&topics)
+	require.NoError(t, err)
+
+	// Test getting brokers list
+	req, err = http.NewRequestWithContext(ctx, http.MethodGet, httpProxyURL+"/brokers", nil)
+	require.NoError(t, err)
+	resp, err = httpCl.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var brokers map[string]any
+	err = json.NewDecoder(resp.Body).Decode(&brokers)
+	require.NoError(t, err)
+	require.Contains(t, brokers, "brokers")
+}
+
+func TestRedpandaHTTPProxyWithAuthentication(t *testing.T) {
+	ctx := context.Background()
+
+	ctr, err := redpanda.Run(ctx, testImage,
+		redpanda.WithEnableKafkaAuthorization(),
+		redpanda.WithEnableSASL(),
+		redpanda.WithEnableHTTPProxyBasicAuth(),
+		redpanda.WithNewServiceAccount("proxy-user", "proxy-pass"),
+		redpanda.WithSuperusers("proxy-user"),
+	)
+	testcontainers.CleanupContainer(t, ctr)
+	require.NoError(t, err)
+
+	httpCl := &http.Client{Timeout: 10 * time.Second}
+
+	// Get HTTP Proxy URL
+	httpProxyURL, err := ctr.HTTPProxyAddress(ctx)
+	require.NoError(t, err)
+
+	// Test authentication failure
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, httpProxyURL+"/topics", nil)
+	require.NoError(t, err)
+	resp, err := httpCl.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+
+	// Test successful authentication
+	req, err = http.NewRequestWithContext(ctx, http.MethodGet, httpProxyURL+"/topics", nil)
+	require.NoError(t, err)
+	req.SetBasicAuth("proxy-user", "proxy-pass")
+	resp, err = httpCl.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var topics []string
+	err = json.NewDecoder(resp.Body).Decode(&topics)
+	require.NoError(t, err)
 }
 
 func containerHost(ctx context.Context, opts ...testcontainers.ContainerCustomizer) (string, error) {

--- a/modules/redpanda/redpanda_test.go
+++ b/modules/redpanda/redpanda_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/testcontainers/testcontainers-go/network"
 )
 
-const testImage = "docker.redpanda.com/redpandadata/redpanda:v23.3.3"
+const testImage = "docker.redpanda.com/redpandadata/redpanda:v25.2.1"
 
 func TestRedpanda(t *testing.T) {
 	ctx := context.Background()


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

1. Add support for Redpanda HTTP Proxy
2. Bump default Redpanda image to latest 25.2.1

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

So users can use Redpanda HTTP Proxy

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- 

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

Run `cd modules/redpanda && go test -v -run TestRedpandaHTTPProxy -timeout 3m`

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
