### PR TITLE
fix: use path.Join instead of url.JoinPath when prepending a custom registry to an image

### DIFF
--- a/image_substitutors_test.go
+++ b/image_substitutors_test.go
@@ -67,7 +67,7 @@ func TestPrependHubRegistrySubstitutor(t *testing.T) {
 			require.Equalf(t, "my-registry/org/user/foo:latest", img, "expected my-registry/org/foo:latest, got %s", img)
 		})
 
-		t.Run("registry with port", func(t *testing.T) {
+		t.Run("registry-with-port", func(t *testing.T) {
 			s := newPrependHubRegistry("my-registry:5000")
 
 			img, err := s.Substitute("foo:latest")

--- a/image_substitutors_test.go
+++ b/image_substitutors_test.go
@@ -66,6 +66,14 @@ func TestPrependHubRegistrySubstitutor(t *testing.T) {
 
 			require.Equalf(t, "my-registry/org/user/foo:latest", img, "expected my-registry/org/foo:latest, got %s", img)
 		})
+
+		t.Run("registry with port", func(t *testing.T) {
+			s := newPrependHubRegistry("my-registry:5000")
+
+			img, err := s.Substitute("foo:latest")
+			require.NoError(t, err)
+			require.Equalf(t, "my-registry:5000/foo:latest", img, "expected my-registry:5000/foo:latest, got %s", img)
+		})
 	})
 
 	t.Run("should not prepend the hub registry to the image name", func(t *testing.T) {

--- a/options.go
+++ b/options.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"maps"
-	"net/url"
+	"path"
 	"time"
 
 	"dario.cat/mergo"
@@ -196,12 +196,7 @@ func (c CustomHubSubstitutor) Substitute(image string) (string, error) {
 		}
 	}
 
-	result, err := url.JoinPath(c.hub, image)
-	if err != nil {
-		return "", err
-	}
-
-	return result, nil
+	return path.Join(c.hub, image), nil
 }
 
 // prependHubRegistry represents a way to prepend a custom Hub registry to the image name,
@@ -244,12 +239,7 @@ func (p prependHubRegistry) Substitute(image string) (string, error) {
 		}
 	}
 
-	result, err := url.JoinPath(p.prefix, image)
-	if err != nil {
-		return "", err
-	}
-
-	return result, nil
+	return path.Join(p.prefix, image), nil
 }
 
 // WithImageSubstitutors sets the image substitutors for a container


### PR DESCRIPTION
## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

This MR swaps `url.JoinPath` with `path.Join` in image substitutors.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

`url.JoinPath` uses `url.Parse` internally, which doesn't correctly parse URLs like `example.com:443` without a schema. Docker image reference cannot have a schema [\[docs\]](https://docs.docker.com/reference/cli/docker/image/tag/). Incorrectly parsed URL inside `url.JoinPath` causes the image tag (second argument) to be completely ignored [\[go playground\]](https://go.dev/play/p/8HjldoU6qyG), which results in 404 errors when pulling an image.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.
-->


- Closes  #3306.
- Relates https://github.com/testcontainers/testcontainers-go/issues/2746.

## How to test this PR

I've added a test case to `image_substitutors_test.go`:

```sh
go test -v -run TestPrependHubRegistrySubstitutor
```
