### PR TITLE
add EXTRA_ADVERTISED_LISTENERS

### DIFF
--- a/modules/kafka/kafka.go
+++ b/modules/kafka/kafka.go
@@ -21,7 +21,7 @@ const (
 	// starterScript {
 	starterScriptContent = `#!/bin/bash
 source /etc/confluent/docker/bash-config
-export KAFKA_ADVERTISED_LISTENERS=%s,BROKER://%s:9092
+export KAFKA_ADVERTISED_LISTENERS="%s,BROKER://%s:9092${EXTRA_ADVERTISED_LISTENERS:+,${EXTRA_ADVERTISED_LISTENERS}}"
 echo Starting Kafka KRaft mode
 sed -i '/KAFKA_ZOOKEEPER_CONNECT/d' /etc/confluent/docker/configure
 echo 'kafka-storage format --ignore-formatted -t "$(kafka-storage random-uuid)" -c /etc/kafka/kafka.properties' >> /etc/confluent/docker/configure


### PR DESCRIPTION
## What does this PR do?

Adds ability to use EXTRA_KAFKA_ADVERTISED_LISTENERS variable declared for kafka module to patch KAFKA_ADVERTISED_LISTENERS in a modules/kafka starterScriptContent.

## Why is it important?

modules/kafka got const `starterScriptContent` with exported `KAFKA_ADVERTISED_LISTENERS` that is currently hidden for modifications from outside of the module. This add few problems with testing.

Because, as you know kafka wants to know what hosts will be used to connect to it before it was started. For my usecase I want to connect from kafka ui to debug messages in topics in a local test environment. Current script have no patch points to KAFKA_ADVERTISED_LISTENERS.

## Related issues

- Closes #2630

## How to test this PR

Add `echo $KAFKA_ADVERTISED_LISTENERS` and see how it works after bash use it. I can see how to test it automatically, i just want to know what do you think about that way of fixing it.
