### PR TITLE
chore!(etcd): use Run function

### DIFF
--- a/modules/etcd/etcd.go
+++ b/modules/etcd/etcd.go
@@ -69,7 +69,9 @@ func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustom
 	settings := defaultOptions()
 	for _, opt := range opts {
 		if apply, ok := opt.(Option); ok {
-			apply(&settings)
+			if err := apply(&settings); err != nil {
+				return nil, fmt.Errorf("apply option: %w", err)
+			}
 		}
 	}
 

--- a/modules/etcd/etcd_test.go
+++ b/modules/etcd/etcd_test.go
@@ -30,6 +30,22 @@ func TestRun(t *testing.T) {
 	require.Contains(t, string(output), "default")
 }
 
+func TestRunWithDataDir(t *testing.T) {
+	ctx := context.Background()
+
+	ctr, err := etcd.Run(ctx, "gcr.io/etcd-development/etcd:v3.5.14", etcd.WithDataDir())
+	testcontainers.CleanupContainer(t, ctr)
+	require.NoError(t, err)
+
+	c, r, err := ctr.Exec(ctx, []string{"etcdctl", "member", "list"}, tcexec.Multiplexed())
+	require.NoError(t, err)
+	require.Zero(t, c)
+
+	output, err := io.ReadAll(r)
+	require.NoError(t, err)
+	require.Contains(t, string(output), "default")
+}
+
 func TestPutGet(t *testing.T) {
 	t.Run("single_node", func(t *testing.T) {
 		ctr, err := etcd.Run(context.Background(), "gcr.io/etcd-development/etcd:v3.5.14")

--- a/modules/etcd/options.go
+++ b/modules/etcd/options.go
@@ -1,27 +1,21 @@
 package etcd
 
 import (
-	"context"
-	"fmt"
-
 	"github.com/testcontainers/testcontainers-go"
-	tcexec "github.com/testcontainers/testcontainers-go/exec"
 )
 
 type options struct {
-	currentNode      int
-	clusterNetwork   *testcontainers.DockerNetwork
-	nodeNames        []string
-	clusterToken     string
-	additionalArgs   []string
-	mountDataDir     bool // flag needed to avoid extra calculations with the lifecycle hooks
-	containerRequest *testcontainers.ContainerRequest
+	currentNode    int
+	clusterNetwork *testcontainers.DockerNetwork
+	nodeNames      []string
+	clusterToken   string
+	additionalArgs []string
+	mountDataDir   bool // flag needed to avoid extra calculations with the lifecycle hooks
 }
 
-func defaultOptions(req *testcontainers.ContainerRequest) options {
+func defaultOptions() options {
 	return options{
-		clusterToken:     defaultClusterToken,
-		containerRequest: req,
+		clusterToken: defaultClusterToken,
 	}
 }
 
@@ -51,19 +45,6 @@ func WithDataDir() Option {
 	return func(o *options) {
 		// Avoid extra calculations with the lifecycle hooks
 		o.mountDataDir = true
-
-		o.containerRequest.LifecycleHooks = append(o.containerRequest.LifecycleHooks, testcontainers.ContainerLifecycleHooks{
-			PostStarts: []testcontainers.ContainerHook{
-				func(ctx context.Context, c testcontainers.Container) error {
-					_, _, err := c.Exec(ctx, []string{"chmod", "o+rwx", "-R", dataDir}, tcexec.Multiplexed())
-					if err != nil {
-						return fmt.Errorf("chmod etcd data dir: %w", err)
-					}
-
-					return nil
-				},
-			},
-		})
 	}
 }
 

--- a/modules/etcd/options.go
+++ b/modules/etcd/options.go
@@ -1,6 +1,8 @@
 package etcd
 
 import (
+	"fmt"
+
 	"github.com/testcontainers/testcontainers-go"
 )
 
@@ -23,7 +25,7 @@ func defaultOptions() options {
 var _ testcontainers.ContainerCustomizer = (Option)(nil)
 
 // Option is an option for the Etcd container.
-type Option func(*options)
+type Option func(*options) error
 
 // Customize is a NOOP. It's defined to satisfy the testcontainers.ContainerCustomizer interface.
 func (o Option) Customize(*testcontainers.GenericContainerRequest) error {
@@ -34,55 +36,64 @@ func (o Option) Customize(*testcontainers.GenericContainerRequest) error {
 // WithAdditionalArgs is an option to pass additional arguments to the etcd container.
 // They will be appended last to the command line.
 func WithAdditionalArgs(args ...string) Option {
-	return func(o *options) {
+	return func(o *options) error {
 		o.additionalArgs = args
+		return nil
 	}
 }
 
 // WithDataDir is an option to mount the data directory, which is located at /data.etcd.
 // The option will add a lifecycle hook to the container to change the permissions of the data directory.
 func WithDataDir() Option {
-	return func(o *options) {
+	return func(o *options) error {
 		// Avoid extra calculations with the lifecycle hooks
 		o.mountDataDir = true
+		return nil
 	}
 }
 
 // WithNodes is an option to set the nodes of the etcd cluster.
 // It should be used to create a cluster with more than one node.
 func WithNodes(node1 string, node2 string, nodes ...string) Option {
-	return func(o *options) {
+	return func(o *options) error {
 		o.nodeNames = append([]string{node1, node2}, nodes...)
+		return nil
 	}
 }
 
 // withCurrentNode is an option to set the current node index.
 // It's an internal option and should not be used by the user.
 func withCurrentNode(i int) Option {
-	return func(o *options) {
+	return func(o *options) error {
 		o.currentNode = i
+		return nil
 	}
 }
 
 // withClusterNetwork is an option to set the cluster network.
 // It's an internal option and should not be used by the user.
 func withClusterNetwork(n *testcontainers.DockerNetwork) Option {
-	return func(o *options) {
+	return func(o *options) error {
 		o.clusterNetwork = n
+		return nil
 	}
 }
 
 // WithClusterToken is an option to set the cluster token.
 func WithClusterToken(token string) Option {
-	return func(o *options) {
+	return func(o *options) error {
 		o.clusterToken = token
+		return nil
 	}
 }
 
 func withClusterOptions(opts []Option) Option {
-	return func(o *options) {
+	return func(o *options) error {
 		for _, opt := range opts {
-			opt(o)
+			if err := opt(o); err != nil {
+				return fmt.Errorf("with cluster options: %w", err)
+			}
 		}
+		return nil
 	}
 }


### PR DESCRIPTION
- **chore(etcd): use Run function**
- **chore(etcd)!: make options return errors**

<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
Use the Run function in the etcd module

It also adds a breaking change in the etcd module by changing the signature of the etcd options.
Only those users of the module assigning the options to a variable are affected.
If you're just passing them as arguments, you don't have to do anything with this BC.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
Migrate modules to the new API
<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Relates #3174

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
