### PR TITLE
chore(atlas): simplify host-port calculation in tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ TEST-*.xml
 
 # Environment variables
 .env
+
+# Coverage files
+coverage.out


### PR DESCRIPTION
- **chore: simpler host-port detection in tests**
- **chore: ignore coverage files**

<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
It adds a simplification in the tests, something I missed to commit while reviewing #3254

I'm also ignoring the code coverage files, to avoid commiting them to git.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
Simpler code
<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Continuation of #3254

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
