### PR TITLE
fix(redpanda): closing provider in test after use

### DIFF
--- a/modules/redpanda/redpanda_test.go
+++ b/modules/redpanda/redpanda_test.go
@@ -803,6 +803,8 @@ func containerHost(ctx context.Context, opts ...testcontainers.ContainerCustomiz
 		return "", err
 	}
 
+	defer p.Close()
+
 	if p, ok := p.(*testcontainers.DockerProvider); ok {
 		return p.DaemonHost(ctx)
 	}


### PR DESCRIPTION
## Changes

* fix(redpanda): closing provider in test after use

## What does this PR do?

This PR fixes [issue](https://github.com/testcontainers/testcontainers-go/pull/3165#discussion_r2671107719) found in #3165.

## Why is it important?

Proper resource management in test for `redpanda` module.

## How to test this PR

Run tests for `redpanda` module, like:

```shell
go test -C modules/redpanda -count 1 -v ./...
```
