### PR TITLE
docs: clarify no client SDKs in production modules/images, in contributing.md

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -55,14 +55,9 @@ Please just be sure to:
 
 * when updating the `go.mod` file, please run `make tidy-all` to ensure all modules are updated.
 
-### Technology modules: client/SDK dependency policy
+### Module contribution 
 
-Production modules and images should remain **driver-agnostic**.
-
-- Do not bundle client SDKs (database/message broker/storage drivers, etc.) **in production modules or images.**  
-  Examples: `yugabyte/gocql`, etc.
-- If you need to show how to connect to a given technology, provide bootstrap code as helpers and keep those dependencies in **tests/examples** only.
-- Prefer small helpers that read container state and build a client config. Reference those helpers from examples and tests.
+For detailed policies on module development and contributions, please refer to the [Module Index page](./modules/index.md).
 
 ## Documentation contributions
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -55,6 +55,15 @@ Please just be sure to:
 
 * when updating the `go.mod` file, please run `make tidy-all` to ensure all modules are updated.
 
+### Technology modules: client/SDK dependency policy
+
+Production modules and images should remain **driver-agnostic**.
+
+- Do not bundle client SDKs (database/message broker/storage drivers, etc.) **in production modules or images.**  
+  Examples: `yugabyte/gocql`, etc.
+- If you need to show how to connect to a given technology, provide bootstrap code as helpers and keep those dependencies in **tests/examples** only.
+- Prefer small helpers that read container state and build a client config. Reference those helpers from examples and tests.
+
 ## Documentation contributions
 
 The _Testcontainers for Go_ documentation is a static site built with [MkDocs](https://www.mkdocs.org/).

--- a/docs/modules/index.md
+++ b/docs/modules/index.md
@@ -96,6 +96,15 @@ go run . new module --name ${NAME_OF_YOUR_MODULE} --image "${REGISTRY}/${MODULE}
     go run . new example --name ${NAME_OF_YOUR_MODULE} --image "${REGISTRY}/${MODULE}:${TAG}" --title ${TITLE_OF_YOUR_MODULE}
     ```
 
+### Technology modules: client/SDK dependency policy
+
+Production modules and images should remain **driver-agnostic**.
+
+- Do not bundle client SDKs (database/message broker/storage drivers, etc.) **in production modules or images.**  
+  Examples: `yugabyte/gocql`, etc.
+- If you need to show how to connect to a given technology, provide bootstrap code as helpers and keep those dependencies in **tests/examples** only.
+- Prefer small helpers that read container state and build a client config. Reference those helpers from examples and tests.
+
 ### Adding types and methods to the module
 
 We are going to propose a set of steps to follow when adding types and methods to the module:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?

- Document a policy to **not bundle client SDKs** in production modules/images, in contributing.d

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

- Keep artifacts driver-agnostic, reduce maintenance/version churn, and let users pick their client.


## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- #2832 

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
