### PR TITLE
feat(kafka): support of Apache Kafka images

### DIFF
--- a/modules/kafka/examples_test.go
+++ b/modules/kafka/examples_test.go
@@ -9,8 +9,7 @@ import (
 	"github.com/testcontainers/testcontainers-go/modules/kafka"
 )
 
-func ExampleRun() {
-	// runKafkaContainer {
+func ExampleRun_confluentLocal() {
 	ctx := context.Background()
 
 	kafkaContainer, err := kafka.Run(ctx,
@@ -26,7 +25,68 @@ func ExampleRun() {
 		log.Printf("failed to start container: %s", err)
 		return
 	}
-	// }
+
+	state, err := kafkaContainer.State(ctx)
+	if err != nil {
+		log.Printf("failed to get container state: %s", err)
+		return
+	}
+
+	fmt.Println(kafkaContainer.ClusterID)
+	fmt.Println(state.Running)
+
+	// Output:
+	// test-cluster
+	// true
+}
+
+func ExampleRun_apacheKafka() {
+	ctx := context.Background()
+
+	kafkaContainer, err := kafka.Run(ctx,
+		"apache/kafka:4.0.1",
+		kafka.WithClusterID("test-cluster"),
+	)
+	defer func() {
+		if err := testcontainers.TerminateContainer(kafkaContainer); err != nil {
+			log.Printf("failed to terminate container: %s", err)
+		}
+	}()
+	if err != nil {
+		log.Printf("failed to start container: %s", err)
+		return
+	}
+
+	state, err := kafkaContainer.State(ctx)
+	if err != nil {
+		log.Printf("failed to get container state: %s", err)
+		return
+	}
+
+	fmt.Println(kafkaContainer.ClusterID)
+	fmt.Println(state.Running)
+
+	// Output:
+	// test-cluster
+	// true
+}
+
+func ExampleRun_apacheKafkaNative() {
+	ctx := context.Background()
+
+	kafkaContainer, err := kafka.Run(ctx,
+		"apache/kafka-native:4.0.1",
+		kafka.WithClusterID("test-cluster"),
+	)
+	defer func() {
+		if err := testcontainers.TerminateContainer(kafkaContainer); err != nil {
+			log.Printf("failed to terminate container: %s", err)
+		}
+	}()
+	if err != nil {
+		log.Printf("failed to start container: %s", err)
+		return
+	}
 
 	state, err := kafkaContainer.State(ctx)
 	if err != nil {

--- a/modules/kafka/kafka_test.go
+++ b/modules/kafka/kafka_test.go
@@ -4,66 +4,137 @@ import (
 	"context"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/IBM/sarama"
 	"github.com/stretchr/testify/require"
 
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/modules/kafka"
+	"github.com/testcontainers/testcontainers-go/wait"
+)
+
+var (
+	gracefulShutdownSupportingKafkaImages = []string{
+		"apache/kafka:3.9.1",
+		"apache/kafka:4.0.1",
+		"apache/kafka-native:3.9.1",
+		"apache/kafka-native:4.0.1",
+	}
+
+	supportedKafkaImages = append(gracefulShutdownSupportingKafkaImages,
+		"confluentinc/confluent-local:7.4.0",
+		"confluentinc/confluent-local:7.5.0",
+	)
 )
 
 func TestKafka(t *testing.T) {
-	topic := "some-topic"
+	for _, image := range supportedKafkaImages {
+		t.Run(image, func(t *testing.T) {
+			topic := "some-topic"
 
+			ctx := context.Background()
+
+			kafkaContainer, err := kafka.Run(ctx, image, kafka.WithClusterID("kraftCluster"))
+			testcontainers.CleanupContainer(t, kafkaContainer, testcontainers.StopTimeout(0))
+			require.NoError(t, err)
+
+			assertAdvertisedListeners(t, kafkaContainer)
+
+			require.Truef(t, strings.EqualFold(kafkaContainer.ClusterID, "kraftCluster"), "expected clusterID to be %s, got %s", "kraftCluster", kafkaContainer.ClusterID)
+
+			// getBrokers {
+			brokers, err := kafkaContainer.Brokers(ctx)
+			// }
+			require.NoError(t, err)
+
+			config := sarama.NewConfig()
+			client, err := sarama.NewConsumerGroup(brokers, "groupName", config)
+			require.NoError(t, err)
+			defer func() {
+				err := client.Close()
+				require.NoError(t, err)
+			}()
+
+			consumer, ready, done, cancel := NewTestKafkaConsumer(t)
+			defer cancel()
+			go func() {
+				if err := client.Consume(context.Background(), []string{topic}, consumer); err != nil {
+					cancel()
+				}
+			}()
+
+			// wait for the consumer to be ready
+			<-ready
+
+			// perform assertions
+
+			// set config to true because successfully delivered messages will be returned on the Successes channel
+			config.Producer.Return.Successes = true
+
+			producer, err := sarama.NewSyncProducer(brokers, config)
+			require.NoError(t, err)
+			defer func() {
+				err := producer.Close()
+				require.NoError(t, err)
+			}()
+
+			_, _, err = producer.SendMessage(&sarama.ProducerMessage{
+				Topic: topic,
+				Key:   sarama.StringEncoder("key"),
+				Value: sarama.StringEncoder("value"),
+			})
+			require.NoError(t, err)
+
+			<-done
+
+			require.Truef(t, strings.EqualFold(string(consumer.message.Key), "key"), "expected key to be %s, got %s", "key", string(consumer.message.Key))
+			require.Truef(t, strings.EqualFold(string(consumer.message.Value), "value"), "expected value to be %s, got %s", "value", string(consumer.message.Value))
+		})
+	}
+}
+
+func TestKafkaGracefulShutdown(t *testing.T) {
+	for _, image := range gracefulShutdownSupportingKafkaImages {
+		t.Run(image, func(t *testing.T) {
+			ctx := context.Background()
+			kafkaContainer, err := kafka.Run(ctx, image)
+			testcontainers.CleanupContainer(t, kafkaContainer, testcontainers.StopTimeout(0))
+			require.NoError(t, err)
+
+			done := make(chan struct{})
+			var stopErr error
+			go func() {
+				stopTimeout := 120 * time.Second
+				stopErr = kafkaContainer.Stop(ctx, &stopTimeout)
+				close(done)
+			}()
+			gracefulShutdownTimeout := 60 * time.Second
+			select {
+			case <-done:
+				require.NoError(t, stopErr)
+			case <-time.After(gracefulShutdownTimeout):
+				require.Failf(t, "Kafka did not gracefully exit", "Kafka did not gracefully exit in %v", gracefulShutdownTimeout)
+			}
+		})
+	}
+}
+
+func TestKafkaLocalhostListener(t *testing.T) {
 	ctx := context.Background()
-
-	kafkaContainer, err := kafka.Run(ctx, "confluentinc/confluent-local:7.5.0", kafka.WithClusterID("kraftCluster"))
-	testcontainers.CleanupContainer(t, kafkaContainer)
+	kafkaContainer, err := kafka.Run(ctx, "apache/kafka:4.0.1",
+		testcontainers.WithWaitStrategy(
+			wait.NewExecStrategy([]string{
+				"/opt/kafka/bin/kafka-topics.sh",
+				"--bootstrap-server",
+				"localhost:9095",
+				"--list",
+			}).
+				WithExitCode(0).
+				WithPollInterval(2*time.Second).
+				WithStartupTimeout(120*time.Second)))
+	testcontainers.CleanupContainer(t, kafkaContainer, testcontainers.StopTimeout(0))
 	require.NoError(t, err)
-
-	assertAdvertisedListeners(t, kafkaContainer)
-
-	require.Truef(t, strings.EqualFold(kafkaContainer.ClusterID, "kraftCluster"), "expected clusterID to be %s, got %s", "kraftCluster", kafkaContainer.ClusterID)
-
-	// getBrokers {
-	brokers, err := kafkaContainer.Brokers(ctx)
-	// }
-	require.NoError(t, err)
-
-	config := sarama.NewConfig()
-	client, err := sarama.NewConsumerGroup(brokers, "groupName", config)
-	require.NoError(t, err)
-
-	consumer, ready, done, cancel := NewTestKafkaConsumer(t)
-	defer cancel()
-	go func() {
-		if err := client.Consume(context.Background(), []string{topic}, consumer); err != nil {
-			cancel()
-		}
-	}()
-
-	// wait for the consumer to be ready
-	<-ready
-
-	// perform assertions
-
-	// set config to true because successfully delivered messages will be returned on the Successes channel
-	config.Producer.Return.Successes = true
-
-	producer, err := sarama.NewSyncProducer(brokers, config)
-	require.NoError(t, err)
-
-	_, _, err = producer.SendMessage(&sarama.ProducerMessage{
-		Topic: topic,
-		Key:   sarama.StringEncoder("key"),
-		Value: sarama.StringEncoder("value"),
-	})
-	require.NoError(t, err)
-
-	<-done
-
-	require.Truef(t, strings.EqualFold(string(consumer.message.Key), "key"), "expected key to be %s, got %s", "key", string(consumer.message.Key))
-	require.Truef(t, strings.EqualFold(string(consumer.message.Value), "value"), "expected value to be %s, got %s", "value", string(consumer.message.Value))
 }
 
 func TestKafka_invalidVersion(t *testing.T) {


### PR DESCRIPTION
## Changes

* feat(kafka): support of Apache Kafka images (apache/kafka and apache/kafka-native).

<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?

Adding support of Apache Kafka Docker Hub images - [apache/kafka](https://hub.docker.com/r/apache/kafka) and [apache/kafka-native](https://hub.docker.com/r/apache/kafka-native) - into kafka module.

## Why is it important?

Images supported by kafka module are limited to confluentinc/confluent-local and these images have issues with graceful stop - refer to https://github.com/testcontainers/testcontainers-go/issues/2206#issuecomment-2887726469. apache/kafka and apache/kafka-native images support graceful shutdown. apache/kafka-native image is also faster and can be used to speedup tests.

## Related issues

- Relates #2206

## Follow-ups

Need to decide if https://github.com/testcontainers/testcontainers-go/pull/3249 is a better choice to go.
