### PR TITLE
fix(k3s): fix cross platform image loading

### DIFF
--- a/docker.go
+++ b/docker.go
@@ -1918,6 +1918,27 @@ func (p *DockerProvider) PullImageWithPlatform(ctx context.Context, img, platfor
 	return p.attemptToPullImage(ctx, img, pullOpt)
 }
 
+// PullImageWithOpts pulls image from registry, passing options to the provider
+func (p *DockerProvider) PullImageWithOpts(ctx context.Context, img string, opts ...PullImageOption) error {
+	pullOpts := pullImageOptions{}
+
+	for _, opt := range opts {
+		if err := opt(&pullOpts); err != nil {
+			return fmt.Errorf("applying pull image option: %w", err)
+		}
+	}
+
+	return p.attemptToPullImage(ctx, img, pullOpts.dockerPullOpts)
+}
+
+func PullDockerImageWithPlatform(platform specs.Platform) PullImageOption {
+	return func(opts *pullImageOptions) error {
+		opts.dockerPullOpts.Platform = platforms.Format(platform)
+
+		return nil
+	}
+}
+
 var permanentClientErrors = []func(error) bool{
 	errdefs.IsNotFound,
 	errdefs.IsInvalidArgument,

--- a/image.go
+++ b/image.go
@@ -18,6 +18,12 @@ type saveImageOptions struct {
 
 type SaveImageOption func(*saveImageOptions) error
 
+type pullImageOptions struct {
+	dockerPullOpts client.ImagePullOptions
+}
+
+type PullImageOption func(*pullImageOptions) error
+
 // ImageProvider allows manipulating images
 type ImageProvider interface {
 	ListImages(context.Context) ([]ImageInfo, error)

--- a/modules/k3s/go.mod
+++ b/modules/k3s/go.mod
@@ -5,7 +5,9 @@ go 1.25.0
 toolchain go1.25.9
 
 require (
+	github.com/containerd/platforms v0.2.1
 	github.com/moby/moby/api v1.54.2
+	github.com/opencontainers/image-spec v1.1.1
 	github.com/stretchr/testify v1.11.1
 	github.com/testcontainers/testcontainers-go v0.42.0
 	go.yaml.in/yaml/v3 v3.0.4
@@ -23,7 +25,6 @@ require (
 	github.com/containerd/errdefs v1.0.0 // indirect
 	github.com/containerd/errdefs/pkg v0.3.0 // indirect
 	github.com/containerd/log v0.1.0 // indirect
-	github.com/containerd/platforms v0.2.1 // indirect
 	github.com/cpuguy83/dockercfg v0.3.2 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/distribution/reference v0.6.0 // indirect
@@ -62,7 +63,6 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
-	github.com/opencontainers/image-spec v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55 // indirect
 	github.com/shirou/gopsutil/v4 v4.26.4 // indirect

--- a/modules/k3s/k3s.go
+++ b/modules/k3s/k3s.go
@@ -7,8 +7,10 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/containerd/platforms"
 	"github.com/moby/moby/api/types/container"
 	"github.com/moby/moby/api/types/mount"
+	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"go.yaml.in/yaml/v3"
 
 	"github.com/testcontainers/testcontainers-go"
@@ -178,10 +180,12 @@ func unmarshal(bytes []byte) (*KubeConfigValue, error) {
 	return &kubeConfig, nil
 }
 
+// LoadImages imports local images into the cluster using containerd
 func (c *K3sContainer) LoadImages(ctx context.Context, images ...string) error {
-	return c.LoadImagesWithOpts(ctx, images)
+	return c.LoadImagesWithPlatform(ctx, images, nil)
 }
 
+// Deprecated: use LoadImagesWithPlatform instead
 func (c *K3sContainer) LoadImagesWithOpts(ctx context.Context, images []string, opts ...testcontainers.SaveImageOption) error {
 	provider, err := testcontainers.ProviderDocker.GetProvider()
 	if err != nil {
@@ -214,6 +218,58 @@ func (c *K3sContainer) LoadImagesWithOpts(ctx context.Context, images []string, 
 	}
 
 	exit, reader, err := c.Exec(ctx, []string{"ctr", "-n=k8s.io", "images", "import", "--all-platforms", containerPath})
+	if err != nil {
+		return fmt.Errorf("importing image %w", err)
+	}
+	if exit != 0 {
+		b, _ := io.ReadAll(reader)
+		return fmt.Errorf("importing image %s", string(b))
+	}
+
+	return nil
+}
+
+// LoadImagesWithPlatform imports local images into the cluster using containerd for a specific platform
+func (c *K3sContainer) LoadImagesWithPlatform(ctx context.Context, images []string, platform *v1.Platform) error {
+	provider, err := testcontainers.ProviderDocker.GetProvider()
+	if err != nil {
+		return fmt.Errorf("getting docker provider %w", err)
+	}
+
+	opts := []testcontainers.SaveImageOption{}
+	if platform != nil {
+		opts = append(opts, testcontainers.SaveDockerImageWithPlatforms(*platform))
+	}
+
+	// save image
+	imagesTar, err := os.CreateTemp(os.TempDir(), "images*.tar")
+	if err != nil {
+		return fmt.Errorf("creating temporary images file %w", err)
+	}
+	defer func() {
+		_ = os.Remove(imagesTar.Name())
+	}()
+
+	err = provider.SaveImagesWithOpts(context.Background(), imagesTar.Name(), images, opts...)
+	if err != nil {
+		return fmt.Errorf("saving images %w", err)
+	}
+
+	containerPath := "/tmp/" + filepath.Base(imagesTar.Name())
+	err = c.CopyFileToContainer(ctx, imagesTar.Name(), containerPath, 0x644)
+	if err != nil {
+		return fmt.Errorf("copying image to container %w", err)
+	}
+
+	cmd := []string{"ctr", "-n=k8s.io", "images", "import"}
+
+	if platform != nil {
+		cmd = append(cmd, "--platform", platforms.Format(*platform))
+	}
+
+	cmd = append(cmd, containerPath)
+
+	exit, reader, err := c.Exec(ctx, cmd)
 	if err != nil {
 		return fmt.Errorf("importing image %w", err)
 	}

--- a/modules/k3s/k3s.go
+++ b/modules/k3s/k3s.go
@@ -213,9 +213,13 @@ func (c *K3sContainer) LoadImagesWithOpts(ctx context.Context, images []string, 
 		return fmt.Errorf("copying image to container %w", err)
 	}
 
-	_, _, err = c.Exec(ctx, []string{"ctr", "-n=k8s.io", "images", "import", "--all-platforms", containerPath})
+	exit, reader, err := c.Exec(ctx, []string{"ctr", "-n=k8s.io", "images", "import", "--all-platforms", containerPath})
 	if err != nil {
 		return fmt.Errorf("importing image %w", err)
+	}
+	if exit != 0 {
+		b, _ := io.ReadAll(reader)
+		return fmt.Errorf("importing image %s", string(b))
 	}
 
 	return nil


### PR DESCRIPTION
## What does this PR do?

This PR adds more robust error handling around image loading and replaces the LoadImagesWithOpt that uses `--all-platform` to a `LoadImagesWithPlatform` function that allows loading the platform correctly.

This is required because `--all-platform` fails when some digests for some platform are missing.

## Why is it important?

This is important because loading an image without specifying a platform is now broken.
