### PR TITLE
chore(k6|localstack|kafka|mariadb): use Run function

### DIFF
--- a/modules/k3s/k3s.go
+++ b/modules/k3s/k3s.go
@@ -39,12 +39,10 @@ func WithManifest(manifestPath string) testcontainers.CustomizeRequestOption {
 		manifest := filepath.Base(manifestPath)
 		target := k3sManifests + manifest
 
-		req.Files = append(req.Files, testcontainers.ContainerFile{
+		return testcontainers.WithFiles(testcontainers.ContainerFile{
 			HostFilePath:      manifestPath,
 			ContainerFilePath: target,
-		})
-
-		return nil
+		})(req)
 	}
 }
 

--- a/modules/kafka/kafka.go
+++ b/modules/kafka/kafka.go
@@ -199,8 +199,13 @@ func validateKRaftVersion(fqName string) error {
 		return errors.New("image cannot be empty")
 	}
 
-	image := fqName[:strings.LastIndex(fqName, ":")]
-	version := fqName[strings.LastIndex(fqName, ":")+1:]
+	idx := strings.LastIndex(fqName, ":")
+	if idx == -1 || idx == len(fqName)-1 {
+		return nil
+	}
+
+	image := fqName[:idx]
+	version := fqName[idx+1:]
 
 	if !strings.EqualFold(image, "confluentinc/confluent-local") {
 		// do not validate if the image is not the official one.

--- a/modules/kafka/kafka.go
+++ b/modules/kafka/kafka.go
@@ -73,7 +73,7 @@ func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustom
 		testcontainers.WithEntrypoint("sh"),
 		// this CMD will wait for the starter script to be copied into the container and then execute it
 		testcontainers.WithCmd("-c", "while [ ! -f "+starterScript+" ]; do sleep 0.1; done; bash "+starterScript),
-		testcontainers.WithAdditionalLifecycleHooks(testcontainers.ContainerLifecycleHooks{
+		testcontainers.WithLifecycleHooks(testcontainers.ContainerLifecycleHooks{
 			PostStarts: []testcontainers.ContainerHook{
 				// Use a single hook to copy the starter script and wait for
 				// the Kafka server to be ready. This prevents the wait running

--- a/modules/kafka/kafka.go
+++ b/modules/kafka/kafka.go
@@ -72,7 +72,7 @@ func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustom
 		}),
 		testcontainers.WithEntrypoint("sh"),
 		// this CMD will wait for the starter script to be copied into the container and then execute it
-		testcontainers.WithCmdArgs("-c", "while [ ! -f "+starterScript+" ]; do sleep 0.1; done; bash "+starterScript),
+		testcontainers.WithCmd("-c", "while [ ! -f "+starterScript+" ]; do sleep 0.1; done; bash "+starterScript),
 		testcontainers.WithAdditionalLifecycleHooks(testcontainers.ContainerLifecycleHooks{
 			PostStarts: []testcontainers.ContainerHook{
 				// Use a single hook to copy the starter script and wait for

--- a/modules/kafka/kafka.go
+++ b/modules/kafka/kafka.go
@@ -46,10 +46,13 @@ func RunContainer(ctx context.Context, opts ...testcontainers.ContainerCustomize
 
 // Run creates an instance of the Kafka container type
 func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustomizer) (*KafkaContainer, error) {
-	req := testcontainers.ContainerRequest{
-		Image:        img,
-		ExposedPorts: []string{string(publicPort)},
-		Env: map[string]string{
+	if err := validateKRaftVersion(img); err != nil {
+		return nil, err
+	}
+
+	moduleOpts := []testcontainers.ContainerCustomizer{
+		testcontainers.WithExposedPorts(string(publicPort)),
+		testcontainers.WithEnv(map[string]string{
 			// envVars {
 			"KAFKA_LISTENERS":                                "PLAINTEXT://0.0.0.0:9093,BROKER://0.0.0.0:9092,CONTROLLER://0.0.0.0:9094",
 			"KAFKA_REST_BOOTSTRAP_SERVERS":                   "PLAINTEXT://0.0.0.0:9093,BROKER://0.0.0.0:9092,CONTROLLER://0.0.0.0:9094",
@@ -66,56 +69,53 @@ func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustom
 			"KAFKA_PROCESS_ROLES":                            "broker,controller",
 			"KAFKA_CONTROLLER_LISTENER_NAMES":                "CONTROLLER",
 			// }
-		},
-		Entrypoint: []string{"sh"},
+		}),
+		testcontainers.WithEntrypoint("sh"),
 		// this CMD will wait for the starter script to be copied into the container and then execute it
-		Cmd: []string{"-c", "while [ ! -f " + starterScript + " ]; do sleep 0.1; done; bash " + starterScript},
-		LifecycleHooks: []testcontainers.ContainerLifecycleHooks{
-			{
-				PostStarts: []testcontainers.ContainerHook{
-					// Use a single hook to copy the starter script and wait for
-					// the Kafka server to be ready. This prevents the wait running
-					// if the starter script fails to copy.
-					func(ctx context.Context, c testcontainers.Container) error {
-						// 1. copy the starter script into the container
-						if err := copyStarterScript(ctx, c); err != nil {
-							return fmt.Errorf("copy starter script: %w", err)
-						}
+		testcontainers.WithCmdArgs("-c", "while [ ! -f "+starterScript+" ]; do sleep 0.1; done; bash "+starterScript),
+		testcontainers.WithAdditionalLifecycleHooks(testcontainers.ContainerLifecycleHooks{
+			PostStarts: []testcontainers.ContainerHook{
+				// Use a single hook to copy the starter script and wait for
+				// the Kafka server to be ready. This prevents the wait running
+				// if the starter script fails to copy.
+				func(ctx context.Context, c testcontainers.Container) error {
+					// 1. copy the starter script into the container
+					if err := copyStarterScript(ctx, c); err != nil {
+						return fmt.Errorf("copy starter script: %w", err)
+					}
 
-						// 2. wait for the Kafka server to be ready
-						return wait.ForLog(".*Transitioning from RECOVERY to RUNNING.*").AsRegexp().WaitUntilReady(ctx, c)
-					},
+					// 2. wait for the Kafka server to be ready
+					return wait.ForLog(".*Transitioning from RECOVERY to RUNNING.*").AsRegexp().WaitUntilReady(ctx, c)
 				},
 			},
-		},
+		}),
 	}
 
-	genericContainerReq := testcontainers.GenericContainerRequest{
-		ContainerRequest: req,
-		Started:          true,
-	}
+	moduleOpts = append(moduleOpts, opts...)
 
-	for _, opt := range opts {
-		if err := opt.Customize(&genericContainerReq); err != nil {
-			return nil, err
-		}
-	}
+	// configure the controller quorum voters after all the options have been applied
+	moduleOpts = append(moduleOpts, configureControllerQuorumVoters())
 
-	err := validateKRaftVersion(genericContainerReq.Image)
-	if err != nil {
-		return nil, err
-	}
-
-	configureControllerQuorumVoters(&genericContainerReq)
-
-	container, err := testcontainers.GenericContainer(ctx, genericContainerReq)
 	var c *KafkaContainer
-	if container != nil {
-		c = &KafkaContainer{Container: container, ClusterID: genericContainerReq.Env["CLUSTER_ID"]}
+	ctr, err := testcontainers.Run(ctx, img, moduleOpts...)
+	if ctr != nil {
+		c = &KafkaContainer{Container: ctr}
+	}
+	if err != nil {
+		return c, fmt.Errorf("run kafka: %w", err)
 	}
 
+	// Inspect the container to get the CLUSTER_ID environment variable
+	inspect, err := ctr.Inspect(ctx)
 	if err != nil {
-		return c, fmt.Errorf("generic container: %w", err)
+		return c, fmt.Errorf("inspect kafka: %w", err)
+	}
+
+	for _, env := range inspect.Config.Env {
+		if v, ok := strings.CutPrefix(env, "CLUSTER_ID="); ok {
+			c.ClusterID = v
+			break
+		}
 	}
 
 	return c, nil
@@ -150,11 +150,9 @@ func copyStarterScript(ctx context.Context, c testcontainers.Container) error {
 }
 
 func WithClusterID(clusterID string) testcontainers.CustomizeRequestOption {
-	return func(req *testcontainers.GenericContainerRequest) error {
-		req.Env["CLUSTER_ID"] = clusterID
-
-		return nil
-	}
+	return testcontainers.WithEnv(map[string]string{
+		"CLUSTER_ID": clusterID,
+	})
 }
 
 // Brokers retrieves the broker connection strings from Kafka with only one entry,
@@ -168,24 +166,28 @@ func (kc *KafkaContainer) Brokers(ctx context.Context) ([]string, error) {
 	return []string{endpoint}, nil
 }
 
-// configureControllerQuorumVoters sets the quorum voters for the controller. For that, it will
-// check if there are any network aliases defined for the container and use the first alias in the
-// first network. Else, it will use localhost.
-func configureControllerQuorumVoters(req *testcontainers.GenericContainerRequest) {
-	if req.Env == nil {
-		req.Env = map[string]string{}
-	}
-
-	if req.Env["KAFKA_CONTROLLER_QUORUM_VOTERS"] == "" {
-		host := "localhost"
-		if len(req.Networks) > 0 {
-			nw := req.Networks[0]
-			if len(req.NetworkAliases[nw]) > 0 {
-				host = req.NetworkAliases[nw][0]
-			}
+// configureControllerQuorumVoters returns an option that sets the quorum voters for the controller.
+// For that, it will check if there are any network aliases defined for the container and use the
+// first alias in the first network. Else, it will use localhost.
+func configureControllerQuorumVoters() testcontainers.CustomizeRequestOption {
+	return func(req *testcontainers.GenericContainerRequest) error {
+		if req.Env == nil {
+			req.Env = map[string]string{}
 		}
 
-		req.Env["KAFKA_CONTROLLER_QUORUM_VOTERS"] = fmt.Sprintf("1@%s:9094", host)
+		if req.Env["KAFKA_CONTROLLER_QUORUM_VOTERS"] == "" {
+			host := "localhost"
+			if len(req.Networks) > 0 {
+				nw := req.Networks[0]
+				if len(req.NetworkAliases[nw]) > 0 {
+					host = req.NetworkAliases[nw][0]
+				}
+			}
+
+			req.Env["KAFKA_CONTROLLER_QUORUM_VOTERS"] = "1@" + host + ":9094"
+		}
+
+		return nil
 	}
 	// }
 }

--- a/modules/kafka/kafka_helpers_test.go
+++ b/modules/kafka/kafka_helpers_test.go
@@ -55,7 +55,8 @@ func TestConfigureQuorumVoters(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			configureControllerQuorumVoters(test.req)
+			err := configureControllerQuorumVoters()(test.req)
+			require.NoError(t, err)
 
 			require.Equalf(t, test.expectedVoters, test.req.Env["KAFKA_CONTROLLER_QUORUM_VOTERS"], "expected KAFKA_CONTROLLER_QUORUM_VOTERS to be %s, got %s", test.expectedVoters, test.req.Env["KAFKA_CONTROLLER_QUORUM_VOTERS"])
 		})

--- a/modules/kafka/kafka_helpers_test.go
+++ b/modules/kafka/kafka_helpers_test.go
@@ -94,6 +94,11 @@ func TestValidateKRaftVersion(t *testing.T) {
 			image:   "my-kafka:1.0.0",
 			wantErr: false,
 		},
+		{
+			name:    "lacks tag",
+			image:   "my-kafka",
+			wantErr: false,
+		},
 	}
 
 	for _, test := range tests {

--- a/modules/localstack/localstack.go
+++ b/modules/localstack/localstack.go
@@ -88,7 +88,7 @@ func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustom
 	moduleOpts = append(moduleOpts, opts...)
 
 	// configure the docker host after all the options have been applied
-	moduleOpts = append(moduleOpts, configureDockerHostOption(ctx, envVar))
+	moduleOpts = append(moduleOpts, configureDockerHost(ctx, envVar))
 
 	var c *LocalStackContainer
 	ctr, err := testcontainers.Run(ctx, img, moduleOpts...)
@@ -109,9 +109,10 @@ func StartContainer(ctx context.Context, overrideReq OverrideContainerRequestOpt
 	return RunContainer(ctx, overrideReq)
 }
 
-func configureDockerHostOption(ctx context.Context, envVar string) testcontainers.CustomizeRequestOption {
+// configureDockerHost returns an option that configures the docker host environment variable
+func configureDockerHost(ctx context.Context, envVar string) testcontainers.CustomizeRequestOption {
 	return func(req *testcontainers.GenericContainerRequest) error {
-		reason, err := configureDockerHost(ctx, req, envVar)
+		reason, err := setDockerHost(ctx, req, envVar)
 		if err != nil {
 			return err
 		}
@@ -120,7 +121,7 @@ func configureDockerHostOption(ctx context.Context, envVar string) testcontainer
 	}
 }
 
-func configureDockerHost(ctx context.Context, req *testcontainers.GenericContainerRequest, envVar string) (string, error) {
+func setDockerHost(ctx context.Context, req *testcontainers.GenericContainerRequest, envVar string) (string, error) {
 	if _, ok := req.Env[envVar]; ok {
 		return "explicitly as environment variable", nil
 	}

--- a/modules/localstack/localstack_test.go
+++ b/modules/localstack/localstack_test.go
@@ -39,7 +39,7 @@ func TestConfigureDockerHost(t *testing.T) {
 
 			req.Env[tt.envVar] = "foo"
 
-			reason, err := configureDockerHost(req, tt.envVar)
+			reason, err := configureDockerHost(context.Background(), &req.GenericContainerRequest, tt.envVar)
 			require.NoError(t, err)
 			require.Equal(t, "explicitly as environment variable", reason)
 		})
@@ -54,7 +54,7 @@ func TestConfigureDockerHost(t *testing.T) {
 				"baaz": {"baaz0", "baaz1", "baaz2", "baaz3"},
 			}
 
-			reason, err := configureDockerHost(req, tt.envVar)
+			reason, err := configureDockerHost(context.Background(), &req.GenericContainerRequest, tt.envVar)
 			require.NoError(t, err)
 			require.Equal(t, "to match last network alias on container with non-default network", reason)
 			require.Equal(t, "foo3", req.Env[tt.envVar])
@@ -74,7 +74,7 @@ func TestConfigureDockerHost(t *testing.T) {
 			req.Networks = []string{"foo", "bar", "baaz"}
 			req.NetworkAliases = map[string][]string{}
 
-			reason, err := configureDockerHost(req, tt.envVar)
+			reason, err := configureDockerHost(context.Background(), &req.GenericContainerRequest, tt.envVar)
 			require.NoError(t, err)
 			require.Equal(t, "to match host-routable address for container", reason)
 			require.Equal(t, expectedDaemonHost, req.Env[tt.envVar])

--- a/modules/localstack/types.go
+++ b/modules/localstack/types.go
@@ -9,6 +9,7 @@ type LocalStackContainer struct {
 	testcontainers.Container
 }
 
+// Deprecated: use testcontainers.GenericContainerRequest instead
 // LocalStackContainerRequest represents the LocalStack container request type used in the module
 // to configure the container
 type LocalStackContainerRequest struct {

--- a/modules/mariadb/mariadb.go
+++ b/modules/mariadb/mariadb.go
@@ -67,40 +67,29 @@ func withMySQLEnvVars() testcontainers.CustomizeRequestOption {
 }
 
 func WithUsername(username string) testcontainers.CustomizeRequestOption {
-	return func(req *testcontainers.GenericContainerRequest) error {
-		req.Env["MARIADB_USER"] = username
-
-		return nil
-	}
+	return testcontainers.WithEnv(map[string]string{
+		"MARIADB_USER": username,
+	})
 }
 
 func WithPassword(password string) testcontainers.CustomizeRequestOption {
-	return func(req *testcontainers.GenericContainerRequest) error {
-		req.Env["MARIADB_PASSWORD"] = password
-
-		return nil
-	}
+	return testcontainers.WithEnv(map[string]string{
+		"MARIADB_PASSWORD": password,
+	})
 }
 
 func WithDatabase(database string) testcontainers.CustomizeRequestOption {
-	return func(req *testcontainers.GenericContainerRequest) error {
-		req.Env["MARIADB_DATABASE"] = database
-
-		return nil
-	}
+	return testcontainers.WithEnv(map[string]string{
+		"MARIADB_DATABASE": database,
+	})
 }
 
 func WithConfigFile(configFile string) testcontainers.CustomizeRequestOption {
-	return func(req *testcontainers.GenericContainerRequest) error {
-		cf := testcontainers.ContainerFile{
-			HostFilePath:      configFile,
-			ContainerFilePath: "/etc/mysql/conf.d/my.cnf",
-			FileMode:          0o755,
-		}
-		req.Files = append(req.Files, cf)
-
-		return nil
-	}
+	return testcontainers.WithFiles(testcontainers.ContainerFile{
+		HostFilePath:      configFile,
+		ContainerFilePath: "/etc/mysql/conf.d/my.cnf",
+		FileMode:          0o755,
+	})
 }
 
 func WithScripts(scripts ...string) testcontainers.CustomizeRequestOption {
@@ -114,7 +103,10 @@ func WithScripts(scripts ...string) testcontainers.CustomizeRequestOption {
 			}
 			initScripts = append(initScripts, cf)
 		}
-		req.Files = append(req.Files, initScripts...)
+
+		if err := testcontainers.WithFiles(initScripts...)(req); err != nil {
+			return err
+		}
 
 		return nil
 	}
@@ -128,60 +120,57 @@ func RunContainer(ctx context.Context, opts ...testcontainers.ContainerCustomize
 
 // Run creates an instance of the MariaDB container type
 func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustomizer) (*MariaDBContainer, error) {
-	req := testcontainers.ContainerRequest{
-		Image:        img,
-		ExposedPorts: []string{"3306/tcp", "33060/tcp"},
-		Env: map[string]string{
+	moduleOpts := []testcontainers.ContainerCustomizer{
+		testcontainers.WithExposedPorts("3306/tcp", "33060/tcp"),
+		testcontainers.WithEnv(map[string]string{
 			"MARIADB_USER":     defaultUser,
 			"MARIADB_PASSWORD": defaultPassword,
 			"MARIADB_DATABASE": defaultDatabaseName,
-		},
-		WaitingFor: wait.ForLog("port: 3306  mariadb.org binary distribution"),
+		}),
+		testcontainers.WithWaitStrategy(wait.ForLog("port: 3306  mariadb.org binary distribution")),
 	}
 
-	genericContainerReq := testcontainers.GenericContainerRequest{
-		ContainerRequest: req,
-		Started:          true,
-	}
-
-	opts = append(opts, WithDefaultCredentials())
-
-	for _, opt := range opts {
-		if err := opt.Customize(&genericContainerReq); err != nil {
-			return nil, err
-		}
-	}
+	moduleOpts = append(moduleOpts, opts...)
+	moduleOpts = append(moduleOpts, WithDefaultCredentials())
 
 	// Apply MySQL environment variables after user customization
 	// In future releases of MariaDB, they could remove the MYSQL_* environment variables
 	// at all. Then we can remove this customization.
-	if err := withMySQLEnvVars().Customize(&genericContainerReq); err != nil {
-		return nil, err
-	}
+	moduleOpts = append(moduleOpts, withMySQLEnvVars())
 
-	username, ok := req.Env["MARIADB_USER"]
-	if !ok {
-		username = rootUser
-	}
-	password := req.Env["MARIADB_PASSWORD"]
+	// validate credentials before running the container
+	moduleOpts = append(moduleOpts, validateCredentials())
 
-	if len(password) == 0 && password == "" && !strings.EqualFold(rootUser, username) {
-		return nil, errors.New("empty password can be used only with the root user")
-	}
-
-	container, err := testcontainers.GenericContainer(ctx, genericContainerReq)
 	var c *MariaDBContainer
-	if container != nil {
-		c = &MariaDBContainer{
-			Container: container,
-			username:  username,
-			password:  password,
-			database:  req.Env["MARIADB_DATABASE"],
-		}
+	ctr, err := testcontainers.Run(ctx, img, moduleOpts...)
+	if ctr != nil {
+		c = &MariaDBContainer{Container: ctr, username: rootUser}
+	}
+	if err != nil {
+		return c, fmt.Errorf("run mariadb: %w", err)
 	}
 
+	// Inspect the container to get environment variables
+	inspect, err := ctr.Inspect(ctx)
 	if err != nil {
-		return c, fmt.Errorf("generic container: %w", err)
+		return c, fmt.Errorf("inspect mariadb: %w", err)
+	}
+
+	foundUser, foundPass, foundDB := false, false, false
+	for _, env := range inspect.Config.Env {
+		if v, ok := strings.CutPrefix(env, "MARIADB_USER="); ok {
+			c.username, foundUser = v, true
+		}
+		if v, ok := strings.CutPrefix(env, "MARIADB_PASSWORD="); ok {
+			c.password, foundPass = v, true
+		}
+		if v, ok := strings.CutPrefix(env, "MARIADB_DATABASE="); ok {
+			c.database, foundDB = v, true
+		}
+
+		if foundUser && foundPass && foundDB {
+			break
+		}
 	}
 
 	return c, nil
@@ -212,4 +201,22 @@ func (c *MariaDBContainer) ConnectionString(ctx context.Context, args ...string)
 
 	connectionString := fmt.Sprintf("%s:%s@tcp(%s)/%s%s", c.username, c.password, endpoint, c.database, extraArgs)
 	return connectionString, nil
+}
+
+// validateCredentials validates the credentials to ensure that an empty password
+// is only used with the root user.
+func validateCredentials() testcontainers.CustomizeRequestOption {
+	return func(req *testcontainers.GenericContainerRequest) error {
+		username, ok := req.Env["MARIADB_USER"]
+		if !ok {
+			username = rootUser
+		}
+		password := req.Env["MARIADB_PASSWORD"]
+
+		if len(password) == 0 && password == "" && !strings.EqualFold(rootUser, username) {
+			return errors.New("empty password can be used only with the root user")
+		}
+
+		return nil
+	}
 }

--- a/modules/mariadb/mariadb_test.go
+++ b/modules/mariadb/mariadb_test.go
@@ -53,7 +53,7 @@ func TestMariaDBWithNonRootUserAndEmptyPassword(t *testing.T) {
 		mariadb.WithDatabase("foo"),
 		mariadb.WithUsername("test"),
 		mariadb.WithPassword(""))
-	require.EqualError(t, err, "empty password can be used only with the root user")
+	require.EqualError(t, err, "run mariadb: customize: empty password can be used only with the root user")
 }
 
 func TestMariaDBWithRootUserAndEmptyPassword(t *testing.T) {


### PR DESCRIPTION
## What does this PR do?

Use the Run function in k6, localstack, kafka, and mariadb modules

## Why is it important?

Migrate modules to the new API, improving consistency and leveraging the latest testcontainers functionality.

## Related issues

- Relates to https://github.com/testcontainers/testcontainers-go/pull/3413