### PR TITLE
chore: remove cgroupnsMode setting from K3s container configuration

### DIFF
--- a/modules/k3s/k3s.go
+++ b/modules/k3s/k3s.go
@@ -63,7 +63,6 @@ func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustom
 		testcontainers.WithExposedPorts(defaultKubeSecurePort, defaultRancherWebhookPort),
 		testcontainers.WithHostConfigModifier(func(hc *container.HostConfig) {
 			hc.Privileged = true
-			hc.CgroupnsMode = "host"
 			hc.Tmpfs = map[string]string{
 				"/run":     "",
 				"/var/run": "",


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

Remove `cgroupnsMode` setting from K3s container configuration

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

It mirrors the official k3s documentation about running in Docker:
https://docs.k3s.io/advanced#running-k3s-in-docker

```bash
sudo docker run \
  --privileged \
  --name k3s-server-1 \
  --hostname k3s-server-1 \
  -p 6443:6443 \
  -d rancher/k3s:v1.24.10-k3s1 \
  server
```

My local dev machine is a MacBook Apple Silicon running OrbStack. With `--cgroupns host`, Linux VM development environments (especially when memory ballooning is enabled) Pods will experience `SandboxChanged	Pod sandbox changed, it will be killed and re-created.` issue, and they will never become ready.

PoC, use OrbStack if you start k3s with host cgroupns, get in the k3s docker, check pods, they will never become ready:
```bash
sudo docker run \
  --privileged \
  --name k3s-server-1 \
  --hostname k3s-server-1 \
  --cgroupns=host \
  -p 6443:6443 \
  -d rancher/k3s:v1.24.10-k3s1 \
  server
```

OrbStack features memory ballooning; I presume the ballooning hack kinda interferes with kubelet.

I have to use a workaround.

```go
testcontainers.WithHostConfigModifier(func(hc *dockercontainer.HostConfig) {
			hc.Privileged = true
			// hc.CgroupnsMode = "host"
			hc.Tmpfs = map[string]string{
				"/run":     "",
				"/var/run": "",
			}
			hc.Mounts = []mount.Mount{}
		}
```

k3s docker can handle `cgroupns=private` well, k3d also uses the default containerd cgroupns setting.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- No issue. I have a local workground.

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
