### PR TITLE
chore(cockroachDB): use Run function

### DIFF
--- a/modules/cockroachdb/options.go
+++ b/modules/cockroachdb/options.go
@@ -2,10 +2,13 @@ package cockroachdb
 
 import (
 	"errors"
+	"fmt"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/wait"
 )
 
 // errInsecureWithPassword is returned when trying to use insecure mode with a password.
@@ -113,6 +116,50 @@ func WithInsecure() testcontainers.CustomizeRequestOption {
 		}
 
 		req.Cmd = append(req.Cmd, insecureFlag)
+
+		return nil
+	}
+}
+
+// configure sets the CockroachDBContainer options from the given request and updates the request
+// wait strategies to match the options.
+// This option must be called after all the options have been applied, in order to extract
+// the credentials from the environment variables and the TLS strategy from the wait strategy.
+func (c *CockroachDBContainer) configure() testcontainers.CustomizeRequestOption {
+	return func(req *testcontainers.GenericContainerRequest) error {
+		// refresh the credentials from the environment variables
+		c.user = req.Env[envUser]
+		c.password = req.Env[envPassword]
+		c.database = req.Env[envDatabase]
+
+		var insecure bool
+		if slices.Contains(req.Cmd, insecureFlag) {
+			insecure = true
+		}
+
+		// Walk the wait strategies to find the TLS strategy and either remove it or
+		// update the client certificate files to match the user and configure the
+		// container to use the TLS strategy.
+		if err := wait.Walk(&req.WaitingFor, func(strategy wait.Strategy) error {
+			if cert, ok := strategy.(*wait.TLSStrategy); ok {
+				if insecure {
+					// If insecure mode is enabled, the certificate strategy is removed.
+					return errors.Join(wait.ErrVisitRemove, wait.ErrVisitStop)
+				}
+
+				// Update the client certificate files to match the user which may have changed.
+				cert.WithCert(certsDir+"/client."+c.user+".crt", certsDir+"/client."+c.user+".key")
+
+				c.tlsStrategy = cert
+
+				// Stop the walk as the certificate strategy has been found.
+				return wait.ErrVisitStop
+			}
+
+			return nil
+		}); err != nil {
+			return fmt.Errorf("walk strategies: %w", err)
+		}
 
 		return nil
 	}


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
Use Run function in the CockroachDB module.

The configure method has been converted into a container customiser option, so that it can be applied last, extracting from the request the credentials and the TLS config.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
Migrate modules to the new API
<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Relates to #3174

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
