### PR TITLE
chore: use Run function (part 2)

### DIFF
--- a/docs/features/creating_container.md
+++ b/docs/features/creating_container.md
@@ -196,11 +196,12 @@ The aforementioned `Run` function represents a straightforward way to configure 
 
 ## Reusable container
 
-With `Reuse` option you can reuse an existing container. Reusing will work only if you pass an
-existing container name via 'req.Name' field. If the name is not in a list of existing containers,
-the function will create a new generic container. If `Reuse` is true and `Name` is empty, you will get error.
+Using the `WithReuseByName` option you can reuse an existing container. Reusing works only if you pass an
+existing container name via this options. If the name is not in a list of existing containers,
+the function will create a new container. If the name is empty, you get error.
 
 The following test creates an NGINX container, adds a file into it and then reuses the container again for checking the file:
+
 ```go
 package main
 
@@ -220,15 +221,11 @@ const (
 func main() {
 	ctx := context.Background()
 
-	n1, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
-		ContainerRequest: testcontainers.ContainerRequest{
-			Image:        "nginx:1.17.6",
-			ExposedPorts: []string{"80/tcp"},
-			WaitingFor:   wait.ForListeningPort("80/tcp"),
-			Name:         reusableContainerName,
-		},
-		Started: true,
-	})
+	n1, err := testcontainers.Run(ctx, "nginx:1.17.6",
+		testcontainers.WithExposedPorts("80/tcp"),
+		testcontainers.WithWaitStrategy(wait.ForListeningPort("80/tcp")),
+		testcontainers.WithReuseByName(reusableContainerName),
+	)
 	defer func() {
 		if err := testcontainers.TerminateContainer(n1); err != nil {
 			log.Printf("failed to terminate container: %s", err)
@@ -247,16 +244,11 @@ func main() {
 		return
 	}
 
-	n2, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
-		ContainerRequest: testcontainers.ContainerRequest{
-			Image:        "nginx:1.17.6",
-			ExposedPorts: []string{"80/tcp"},
-			WaitingFor:   wait.ForListeningPort("80/tcp"),
-			Name:         reusableContainerName,
-		},
-		Started: true,
-		Reuse:   true,
-	})
+	n2, err := testcontainers.Run(ctx, "nginx:1.17.6",
+		testcontainers.WithExposedPorts("80/tcp"),
+		testcontainers.WithWaitStrategy(wait.ForListeningPort("80/tcp")),
+		testcontainers.WithReuseByName(reusableContainerName),
+	)
 	defer func() {
 		if err := testcontainers.TerminateContainer(n2); err != nil {
 			log.Printf("failed to terminate container: %s", err)

--- a/docs/features/follow_logs.md
+++ b/docs/features/follow_logs.md
@@ -26,8 +26,8 @@ You can associate `LogConsumer`s in two manners:
 
 ## Passing the LogConsumers in the ContainerRequest
 
-This will represent the current way for associating `LogConsumer`s. You simply define your consumers, and attach them as a slice to the `ContainerRequest` in the
-`LogConsumerCfg` field. See the following example, where `g` is an instance of a given `LogConsumer` struct.
+This will represent the current way for associating `LogConsumer`s. You simply define your consumers, and attach them as a slice using the `WithLogConsumerConfig` functional option.
+See the following example, where `g` is an instance of a given `LogConsumer` struct.
 
 <!--codeinclude-->
 [Passing LogConsumers](../../logconsumer_test.go) inside_block:logConsumersAtRequest

--- a/port_forwarding.go
+++ b/port_forwarding.go
@@ -176,30 +176,22 @@ func exposeHostPorts(ctx context.Context, req *ContainerRequest, ports ...int) (
 
 // newSshdContainer creates a new SSHD container with the provided options.
 func newSshdContainer(ctx context.Context, opts ...ContainerCustomizer) (*sshdContainer, error) {
-	req := GenericContainerRequest{
-		ContainerRequest: ContainerRequest{
-			Image:        sshdImage,
-			ExposedPorts: []string{sshPort},
-			Env:          map[string]string{"PASSWORD": sshPassword},
-			WaitingFor:   wait.ForListeningPort(sshPort),
-		},
-		Started: true,
+	moduleOpts := []ContainerCustomizer{
+		WithExposedPorts(sshPort),
+		WithEnv(map[string]string{"PASSWORD": sshPassword}),
+		WithWaitStrategy(wait.ForListeningPort(sshPort)),
 	}
 
-	for _, opt := range opts {
-		if err := opt.Customize(&req); err != nil {
-			return nil, err
-		}
-	}
+	moduleOpts = append(moduleOpts, opts...)
 
-	c, err := GenericContainer(ctx, req)
+	c, err := Run(ctx, sshdImage, moduleOpts...)
 	var sshd *sshdContainer
 	if c != nil {
 		sshd = &sshdContainer{Container: c}
 	}
 
 	if err != nil {
-		return sshd, fmt.Errorf("generic container: %w", err)
+		return sshd, fmt.Errorf("run sshd container: %w", err)
 	}
 
 	if err = sshd.clientConfig(ctx); err != nil {

--- a/reaper_test.go
+++ b/reaper_test.go
@@ -107,16 +107,7 @@ func testContainerStart(t *testing.T) {
 	t.Helper()
 	ctx := context.Background()
 
-	ctr, err := GenericContainer(ctx, GenericContainerRequest{
-		ProviderType: providerType,
-		ContainerRequest: ContainerRequest{
-			Image: nginxAlpineImage,
-			ExposedPorts: []string{
-				nginxDefaultPort,
-			},
-		},
-		Started: true,
-	})
+	ctr, err := Run(ctx, nginxAlpineImage, WithExposedPorts(nginxDefaultPort))
 	CleanupContainer(t, ctr)
 	require.NoError(t, err)
 }
@@ -171,16 +162,7 @@ func testContainerStop(t *testing.T) {
 
 	ctx := context.Background()
 
-	nginxA, err := GenericContainer(ctx, GenericContainerRequest{
-		ProviderType: providerType,
-		ContainerRequest: ContainerRequest{
-			Image: nginxAlpineImage,
-			ExposedPorts: []string{
-				nginxDefaultPort,
-			},
-		},
-		Started: true,
-	})
+	nginxA, err := Run(ctx, nginxAlpineImage, WithExposedPorts(nginxDefaultPort))
 	CleanupContainer(t, nginxA)
 	require.NoError(t, err)
 
@@ -203,16 +185,7 @@ func testContainerTerminate(t *testing.T) {
 	t.Helper()
 	ctx := context.Background()
 
-	nginxA, err := GenericContainer(ctx, GenericContainerRequest{
-		ProviderType: providerType,
-		ContainerRequest: ContainerRequest{
-			Image: nginxAlpineImage,
-			ExposedPorts: []string{
-				nginxDefaultPort,
-			},
-		},
-		Started: true,
-	})
+	nginxA, err := Run(ctx, nginxAlpineImage, WithExposedPorts(nginxDefaultPort))
 	CleanupContainer(t, nginxA)
 	require.NoError(t, err)
 

--- a/reuse_test.go
+++ b/reuse_test.go
@@ -14,17 +14,12 @@ import (
 func TestGenericContainer_stop_start_withReuse(t *testing.T) {
 	containerName := "my-nginx"
 
-	req := testcontainers.GenericContainerRequest{
-		ContainerRequest: testcontainers.ContainerRequest{
-			Image:        nginxAlpineImage,
-			ExposedPorts: []string{"8080/tcp"},
-			Name:         containerName,
-		},
-		Reuse:   true,
-		Started: true,
+	opts := []testcontainers.ContainerCustomizer{
+		testcontainers.WithExposedPorts("8080/tcp"),
+		testcontainers.WithReuseByName(containerName),
 	}
 
-	ctr, err := testcontainers.GenericContainer(context.Background(), req)
+	ctr, err := testcontainers.Run(context.Background(), nginxAlpineImage, opts...)
 	testcontainers.CleanupContainer(t, ctr)
 	require.NoError(t, err)
 	require.NotNil(t, ctr)
@@ -34,7 +29,7 @@ func TestGenericContainer_stop_start_withReuse(t *testing.T) {
 
 	// Run another container with same container name:
 	// The checks for the exposed ports must not fail when restarting the container.
-	ctr1, err := testcontainers.GenericContainer(context.Background(), req)
+	ctr1, err := testcontainers.Run(context.Background(), nginxAlpineImage, opts...)
 	testcontainers.CleanupContainer(t, ctr1)
 	require.NoError(t, err)
 	require.NotNil(t, ctr1)
@@ -43,17 +38,12 @@ func TestGenericContainer_stop_start_withReuse(t *testing.T) {
 func TestGenericContainer_pause_start_withReuse(t *testing.T) {
 	containerName := "my-nginx"
 
-	req := testcontainers.GenericContainerRequest{
-		ContainerRequest: testcontainers.ContainerRequest{
-			Image:        nginxAlpineImage,
-			ExposedPorts: []string{"8080/tcp"},
-			Name:         containerName,
-		},
-		Reuse:   true,
-		Started: true,
+	opts := []testcontainers.ContainerCustomizer{
+		testcontainers.WithExposedPorts("8080/tcp"),
+		testcontainers.WithReuseByName(containerName),
 	}
 
-	ctr, err := testcontainers.GenericContainer(context.Background(), req)
+	ctr, err := testcontainers.Run(context.Background(), nginxAlpineImage, opts...)
 	testcontainers.CleanupContainer(t, ctr)
 	require.NoError(t, err)
 	require.NotNil(t, ctr)
@@ -67,7 +57,7 @@ func TestGenericContainer_pause_start_withReuse(t *testing.T) {
 	require.NoError(t, err)
 
 	// Because the container is paused, it should not be possible to start it again.
-	ctr1, err := testcontainers.GenericContainer(context.Background(), req)
+	ctr1, err := testcontainers.Run(context.Background(), nginxAlpineImage, opts...)
 	testcontainers.CleanupContainer(t, ctr1)
 	require.ErrorIs(t, err, errors.ErrUnsupported)
 }

--- a/wait/http_test.go
+++ b/wait/http_test.go
@@ -31,16 +31,10 @@ var caBytes []byte
 func ExampleHTTPStrategy() {
 	// waitForHTTPWithDefaultPort {
 	ctx := context.Background()
-	req := testcontainers.ContainerRequest{
-		Image:        "nginx:latest",
-		ExposedPorts: []string{"80/tcp"},
-		WaitingFor:   wait.ForHTTP("/").WithStartupTimeout(10 * time.Second),
-	}
-
-	c, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
-		ContainerRequest: req,
-		Started:          true,
-	})
+	c, err := testcontainers.Run(ctx, "nginx:latest",
+		testcontainers.WithExposedPorts("80/tcp"),
+		testcontainers.WithWaitStrategy(wait.ForHTTP("/").WithStartupTimeout(10*time.Second)),
+	)
 	defer func() {
 		if err := testcontainers.TerminateContainer(c); err != nil {
 			log.Printf("failed to terminate container: %s", err)
@@ -82,26 +76,24 @@ func ExampleHTTPStrategy_WithHeaders() {
 
 	// waitForHTTPHeaders {
 	tlsconfig := &tls.Config{RootCAs: certpool, ServerName: "testcontainer.go.test"}
-	req := testcontainers.ContainerRequest{
-		FromDockerfile: testcontainers.FromDockerfile{
-			Context: "testdata/http",
-		},
-		ExposedPorts: []string{"6443/tcp"},
-		WaitingFor: wait.ForHTTP("/headers").
-			WithTLS(true, tlsconfig).
-			WithPort("6443/tcp").
-			WithHeaders(map[string]string{"X-request-header": "value"}).
-			WithResponseHeadersMatcher(func(headers http.Header) bool {
-				return headers.Get("X-response-header") == "value"
-			},
-			),
-	}
-	// }
 
-	c, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
-		ContainerRequest: req,
-		Started:          true,
-	})
+	c, err := testcontainers.Run(
+		ctx, "",
+		testcontainers.WithDockerfile(testcontainers.FromDockerfile{
+			Context: filepath.Join("testdata", "http"),
+		}),
+		testcontainers.WithExposedPorts("6443/tcp"),
+		testcontainers.WithWaitStrategy(
+			wait.ForHTTP("/headers").
+				WithTLS(true, tlsconfig).
+				WithPort("6443/tcp").
+				WithHeaders(map[string]string{"X-request-header": "value"}).
+				WithResponseHeadersMatcher(func(headers http.Header) bool {
+					return headers.Get("X-response-header") == "value"
+				}),
+		),
+	)
+	// }
 	defer func() {
 		if err := testcontainers.TerminateContainer(c); err != nil {
 			log.Printf("failed to terminate container: %s", err)
@@ -127,16 +119,11 @@ func ExampleHTTPStrategy_WithHeaders() {
 func ExampleHTTPStrategy_WithPort() {
 	// waitForHTTPWithPort {
 	ctx := context.Background()
-	req := testcontainers.ContainerRequest{
-		Image:        "nginx:latest",
-		ExposedPorts: []string{"8080/tcp", "80/tcp"},
-		WaitingFor:   wait.ForHTTP("/").WithPort("80/tcp"),
-	}
-
-	c, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
-		ContainerRequest: req,
-		Started:          true,
-	})
+	c, err := testcontainers.Run(
+		ctx, "nginx:latest",
+		testcontainers.WithExposedPorts("8080/tcp", "80/tcp"),
+		testcontainers.WithWaitStrategy(wait.ForHTTP("/").WithPort("80/tcp")),
+	)
 	defer func() {
 		if err := testcontainers.TerminateContainer(c); err != nil {
 			log.Printf("failed to terminate container: %s", err)
@@ -162,16 +149,11 @@ func ExampleHTTPStrategy_WithPort() {
 
 func ExampleHTTPStrategy_WithForcedIPv4LocalHost() {
 	ctx := context.Background()
-	req := testcontainers.ContainerRequest{
-		Image:        "nginx:latest",
-		ExposedPorts: []string{"8080/tcp", "80/tcp"},
-		WaitingFor:   wait.ForHTTP("/").WithForcedIPv4LocalHost(),
-	}
-
-	c, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
-		ContainerRequest: req,
-		Started:          true,
-	})
+	c, err := testcontainers.Run(
+		ctx, "nginx:latest",
+		testcontainers.WithExposedPorts("8080/tcp", "80/tcp"),
+		testcontainers.WithWaitStrategy(wait.ForHTTP("/").WithForcedIPv4LocalHost()),
+	)
 	defer func() {
 		if err := testcontainers.TerminateContainer(c); err != nil {
 			log.Printf("failed to terminate container: %s", err)
@@ -197,16 +179,10 @@ func ExampleHTTPStrategy_WithForcedIPv4LocalHost() {
 func ExampleHTTPStrategy_WithBasicAuth() {
 	// waitForBasicAuth {
 	ctx := context.Background()
-	req := testcontainers.ContainerRequest{
-		Image:        "gogs/gogs:0.11.91",
-		ExposedPorts: []string{"3000/tcp"},
-		WaitingFor:   wait.ForHTTP("/").WithBasicAuth("username", "password"),
-	}
-
-	gogs, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
-		ContainerRequest: req,
-		Started:          true,
-	})
+	gogs, err := testcontainers.Run(ctx, "gogs/gogs:0.11.91",
+		testcontainers.WithExposedPorts("3000/tcp"),
+		testcontainers.WithWaitStrategy(wait.ForHTTP("/").WithBasicAuth("username", "password")),
+	)
 	defer func() {
 		if err := testcontainers.TerminateContainer(gogs); err != nil {
 			log.Printf("failed to terminate container: %s", err)
@@ -235,12 +211,12 @@ func TestHTTPStrategyWaitUntilReady(t *testing.T) {
 	require.Truef(t, certpool.AppendCertsFromPEM(caBytes), "the ca file isn't valid")
 
 	tlsconfig := &tls.Config{RootCAs: certpool, ServerName: "testcontainer.go.test"}
-	dockerReq := testcontainers.ContainerRequest{
-		FromDockerfile: testcontainers.FromDockerfile{
-			Context: "testdata/http",
-		},
-		ExposedPorts: []string{"6443/tcp"},
-		WaitingFor: wait.NewHTTPStrategy("/auth-ping").WithTLS(true, tlsconfig).
+	opts := []testcontainers.ContainerCustomizer{
+		testcontainers.WithDockerfile(testcontainers.FromDockerfile{
+			Context: filepath.Join("testdata", "http"),
+		}),
+		testcontainers.WithExposedPorts("6443/tcp"),
+		testcontainers.WithWaitStrategy(wait.ForHTTP("/auth-ping").WithTLS(true, tlsconfig).
 			WithStartupTimeout(time.Second*10).WithPort("6443/tcp").
 			WithResponseMatcher(func(body io.Reader) bool {
 				data, _ := io.ReadAll(body)
@@ -248,10 +224,10 @@ func TestHTTPStrategyWaitUntilReady(t *testing.T) {
 			}).
 			WithBasicAuth("admin", "admin").
 			WithMethod(http.MethodPost).WithBody(bytes.NewReader([]byte("ping"))),
+		),
 	}
 
-	ctr, err := testcontainers.GenericContainer(context.Background(),
-		testcontainers.GenericContainerRequest{ContainerRequest: dockerReq, Started: true})
+	ctr, err := testcontainers.Run(context.Background(), "", opts...)
 	testcontainers.CleanupContainer(t, ctr)
 	require.NoError(t, err)
 
@@ -289,22 +265,20 @@ func TestHTTPStrategyWaitUntilReadyWithQueryString(t *testing.T) {
 	require.Truef(t, certpool.AppendCertsFromPEM(caBytes), "the ca file isn't valid")
 
 	tlsconfig := &tls.Config{RootCAs: certpool, ServerName: "testcontainer.go.test"}
-	dockerReq := testcontainers.ContainerRequest{
-		FromDockerfile: testcontainers.FromDockerfile{
-			Context: "testdata/http",
-		},
-
-		ExposedPorts: []string{"6443/tcp"},
-		WaitingFor: wait.NewHTTPStrategy("/query-params-ping?v=pong").WithTLS(true, tlsconfig).
+	opts := []testcontainers.ContainerCustomizer{
+		testcontainers.WithDockerfile(testcontainers.FromDockerfile{
+			Context: filepath.Join("testdata", "http"),
+		}),
+		testcontainers.WithExposedPorts("6443/tcp"),
+		testcontainers.WithWaitStrategy(wait.ForHTTP("/query-params-ping?v=pong").WithTLS(true, tlsconfig).
 			WithStartupTimeout(time.Second * 10).WithPort("6443/tcp").
 			WithResponseMatcher(func(body io.Reader) bool {
 				data, _ := io.ReadAll(body)
 				return bytes.Equal(data, []byte("pong"))
-			}),
+			})),
 	}
 
-	ctr, err := testcontainers.GenericContainer(context.Background(),
-		testcontainers.GenericContainerRequest{ContainerRequest: dockerReq, Started: true})
+	ctr, err := testcontainers.Run(context.Background(), "", opts...)
 	testcontainers.CleanupContainer(t, ctr)
 	require.NoError(t, err)
 
@@ -344,13 +318,13 @@ func TestHTTPStrategyWaitUntilReadyNoBasicAuth(t *testing.T) {
 	// waitForHTTPStatusCode {
 	tlsconfig := &tls.Config{RootCAs: certpool, ServerName: "testcontainer.go.test"}
 	var i int
-	dockerReq := testcontainers.ContainerRequest{
-		FromDockerfile: testcontainers.FromDockerfile{
-			Context: "testdata/http",
-		},
-		ExposedPorts: []string{"6443/tcp"},
-		WaitingFor: wait.NewHTTPStrategy("/ping").WithTLS(true, tlsconfig).
-			WithStartupTimeout(time.Second * 10).
+	opts := []testcontainers.ContainerCustomizer{
+		testcontainers.WithDockerfile(testcontainers.FromDockerfile{
+			Context: filepath.Join("testdata", "http"),
+		}),
+		testcontainers.WithExposedPorts("6443/tcp"),
+		testcontainers.WithWaitStrategy(wait.ForHTTP("/ping").WithTLS(true, tlsconfig).
+			WithStartupTimeout(time.Second * 10).WithPort("6443/tcp").
 			WithResponseMatcher(func(body io.Reader) bool {
 				data, _ := io.ReadAll(body)
 				return bytes.Equal(data, []byte("pong"))
@@ -360,11 +334,12 @@ func TestHTTPStrategyWaitUntilReadyNoBasicAuth(t *testing.T) {
 				return i > 1 && status == 200
 			}).
 			WithMethod(http.MethodPost).WithBody(bytes.NewReader([]byte("ping"))),
+		),
 	}
 	// }
 
 	ctx := context.Background()
-	ctr, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{ContainerRequest: dockerReq, Started: true})
+	ctr, err := testcontainers.Run(ctx, "", opts...)
 	testcontainers.CleanupContainer(t, ctr)
 	require.NoError(t, err)
 

--- a/wait/tls_test.go
+++ b/wait/tls_test.go
@@ -8,6 +8,7 @@ import (
 	_ "embed"
 	"fmt"
 	"io"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -106,18 +107,14 @@ func ExampleForTLSCert() {
 	// be copied to in the container as detailed by the Dockerfile.
 	forCert := wait.ForTLSCert("/app/tls.pem", "/app/tls-key.pem").
 		WithServerName("testcontainer.go.test")
-	req := testcontainers.ContainerRequest{
-		FromDockerfile: testcontainers.FromDockerfile{
-			Context: "testdata/http",
-		},
-		WaitingFor: forCert,
-	}
-	// }
 
-	c, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
-		ContainerRequest: req,
-		Started:          true,
-	})
+	c, err := testcontainers.Run(ctx, "",
+		testcontainers.WithDockerfile(testcontainers.FromDockerfile{
+			Context: filepath.Join("testdata", "http"),
+		}),
+		testcontainers.WithWaitStrategy(forCert),
+	)
+	// }
 	defer func() {
 		if err := testcontainers.TerminateContainer(c); err != nil {
 			log.Printf("failed to terminate container: %s", err)


### PR DESCRIPTION
- **chore: use Run in log consumer tests**
- **chore: use Run in reaper tests**
- **chore: use Run in sshd container**
- **chore: use Run in wait strategies**
- **chore: use Run in reuse**

<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
This PR uses the Run function instead of GenericContainer in a reduced list of places:
- reaper tests
- log consumer tests
- the sshd container creation for HostPort access
- wait strategies
- reused containers

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
Continue with the migration from GenericContainer to Run
<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Relates #3174

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
