### PR TITLE
chore(go): bump to Go 1.24 as minimal version

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,7 +2,7 @@
 // README at: https://github.com/devcontainers/templates/tree/main/src/go
 {
 	"name": "Go",
-	"image": "mcr.microsoft.com/devcontainers/go:1.23-bookworm",
+	"image": "mcr.microsoft.com/devcontainers/go:1.24-trixie",
 
 	// Features to add to the dev container. More info: https://containers.dev/features.
 	// "features": {},

--- a/.github/workflows/ci-test-go.yml
+++ b/.github/workflows/ci-test-go.yml
@@ -118,7 +118,7 @@ jobs:
       - name: Decide if Sonar must be run
         if: ${{ matrix.platform == 'ubuntu-latest' }}
         run: |
-          if [[ "1.23.x" == "${{ inputs.go-version }}" ]] && \
+          if [[ "1.24.x" == "${{ inputs.go-version }}" ]] && \
              [[ "true" != "${{ inputs.rootless-docker }}" ]] && \
              [[ "true" != "${{ inputs.testcontainers-cloud }}" ]] && \
              [[ "true" != "${{ inputs.ryuk-disabled }}" ]] && \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
       # We don't want to fail the build the soonest but identify which modules passed and failed.
       fail-fast: false
       matrix:
-        go-version: [1.23.x, 1.24.x]
+        go-version: [1.24.x, 1.25.x]
         module: ${{ fromJSON(needs.detect-modules.outputs.modules) }}
     permissions:
       contents: read  # for actions/checkout to fetch code
@@ -88,7 +88,7 @@ jobs:
       # We don't want to fail the build the soonest but identify which modules passed and failed.
       fail-fast: false
       matrix:
-        go-version: [1.23.x, 1.24.x]
+        go-version: [1.24.x, 1.25.x]
     uses: ./.github/workflows/ci-test-go.yml
     with:
       go-version: ${{ matrix.go-version }}
@@ -109,7 +109,7 @@ jobs:
     name: "Test with reaper off"
     strategy:
       matrix:
-        go-version: [1.23.x, 1.24.x]
+        go-version: [1.24.x, 1.25.x]
     uses: ./.github/workflows/ci-test-go.yml
     with:
       go-version: ${{ matrix.go-version }}
@@ -130,7 +130,7 @@ jobs:
     name: "Test with Rootless Docker"
     strategy:
       matrix:
-        go-version: [1.23.x, 1.24.x]
+        go-version: [1.24.x, 1.25.x]
     uses: ./.github/workflows/ci-test-go.yml
     with:
       go-version: ${{ matrix.go-version }}

--- a/docs/system_requirements/ci/aws_codebuild.md
+++ b/docs/system_requirements/ci/aws_codebuild.md
@@ -11,7 +11,7 @@ version: 0.2
 phases:
   install:
     runtime-versions:
-      golang: 1.23
+      golang: 1.24
   build:
     commands:
       - go test ./...

--- a/docs/system_requirements/ci/circle_ci.md
+++ b/docs/system_requirements/ci/circle_ci.md
@@ -57,7 +57,7 @@ workflows:
       - tests:
           matrix:
             parameters:
-              go-version: ["1.23.6", "1.24.0"]
+              go-version: ["1.24.7", "1.25.1"]
 
 ```
 

--- a/docs/system_requirements/ci/concourse_ci.md
+++ b/docs/system_requirements/ci/concourse_ci.md
@@ -36,7 +36,7 @@ jobs:
             start_docker
 
             cd repo
-            docker run -it --rm -v "$PWD:$PWD" -w "$PWD" -v /var/run/docker.sock:/var/run/docker.sock golang:1.23 go test ./...
+            docker run -it --rm -v "$PWD:$PWD" -w "$PWD" -v /var/run/docker.sock:/var/run/docker.sock golang:1.24 go test ./...
 ```
 
 Finally, you can use Concourse's [fly CLI](https://concourse-ci.org/fly.html) to set the pipeline and trigger the job:

--- a/docs/system_requirements/ci/dind_patterns.md
+++ b/docs/system_requirements/ci/dind_patterns.md
@@ -24,7 +24,7 @@ $ tree .
 └── platform
     └── integration_test.go
 
-$ docker run -it --rm -v $PWD:$PWD -w $PWD -v /var/run/docker.sock:/var/run/docker.sock golang:1.23 go test ./... -v
+$ docker run -it --rm -v $PWD:$PWD -w $PWD -v /var/run/docker.sock:/var/run/docker.sock golang:1.24 go test ./... -v
 ```
 
 Where:
@@ -45,7 +45,7 @@ The same can be achieved with Docker Compose:
 
 ```yaml
 tests:
-  image: golang:1.23
+  image: golang:1.24
   stop_signal: SIGKILL
   stdin_open: true
   tty: true

--- a/docs/system_requirements/ci/gitlab_ci.md
+++ b/docs/system_requirements/ci/gitlab_ci.md
@@ -57,7 +57,7 @@ variables:
   DOCKER_DRIVER: overlay2
 
 test:
- image: golang:1.23
+ image: golang:1.24
  stage: test
  script: go test ./... -v
 ```

--- a/docs/system_requirements/ci/tekton.md
+++ b/docs/system_requirements/ci/tekton.md
@@ -16,7 +16,7 @@ spec:
     - name: source
   steps:
     - name: read
-      image: golang:1.23
+      image: golang:1.24
       workingDir: $(workspaces.source.path)
       script: go test ./... -v
       volumeMounts:

--- a/examples/nginx/go.mod
+++ b/examples/nginx/go.mod
@@ -1,8 +1,8 @@
 module github.com/testcontainers/testcontainers-go/examples/nginx
 
-go 1.23.0
+go 1.24
 
-toolchain go1.23.6
+toolchain go1.24.7
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/testcontainers/testcontainers-go
 
-go 1.23.0
+go 1.24
 
-toolchain go1.23.6
+toolchain go1.24.7
 
 require (
 	dario.cat/mergo v1.0.1

--- a/modulegen/go.mod
+++ b/modulegen/go.mod
@@ -1,8 +1,8 @@
 module github.com/testcontainers/testcontainers-go/modulegen
 
-go 1.23.0
+go 1.24
 
-toolchain go1.23.6
+toolchain go1.24.7
 
 require (
 	github.com/spf13/cobra v1.8.0

--- a/modules/aerospike/go.mod
+++ b/modules/aerospike/go.mod
@@ -1,6 +1,6 @@
 module github.com/testcontainers/testcontainers-go/modules/aerospike
 
-go 1.23.0
+go 1.24
 
 require (
 	github.com/aerospike/aerospike-client-go/v8 v8.2.0

--- a/modules/arangodb/go.mod
+++ b/modules/arangodb/go.mod
@@ -1,6 +1,6 @@
 module github.com/testcontainers/testcontainers-go/modules/arangodb
 
-go 1.23.0
+go 1.24
 
 toolchain go1.24.1
 

--- a/modules/artemis/go.mod
+++ b/modules/artemis/go.mod
@@ -1,8 +1,8 @@
 module github.com/testcontainers/testcontainers-go/modules/artemis
 
-go 1.23.0
+go 1.24
 
-toolchain go1.23.6
+toolchain go1.24.7
 
 require (
 	github.com/docker/go-connections v0.6.0

--- a/modules/azure/go.mod
+++ b/modules/azure/go.mod
@@ -1,6 +1,6 @@
 module github.com/testcontainers/testcontainers-go/modules/azure
 
-go 1.23.0
+go 1.24
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.17.0

--- a/modules/azurite/go.mod
+++ b/modules/azurite/go.mod
@@ -1,8 +1,8 @@
 module github.com/testcontainers/testcontainers-go/modules/azurite
 
-go 1.23.0
+go 1.24
 
-toolchain go1.23.6
+toolchain go1.24.7
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/modules/cassandra/go.mod
+++ b/modules/cassandra/go.mod
@@ -1,8 +1,8 @@
 module github.com/testcontainers/testcontainers-go/modules/cassandra
 
-go 1.23.0
+go 1.24
 
-toolchain go1.23.6
+toolchain go1.24.7
 
 require (
 	github.com/docker/go-connections v0.6.0

--- a/modules/chroma/go.mod
+++ b/modules/chroma/go.mod
@@ -1,8 +1,8 @@
 module github.com/testcontainers/testcontainers-go/modules/chroma
 
-go 1.23.0
+go 1.24
 
-toolchain go1.23.6
+toolchain go1.24.7
 
 require (
 	github.com/amikos-tech/chroma-go v0.1.2

--- a/modules/clickhouse/go.mod
+++ b/modules/clickhouse/go.mod
@@ -1,8 +1,8 @@
 module github.com/testcontainers/testcontainers-go/modules/clickhouse
 
-go 1.23.0
+go 1.24
 
-toolchain go1.23.6
+toolchain go1.24.7
 
 require (
 	github.com/ClickHouse/clickhouse-go/v2 v2.34.0

--- a/modules/cockroachdb/go.mod
+++ b/modules/cockroachdb/go.mod
@@ -1,8 +1,8 @@
 module github.com/testcontainers/testcontainers-go/modules/cockroachdb
 
-go 1.23.0
+go 1.24
 
-toolchain go1.23.6
+toolchain go1.24.7
 
 require (
 	github.com/docker/go-connections v0.6.0

--- a/modules/compose/testdata/echoserver.Dockerfile
+++ b/modules/compose/testdata/echoserver.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23-alpine@sha256:f8113c4b13e2a8b3a168dceaee88ac27743cc84e959f43b9dbd2291e9c3f57a0
+FROM golang:1.24-alpine@sha256:fc2cff6625f3c1c92e6c85938ac5bd09034ad0d4bc2dfb08278020b68540dbb5
 
 WORKDIR /app
 

--- a/modules/consul/go.mod
+++ b/modules/consul/go.mod
@@ -1,8 +1,8 @@
 module github.com/testcontainers/testcontainers-go/modules/consul
 
-go 1.23.0
+go 1.24
 
-toolchain go1.23.6
+toolchain go1.24.7
 
 require (
 	github.com/hashicorp/consul/api v1.27.0

--- a/modules/couchbase/go.mod
+++ b/modules/couchbase/go.mod
@@ -1,8 +1,8 @@
 module github.com/testcontainers/testcontainers-go/modules/couchbase
 
-go 1.23.0
+go 1.24
 
-toolchain go1.23.6
+toolchain go1.24.7
 
 require (
 	github.com/cenkalti/backoff/v4 v4.2.1

--- a/modules/databend/go.mod
+++ b/modules/databend/go.mod
@@ -1,8 +1,8 @@
 module github.com/testcontainers/testcontainers-go/modules/databend
 
-go 1.23.0
+go 1.24
 
-toolchain go1.23.6
+toolchain go1.24.7
 
 require (
 	github.com/datafuselabs/databend-go v0.7.0

--- a/modules/dind/go.mod
+++ b/modules/dind/go.mod
@@ -1,8 +1,8 @@
 module github.com/testcontainers/testcontainers-go/modules/dind
 
-go 1.23.0
+go 1.24
 
-toolchain go1.23.6
+toolchain go1.24.7
 
 require (
 	github.com/docker/docker v28.3.3+incompatible

--- a/modules/dockermcpgateway/go.mod
+++ b/modules/dockermcpgateway/go.mod
@@ -1,6 +1,6 @@
 module github.com/testcontainers/testcontainers-go/modules/dockermcpgateway
 
-go 1.23.0
+go 1.24
 
 require (
 	github.com/docker/docker v28.3.3+incompatible

--- a/modules/dockermodelrunner/go.mod
+++ b/modules/dockermodelrunner/go.mod
@@ -1,6 +1,6 @@
 module github.com/testcontainers/testcontainers-go/modules/dockermodelrunner
 
-go 1.23.0
+go 1.24
 
 require (
 	github.com/openai/openai-go v0.1.0-beta.9

--- a/modules/dolt/go.mod
+++ b/modules/dolt/go.mod
@@ -1,8 +1,8 @@
 module github.com/testcontainers/testcontainers-go/modules/dolt
 
-go 1.23.0
+go 1.24
 
-toolchain go1.23.6
+toolchain go1.24.7
 
 require (
 	github.com/go-sql-driver/mysql v1.7.1

--- a/modules/dynamodb/go.mod
+++ b/modules/dynamodb/go.mod
@@ -1,8 +1,8 @@
 module github.com/testcontainers/testcontainers-go/modules/dynamodb
 
-go 1.23.0
+go 1.24
 
-toolchain go1.23.6
+toolchain go1.24.7
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.31.0

--- a/modules/elasticsearch/go.mod
+++ b/modules/elasticsearch/go.mod
@@ -1,8 +1,8 @@
 module github.com/testcontainers/testcontainers-go/modules/elasticsearch
 
-go 1.23.0
+go 1.24
 
-toolchain go1.23.6
+toolchain go1.24.7
 
 require (
 	github.com/elastic/go-elasticsearch/v8 v8.12.1

--- a/modules/etcd/go.mod
+++ b/modules/etcd/go.mod
@@ -1,8 +1,8 @@
 module github.com/testcontainers/testcontainers-go/modules/etcd
 
-go 1.23.0
+go 1.24
 
-toolchain go1.23.6
+toolchain go1.24.7
 
 require (
 	github.com/containerd/errdefs v1.0.0

--- a/modules/gcloud/go.mod
+++ b/modules/gcloud/go.mod
@@ -1,8 +1,8 @@
 module github.com/testcontainers/testcontainers-go/modules/gcloud
 
-go 1.23.0
+go 1.24
 
-toolchain go1.23.6
+toolchain go1.24.7
 
 require (
 	cloud.google.com/go/bigquery v1.59.1

--- a/modules/grafana-lgtm/go.mod
+++ b/modules/grafana-lgtm/go.mod
@@ -1,8 +1,8 @@
 module github.com/testcontainers/testcontainers-go/modules/grafana-lgtm
 
-go 1.23.0
+go 1.24
 
-toolchain go1.23.6
+toolchain go1.24.7
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/modules/inbucket/go.mod
+++ b/modules/inbucket/go.mod
@@ -1,8 +1,8 @@
 module github.com/testcontainers/testcontainers-go/modules/inbucket
 
-go 1.23.0
+go 1.24
 
-toolchain go1.23.6
+toolchain go1.24.7
 
 require (
 	github.com/inbucket/inbucket v2.0.0+incompatible

--- a/modules/influxdb/go.mod
+++ b/modules/influxdb/go.mod
@@ -1,8 +1,8 @@
 module github.com/testcontainers/testcontainers-go/modules/influxdb
 
-go 1.23.0
+go 1.24
 
-toolchain go1.23.6
+toolchain go1.24.7
 
 require (
 	github.com/influxdata/influxdb-client-go/v2 v2.14.0

--- a/modules/k3s/go.mod
+++ b/modules/k3s/go.mod
@@ -1,8 +1,8 @@
 module github.com/testcontainers/testcontainers-go/modules/k3s
 
-go 1.23.0
+go 1.24
 
-toolchain go1.23.6
+toolchain go1.24.7
 
 require (
 	github.com/docker/docker v28.3.3+incompatible

--- a/modules/k6/go.mod
+++ b/modules/k6/go.mod
@@ -1,8 +1,8 @@
 module github.com/testcontainers/testcontainers-go/modules/k6
 
-go 1.23.0
+go 1.24
 
-toolchain go1.23.6
+toolchain go1.24.7
 
 require (
 	github.com/docker/docker v28.3.3+incompatible

--- a/modules/kafka/go.mod
+++ b/modules/kafka/go.mod
@@ -1,8 +1,8 @@
 module github.com/testcontainers/testcontainers-go/modules/kafka
 
-go 1.23.0
+go 1.24
 
-toolchain go1.23.6
+toolchain go1.24.7
 
 require (
 	github.com/IBM/sarama v1.42.1

--- a/modules/localstack/go.mod
+++ b/modules/localstack/go.mod
@@ -1,8 +1,8 @@
 module github.com/testcontainers/testcontainers-go/modules/localstack
 
-go 1.23.0
+go 1.24
 
-toolchain go1.23.6
+toolchain go1.24.7
 
 require (
 	github.com/aws/aws-sdk-go v1.50.31

--- a/modules/mariadb/go.mod
+++ b/modules/mariadb/go.mod
@@ -1,8 +1,8 @@
 module github.com/testcontainers/testcontainers-go/modules/mariadb
 
-go 1.23.0
+go 1.24
 
-toolchain go1.23.6
+toolchain go1.24.7
 
 require (
 	github.com/go-sql-driver/mysql v1.7.1

--- a/modules/meilisearch/go.mod
+++ b/modules/meilisearch/go.mod
@@ -1,8 +1,8 @@
 module github.com/testcontainers/testcontainers-go/modules/meilisearch
 
-go 1.23.0
+go 1.24
 
-toolchain go1.23.6
+toolchain go1.24.7
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/modules/memcached/go.mod
+++ b/modules/memcached/go.mod
@@ -1,6 +1,6 @@
 module github.com/testcontainers/testcontainers-go/modules/memcached
 
-go 1.23.0
+go 1.24
 
 require (
 	github.com/bradfitz/gomemcache v0.0.0-20250403215159-8d39553ac7cf

--- a/modules/milvus/go.mod
+++ b/modules/milvus/go.mod
@@ -1,8 +1,8 @@
 module github.com/testcontainers/testcontainers-go/modules/milvus
 
-go 1.23.0
+go 1.24
 
-toolchain go1.23.6
+toolchain go1.24.7
 
 require (
 	github.com/milvus-io/milvus-sdk-go/v2 v2.4.0

--- a/modules/minio/go.mod
+++ b/modules/minio/go.mod
@@ -1,8 +1,8 @@
 module github.com/testcontainers/testcontainers-go/modules/minio
 
-go 1.23.0
+go 1.24
 
-toolchain go1.23.6
+toolchain go1.24.7
 
 require (
 	github.com/minio/minio-go/v7 v7.0.68

--- a/modules/mockserver/go.mod
+++ b/modules/mockserver/go.mod
@@ -1,8 +1,8 @@
 module github.com/testcontainers/testcontainers-go/modules/mockserver
 
-go 1.23.0
+go 1.24
 
-toolchain go1.23.6
+toolchain go1.24.7
 
 require (
 	github.com/BraspagDevelopers/mock-server-client v0.2.2

--- a/modules/mongodb/go.mod
+++ b/modules/mongodb/go.mod
@@ -1,8 +1,8 @@
 module github.com/testcontainers/testcontainers-go/modules/mongodb
 
-go 1.23.0
+go 1.24
 
-toolchain go1.23.6
+toolchain go1.24.7
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/modules/mssql/go.mod
+++ b/modules/mssql/go.mod
@@ -1,8 +1,8 @@
 module github.com/testcontainers/testcontainers-go/modules/mssql
 
-go 1.23.0
+go 1.24
 
-toolchain go1.23.6
+toolchain go1.24.7
 
 require (
 	github.com/microsoft/go-mssqldb v1.7.0

--- a/modules/mysql/go.mod
+++ b/modules/mysql/go.mod
@@ -1,8 +1,8 @@
 module github.com/testcontainers/testcontainers-go/modules/mysql
 
-go 1.23.0
+go 1.24
 
-toolchain go1.23.6
+toolchain go1.24.7
 
 require (
 	github.com/go-sql-driver/mysql v1.7.1

--- a/modules/nats/go.mod
+++ b/modules/nats/go.mod
@@ -1,8 +1,8 @@
 module github.com/testcontainers/testcontainers-go/modules/nats
 
-go 1.23.0
+go 1.24
 
-toolchain go1.23.6
+toolchain go1.24.7
 
 require (
 	github.com/nats-io/nats.go v1.33.1

--- a/modules/neo4j/go.mod
+++ b/modules/neo4j/go.mod
@@ -1,8 +1,8 @@
 module github.com/testcontainers/testcontainers-go/modules/neo4j
 
-go 1.23.0
+go 1.24
 
-toolchain go1.23.6
+toolchain go1.24.7
 
 require (
 	github.com/neo4j/neo4j-go-driver/v5 v5.18.0

--- a/modules/ollama/go.mod
+++ b/modules/ollama/go.mod
@@ -1,8 +1,8 @@
 module github.com/testcontainers/testcontainers-go/modules/ollama
 
-go 1.23.0
+go 1.24
 
-toolchain go1.23.6
+toolchain go1.24.7
 
 require (
 	github.com/containerd/errdefs v1.0.0

--- a/modules/openfga/go.mod
+++ b/modules/openfga/go.mod
@@ -1,8 +1,8 @@
 module github.com/testcontainers/testcontainers-go/modules/openfga
 
-go 1.23.0
+go 1.24
 
-toolchain go1.23.6
+toolchain go1.24.7
 
 require (
 	github.com/openfga/go-sdk v0.3.5

--- a/modules/openldap/go.mod
+++ b/modules/openldap/go.mod
@@ -1,8 +1,8 @@
 module github.com/testcontainers/testcontainers-go/modules/openldap
 
-go 1.23.0
+go 1.24
 
-toolchain go1.23.6
+toolchain go1.24.7
 
 require (
 	github.com/go-ldap/ldap/v3 v3.4.6

--- a/modules/opensearch/go.mod
+++ b/modules/opensearch/go.mod
@@ -1,8 +1,8 @@
 module github.com/testcontainers/testcontainers-go/modules/opensearch
 
-go 1.23.0
+go 1.24
 
-toolchain go1.23.6
+toolchain go1.24.7
 
 require (
 	github.com/docker/docker v28.3.3+incompatible

--- a/modules/pinecone/go.mod
+++ b/modules/pinecone/go.mod
@@ -1,8 +1,8 @@
 module github.com/testcontainers/testcontainers-go/modules/pinecone
 
-go 1.23.0
+go 1.24
 
-toolchain go1.23.6
+toolchain go1.24.7
 
 require (
 	github.com/pinecone-io/go-pinecone/v2 v2.2.0

--- a/modules/postgres/go.mod
+++ b/modules/postgres/go.mod
@@ -1,8 +1,8 @@
 module github.com/testcontainers/testcontainers-go/modules/postgres
 
-go 1.23.0
+go 1.24
 
-toolchain go1.23.6
+toolchain go1.24.7
 
 require (
 	github.com/docker/go-connections v0.6.0

--- a/modules/pulsar/go.mod
+++ b/modules/pulsar/go.mod
@@ -1,8 +1,8 @@
 module github.com/testcontainers/testcontainers-go/modules/pulsar
 
-go 1.23.0
+go 1.24
 
-toolchain go1.23.6
+toolchain go1.24.7
 
 require (
 	github.com/apache/pulsar-client-go v0.14.0

--- a/modules/qdrant/go.mod
+++ b/modules/qdrant/go.mod
@@ -1,8 +1,8 @@
 module github.com/testcontainers/testcontainers-go/modules/qdrant
 
-go 1.23.0
+go 1.24
 
-toolchain go1.23.6
+toolchain go1.24.7
 
 require (
 	github.com/qdrant/go-client v1.7.0

--- a/modules/rabbitmq/go.mod
+++ b/modules/rabbitmq/go.mod
@@ -1,8 +1,8 @@
 module github.com/testcontainers/testcontainers-go/modules/rabbitmq
 
-go 1.23.0
+go 1.24
 
-toolchain go1.23.6
+toolchain go1.24.7
 
 require (
 	github.com/docker/go-connections v0.6.0

--- a/modules/redis/go.mod
+++ b/modules/redis/go.mod
@@ -1,8 +1,8 @@
 module github.com/testcontainers/testcontainers-go/modules/redis
 
-go 1.23.0
+go 1.24
 
-toolchain go1.23.6
+toolchain go1.24.7
 
 require (
 	github.com/google/uuid v1.6.0

--- a/modules/redpanda/go.mod
+++ b/modules/redpanda/go.mod
@@ -1,8 +1,8 @@
 module github.com/testcontainers/testcontainers-go/modules/redpanda
 
-go 1.23.0
+go 1.24
 
-toolchain go1.23.6
+toolchain go1.24.7
 
 require (
 	github.com/docker/docker v28.3.3+incompatible

--- a/modules/registry/go.mod
+++ b/modules/registry/go.mod
@@ -1,8 +1,8 @@
 module github.com/testcontainers/testcontainers-go/modules/registry
 
-go 1.23.0
+go 1.24
 
-toolchain go1.23.6
+toolchain go1.24.7
 
 require (
 	github.com/cpuguy83/dockercfg v0.3.2

--- a/modules/scylladb/go.mod
+++ b/modules/scylladb/go.mod
@@ -1,8 +1,8 @@
 module github.com/testcontainers/testcontainers-go/modules/scylladb
 
-go 1.23.0
+go 1.24
 
-toolchain go1.23.6
+toolchain go1.24.7
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.32.5

--- a/modules/socat/go.mod
+++ b/modules/socat/go.mod
@@ -1,8 +1,8 @@
 module github.com/testcontainers/testcontainers-go/modules/socat
 
-go 1.23.0
+go 1.24
 
-toolchain go1.23.6
+toolchain go1.24.7
 
 require (
 	github.com/docker/go-connections v0.6.0

--- a/modules/solace/go.mod
+++ b/modules/solace/go.mod
@@ -1,6 +1,6 @@
 module github.com/testcontainers/testcontainers-go/modules/solace
 
-go 1.23.0
+go 1.24
 
 require (
 	github.com/docker/docker v28.3.3+incompatible

--- a/modules/surrealdb/go.mod
+++ b/modules/surrealdb/go.mod
@@ -1,8 +1,8 @@
 module github.com/testcontainers/testcontainers-go/modules/surrealdb
 
-go 1.23.0
+go 1.24
 
-toolchain go1.23.6
+toolchain go1.24.7
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/modules/toxiproxy/go.mod
+++ b/modules/toxiproxy/go.mod
@@ -1,6 +1,6 @@
 module github.com/testcontainers/testcontainers-go/modules/toxiproxy
 
-go 1.23.0
+go 1.24
 
 require (
 	github.com/Shopify/toxiproxy/v2 v2.12.0

--- a/modules/valkey/go.mod
+++ b/modules/valkey/go.mod
@@ -1,8 +1,8 @@
 module github.com/testcontainers/testcontainers-go/modules/valkey
 
-go 1.23.0
+go 1.24
 
-toolchain go1.23.6
+toolchain go1.24.7
 
 require (
 	github.com/google/uuid v1.6.0

--- a/modules/vault/go.mod
+++ b/modules/vault/go.mod
@@ -1,8 +1,8 @@
 module github.com/testcontainers/testcontainers-go/modules/vault
 
-go 1.23.0
+go 1.24
 
-toolchain go1.23.6
+toolchain go1.24.7
 
 require (
 	github.com/docker/docker v28.3.3+incompatible

--- a/modules/vearch/go.mod
+++ b/modules/vearch/go.mod
@@ -1,8 +1,8 @@
 module github.com/testcontainers/testcontainers-go/modules/vearch
 
-go 1.23.0
+go 1.24
 
-toolchain go1.23.6
+toolchain go1.24.7
 
 require (
 	github.com/docker/docker v28.3.3+incompatible

--- a/modules/weaviate/go.mod
+++ b/modules/weaviate/go.mod
@@ -1,8 +1,8 @@
 module github.com/testcontainers/testcontainers-go/modules/weaviate
 
-go 1.23.0
+go 1.24
 
-toolchain go1.23.6
+toolchain go1.24.7
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/modules/yugabytedb/go.mod
+++ b/modules/yugabytedb/go.mod
@@ -1,8 +1,8 @@
 module github.com/testcontainers/testcontainers-go/modules/yugabytedb
 
-go 1.23.0
+go 1.24
 
-toolchain go1.23.6
+toolchain go1.24.7
 
 require (
 	github.com/lib/pq v1.10.9

--- a/testdata/args.Dockerfile
+++ b/testdata/args.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23-alpine@sha256:f8113c4b13e2a8b3a168dceaee88ac27743cc84e959f43b9dbd2291e9c3f57a0
+FROM golang:1.24-alpine@sha256:fc2cff6625f3c1c92e6c85938ac5bd09034ad0d4bc2dfb08278020b68540dbb5
 
 ARG FOO
 

--- a/testdata/echoserver.Dockerfile
+++ b/testdata/echoserver.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23-alpine@sha256:f8113c4b13e2a8b3a168dceaee88ac27743cc84e959f43b9dbd2291e9c3f57a0
+FROM golang:1.24-alpine@sha256:fc2cff6625f3c1c92e6c85938ac5bd09034ad0d4bc2dfb08278020b68540dbb5
 
 WORKDIR /app
 

--- a/wait/testdata/http/Dockerfile
+++ b/wait/testdata/http/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23-alpine@sha256:f8113c4b13e2a8b3a168dceaee88ac27743cc84e959f43b9dbd2291e9c3f57a0 as builder
+FROM golang:1.24-alpine@sha256:fc2cff6625f3c1c92e6c85938ac5bd09034ad0d4bc2dfb08278020b68540dbb5 as builder
 WORKDIR /app
 COPY . .
 RUN mkdir -p dist

--- a/wait/testdata/http/go.mod
+++ b/wait/testdata/http/go.mod
@@ -1,5 +1,5 @@
 module httptest
 
-go 1.23.0
+go 1.24
 
-toolchain go1.23.6
+toolchain go1.24.7


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
Bumps the base Go version from 1.23.x to 1.24.x, setting the higher limit to 1.25.x

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
1.23 EOL happened on 12 Aug 2025 (see https://endoflife.date/go)

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Needed by #3282

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
