### PR TITLE
fix(reaper): remove termSignal override

### DIFF
--- a/docker.go
+++ b/docker.go
@@ -1351,7 +1351,7 @@ func (p *DockerProvider) ReuseOrCreateContainer(ctx context.Context, req Contain
 			return nil, fmt.Errorf("reaper: %w", err)
 		}
 
-		termSignal, err := r.Connect()
+		termSignal, err = r.Connect()
 		if err != nil {
 			return nil, fmt.Errorf("reaper connect: %w", err)
 		}
@@ -1591,7 +1591,7 @@ func (p *DockerProvider) CreateNetwork(ctx context.Context, req NetworkRequest) 
 			return nil, fmt.Errorf("reaper: %w", err)
 		}
 
-		termSignal, err := r.Connect()
+		termSignal, err = r.Connect()
 		if err != nil {
 			return nil, fmt.Errorf("reaper connect: %w", err)
 		}


### PR DESCRIPTION
## What does this PR do?

Fixes termSignal variable override which led to goroutine leak in reaper.

## Why is it important?

Without this change certain scenarios would lead to goroutine leak.

## Related issues

- Closes #3260 

## How to test this PR

Use a test from #3260:

```go
func TestContainersFail(t *testing.T) {
	defer goleak.VerifyNone(t)

	net, err := network.New(t.Context())
	require.NoError(t, err)

	req := testcontainers.ContainerRequest{
		Image:        "redis:latest",
		ExposedPorts: []string{"6379/tcp"},
		WaitingFor:   wait.ForLog("Ready to accept connections"),
		Networks:     []string{net.Name},
	}
	redisC, err := testcontainers.GenericContainer(t.Context(), testcontainers.GenericContainerRequest{
		ContainerRequest: req,
		Started:          true,
	})
	require.NoError(t, err)
	require.NoError(t, testcontainers.TerminateContainer(redisC))
	require.NoError(t, net.Remove(t.Context()))
}
```

I can also commit this test to the PR, if I am allowed to add goleak dependency to go.mod.