### PR TITLE
chore(redpanda)!: use Run function

### DIFF
--- a/modules/redpanda/options.go
+++ b/modules/redpanda/options.go
@@ -1,6 +1,7 @@
 package redpanda
 
 import (
+	"fmt"
 	"net"
 	"strconv"
 
@@ -84,7 +85,7 @@ func defaultOptions() options {
 var _ testcontainers.ContainerCustomizer = (Option)(nil)
 
 // Option is an option for the Redpanda container.
-type Option func(*options)
+type Option func(*options) error
 
 // Customize is a NOOP. It's defined to satisfy the testcontainers.ContainerCustomizer interface.
 func (o Option) Customize(*testcontainers.GenericContainerRequest) error {
@@ -96,16 +97,18 @@ func (o Option) Customize(*testcontainers.GenericContainerRequest) error {
 // that shall be created, so that you can use these to authenticate against
 // Redpanda (either for the Kafka API or Schema Registry HTTP access).
 func WithNewServiceAccount(username, password string) Option {
-	return func(o *options) {
+	return func(o *options) error {
 		o.ServiceAccounts[username] = password
+		return nil
 	}
 }
 
 // WithSuperusers defines the superusers added to the redpanda config.
 // By default, there are no superusers.
 func WithSuperusers(superusers ...string) Option {
-	return func(o *options) {
+	return func(o *options) error {
 		o.Superusers = superusers
+		return nil
 	}
 }
 
@@ -114,31 +117,35 @@ func WithSuperusers(superusers ...string) Option {
 // When setting an authentication method, make sure to add users
 // as well as authorize them using the WithSuperusers() option.
 func WithEnableSASL() Option {
-	return func(o *options) {
+	return func(o *options) error {
 		o.KafkaAuthenticationMethod = "sasl"
+		return nil
 	}
 }
 
 // WithEnableKafkaAuthorization enables authorization for connections on the Kafka API.
 func WithEnableKafkaAuthorization() Option {
-	return func(o *options) {
+	return func(o *options) error {
 		o.KafkaEnableAuthorization = true
+		return nil
 	}
 }
 
 // WithEnableWasmTransform enables wasm transform.
 // Should not be used with RP versions before 23.3
 func WithEnableWasmTransform() Option {
-	return func(o *options) {
+	return func(o *options) error {
 		o.EnableWasmTransform = true
+		return nil
 	}
 }
 
 // WithEnableSchemaRegistryHTTPBasicAuth enables HTTP basic authentication for
 // Schema Registry.
 func WithEnableSchemaRegistryHTTPBasicAuth() Option {
-	return func(o *options) {
+	return func(o *options) error {
 		o.SchemaRegistryAuthenticationMethod = "http_basic"
+		return nil
 	}
 }
 
@@ -147,29 +154,33 @@ func WithEnableSchemaRegistryHTTPBasicAuth() Option {
 func WithHTTPProxyAuthMethod(method HTTPProxyAuthMethod) Option {
 	switch method {
 	case HTTPProxyAuthMethodNone, HTTPProxyAuthMethodHTTPBasic, HTTPProxyAuthMethodOIDC:
-		return func(o *options) {
+		return func(o *options) error {
 			o.HTTPProxyAuthenticationMethod = method
+			return nil
 		}
 	default:
-		return func(o *options) {
+		return func(o *options) error {
 			// Invalid method, default to "none"
 			o.HTTPProxyAuthenticationMethod = HTTPProxyAuthMethodNone
+			return nil
 		}
 	}
 }
 
 // WithAutoCreateTopics enables topic auto creation.
 func WithAutoCreateTopics() Option {
-	return func(o *options) {
+	return func(o *options) error {
 		o.AutoCreateTopics = true
+		return nil
 	}
 }
 
 func WithTLS(cert, key []byte) Option {
-	return func(o *options) {
+	return func(o *options) error {
 		o.EnableTLS = true
 		o.cert = cert
 		o.key = key
+		return nil
 	}
 }
 
@@ -178,22 +189,23 @@ func WithTLS(cert, key []byte) Option {
 // networks. At least one network must be attached to the container, if not an
 // error will be thrown when starting the container.
 func WithListener(lis string) Option {
-	host, port, err := net.SplitHostPort(lis)
-	if err != nil {
-		return func(_ *options) {}
-	}
+	return func(o *options) error {
+		host, port, err := net.SplitHostPort(lis)
+		if err != nil {
+			return fmt.Errorf("split host port: %w", err)
+		}
 
-	portInt, err := strconv.Atoi(port)
-	if err != nil {
-		return func(_ *options) {}
-	}
+		portInt, err := strconv.Atoi(port)
+		if err != nil {
+			return fmt.Errorf("parse port: %w", err)
+		}
 
-	return func(o *options) {
 		o.Listeners = append(o.Listeners, listener{
 			Address:              host,
 			Port:                 portInt,
 			AuthenticationMethod: o.KafkaAuthenticationMethod,
 		})
+		return nil
 	}
 }
 
@@ -202,8 +214,9 @@ func WithListener(lis string) Option {
 // config file, which is particularly useful for configs requiring a restart
 // when otherwise applied to a running Redpanda instance.
 func WithBootstrapConfig(cfg string, val any) Option {
-	return func(o *options) {
+	return func(o *options) error {
 		o.ExtraBootstrapConfig[cfg] = val
+		return nil
 	}
 }
 
@@ -211,7 +224,8 @@ func WithBootstrapConfig(cfg string, val any) Option {
 // It sets `admin_api_require_auth` configuration to true and configures a bootstrap user account.
 // See https://docs.redpanda.com/current/deploy/deployment-option/self-hosted/manual/production/production-deployment/#bootstrap-a-user-account
 func WithAdminAPIAuthentication() Option {
-	return func(o *options) {
+	return func(o *options) error {
 		o.enableAdminAPIAuthentication = true
+		return nil
 	}
 }

--- a/modules/redpanda/redpanda.go
+++ b/modules/redpanda/redpanda.go
@@ -146,12 +146,12 @@ func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustom
 		{
 			Reader:            bytes.NewReader(entrypoint),
 			ContainerFilePath: entrypointFile,
-			FileMode:          700,
+			FileMode:          0o700,
 		},
 		{
 			Reader:            bytes.NewReader(bootstrapConfig),
 			ContainerFilePath: path.Join(redpandaDir, bootstrapConfigFile),
-			FileMode:          600,
+			FileMode:          0o600,
 		},
 	}
 
@@ -161,12 +161,12 @@ func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustom
 			testcontainers.ContainerFile{
 				Reader:            bytes.NewReader(settings.cert),
 				ContainerFilePath: path.Join(redpandaDir, certFile),
-				FileMode:          600,
+				FileMode:          0o600,
 			},
 			testcontainers.ContainerFile{
 				Reader:            bytes.NewReader(settings.key),
 				ContainerFilePath: path.Join(redpandaDir, keyFile),
-				FileMode:          600,
+				FileMode:          0o600,
 			},
 		)
 	}

--- a/modules/redpanda/redpanda.go
+++ b/modules/redpanda/redpanda.go
@@ -214,7 +214,8 @@ func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustom
 	}
 
 	// 7. Wait until Redpanda is ready to serve requests.
-	waitHTTP := wait.ForHTTP(defaultAdminAPIPort).
+	waitHTTP := wait.ForHTTP("/").
+		WithPort(defaultAdminAPIPort).
 		WithStatusCodeMatcher(func(status int) bool {
 			// Redpanda's admin API returns 404 for requests to "/".
 			return status == http.StatusNotFound

--- a/modules/redpanda/redpanda.go
+++ b/modules/redpanda/redpanda.go
@@ -346,6 +346,10 @@ func withListeners(listeners []listener) testcontainers.CustomizeRequestOption {
 			return errors.New("container must be attached to at least one network")
 		}
 
+		if req.NetworkAliases == nil {
+			req.NetworkAliases = map[string][]string{}
+		}
+
 		for _, listener := range listeners {
 			if listener.Port < 0 || listener.Port > math.MaxUint16 {
 				return fmt.Errorf("invalid port on listener %s:%d (must be between 0 and 65535)", listener.Address, listener.Port)


### PR DESCRIPTION
## What does this PR do?

Use the Run function in redpanda

## Why is it important?

Migrate modules to the new API, improving consistency and leveraging the latest testcontainers functionality.

## Breaking Changes

**BREAKING CHANGE**: The `Option` type signature has changed to return an error:
- Old: `type Option func(*options)`
- New: `type Option func(*options) error`

All option functions now return `error` (returning `nil` for success). The `WithListener` option now properly validates and returns errors for invalid host:port formats instead of silently ignoring them.

## Related issues

- Relates to https://github.com/testcontainers/testcontainers-go/pull/3174

🤖 Generated with [Claude Code](https://claude.com/claude-code)