### PR TITLE
chore(nats): use Run function

### DIFF
--- a/modules/nats/nats.go
+++ b/modules/nats/nats.go
@@ -29,47 +29,44 @@ func RunContainer(ctx context.Context, opts ...testcontainers.ContainerCustomize
 
 // Run creates an instance of the NATS container type
 func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustomizer) (*NATSContainer, error) {
-	req := testcontainers.ContainerRequest{
-		Image:        img,
-		ExposedPorts: []string{defaultClientPort, defaultRoutingPort, defaultMonitoringPort},
-		Cmd:          []string{"-DV", "-js"},
-		WaitingFor:   wait.ForListeningPort(defaultClientPort),
-	}
-
-	genericContainerReq := testcontainers.GenericContainerRequest{
-		ContainerRequest: req,
-		Started:          true,
-	}
-
 	// Gather all config options (defaults and then apply provided options)
 	settings := defaultOptions()
 	for _, opt := range opts {
 		if apply, ok := opt.(CmdOption); ok {
 			apply(&settings)
 		}
-		if err := opt.Customize(&genericContainerReq); err != nil {
-			return nil, err
-		}
 	}
+
+	moduleOpts := []testcontainers.ContainerCustomizer{
+		testcontainers.WithExposedPorts(defaultClientPort, defaultRoutingPort, defaultMonitoringPort),
+		testcontainers.WithCmd("-DV", "-js"),
+		testcontainers.WithWaitStrategy(wait.ForListeningPort(defaultClientPort)),
+	}
+
+	moduleOpts = append(moduleOpts, opts...)
 
 	// Include the command line arguments
+	cmdArgs := []string{}
 	for k, v := range settings.CmdArgs {
 		// always prepend the dash because it was removed in the options
-		genericContainerReq.Cmd = append(genericContainerReq.Cmd, []string{"--" + k, v}...)
+		cmdArgs = append(cmdArgs, "--"+k, v)
+	}
+	if len(cmdArgs) > 0 {
+		moduleOpts = append(moduleOpts, testcontainers.WithCmdArgs(cmdArgs...))
 	}
 
-	container, err := testcontainers.GenericContainer(ctx, genericContainerReq)
+	ctr, err := testcontainers.Run(ctx, img, moduleOpts...)
 	var c *NATSContainer
-	if container != nil {
+	if ctr != nil {
 		c = &NATSContainer{
-			Container: container,
+			Container: ctr,
 			User:      settings.CmdArgs["user"],
 			Password:  settings.CmdArgs["pass"],
 		}
 	}
 
 	if err != nil {
-		return c, fmt.Errorf("generic container: %w", err)
+		return c, fmt.Errorf("run nats: %w", err)
 	}
 
 	return c, nil


### PR DESCRIPTION
## What does this PR do?

Use the Run function in nats module

## Why is it important?

Migrate modules to the new API, improving consistency and leveraging the latest testcontainers functionality.

## Related issues

- Relates to https://github.com/testcontainers/testcontainers-go/pull/3174