### PR TITLE
fix: return an error when docker host cannot be retrieved

### DIFF
--- a/docker_client.go
+++ b/docker_client.go
@@ -73,13 +73,17 @@ func (c *DockerClient) Info(ctx context.Context, options client.InfoOptions) (cl
 		infoLabels += infoLabelsSb72.String()
 	}
 
+	host, err := core.ExtractDockerHost(ctx)
+	if err != nil {
+		return dockerInfo, err
+	}
 	log.Printf(infoMessage, packagePath,
 		dockerInfo.Info.ServerVersion,
 		c.ClientVersion(),
 		dockerInfo.Info.OperatingSystem, dockerInfo.Info.MemTotal/1024/1024,
 		infoLabels,
 		internal.Version,
-		core.MustExtractDockerHost(ctx),
+		host,
 		core.MustExtractDockerSocket(ctx),
 		core.SessionID(),
 		core.ProcessID(),

--- a/internal/core/client.go
+++ b/internal/core/client.go
@@ -12,9 +12,12 @@ import (
 
 // NewClient returns a new docker client extracting the docker host from the different alternatives
 func NewClient(ctx context.Context, ops ...client.Opt) (*client.Client, error) {
-	tcConfig := config.Read()
+	dockerHost, err := ExtractDockerHost(ctx)
+	if err != nil {
+		return nil, err
+	}
 
-	dockerHost := MustExtractDockerHost(ctx)
+	tcConfig := config.Read()
 
 	opts := []client.Opt{client.FromEnv}
 	if dockerHost != "" {

--- a/internal/core/docker_host.go
+++ b/internal/core/docker_host.go
@@ -31,8 +31,9 @@ var (
 )
 
 var (
-	dockerHostCache string
-	dockerHostOnce  sync.Once
+	dockerHostCache    string
+	dockerHostErrCache error
+	dockerHostOnce     sync.Once
 )
 
 var (
@@ -85,16 +86,18 @@ var dockerHostCheck = func(ctx context.Context, host string) error {
 //  6. Rootless docker socket path.
 //  7. Else, because the Docker host is not set, it panics.
 func MustExtractDockerHost(ctx context.Context) string {
+	host, err := ExtractDockerHost(ctx)
+	if err != nil {
+		panic(err)
+	}
+	return host
+}
+
+func ExtractDockerHost(ctx context.Context) (string, error) {
 	dockerHostOnce.Do(func() {
-		cache, err := extractDockerHost(ctx)
-		if err != nil {
-			panic(err)
-		}
-
-		dockerHostCache = cache
+		dockerHostCache, dockerHostErrCache = extractDockerHost(ctx)
 	})
-
-	return dockerHostCache
+	return dockerHostCache, dockerHostErrCache
 }
 
 // MustExtractDockerSocket Extracts the docker socket from the different alternatives, removing the socket schema and

--- a/provider.go
+++ b/provider.go
@@ -141,15 +141,18 @@ func NewDockerProvider(provOpts ...DockerProviderOption) (*DockerProvider, error
 	}
 
 	ctx := context.Background()
+	host, err := core.ExtractDockerHost(ctx)
+	if err != nil {
+		return nil, err
+	}
 	c, err := NewDockerClientWithOpts(ctx)
 	if err != nil {
 		return nil, err
 	}
-
 	return &DockerProvider{
 		DockerProviderOptions: o,
-		host:                  core.MustExtractDockerHost(ctx),
 		client:                c,
+		host:                  host,
 		config:                config.Read(),
 	}, nil
 }


### PR DESCRIPTION
## What does this PR do?

When I run some of my tests without Docker running, they panic. I'd like them to just return an error from `testcontainers.Run()` (and everything that is built on top).

## Why is it important?

It's not useful to get a panic when just a normal error is enough. Panic should be reserved for programming errors/etc - "Docker is not running" is not that.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- 

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
