### PR TITLE
fix(postgres): snapshot restore

### DIFF
--- a/modules/postgres/postgres.go
+++ b/modules/postgres/postgres.go
@@ -298,8 +298,8 @@ func (c *PostgresContainer) Restore(ctx context.Context, opts ...SnapshotOption)
 		// Terminate all connections to the template database explicitly as the forced drop below will sometimes
 		// not terminate them and then fail to drop the database.
 		fmt.Sprintf(`SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = '%s' AND pid <> pg_backend_pid()`, snapshotName),
-		// Drop the entire database by connecting to the postgres global database
-		fmt.Sprintf(`DROP DATABASE "%s" with (FORCE)`, c.dbName),
+		// Drop the database if it exists
+		fmt.Sprintf(`DROP DATABASE IF EXISTS "%s" with (FORCE)`, c.dbName),
 		// Then restore the previous snapshot
 		fmt.Sprintf(`CREATE DATABASE "%s" WITH TEMPLATE "%s" OWNER "%s"`, c.dbName, snapshotName, c.user),
 	)


### PR DESCRIPTION
Label: Bug

## What does this PR do?

It fixes #3263 by providing two changes
- Close any existing connection on the snapshot DB
- Drop the database only if it exists

## Why is it important?

We had very flaky tests without this change.

## Related issues

Seldomly, we still run into #3233 and would be happy about a fix as well.

- Closes #3263
- Relates #3233

## How to test this PR

As the error(s) only occur in some unknown circumstances it is very hard to enforce their occurrence and also a test situation where they fire.
