### PR TITLE
chore(openfga): use Run function

### DIFF
--- a/modules/openfga/openfga.go
+++ b/modules/openfga/openfga.go
@@ -49,11 +49,10 @@ func RunContainer(ctx context.Context, opts ...testcontainers.ContainerCustomize
 
 // Run creates an instance of the OpenFGA container type
 func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustomizer) (*OpenFGAContainer, error) {
-	req := testcontainers.ContainerRequest{
-		Image:        img,
-		Cmd:          []string{"run"},
-		ExposedPorts: []string{"3000/tcp", "8080/tcp", "8081/tcp"},
-		WaitingFor: wait.ForAll(
+	moduleOpts := []testcontainers.ContainerCustomizer{
+		testcontainers.WithCmd("run"),
+		testcontainers.WithExposedPorts("3000/tcp", "8080/tcp", "8081/tcp"),
+		testcontainers.WithWaitStrategy(wait.ForAll(
 			wait.ForHTTP("/healthz").WithPort("8080/tcp").WithResponseMatcher(func(r io.Reader) bool {
 				bs, err := io.ReadAll(r)
 				if err != nil {
@@ -65,28 +64,19 @@ func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustom
 			wait.ForHTTP("/playground").WithPort("3000/tcp").WithStatusCodeMatcher(func(status int) bool {
 				return status == http.StatusOK
 			}),
-		),
+		)),
 	}
 
-	genericContainerReq := testcontainers.GenericContainerRequest{
-		ContainerRequest: req,
-		Started:          true,
-	}
+	moduleOpts = append(moduleOpts, opts...)
 
-	for _, opt := range opts {
-		if err := opt.Customize(&genericContainerReq); err != nil {
-			return nil, fmt.Errorf("customize: %w", err)
-		}
-	}
-
-	container, err := testcontainers.GenericContainer(ctx, genericContainerReq)
+	ctr, err := testcontainers.Run(ctx, img, moduleOpts...)
 	var c *OpenFGAContainer
-	if container != nil {
-		c = &OpenFGAContainer{Container: container}
+	if ctr != nil {
+		c = &OpenFGAContainer{Container: ctr}
 	}
 
 	if err != nil {
-		return c, fmt.Errorf("generic container: %w", err)
+		return c, fmt.Errorf("run openfga: %w", err)
 	}
 
 	return c, nil


### PR DESCRIPTION
## What does this PR do?

Use the Run function in openfga

## Why is it important?

Migrate modules to the new API, improving consistency and leveraging the latest testcontainers functionality.

## Related issues

- Relates to https://github.com/testcontainers/testcontainers-go/pull/3174