### PR TITLE
fix(localstack): accept community-archive as a valid tag

### DIFF
--- a/modules/localstack/localstack.go
+++ b/modules/localstack/localstack.go
@@ -23,6 +23,7 @@ const (
 )
 
 var recentVersionTags = []string{
+	"community-archive",
 	"latest",
 	"s3",
 	"s3-latest",
@@ -33,10 +34,15 @@ func isMinimumVersion(image string, minVersion string) bool {
 	parts := strings.Split(strings.Split(image, "@")[0], ":")
 	version := parts[len(parts)-1]
 
+	if slices.Contains(recentVersionTags, version) {
+		return true
+	}
+
 	if pos := strings.LastIndexByte(version, '-'); pos >= 0 {
 		version = version[0:pos]
 	}
 
+	// Re-check after stripping the arch suffix (e.g. "community-archive-amd64" -> "community-archive").
 	if slices.Contains(recentVersionTags, version) {
 		return true
 	}

--- a/modules/localstack/localstack_test.go
+++ b/modules/localstack/localstack_test.go
@@ -87,6 +87,8 @@ func TestIsLegacyVersion(t *testing.T) {
 		want    bool
 	}{
 		{"foo", true},
+		{"community-archive", false},
+		{"community-archive-amd64", false},
 		{"latest", false},
 		{"latest-amd64", false},
 		{"s3-latest", false},
@@ -124,6 +126,8 @@ func TestIsMinimumVersion2(t *testing.T) {
 		want    bool
 	}{
 		{"foo", false},
+		{"community-archive", true},
+		{"community-archive-amd64", true},
 		{"latest", true},
 		{"latest-amd64", true},
 		{"s3-latest", true},


### PR DESCRIPTION
## Summary
- Add `community-archive` to the `recentVersionTags` list so it is recognized as a modern (non-legacy) LocalStack tag
- Move the `recentVersionTags` check before the hyphen-suffix stripping in `isMinimumVersion`, so tags containing hyphens (like `community-archive`) are matched correctly
- Add test cases for `community-archive` and `community-archive-amd64` in both version check tests

See also: #3592

## Test plan
- [x] `TestIsLegacyVersion` passes with `community-archive` and `community-archive-amd64`
- [x] `TestIsMinimumVersion2` passes with `community-archive` and `community-archive-amd64`
- [x] All existing version tag tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)