### PR TITLE
chore(meilisearch|memcached|milvus|minio|mockserver|mssql): use Run function

### DIFF
--- a/modules/meilisearch/meilisearch.go
+++ b/modules/meilisearch/meilisearch.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/testcontainers/testcontainers-go"
@@ -31,70 +32,73 @@ func (c *MeilisearchContainer) MasterKey() string {
 
 // Run creates an instance of the Meilisearch container type
 func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustomizer) (*MeilisearchContainer, error) {
-	req := testcontainers.ContainerRequest{
-		Image:        img,
-		ExposedPorts: []string{defaultHTTPPort},
-		Env: map[string]string{
-			masterKeyEnvVar: defaultMasterKey,
-		},
-	}
-
-	genericContainerReq := testcontainers.GenericContainerRequest{
-		ContainerRequest: req,
-		Started:          true,
-	}
-
 	// Gather all config options (defaults and then apply provided options)
 	settings := defaultOptions()
 	for _, opt := range opts {
 		if apply, ok := opt.(Option); ok {
 			apply(settings)
 		}
-		if err := opt.Customize(&genericContainerReq); err != nil {
-			return nil, fmt.Errorf("customize: %w", err)
-		}
+	}
+
+	moduleOpts := []testcontainers.ContainerCustomizer{
+		testcontainers.WithExposedPorts(defaultHTTPPort),
+		testcontainers.WithEnv(map[string]string{
+			masterKeyEnvVar: defaultMasterKey,
+		}),
+		// the wait strategy does not support TLS at the moment,
+		// so we need to disable it in the strategy for now.
+		testcontainers.WithWaitStrategy(wait.ForHTTP("/health").
+			WithPort(defaultHTTPPort).
+			WithTLS(false).
+			WithStartupTimeout(120 * time.Second).
+			WithStatusCodeMatcher(func(status int) bool {
+				return status == http.StatusOK
+			}).
+			WithResponseMatcher(func(body io.Reader) bool {
+				decoder := json.NewDecoder(body)
+				r := struct {
+					Status string `json:"status"`
+				}{}
+				if err := decoder.Decode(&r); err != nil {
+					return false
+				}
+
+				return r.Status == "available"
+			}),
+		),
 	}
 
 	if settings.DumpDataFilePath != "" {
-		genericContainerReq.Files = []testcontainers.ContainerFile{
-			{
+		moduleOpts = append(moduleOpts,
+			testcontainers.WithFiles(testcontainers.ContainerFile{
 				HostFilePath:      settings.DumpDataFilePath,
 				ContainerFilePath: "/dumps/" + settings.DumpDataFileName,
 				FileMode:          0o755,
-			},
-		}
-		genericContainerReq.Cmd = []string{"meilisearch", "--import-dump", "/dumps/" + settings.DumpDataFileName}
+			}),
+			testcontainers.WithCmd("meilisearch", "--import-dump", "/dumps/"+settings.DumpDataFileName),
+		)
 	}
 
-	// the wait strategy does not support TLS at the moment,
-	// so we need to disable it in the strategy for now.
-	genericContainerReq.WaitingFor = wait.ForHTTP("/health").
-		WithPort(defaultHTTPPort).
-		WithTLS(false).
-		WithStartupTimeout(120 * time.Second).
-		WithStatusCodeMatcher(func(status int) bool {
-			return status == http.StatusOK
-		}).
-		WithResponseMatcher(func(body io.Reader) bool {
-			decoder := json.NewDecoder(body)
-			r := struct {
-				Status string `json:"status"`
-			}{}
-			if err := decoder.Decode(&r); err != nil {
-				return false
-			}
-
-			return r.Status == "available"
-		})
-
-	container, err := testcontainers.GenericContainer(ctx, genericContainerReq)
+	ctr, err := testcontainers.Run(ctx, img, append(moduleOpts, opts...)...)
 	var c *MeilisearchContainer
-	if container != nil {
-		c = &MeilisearchContainer{Container: container, masterKey: req.Env[masterKeyEnvVar]}
+	if ctr != nil {
+		c = &MeilisearchContainer{Container: ctr}
 	}
 
 	if err != nil {
-		return c, fmt.Errorf("generic container: %w", err)
+		return c, fmt.Errorf("run meilisearch: %w", err)
+	}
+
+	inspect, err := ctr.Inspect(ctx)
+	if err != nil {
+		return c, fmt.Errorf("inspect meilisearch: %w", err)
+	}
+
+	for _, env := range inspect.Config.Env {
+		if v, ok := strings.CutPrefix(env, masterKeyEnvVar+"="); ok {
+			c.masterKey = v
+			break
+		}
 	}
 
 	return c, nil

--- a/modules/milvus/milvus.go
+++ b/modules/milvus/milvus.go
@@ -47,45 +47,36 @@ func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustom
 	}
 
 	// Adapted from https://github.com/milvus-io/milvus/blob/v2.6.3/scripts/standalone_embed.sh
-	req := testcontainers.ContainerRequest{
-		Image:        img,
-		ExposedPorts: []string{"19530/tcp", "9091/tcp", "2379/tcp"},
-		Env: map[string]string{
+	moduleOpts := []testcontainers.ContainerCustomizer{
+		testcontainers.WithExposedPorts("19530/tcp", "9091/tcp", "2379/tcp"),
+		testcontainers.WithEnv(map[string]string{
 			"ETCD_USE_EMBED":     "true",
 			"ETCD_DATA_DIR":      "/var/lib/milvus/etcd",
 			"ETCD_CONFIG_PATH":   embedEtcdContainerPath,
 			"COMMON_STORAGETYPE": "local",
 			"DEPLOY_MODE":        "STANDALONE",
-		},
-		Cmd: []string{"milvus", "run", "standalone"},
-		WaitingFor: wait.ForHTTP("/healthz").
+		}),
+		testcontainers.WithCmd("milvus", "run", "standalone"),
+		testcontainers.WithWaitStrategy(wait.ForHTTP("/healthz").
 			WithPort("9091").
 			WithStartupTimeout(time.Minute).
-			WithPollInterval(time.Second),
-		Files: []testcontainers.ContainerFile{
-			{ContainerFilePath: embedEtcdContainerPath, Reader: config},
-		},
+			WithPollInterval(time.Second)),
+		testcontainers.WithFiles(testcontainers.ContainerFile{
+			ContainerFilePath: embedEtcdContainerPath,
+			Reader:            config,
+		}),
 	}
 
-	genericContainerReq := testcontainers.GenericContainerRequest{
-		ContainerRequest: req,
-		Started:          true,
-	}
+	moduleOpts = append(moduleOpts, opts...)
 
-	for _, opt := range opts {
-		if err := opt.Customize(&genericContainerReq); err != nil {
-			return nil, err
-		}
-	}
-
-	container, err := testcontainers.GenericContainer(ctx, genericContainerReq)
+	ctr, err := testcontainers.Run(ctx, img, moduleOpts...)
 	var c *MilvusContainer
-	if container != nil {
-		c = &MilvusContainer{Container: container}
+	if ctr != nil {
+		c = &MilvusContainer{Container: ctr}
 	}
 
 	if err != nil {
-		return c, fmt.Errorf("generic container: %w", err)
+		return c, fmt.Errorf("run milvus: %w", err)
 	}
 
 	return c, nil

--- a/modules/mockserver/mockserver.go
+++ b/modules/mockserver/mockserver.go
@@ -21,34 +21,24 @@ func RunContainer(ctx context.Context, opts ...testcontainers.ContainerCustomize
 
 // Run creates an instance of the MockServer container type
 func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustomizer) (*MockServerContainer, error) {
-	req := testcontainers.ContainerRequest{
-		Image:        img,
-		ExposedPorts: []string{"1080/tcp"},
-		WaitingFor: wait.ForAll(
+	moduleOpts := []testcontainers.ContainerCustomizer{
+		testcontainers.WithExposedPorts("1080/tcp"),
+		testcontainers.WithWaitStrategy(wait.ForAll(
 			wait.ForLog("started on port: 1080"),
 			wait.ForListeningPort("1080/tcp").SkipInternalCheck(),
-		),
-		Env: map[string]string{},
+		)),
 	}
 
-	genericContainerReq := testcontainers.GenericContainerRequest{
-		ContainerRequest: req,
-		Started:          true,
-	}
+	moduleOpts = append(moduleOpts, opts...)
 
-	for _, opt := range opts {
-		if err := opt.Customize(&genericContainerReq); err != nil {
-			return nil, err
-		}
-	}
-
-	container, err := testcontainers.GenericContainer(ctx, genericContainerReq)
+	ctr, err := testcontainers.Run(ctx, img, moduleOpts...)
 	var c *MockServerContainer
-	if container != nil {
-		c = &MockServerContainer{Container: container}
+	if ctr != nil {
+		c = &MockServerContainer{Container: ctr}
 	}
+
 	if err != nil {
-		return c, fmt.Errorf("generic container: %w", err)
+		return c, fmt.Errorf("run mockserver: %w", err)
 	}
 
 	return c, nil

--- a/modules/mssql/mssql.go
+++ b/modules/mssql/mssql.go
@@ -33,11 +33,9 @@ func (c *MSSQLServerContainer) Password() string {
 
 // WithAcceptEULA sets the ACCEPT_EULA environment variable to "Y"
 func WithAcceptEULA() testcontainers.CustomizeRequestOption {
-	return func(req *testcontainers.GenericContainerRequest) error {
-		req.Env["ACCEPT_EULA"] = "Y"
-
-		return nil
-	}
+	return testcontainers.WithEnv(map[string]string{
+		"ACCEPT_EULA": "Y",
+	})
 }
 
 // WithPassword sets the MSSQL_SA_PASSWORD environment variable to the provided password
@@ -46,9 +44,10 @@ func WithPassword(password string) testcontainers.CustomizeRequestOption {
 		if password == "" {
 			password = defaultPassword
 		}
-		req.Env["MSSQL_SA_PASSWORD"] = password
 
-		return nil
+		return testcontainers.WithEnv(map[string]string{
+			"MSSQL_SA_PASSWORD": password,
+		})(req)
 	}
 }
 
@@ -96,11 +95,9 @@ func WithInitSQL(files ...io.Reader) testcontainers.CustomizeRequestOption {
 			hooks = append(hooks, hook)
 		}
 
-		req.LifecycleHooks = append(req.LifecycleHooks, testcontainers.ContainerLifecycleHooks{
+		return testcontainers.WithAdditionalLifecycleHooks(testcontainers.ContainerLifecycleHooks{
 			PostReadies: hooks,
-		})
-
-		return nil
+		})(req)
 	}
 }
 

--- a/modules/mssql/mssql.go
+++ b/modules/mssql/mssql.go
@@ -112,41 +112,50 @@ func RunContainer(ctx context.Context, opts ...testcontainers.ContainerCustomize
 
 // Run creates an instance of the MSSQLServer container type
 func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustomizer) (*MSSQLServerContainer, error) {
-	req := testcontainers.ContainerRequest{
-		Image:        img,
-		ExposedPorts: []string{defaultPort},
-		Env: map[string]string{
+	moduleOpts := []testcontainers.ContainerCustomizer{
+		testcontainers.WithExposedPorts(defaultPort),
+		testcontainers.WithEnv(map[string]string{
 			"MSSQL_SA_PASSWORD": defaultPassword,
-		},
-		WaitingFor: wait.ForAll(
+		}),
+		testcontainers.WithWaitStrategy(wait.ForAll(
 			wait.ForListeningPort(defaultPort).WithStartupTimeout(time.Minute),
 			wait.ForLog("Recovery is complete."),
-		),
+		)),
 	}
 
-	genericContainerReq := testcontainers.GenericContainerRequest{
-		ContainerRequest: req,
-		Started:          true,
-	}
+	moduleOpts = append(moduleOpts, opts...)
 
-	for _, opt := range opts {
-		if err := opt.Customize(&genericContainerReq); err != nil {
-			return nil, fmt.Errorf("customize: %w", err)
+	// Validate EULA acceptance after applying user options
+	validateEULA := func(req *testcontainers.GenericContainerRequest) error {
+		if strings.ToUpper(req.Env["ACCEPT_EULA"]) != "Y" {
+			return errors.New("EULA not accepted. Please use the WithAcceptEULA option to accept the EULA")
 		}
+		return nil
 	}
 
-	if strings.ToUpper(genericContainerReq.Env["ACCEPT_EULA"]) != "Y" {
-		return nil, errors.New("EULA not accepted. Please use the WithAcceptEULA option to accept the EULA")
-	}
+	moduleOpts = append(moduleOpts, testcontainers.CustomizeRequestOption(validateEULA))
 
-	container, err := testcontainers.GenericContainer(ctx, genericContainerReq)
+	ctr, err := testcontainers.Run(ctx, img, moduleOpts...)
 	var c *MSSQLServerContainer
-	if container != nil {
-		c = &MSSQLServerContainer{Container: container, password: req.Env["MSSQL_SA_PASSWORD"], username: defaultUsername}
+	if ctr != nil {
+		c = &MSSQLServerContainer{Container: ctr, username: defaultUsername}
 	}
 
 	if err != nil {
-		return c, fmt.Errorf("generic container: %w", err)
+		return c, fmt.Errorf("run mssql: %w", err)
+	}
+
+	// Retrieve password from container environment
+	inspect, err := ctr.Inspect(ctx)
+	if err != nil {
+		return c, fmt.Errorf("inspect mssql: %w", err)
+	}
+
+	for _, env := range inspect.Config.Env {
+		if v, ok := strings.CutPrefix(env, "MSSQL_SA_PASSWORD="); ok {
+			c.password = v
+			break
+		}
 	}
 
 	return c, nil


### PR DESCRIPTION
## What does this PR do?

Use the Run function in meilisearch, memcached, milvus, minio, mockserver and mssql modules

Also fixes test flakiness in milvus by adding wait strategies for both HTTP and gRPC ports.

## Why is it important?

Migrate modules to the new API, improving consistency and leveraging the latest testcontainers functionality.

## Related issues

- Relates to https://github.com/testcontainers/testcontainers-go/pull/3174