### PR TITLE
feat: add network driver options

### DIFF
--- a/docker.go
+++ b/docker.go
@@ -1575,6 +1575,7 @@ func (p *DockerProvider) CreateNetwork(ctx context.Context, req NetworkRequest) 
 
 	nc := network.CreateOptions{
 		Driver:     req.Driver,
+		Options:    req.DriverOptions,
 		Internal:   req.Internal,
 		EnableIPv6: req.EnableIPv6,
 		Attachable: req.Attachable,

--- a/docs/features/networking.md
+++ b/docs/features/networking.md
@@ -17,6 +17,7 @@ Then, you can create a network using the `network.New` function. This function r
 - `WithAttachable()`
 - `WithCheckDuplicate()`
 - `WithDriver(driver string)`
+- `WithDriverOptions(options map[string]string)`
 - `WithEnableIPv6()`
 - `WithInternal()`
 - `WithLabels(labels map[string]string)`

--- a/network.go
+++ b/network.go
@@ -37,6 +37,7 @@ func (n DefaultNetwork) ApplyDockerTo(opts *DockerProviderOptions) {
 // NetworkRequest represents the parameters used to get a network
 type NetworkRequest struct {
 	Driver         string
+	DriverOptions  map[string]string
 	CheckDuplicate bool // Deprecated: CheckDuplicate is deprecated since API v1.44, but it defaults to true when sent by the client package to older daemons.
 	Internal       bool
 	EnableIPv6     *bool

--- a/network/network.go
+++ b/network/network.go
@@ -33,13 +33,14 @@ func New(ctx context.Context, opts ...NetworkCustomizer) (*testcontainers.Docker
 
 	//nolint:staticcheck
 	netReq := testcontainers.NetworkRequest{
-		Driver:     nc.Driver,
-		Internal:   nc.Internal,
-		EnableIPv6: nc.EnableIPv6,
-		Name:       uuid.NewString(),
-		Labels:     nc.Labels,
-		Attachable: nc.Attachable,
-		IPAM:       nc.IPAM,
+		Driver:        nc.Driver,
+		DriverOptions: nc.Options,
+		Internal:      nc.Internal,
+		EnableIPv6:    nc.EnableIPv6,
+		Name:          uuid.NewString(),
+		Labels:        nc.Labels,
+		Attachable:    nc.Attachable,
+		IPAM:          nc.IPAM,
 	}
 
 	//nolint:staticcheck
@@ -91,6 +92,15 @@ func WithCheckDuplicate() CustomizeNetworkOption {
 func WithDriver(driver string) CustomizeNetworkOption {
 	return func(original *network.CreateOptions) error {
 		original.Driver = driver
+
+		return nil
+	}
+}
+
+// WithDriverOptions allows to set driver options.
+func WithDriverOptions(options map[string]string) CustomizeNetworkOption {
+	return func(original *network.CreateOptions) error {
+		original.Options = options
 
 		return nil
 	}


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

Used the field `Options` in `network.CreateOptions` (docker).
Also added a `DriverOptions` field to the (deprecated) `NetworkRequest` since we convert from `CreateOptions` to `NetworkRequest` and then back to `CreateOptions` in the docker provider.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

This gives more control over network creation.

For example it allows to set a container interface prefix with `com.docker.network.container_iface_prefix`.
This can give stability to the interface names when needing to inject one in the config (before the container is running) when the container attaches to multiple network.
Without it there is no way of predicting which interface (`eth0`, `eth1`, ...) would correspond with which network.


## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes #3301 

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
