### PR TITLE
feat(registry): add helper functions to pull and tag images

### DIFF
--- a/docs/modules/registry.md
+++ b/docs/modules/registry.md
@@ -137,6 +137,34 @@ The `PushImage` method allows to push an image to the Registry. It receives the 
 
 If the push operation is successful, the method will internally wait for the image to be available in the Registry, querying the Registry API, returning an error in case of any failure (e.g. pushing or waiting for the image).
 
+#### PullImage
+
+- Not available until the next release <a href="https://github.com/testcontainers/testcontainers-go"><span class="tc-version">:material-tag: main</span></a>
+
+The `PullImage` method allows to pull an image to local Docker daemon.
+This method downloads (copies) the specified image reference so it becomes available locally for further operations such as tagging or pushing.
+It receives the Go context and the image reference as parameters.
+
+!!! info
+    The image reference should be in the format `my-registry:port/image:tag` in order to be pulled from the Registry.
+
+<!--codeinclude-->
+[Pulling images](../../modules/registry/examples_test.go) inside_block:pullingImage
+<!--/codeinclude-->
+
+#### TagImage
+
+- Not available until the next release <a href="https://github.com/testcontainers/testcontainers-go"><span class="tc-version">:material-tag: main</span></a>
+
+The `TagImage` method allows to tag an image from the local Registry. It receives the Go context, the image reference and the name of the new tag as parameters.
+
+!!! info
+    The image reference should be in the format `my-registry:port/image:tag` in order to be tagged properly.
+
+<!--codeinclude-->
+[Tagging images](../../modules/registry/examples_test.go) inside_block:taggingImage
+<!--/codeinclude-->
+
 #### DeleteImage
 
 - Since <a href="https://github.com/testcontainers/testcontainers-go/releases/tag/v0.30.0"><span class="tc-version">:material-tag: v0.30.0</span></a>

--- a/docs/modules/registry.md
+++ b/docs/modules/registry.md
@@ -143,7 +143,7 @@ If the push operation is successful, the method will internally wait for the ima
 
 The `PullImage` method allows to pull an image to local Docker daemon.
 This method downloads (copies) the specified image reference so it becomes available locally for further operations such as tagging or pushing.
-It receives the Go context and the image reference as parameters.
+It receives the Go context and the image reference as parameters, pulling the image with the same platform as the registry container's image.
 
 !!! info
     The image reference should be in the format `my-registry:port/image:tag` in order to be pulled from the Registry.

--- a/modules/registry/examples_test.go
+++ b/modules/registry/examples_test.go
@@ -203,7 +203,7 @@ func ExampleRun_pushImage() {
 	// pullingImage {
 	// defaultRegistryURI is localhost:32878
 	// defaultImage is customredis
-	// defaulTag is v1.2.3
+	// defaultTag is v1.2.3
 	imageRef := fmt.Sprintf("%s/%s:%s", defaultRegistryURI, defaultImage, defaultTag)
 	err = registryContainer.PullImage(ctx, imageRef)
 	if err != nil {
@@ -215,7 +215,7 @@ func ExampleRun_pushImage() {
 	// taggingImage {
 	// defaultRegistryURI is localhost:32878
 	// defaultImage is customredis
-	// defaulTag is v1.2.3
+	// defaultTag is v1.2.3
 	taggedImage := fmt.Sprintf("%s/%s:%s", registryContainer.RegistryName, defaultImage, defaultTag)
 	err = registryContainer.TagImage(ctx, imageRef, taggedImage)
 	if err != nil {

--- a/modules/registry/examples_test.go
+++ b/modules/registry/examples_test.go
@@ -181,33 +181,58 @@ func ExampleRun_pushImage() {
 		return
 	}
 
-	// pushingImage {
-	// repo is localhost:32878/customredis
-	// tag is v1.2.3
+	newImage := fmt.Sprintf("%s:%s", repo, tag)
 	err = registryContainer.PushImage(context.Background(), fmt.Sprintf("%s:%s", repo, tag))
 	if err != nil {
 		log.Printf("failed to push image: %s", err)
 		return
 	}
-	// }
 
-	newImage := fmt.Sprintf("%s:%s", repo, tag)
+	// pull a redis image from an public registry,
+	// tag it specifying the local registry name,
+	// and push to the private registry.
+
+	defaultRegistryURI := "docker.io/library"
+	defaultImage := "redis"
+	defaultTag := "5.0-alpine"
+
+	imageRef := fmt.Sprintf("%s/%s:%s", defaultRegistryURI, defaultImage, defaultTag)
+	err = registryContainer.PullImage(ctx, imageRef)
+	if err != nil {
+		log.Printf("failed to pull image: %s", err)
+		return
+	}
+
+	taggedImage := fmt.Sprintf("%s/%s:%s", registryContainer.RegistryName, defaultImage, defaultTag)
+	err = registryContainer.TagImage(ctx, imageRef, taggedImage)
+	if err != nil {
+		log.Printf("failed to tag image: %s", err)
+		return
+	}
+
+	err = registryContainer.PushImage(context.Background(), taggedImage)
+	if err != nil {
+		log.Printf("failed to push image: %s", err)
+		return
+	}
 
 	// now run a container from the new image
 	// But first remove the local image to avoid using the local one.
 
-	// deletingImage {
-	// newImage is customredis:v1.2.3
 	err = registryContainer.DeleteImage(context.Background(), newImage)
 	if err != nil {
 		log.Printf("failed to delete image: %s", err)
 		return
 	}
-	// }
+	err = registryContainer.DeleteImage(context.Background(), taggedImage)
+	if err != nil {
+		log.Printf("failed to delete image: %s", err)
+		return
+	}
 
 	newRedisC, err := testcontainers.GenericContainer(context.Background(), testcontainers.GenericContainerRequest{
 		ContainerRequest: testcontainers.ContainerRequest{
-			Image:        newImage,
+			Image:        taggedImage,
 			ExposedPorts: []string{"6379/tcp"},
 			WaitingFor:   wait.ForLog("Ready to accept connections"),
 		},
@@ -219,13 +244,13 @@ func ExampleRun_pushImage() {
 		}
 	}()
 	if err != nil {
-		log.Printf("failed to start container from %s: %s", newImage, err)
+		log.Printf("failed to start container from %s: %s", taggedImage, err)
 		return
 	}
 
 	state, err := newRedisC.State(context.Background())
 	if err != nil {
-		log.Printf("failed to get redis container state from %s: %s", newImage, err)
+		log.Printf("failed to get redis container state from %s: %s", taggedImage, err)
 		return
 	}
 

--- a/modules/registry/examples_test.go
+++ b/modules/registry/examples_test.go
@@ -181,12 +181,16 @@ func ExampleRun_pushImage() {
 		return
 	}
 
+	// pushingImage {
+	// repo is localhost:32878/customredis
+	// tag is v1.2.3
 	newImage := fmt.Sprintf("%s:%s", repo, tag)
 	err = registryContainer.PushImage(context.Background(), fmt.Sprintf("%s:%s", repo, tag))
 	if err != nil {
 		log.Printf("failed to push image: %s", err)
 		return
 	}
+	// }
 
 	// pull a redis image from an public registry,
 	// tag it specifying the local registry name,
@@ -196,19 +200,29 @@ func ExampleRun_pushImage() {
 	defaultImage := "redis"
 	defaultTag := "5.0-alpine"
 
+	// pullingImage {
+	// defaultRegistryURI is localhost:32878
+	// defaultImage is customredis
+	// defaulTag is v1.2.3
 	imageRef := fmt.Sprintf("%s/%s:%s", defaultRegistryURI, defaultImage, defaultTag)
 	err = registryContainer.PullImage(ctx, imageRef)
 	if err != nil {
 		log.Printf("failed to pull image: %s", err)
 		return
 	}
+	// }
 
+	// taggingImage {
+	// defaultRegistryURI is localhost:32878
+	// defaultImage is customredis
+	// defaulTag is v1.2.3
 	taggedImage := fmt.Sprintf("%s/%s:%s", registryContainer.RegistryName, defaultImage, defaultTag)
 	err = registryContainer.TagImage(ctx, imageRef, taggedImage)
 	if err != nil {
 		log.Printf("failed to tag image: %s", err)
 		return
 	}
+	// }
 
 	err = registryContainer.PushImage(context.Background(), taggedImage)
 	if err != nil {
@@ -219,11 +233,14 @@ func ExampleRun_pushImage() {
 	// now run a container from the new image
 	// But first remove the local image to avoid using the local one.
 
+	// deletingImage {
+	// newImage is customredis:v1.2.3
 	err = registryContainer.DeleteImage(context.Background(), newImage)
 	if err != nil {
 		log.Printf("failed to delete image: %s", err)
 		return
 	}
+	// }
 	err = registryContainer.DeleteImage(context.Background(), taggedImage)
 	if err != nil {
 		log.Printf("failed to delete image: %s", err)

--- a/modules/registry/registry.go
+++ b/modules/registry/registry.go
@@ -18,7 +18,6 @@ import (
 	"github.com/docker/docker/api/types/registry"
 
 	"github.com/testcontainers/testcontainers-go"
-	"github.com/testcontainers/testcontainers-go/log"
 	"github.com/testcontainers/testcontainers-go/wait"
 )
 
@@ -222,14 +221,8 @@ func (c *RegistryContainer) PullImage(ctx context.Context, ref string) error {
 		return fmt.Errorf("inspect registry container: %w", err)
 	}
 	platform := "amd64"
-	if inspect.ImageManifestDescriptor != nil {
-		if inspect.ImageManifestDescriptor.Platform != nil {
-			platform = inspect.ImageManifestDescriptor.Platform.Architecture
-		} else {
-			log.Printf("DEBUG: No platform found for image %s: %+v", ref, inspect)
-		}
-	} else {
-		log.Printf("DEBUG: No image manifest descriptor found for image %s: %+v", ref, inspect)
+	if inspect.ImageManifestDescriptor != nil && inspect.ImageManifestDescriptor.Platform != nil {
+		platform = inspect.ImageManifestDescriptor.Platform.Architecture
 	}
 
 	pullOpts := image.PullOptions{

--- a/modules/registry/registry.go
+++ b/modules/registry/registry.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"os"
@@ -175,7 +176,7 @@ func (c *RegistryContainer) ImageExists(ctx context.Context, imageRef string) er
 func (c *RegistryContainer) PushImage(ctx context.Context, ref string) error {
 	dockerProvider, err := testcontainers.NewDockerProvider()
 	if err != nil {
-		return fmt.Errorf("failed to create Docker provider: %w", err)
+		return fmt.Errorf("create docker client: %w", err)
 	}
 	defer dockerProvider.Close()
 
@@ -199,10 +200,62 @@ func (c *RegistryContainer) PushImage(ctx context.Context, ref string) error {
 
 	_, err = dockerCli.ImagePush(ctx, ref, pushOpts)
 	if err != nil {
-		return fmt.Errorf("failed to push image %s: %w", ref, err)
+		return fmt.Errorf("push image %q: %w", ref, err)
 	}
 
 	return c.ImageExists(ctx, ref)
+}
+
+// PullImage pulls an image from an external registry into the local Docker daemon.
+// Differently from PushImage, which uploads an image to the testcontainers managed registry,
+// this method downloads (copies) the specified image reference so it becomes
+// available locally for further operations such as tagging or pushing.
+func (c *RegistryContainer) PullImage(ctx context.Context, ref string) error {
+	dockerProvider, err := testcontainers.NewDockerProvider()
+	if err != nil {
+		return fmt.Errorf("create docker client: %w", err)
+	}
+	defer dockerProvider.Close()
+
+	dockerCli := dockerProvider.Client()
+
+	pullOpts := image.PullOptions{
+		All:      false,
+		Platform: "linux/amd64",
+	}
+
+	output, err := dockerCli.ImagePull(ctx, ref, pullOpts)
+	if err != nil {
+		return fmt.Errorf("pull image %q: %w", ref, err)
+	}
+	defer output.Close()
+
+	_, err = io.Copy(io.Discard, output)
+	if err != nil {
+		return fmt.Errorf("read image pull output: %w", err)
+	}
+
+	return nil
+}
+
+// TagImage tags an image from the local Registry.
+// This function is helpful when you want to push an image to your Registry
+// instance made by testcontainer.
+func (c *RegistryContainer) TagImage(ctx context.Context, image, ref string) error {
+	dockerProvider, err := testcontainers.NewDockerProvider()
+	if err != nil {
+		return fmt.Errorf("create docker client: %w", err)
+	}
+	defer dockerProvider.Close()
+
+	dockerCli := dockerProvider.Client()
+
+	err = dockerCli.ImageTag(ctx, image, ref)
+	if err != nil {
+		return fmt.Errorf("tag image %q: %w", image, err)
+	}
+
+	return nil
 }
 
 // Deprecated: use Run instead

--- a/modules/registry/registry.go
+++ b/modules/registry/registry.go
@@ -10,6 +10,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"runtime"
 	"strings"
 	"time"
 
@@ -220,7 +221,8 @@ func (c *RegistryContainer) PullImage(ctx context.Context, ref string) error {
 	if err != nil {
 		return fmt.Errorf("inspect registry container: %w", err)
 	}
-	platform := "amd64"
+
+	platform := runtime.GOARCH
 	if inspect.ImageManifestDescriptor != nil && inspect.ImageManifestDescriptor.Platform != nil {
 		platform = inspect.ImageManifestDescriptor.Platform.Architecture
 	}

--- a/modules/registry/registry.go
+++ b/modules/registry/registry.go
@@ -174,13 +174,11 @@ func (c *RegistryContainer) ImageExists(ctx context.Context, imageRef string) er
 // PushImage pushes an image to the Registry container. It will use the internally stored RegistryName
 // to push the image to the container, and it will finally wait for the image to be pushed.
 func (c *RegistryContainer) PushImage(ctx context.Context, ref string) error {
-	dockerProvider, err := testcontainers.NewDockerProvider()
+	dockerCli, err := testcontainers.NewDockerClientWithOpts(ctx)
 	if err != nil {
 		return fmt.Errorf("create docker client: %w", err)
 	}
-	defer dockerProvider.Close()
-
-	dockerCli := dockerProvider.Client()
+	defer dockerCli.Close()
 
 	_, imageAuth, err := testcontainers.DockerImageAuth(ctx, ref)
 	if err != nil {
@@ -211,13 +209,11 @@ func (c *RegistryContainer) PushImage(ctx context.Context, ref string) error {
 // this method downloads (copies) the specified image reference so it becomes
 // available locally for further operations such as tagging or pushing.
 func (c *RegistryContainer) PullImage(ctx context.Context, ref string) error {
-	dockerProvider, err := testcontainers.NewDockerProvider()
+	dockerCli, err := testcontainers.NewDockerClientWithOpts(ctx)
 	if err != nil {
 		return fmt.Errorf("create docker client: %w", err)
 	}
-	defer dockerProvider.Close()
-
-	dockerCli := dockerProvider.Client()
+	defer dockerCli.Close()
 
 	pullOpts := image.PullOptions{
 		All:      false,
@@ -242,13 +238,11 @@ func (c *RegistryContainer) PullImage(ctx context.Context, ref string) error {
 // This function is helpful when you want to push an image to your Registry
 // instance made by testcontainer.
 func (c *RegistryContainer) TagImage(ctx context.Context, image, ref string) error {
-	dockerProvider, err := testcontainers.NewDockerProvider()
+	dockerCli, err := testcontainers.NewDockerClientWithOpts(ctx)
 	if err != nil {
 		return fmt.Errorf("create docker client: %w", err)
 	}
-	defer dockerProvider.Close()
-
-	dockerCli := dockerProvider.Client()
+	defer dockerCli.Close()
 
 	err = dockerCli.ImageTag(ctx, image, ref)
 	if err != nil {

--- a/modules/registry/registry_test.go
+++ b/modules/registry/registry_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/cpuguy83/dockercfg"
@@ -306,8 +307,14 @@ func TestPullImage_samePlatform(t *testing.T) {
 
 	imgInspect, err := dockerCli.ImageInspect(ctx, img)
 	require.NoError(t, err)
-	require.Equal(t, inspect.ImageManifestDescriptor.Platform.Architecture, imgInspect.Architecture)
-	require.Equal(t, inspect.ImageManifestDescriptor.Platform.OS, imgInspect.Os)
+
+	if inspect.ImageManifestDescriptor != nil && inspect.ImageManifestDescriptor.Platform != nil {
+		require.Equal(t, inspect.ImageManifestDescriptor.Platform.Architecture, imgInspect.Architecture)
+		require.Equal(t, inspect.ImageManifestDescriptor.Platform.OS, imgInspect.Os)
+	} else {
+		require.Equal(t, "linux", imgInspect.Os)
+		require.Equal(t, runtime.GOARCH, imgInspect.Architecture)
+	}
 }
 
 // setAuthConfig sets the DOCKER_AUTH_CONFIG environment variable with

--- a/modules/registry/registry_test.go
+++ b/modules/registry/registry_test.go
@@ -224,6 +224,14 @@ func TestPullImage_samePlatform(t *testing.T) {
 	require.NoError(t, err)
 	defer dockerCli.Close()
 
+	t.Logf("Docker info: checking daemon configuration...")
+	info, err := dockerCli.Info(ctx)
+	if err == nil {
+		t.Logf("Docker version: %s", info.ServerVersion)
+		t.Logf("Docker storage driver: %s", info.Driver)
+		t.Logf("Docker experimental: %v", info.ExperimentalBuild)
+	}
+
 	// Pull an image that shares the same platform as the registry container's image.
 	const img = "redis:latest"
 

--- a/modules/registry/registry_test.go
+++ b/modules/registry/registry_test.go
@@ -287,14 +287,6 @@ func TestPullImage_samePlatform(t *testing.T) {
 	require.NoError(t, err)
 	defer dockerCli.Close()
 
-	t.Logf("Docker info: checking daemon configuration...")
-	info, err := dockerCli.Info(ctx)
-	if err == nil {
-		t.Logf("Docker version: %s", info.ServerVersion)
-		t.Logf("Docker storage driver: %s", info.Driver)
-		t.Logf("Docker experimental: %v", info.ExperimentalBuild)
-	}
-
 	// Pull an image that shares the same platform as the registry container's image.
 	const img = "redis:latest"
 


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->
This PR adds a couple of helper functions to interact with the registry module:
* `PullImage`
* `TagImage`

When pulling images, it will use the same architecture as the image used to run the registry, as it could be using and arm-based image. Important to notice that, when inspecting an image, the field `ImageManifestDescriptor` response field is only available with containerd integration enabled. This happens on recent installations of Docker Desktop. If that field is `nil`, the pulled image will use `linux` as OS and the host's architecture.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->
Currently, the registry module does not support these two simple operations.
I've found them useful to have in the library, since most tests that rely on `modules/registry` will probably need to use them.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Supersedes and Closes #3271 

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
