### PR TITLE
chore: use the Run funcion in tests and docs (part 1)

### DIFF
--- a/docker_exec_test.go
+++ b/docker_exec_test.go
@@ -47,14 +47,8 @@ func TestExecWithOptions(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := context.Background()
-			req := ContainerRequest{
-				Image: nginxAlpineImage,
-			}
 
-			ctr, err := GenericContainer(ctx, GenericContainerRequest{
-				ContainerRequest: req,
-				Started:          true,
-			})
+			ctr, err := Run(ctx, nginxAlpineImage)
 			CleanupContainer(t, ctr)
 			require.NoError(t, err)
 
@@ -79,14 +73,8 @@ func TestExecWithOptions(t *testing.T) {
 
 func TestExecWithMultiplexedResponse(t *testing.T) {
 	ctx := context.Background()
-	req := ContainerRequest{
-		Image: nginxAlpineImage,
-	}
 
-	ctr, err := GenericContainer(ctx, GenericContainerRequest{
-		ContainerRequest: req,
-		Started:          true,
-	})
+	ctr, err := Run(ctx, nginxAlpineImage)
 	CleanupContainer(t, ctr)
 	require.NoError(t, err)
 
@@ -106,14 +94,8 @@ func TestExecWithMultiplexedResponse(t *testing.T) {
 
 func TestExecWithNonMultiplexedResponse(t *testing.T) {
 	ctx := context.Background()
-	req := ContainerRequest{
-		Image: nginxAlpineImage,
-	}
 
-	ctr, err := GenericContainer(ctx, GenericContainerRequest{
-		ContainerRequest: req,
-		Started:          true,
-	})
+	ctr, err := Run(ctx, nginxAlpineImage)
 	CleanupContainer(t, ctr)
 	require.NoError(t, err)
 

--- a/docker_files_test.go
+++ b/docker_files_test.go
@@ -26,22 +26,16 @@ func TestCopyFileToContainer(t *testing.T) {
 	r, err := os.Open(absPath)
 	require.NoError(t, err)
 
-	ctr, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
-		ContainerRequest: testcontainers.ContainerRequest{
-			Image: testBashImage,
-			Files: []testcontainers.ContainerFile{
-				{
-					Reader:            r,
-					HostFilePath:      absPath, // will be discarded internally
-					ContainerFilePath: "/hello.sh",
-					FileMode:          0o700,
-				},
-			},
-			Cmd:        []string{"bash", "/hello.sh"},
-			WaitingFor: wait.ForLog("done"),
-		},
-		Started: true,
-	})
+	ctr, err := testcontainers.Run(ctx, testBashImage,
+		testcontainers.WithFiles(testcontainers.ContainerFile{
+			Reader:            r,
+			HostFilePath:      absPath, // will be discarded internally
+			ContainerFilePath: "/hello.sh",
+			FileMode:          0o700,
+		}),
+		testcontainers.WithCmd("bash", "/hello.sh"),
+		testcontainers.WithWaitStrategy(wait.ForLog("done")),
+	)
 	// }
 	testcontainers.CleanupContainer(t, ctr)
 	require.NoError(t, err)
@@ -58,20 +52,14 @@ func TestCopyFileToRunningContainer(t *testing.T) {
 	helloPath, err := filepath.Abs(filepath.Join(".", "testdata", "hello.sh"))
 	require.NoError(t, err)
 
-	ctr, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
-		ContainerRequest: testcontainers.ContainerRequest{
-			Image: testBashImage,
-			Files: []testcontainers.ContainerFile{
-				{
-					HostFilePath:      waitForPath,
-					ContainerFilePath: "/waitForHello.sh",
-					FileMode:          0o700,
-				},
-			},
-			Cmd: []string{"bash", "/waitForHello.sh"},
-		},
-		Started: true,
-	})
+	ctr, err := testcontainers.Run(ctx, testBashImage,
+		testcontainers.WithFiles(testcontainers.ContainerFile{
+			HostFilePath:      waitForPath,
+			ContainerFilePath: "/waitForHello.sh",
+			FileMode:          0o700,
+		}),
+		testcontainers.WithCmd("bash", "/waitForHello.sh"),
+	)
 	testcontainers.CleanupContainer(t, ctr)
 	require.NoError(t, err)
 
@@ -94,24 +82,18 @@ func TestCopyDirectoryToContainer(t *testing.T) {
 	dataDirectory, err := filepath.Abs(filepath.Join(".", "testdata"))
 	require.NoError(t, err)
 
-	ctr, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
-		ContainerRequest: testcontainers.ContainerRequest{
-			Image: testBashImage,
-			Files: []testcontainers.ContainerFile{
-				{
-					HostFilePath: dataDirectory,
-					// ContainerFile cannot create the parent directory, so we copy the scripts
-					// to the root of the container instead. Make sure to create the container directory
-					// before you copy a host directory on create.
-					ContainerFilePath: "/",
-					FileMode:          0o700,
-				},
-			},
-			Cmd:        []string{"bash", "/testdata/hello.sh"},
-			WaitingFor: wait.ForLog("done"),
-		},
-		Started: true,
-	})
+	ctr, err := testcontainers.Run(ctx, testBashImage,
+		testcontainers.WithFiles(testcontainers.ContainerFile{
+			HostFilePath: dataDirectory,
+			// ContainerFile cannot create the parent directory, so we copy the scripts
+			// to the root of the container instead. Make sure to create the container directory
+			// before you copy a host directory on create.
+			ContainerFilePath: "/",
+			FileMode:          0o700,
+		}),
+		testcontainers.WithCmd("bash", "/testdata/hello.sh"),
+		testcontainers.WithWaitStrategy(wait.ForLog("done")),
+	)
 	// }
 	testcontainers.CleanupContainer(t, ctr)
 	require.NoError(t, err)
@@ -127,20 +109,14 @@ func TestCopyDirectoryToRunningContainerAsFile(t *testing.T) {
 	waitForPath, err := filepath.Abs(filepath.Join(dataDirectory, "waitForHello.sh"))
 	require.NoError(t, err)
 
-	ctr, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
-		ContainerRequest: testcontainers.ContainerRequest{
-			Image: testBashImage,
-			Files: []testcontainers.ContainerFile{
-				{
-					HostFilePath:      waitForPath,
-					ContainerFilePath: "/waitForHello.sh",
-					FileMode:          0o700,
-				},
-			},
-			Cmd: []string{"bash", "/waitForHello.sh"},
-		},
-		Started: true,
-	})
+	ctr, err := testcontainers.Run(ctx, testBashImage,
+		testcontainers.WithFiles(testcontainers.ContainerFile{
+			HostFilePath:      waitForPath,
+			ContainerFilePath: "/waitForHello.sh",
+			FileMode:          0o700,
+		}),
+		testcontainers.WithCmd("bash", "/waitForHello.sh"),
+	)
 	testcontainers.CleanupContainer(t, ctr)
 	require.NoError(t, err)
 
@@ -165,20 +141,14 @@ func TestCopyDirectoryToRunningContainerAsDir(t *testing.T) {
 	dataDirectory, err := filepath.Abs(filepath.Join(".", "testdata"))
 	require.NoError(t, err)
 
-	ctr, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
-		ContainerRequest: testcontainers.ContainerRequest{
-			Image: testBashImage,
-			Files: []testcontainers.ContainerFile{
-				{
-					HostFilePath:      waitForPath,
-					ContainerFilePath: "/waitForHello.sh",
-					FileMode:          0o700,
-				},
-			},
-			Cmd: []string{"bash", "/waitForHello.sh"},
-		},
-		Started: true,
-	})
+	ctr, err := testcontainers.Run(ctx, testBashImage,
+		testcontainers.WithFiles(testcontainers.ContainerFile{
+			HostFilePath:      waitForPath,
+			ContainerFilePath: "/waitForHello.sh",
+			FileMode:          0o700,
+		}),
+		testcontainers.WithCmd("bash", "/waitForHello.sh"),
+	)
 	testcontainers.CleanupContainer(t, ctr)
 	require.NoError(t, err)
 

--- a/docs/features/creating_container.md
+++ b/docs/features/creating_container.md
@@ -171,15 +171,15 @@ It's important to notice that the `Readiness` of a container is defined by the w
 In the following example, we are going to create a container using all the lifecycle hooks, all of them printing a message when any of the lifecycle hooks is called:
 
 <!--codeinclude-->
-[Extending container with lifecycle hooks](../../lifecycle_test.go) inside_block:reqWithLifecycleHooks
+[Extending container with lifecycle hooks](../../lifecycle_test.go) inside_block:optsWithLifecycleHooks
 <!--/codeinclude-->
 
 #### Default Logging Hook
 
-_Testcontainers for Go_ comes with a default logging hook that will print a log message for each container lifecycle event, using the default logger. You can add your own logger by passing the `testcontainers.DefaultLoggingHook` option to the `ContainerRequest`, passing a reference to your preferred logger:
+_Testcontainers for Go_ comes with a default logging hook that will print a log message for each container lifecycle event, using the default logger. You can add your own logger by passing the `testcontainers.DefaultLoggingHook` option to the `Run` options, passing a reference to your preferred logger:
 
 <!--codeinclude-->
-[Use a custom logger for container hooks](../../lifecycle_test.go) inside_block:reqWithDefaultLoggingHook
+[Use a custom logger for container hooks](../../lifecycle_test.go) inside_block:optsWithDefaultLoggingHook
 [Custom Logger implementation](../../lifecycle_test.go) inside_block:customLoggerImplementation
 <!--/codeinclude-->
 

--- a/docs/features/creating_container.md
+++ b/docs/features/creating_container.md
@@ -131,14 +131,13 @@ func TestIntegrationNginxLatestReturn(t *testing.T) {
 }
 ```
 
-
-
-
 ### Lifecycle hooks
 
-_Testcontainers for Go_ allows you to define your own lifecycle hooks for better control over your containers. You just need to define functions that return an error and receive the Go context as first argument, and a `ContainerRequest` for the `Creating` hook, and a `Container` for the rest of them as second argument.
+_Testcontainers for Go_ allows you to define your own lifecycle hooks for better control over your containers. You just need to define functions that return an error and receive the Go context as first argument.
 
-You'll be able to pass multiple lifecycle hooks at the `ContainerRequest` as an array of `testcontainers.ContainerLifecycleHooks`. The `testcontainers.ContainerLifecycleHooks` struct defines the following lifecycle hooks, each of them backed by an array of functions representing the hooks:
+You'll be able to pass multiple lifecycle hooks using the `WithLifecycleHooks` and `WithAdditionalLifecycleHooks` options, passing an array of `testcontainers.ContainerLifecycleHooks`. The first one replaces the existing lifecycle hooks with the new ones, while the second one appends the new lifecycle hooks to the existing ones.
+
+The `testcontainers.ContainerLifecycleHooks` struct defines the following lifecycle hooks, each of them backed by an array of functions representing the hooks:
 
 * `PreBuilds` - hooks that are executed before the image is built. This hook is only available when creating a container from a Dockerfile
 * `PostBuilds` - hooks that are executed after the image is built. This hook is only available when creating a container from a Dockerfile
@@ -164,7 +163,7 @@ Inside each group, the hooks will be executed in the order they were defined.
 !!!info
 	The default hooks are for logging (applied to all hooks), customising the Docker config (applied to the pre-create hook), copying files in to the container (applied to the post-create hook), adding log consumers (applied to the post-start and pre-terminate hooks), and running the wait strategies as a readiness check (applied to the post-start hook).
 
-It's important to notice that the `Readiness` of a container is defined by the wait strategies defined for the container. **This hook will be executed right after the `PostStarts` hook**. If you want to add your own readiness checks, you can do it by adding a `PostReadies` hook to the container request, which will execute your own readiness check after the default ones. That said, the `PostStarts` hooks don't warrant that the container is ready, so you should not rely on that.
+It's important to notice that the `Readiness` of a container is defined by the wait strategies defined for the container. **This hook will be executed right after the `PostStarts` hook**. If you want to add your own readiness checks, you can do it by adding a `PostReadies` hook, which will execute your own readiness check after the default ones. That said, the `PostStarts` hooks don't warrant that the container is ready, so you should not rely on that.
 
 !!!warning
 	Up to `v0.37.0`, the readiness hook included checks for all the exposed ports to be ready. This is not the case anymore, and the readiness hook only uses the wait strategies defined for the container to determine if the container is ready.
@@ -186,14 +185,14 @@ _Testcontainers for Go_ comes with a default logging hook that will print a log 
 
 ### Advanced Settings
 
-The aforementioned `GenericContainer` function and the `ContainerRequest` struct represent a straightforward manner to configure the containers, but you could need to create your containers with more advance settings regarding the config, host config and endpoint settings Docker types. For those more advance settings, _Testcontainers for Go_ offers a way to fully customize the container request and those internal Docker types. These customisations, called _modifiers_, will be applied just before the internal call to the Docker client to create the container.
+The aforementioned `Run` function represents a straightforward manner to configure the containers, but you could need to create your containers with more advance settings regarding the config, host config and endpoint settings Docker types. For those more advance settings, _Testcontainers for Go_ offers a way to fully customize the container and those internal Docker types. These customisations, called _modifiers_, will be applied just before the internal call to the Docker client to create the container.
 
 <!--codeinclude-->
 [Using modifiers](../../lifecycle_test.go) inside_block:reqWithModifiers
 <!--/codeinclude-->
 
 !!!warning
-	The only special case where the modifiers are not applied last, is when there are no exposed ports in the container request and the container does not use a network mode from a container (e.g. `req.NetworkMode = container.NetworkMode("container:$CONTAINER_ID")`). In that case, _Testcontainers for Go_ will extract the ports from the underlying Docker image and export them.
+	The only special case where the modifiers are not applied last, is when there are no exposed ports and the container does not use a network mode from a container (e.g. `req.NetworkMode = container.NetworkMode("container:$CONTAINER_ID")`). In that case, _Testcontainers for Go_ will extract the ports from the underlying Docker image and export them.
 
 ## Reusable container
 

--- a/image_substitutors_test.go
+++ b/image_substitutors_test.go
@@ -99,22 +99,14 @@ func TestPrependHubRegistrySubstitutor(t *testing.T) {
 }
 
 func TestSubstituteBuiltImage(t *testing.T) {
-	req := GenericContainerRequest{
-		ContainerRequest: ContainerRequest{
-			FromDockerfile: FromDockerfile{
-				Context:    "testdata",
-				Dockerfile: "echo.Dockerfile",
-				Tag:        "my-image",
-				Repo:       "my-repo",
-			},
-			ImageSubstitutors: []ImageSubstitutor{newPrependHubRegistry("my-registry")},
-		},
-		Started: false,
-	}
-
 	t.Run("should not use the properties prefix on built images", func(t *testing.T) {
 		config.Reset()
-		c, err := GenericContainer(context.Background(), req)
+		c, err := Run(context.Background(), "", WithDockerfile(FromDockerfile{
+			Context:    "testdata",
+			Dockerfile: "echo.Dockerfile",
+			Tag:        "my-image",
+			Repo:       "my-repo",
+		}), WithImageSubstitutors(newPrependHubRegistry("my-registry")))
 		CleanupContainer(t, c)
 		require.NoError(t, err)
 

--- a/lifecycle_test.go
+++ b/lifecycle_test.go
@@ -481,11 +481,11 @@ func TestLifecycleHooks(t *testing.T) {
 		reuse bool
 	}{
 		{
-			name:  "GenericContainer",
+			name:  "RunContainer",
 			reuse: false,
 		},
 		{
-			name:  "ReuseContainer",
+			name:  "RunReusableContainer",
 			reuse: true,
 		},
 	}
@@ -494,115 +494,108 @@ func TestLifecycleHooks(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			prints := []string{}
 			ctx := context.Background()
-			// reqWithLifecycleHooks {
-			req := ContainerRequest{
-				Image: nginxAlpineImage,
-				LifecycleHooks: []ContainerLifecycleHooks{
-					{
-						PreCreates: []ContainerRequestHook{
-							func(_ context.Context, _ ContainerRequest) error {
-								prints = append(prints, "pre-create hook 1")
-								return nil
-							},
-							func(_ context.Context, _ ContainerRequest) error {
-								prints = append(prints, "pre-create hook 2")
-								return nil
-							},
+			// optsWithLifecycleHooks {
+			opts := []ContainerCustomizer{
+				WithAdditionalLifecycleHooks(ContainerLifecycleHooks{
+					PreCreates: []ContainerRequestHook{
+						func(_ context.Context, _ ContainerRequest) error {
+							prints = append(prints, "pre-create hook 1")
+							return nil
 						},
-						PostCreates: []ContainerHook{
-							func(_ context.Context, _ Container) error {
-								prints = append(prints, "post-create hook 1")
-								return nil
-							},
-							func(_ context.Context, _ Container) error {
-								prints = append(prints, "post-create hook 2")
-								return nil
-							},
-						},
-						PreStarts: []ContainerHook{
-							func(_ context.Context, _ Container) error {
-								prints = append(prints, "pre-start hook 1")
-								return nil
-							},
-							func(_ context.Context, _ Container) error {
-								prints = append(prints, "pre-start hook 2")
-								return nil
-							},
-						},
-						PostStarts: []ContainerHook{
-							func(_ context.Context, _ Container) error {
-								prints = append(prints, "post-start hook 1")
-								return nil
-							},
-							func(_ context.Context, _ Container) error {
-								prints = append(prints, "post-start hook 2")
-								return nil
-							},
-						},
-						PostReadies: []ContainerHook{
-							func(_ context.Context, _ Container) error {
-								prints = append(prints, "post-ready hook 1")
-								return nil
-							},
-							func(_ context.Context, _ Container) error {
-								prints = append(prints, "post-ready hook 2")
-								return nil
-							},
-						},
-						PreStops: []ContainerHook{
-							func(_ context.Context, _ Container) error {
-								prints = append(prints, "pre-stop hook 1")
-								return nil
-							},
-							func(_ context.Context, _ Container) error {
-								prints = append(prints, "pre-stop hook 2")
-								return nil
-							},
-						},
-						PostStops: []ContainerHook{
-							func(_ context.Context, _ Container) error {
-								prints = append(prints, "post-stop hook 1")
-								return nil
-							},
-							func(_ context.Context, _ Container) error {
-								prints = append(prints, "post-stop hook 2")
-								return nil
-							},
-						},
-						PreTerminates: []ContainerHook{
-							func(_ context.Context, _ Container) error {
-								prints = append(prints, "pre-terminate hook 1")
-								return nil
-							},
-							func(_ context.Context, _ Container) error {
-								prints = append(prints, "pre-terminate hook 2")
-								return nil
-							},
-						},
-						PostTerminates: []ContainerHook{
-							func(_ context.Context, _ Container) error {
-								prints = append(prints, "post-terminate hook 1")
-								return nil
-							},
-							func(_ context.Context, _ Container) error {
-								prints = append(prints, "post-terminate hook 2")
-								return nil
-							},
+						func(_ context.Context, _ ContainerRequest) error {
+							prints = append(prints, "pre-create hook 2")
+							return nil
 						},
 					},
-				},
+					PostCreates: []ContainerHook{
+						func(_ context.Context, _ Container) error {
+							prints = append(prints, "post-create hook 1")
+							return nil
+						},
+						func(_ context.Context, _ Container) error {
+							prints = append(prints, "post-create hook 2")
+							return nil
+						},
+					},
+					PreStarts: []ContainerHook{
+						func(_ context.Context, _ Container) error {
+							prints = append(prints, "pre-start hook 1")
+							return nil
+						},
+						func(_ context.Context, _ Container) error {
+							prints = append(prints, "pre-start hook 2")
+							return nil
+						},
+					},
+					PostStarts: []ContainerHook{
+						func(_ context.Context, _ Container) error {
+							prints = append(prints, "post-start hook 1")
+							return nil
+						},
+						func(_ context.Context, _ Container) error {
+							prints = append(prints, "post-start hook 2")
+							return nil
+						},
+					},
+					PostReadies: []ContainerHook{
+						func(_ context.Context, _ Container) error {
+							prints = append(prints, "post-ready hook 1")
+							return nil
+						},
+						func(_ context.Context, _ Container) error {
+							prints = append(prints, "post-ready hook 2")
+							return nil
+						},
+					},
+					PreStops: []ContainerHook{
+						func(_ context.Context, _ Container) error {
+							prints = append(prints, "pre-stop hook 1")
+							return nil
+						},
+						func(_ context.Context, _ Container) error {
+							prints = append(prints, "pre-stop hook 2")
+							return nil
+						},
+					},
+					PostStops: []ContainerHook{
+						func(_ context.Context, _ Container) error {
+							prints = append(prints, "post-stop hook 1")
+							return nil
+						},
+						func(_ context.Context, _ Container) error {
+							prints = append(prints, "post-stop hook 2")
+							return nil
+						},
+					},
+					PreTerminates: []ContainerHook{
+						func(_ context.Context, _ Container) error {
+							prints = append(prints, "pre-terminate hook 1")
+							return nil
+						},
+						func(_ context.Context, _ Container) error {
+							prints = append(prints, "pre-terminate hook 2")
+							return nil
+						},
+					},
+					PostTerminates: []ContainerHook{
+						func(_ context.Context, _ Container) error {
+							prints = append(prints, "post-terminate hook 1")
+							return nil
+						},
+						func(_ context.Context, _ Container) error {
+							prints = append(prints, "post-terminate hook 2")
+							return nil
+						},
+					},
+				}),
 			}
 			// }
 
 			if tt.reuse {
-				req.Name = "reuse-container"
+				opts = append(opts, WithReuseByName("reuse-container"))
 			}
 
-			c, err := GenericContainer(ctx, GenericContainerRequest{
-				ContainerRequest: req,
-				Reuse:            tt.reuse,
-				Started:          true,
-			})
+			c, err := Run(ctx, nginxAlpineImage, opts...)
 			CleanupContainer(t, c)
 			require.NoError(t, err)
 			require.NotNil(t, c)
@@ -636,21 +629,15 @@ func (l *inMemoryLogger) Printf(format string, args ...any) {
 func TestLifecycleHooks_WithDefaultLogger(t *testing.T) {
 	ctx := context.Background()
 
-	// reqWithDefaultLoggingHook {
+	// optsWithDefaultLoggingHook {
 	dl := inMemoryLogger{}
 
-	req := ContainerRequest{
-		Image: nginxAlpineImage,
-		LifecycleHooks: []ContainerLifecycleHooks{
-			DefaultLoggingHook(&dl),
-		},
+	opts := []ContainerCustomizer{
+		WithLifecycleHooks(DefaultLoggingHook(&dl)),
 	}
 	// }
 
-	c, err := GenericContainer(ctx, GenericContainerRequest{
-		ContainerRequest: req,
-		Started:          true,
-	})
+	c, err := Run(ctx, nginxAlpineImage, opts...)
 	CleanupContainer(t, c)
 	require.NoError(t, err)
 	require.NotNil(t, c)
@@ -807,18 +794,11 @@ func TestLifecycleHooks_WithMultipleHooks(t *testing.T) {
 
 	dl := inMemoryLogger{}
 
-	req := ContainerRequest{
-		Image: nginxAlpineImage,
-		LifecycleHooks: []ContainerLifecycleHooks{
-			DefaultLoggingHook(&dl),
-			DefaultLoggingHook(&dl),
-		},
+	opts := []ContainerCustomizer{
+		WithLifecycleHooks(DefaultLoggingHook(&dl), DefaultLoggingHook(&dl)),
 	}
 
-	c, err := GenericContainer(ctx, GenericContainerRequest{
-		ContainerRequest: req,
-		Started:          true,
-	})
+	c, err := Run(ctx, nginxAlpineImage, opts...)
 	CleanupContainer(t, c)
 	require.NoError(t, err)
 	require.NotNil(t, c)
@@ -848,22 +828,17 @@ func (l *linesTestLogger) Printf(format string, args ...any) {
 func TestPrintContainerLogsOnError(t *testing.T) {
 	ctx := context.Background()
 
-	req := ContainerRequest{
-		Image:      "alpine",
-		Cmd:        []string{"echo", "-n", "I am expecting this"},
-		WaitingFor: wait.ForLog("I was expecting that").WithStartupTimeout(5 * time.Second),
-	}
-
 	arrayOfLinesLogger := linesTestLogger{
 		data: []string{},
 	}
 
-	ctr, err := GenericContainer(ctx, GenericContainerRequest{
-		ProviderType:     providerType,
-		ContainerRequest: req,
-		Logger:           &arrayOfLinesLogger,
-		Started:          true,
-	})
+	opts := []ContainerCustomizer{
+		WithCmd("echo", "-n", "I am expecting this"),
+		WithLogger(&arrayOfLinesLogger),
+		WithWaitStrategy(wait.ForLog("I was expecting that").WithStartupTimeout(5 * time.Second)),
+	}
+
+	ctr, err := Run(ctx, "alpine", opts...)
 	CleanupContainer(t, ctr)
 	// it should fail because the waiting for condition is not met
 	require.Error(t, err)

--- a/mounts_test.go
+++ b/mounts_test.go
@@ -222,26 +222,19 @@ func TestContainerMounts_PrepareMounts(t *testing.T) {
 }
 
 func TestCreateContainerWithVolume(t *testing.T) {
-	volumeName := "test-volume"
 	// volumeMounts {
-	req := testcontainers.ContainerRequest{
-		Image: "alpine",
-		Mounts: testcontainers.ContainerMounts{
-			{
-				Source: testcontainers.GenericVolumeMountSource{
-					Name: volumeName,
-				},
-				Target: "/data",
-			},
-		},
-	}
-	// }
-
+	volumeName := "test-volume"
 	ctx := context.Background()
-	c, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
-		ContainerRequest: req,
-		Started:          true,
-	})
+
+	c, err := testcontainers.Run(ctx, "alpine",
+		testcontainers.WithMounts(testcontainers.ContainerMount{
+			Source: testcontainers.GenericVolumeMountSource{
+				Name: volumeName,
+			},
+			Target: "/data",
+		}),
+	)
+	// }
 	testcontainers.CleanupContainer(t, c, testcontainers.RemoveVolumes(volumeName))
 	require.NoError(t, err)
 
@@ -257,19 +250,8 @@ func TestCreateContainerWithVolume(t *testing.T) {
 
 func TestMountsReceiveRyukLabels(t *testing.T) {
 	volumeName := "app-data"
-	req := testcontainers.ContainerRequest{
-		Image: "alpine",
-		Mounts: testcontainers.ContainerMounts{
-			{
-				Source: testcontainers.GenericVolumeMountSource{
-					Name: volumeName,
-				},
-				Target: "/data",
-			},
-		},
-	}
-
 	ctx := context.Background()
+
 	client, err := testcontainers.NewDockerClientWithOpts(ctx)
 	require.NoError(t, err)
 	defer client.Close()
@@ -279,10 +261,14 @@ func TestMountsReceiveRyukLabels(t *testing.T) {
 	err = client.VolumeRemove(ctx, volumeName, true)
 	require.NoError(t, err)
 
-	c, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
-		ContainerRequest: req,
-		Started:          true,
-	})
+	c, err := testcontainers.Run(ctx, "alpine",
+		testcontainers.WithMounts(testcontainers.ContainerMount{
+			Source: testcontainers.GenericVolumeMountSource{
+				Name: volumeName,
+			},
+			Target: "/data",
+		}),
+	)
 	testcontainers.CleanupContainer(t, c, testcontainers.RemoveVolumes(volumeName))
 	require.NoError(t, err)
 

--- a/port_forwarding_test.go
+++ b/port_forwarding_test.go
@@ -76,27 +76,24 @@ func testExposeHostPorts(t *testing.T, hostPorts []int, hasNetwork, hasHostAcces
 	if hasHostAccess {
 		hostAccessPorts = hostPorts
 	}
-	req := testcontainers.GenericContainerRequest{
-		// hostAccessPorts {
-		ContainerRequest: testcontainers.ContainerRequest{
-			Image:           "alpine:3.17",
-			HostAccessPorts: hostAccessPorts,
-			Cmd:             []string{"top"},
-		},
-		// }
-		Started: true,
+
+	// hostAccessPorts {
+	opts := []testcontainers.ContainerCustomizer{
+		testcontainers.WithHostPortAccess(hostAccessPorts...),
+		testcontainers.WithCmd("top"),
 	}
+	// }
 
 	if hasNetwork {
 		nw, err := network.New(ctx)
 		require.NoError(t, err)
 		testcontainers.CleanupNetwork(t, nw)
 
-		req.Networks = []string{nw.Name}
-		req.NetworkAliases = map[string][]string{nw.Name: {"myalpine"}}
+		opts = append(opts, network.WithNetwork([]string{"myalpine"}, nw))
+
 	}
 
-	c, err := testcontainers.GenericContainer(ctx, req)
+	c, err := testcontainers.Run(ctx, "alpine", opts...)
 	testcontainers.CleanupContainer(t, c)
 	require.NoError(t, err)
 


### PR DESCRIPTION
- **chore: migrate tests to Run**
- **docs: update quickstart with the Run function**
- **chore: update more tests**

<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
This is the first chunk of many PRs trying to make progress with #3174

The idea behind this PR, and the upcoming ones, is to replace GenericContainer with Run. The last PR would mean the deprecation of the GenericContainer function.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
Start adopting the new APIs for running containers using functional options, like in the modules

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Relates #3174

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
