### PR TITLE
chore: fix "Redpanda" copy-paste comment everywhere

### DIFF
--- a/modules/azure/servicebus/options.go
+++ b/modules/azure/servicebus/options.go
@@ -26,7 +26,7 @@ func defaultOptions() options {
 // Satisfy the testcontainers.CustomizeRequestOption interface
 var _ testcontainers.ContainerCustomizer = (Option)(nil)
 
-// Option is an option for the Redpanda container.
+// Option is an option for the ServiceBus container.
 type Option func(*options) error
 
 // Customize is a NOOP. It's defined to satisfy the testcontainers.ContainerCustomizer interface.

--- a/modules/dockermcpgateway/options.go
+++ b/modules/dockermcpgateway/options.go
@@ -23,7 +23,7 @@ func defaultOptions() options {
 // Compiler check to ensure that Option implements the testcontainers.ContainerCustomizer interface.
 var _ testcontainers.ContainerCustomizer = (Option)(nil)
 
-// Option is an option for the Redpanda container.
+// Option is an option for the DockerMCPGateway container.
 type Option func(*options) error
 
 // Customize is a NOOP. It's defined to satisfy the testcontainers.ContainerCustomizer interface.

--- a/modules/dockermodelrunner/options.go
+++ b/modules/dockermodelrunner/options.go
@@ -13,7 +13,7 @@ func defaultOptions() options {
 // Compiler check to ensure that Option implements the testcontainers.ContainerCustomizer interface.
 var _ testcontainers.ContainerCustomizer = (Option)(nil)
 
-// Option is an option for the Redpanda container.
+// Option is an option for the DockerModelRunner container.
 type Option func(*options) error
 
 // Customize is a NOOP. It's defined to satisfy the testcontainers.ContainerCustomizer interface.

--- a/modules/postgres/options.go
+++ b/modules/postgres/options.go
@@ -20,7 +20,7 @@ func defaultOptions() options {
 // Compiler check to ensure that Option implements the testcontainers.ContainerCustomizer interface.
 var _ testcontainers.ContainerCustomizer = (Option)(nil)
 
-// Option is an option for the Redpanda container.
+// Option is an option for the Postgres container.
 type Option func(*options)
 
 // Customize is a NOOP. It's defined to satisfy the testcontainers.ContainerCustomizer interface.

--- a/modules/redis/options.go
+++ b/modules/redis/options.go
@@ -19,7 +19,7 @@ type options struct {
 // Compiler check to ensure that Option implements the testcontainers.ContainerCustomizer interface.
 var _ testcontainers.ContainerCustomizer = (Option)(nil)
 
-// Option is an option for the Redpanda container.
+// Option is an option for the Redis container.
 type Option func(*options) error
 
 // Customize is a NOOP. It's defined to satisfy the testcontainers.ContainerCustomizer interface.

--- a/modules/socat/options.go
+++ b/modules/socat/options.go
@@ -22,7 +22,7 @@ func defaultOptions() options {
 // Compiler check to ensure that Option implements the testcontainers.ContainerCustomizer interface.
 var _ testcontainers.ContainerCustomizer = (Option)(nil)
 
-// Option is an option for the Redpanda container.
+// Option is an option for the Socat container.
 type Option func(*options) error
 
 // Customize is a NOOP. It's defined to satisfy the testcontainers.ContainerCustomizer interface.

--- a/modules/toxiproxy/options.go
+++ b/modules/toxiproxy/options.go
@@ -21,7 +21,7 @@ func defaultOptions() options {
 // Compiler check to ensure that Option implements the testcontainers.ContainerCustomizer interface.
 var _ testcontainers.ContainerCustomizer = (Option)(nil)
 
-// Option is an option for the Redpanda container.
+// Option is an option for the Toxiproxy container.
 type Option func(*options) error
 
 // Customize is a NOOP. It's defined to satisfy the testcontainers.ContainerCustomizer interface.

--- a/modules/valkey/options.go
+++ b/modules/valkey/options.go
@@ -18,7 +18,7 @@ type options struct {
 // Compiler check to ensure that Option implements the testcontainers.ContainerCustomizer interface.
 var _ testcontainers.ContainerCustomizer = (Option)(nil)
 
-// Option is an option for the Redpanda container.
+// Option is an option for the Valkey container.
 type Option func(*options) error
 
 // Customize is a NOOP. It's defined to satisfy the testcontainers.ContainerCustomizer interface.


### PR DESCRIPTION
## What does this PR do?

Noticed a "Redpanda" comment reference in 8 unrelated modules, likely just a silly copy-paste accident.

## Why is it important?

I wouldn't call it "important" but it's an easy fix for something clearly wrong.