### PR TITLE
fix: wait for log production goroutine to drain on stop

### DIFF
--- a/docker.go
+++ b/docker.go
@@ -87,6 +87,8 @@ type DockerContainer struct {
 	// logProductionCancel is used to signal the log production to stop.
 	logProductionCancel context.CancelCauseFunc
 	logProductionCtx    context.Context
+	// logProductionDone is closed when the log production goroutine exits.
+	logProductionDone chan struct{}
 
 	logProductionTimeout *time.Duration
 	logger               log.Logger
@@ -813,16 +815,19 @@ func (c *DockerContainer) startLogProduction(ctx context.Context, opts ...LogPro
 
 	// Setup the log production context which will be used to stop the log production.
 	c.logProductionCtx, c.logProductionCancel = context.WithCancelCause(ctx)
+	c.logProductionDone = make(chan struct{})
 
 	// We capture context cancel function to avoid data race with multiple
 	// calls to startLogProduction.
-	go func(cancel context.CancelCauseFunc) {
+	go func(cancel context.CancelCauseFunc, done chan struct{}) {
 		// Ensure the context is cancelled when log productions completes
 		// so that GetLogProductionErrorChannel functions correctly.
 		defer cancel(nil)
+		// Signal that the goroutine has exited so stopLogProduction can drain.
+		defer close(done)
 
 		c.logProducer(stdout, stderr)
-	}(c.logProductionCancel)
+	}(c.logProductionCancel, c.logProductionDone)
 
 	return nil
 }
@@ -903,8 +908,29 @@ func (c *DockerContainer) stopLogProduction() error {
 		return nil
 	}
 
-	// Signal the log production to stop.
+	// Wait for the log production goroutine to finish draining any buffered
+	// logs before cancelling. When the container has already exited, the
+	// goroutine will reach EOF naturally and close logProductionDone on its
+	// own. The bounded timeout prevents blocking indefinitely when the
+	// container is still actively streaming (e.g. Stop() called on a running
+	// container).
+	if c.logProductionDone != nil {
+		select {
+		case <-c.logProductionDone:
+			// Goroutine already finished naturally; nothing more to do.
+			return nil
+		case <-time.After(5 * time.Second):
+			// Timed out waiting for natural exit; force-cancel now.
+		}
+	}
+
+	// Signal the log production to stop (for still-running containers).
 	c.logProductionCancel(errLogProductionStop)
+
+	// Wait for the goroutine to acknowledge the cancellation.
+	if c.logProductionDone != nil {
+		<-c.logProductionDone
+	}
 
 	if err := context.Cause(c.logProductionCtx); err != nil {
 		switch {

--- a/docker.go
+++ b/docker.go
@@ -927,9 +927,16 @@ func (c *DockerContainer) stopLogProduction() error {
 	// Signal the log production to stop (for still-running containers).
 	c.logProductionCancel(errLogProductionStop)
 
-	// Wait for the goroutine to acknowledge the cancellation.
+	// Wait for the goroutine to acknowledge the cancellation. Context
+	// cancellation propagates into the Docker transport and should unblock
+	// stdcopy.StdCopy promptly, but we bound the wait to match
+	// minLogProductionTimeout to guard against stuck kernel socket reads or
+	// daemon transport failures that might not honour context cancellation.
 	if c.logProductionDone != nil {
-		<-c.logProductionDone
+		select {
+		case <-c.logProductionDone:
+		case <-time.After(minLogProductionTimeout):
+		}
 	}
 
 	if err := context.Cause(c.logProductionCtx); err != nil {

--- a/docker.go
+++ b/docker.go
@@ -936,6 +936,7 @@ func (c *DockerContainer) stopLogProduction() error {
 		select {
 		case <-c.logProductionDone:
 		case <-time.After(minLogProductionTimeout):
+			c.logger.Printf("timeout waiting for log production goroutine to exit; a goroutine may have leaked")
 		}
 	}
 

--- a/docker.go
+++ b/docker.go
@@ -919,7 +919,7 @@ func (c *DockerContainer) stopLogProduction() error {
 		case <-c.logProductionDone:
 			// Goroutine already finished naturally; nothing more to do.
 			return nil
-		case <-time.After(5 * time.Second):
+		case <-time.After(minLogProductionTimeout):
 			// Timed out waiting for natural exit; force-cancel now.
 		}
 	}

--- a/logconsumer_test.go
+++ b/logconsumer_test.go
@@ -685,3 +685,68 @@ func TestRestartContainerWithLogConsumer(t *testing.T) {
 	logConsumer.AssertRead()
 	logConsumer.AssertRead()
 }
+
+// countingLogConsumer counts all log lines received.
+type countingLogConsumer struct {
+	mu    sync.Mutex
+	count int
+}
+
+func (c *countingLogConsumer) Accept(_ Log) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.count++
+}
+
+func (c *countingLogConsumer) Count() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.count
+}
+
+// TestContainerLogDrainOnTerminate verifies that no log lines are dropped when
+// Terminate() is called on a container that has already exited after emitting a
+// burst of logs. This is a regression test for the data-loss race described in
+// https://github.com/testcontainers/testcontainers-go/issues/2887, where
+// stopLogProduction() returned immediately after cancelling the context, leaving
+// the logProducer goroutine mid-read with buffered data that was never delivered.
+func TestContainerLogDrainOnTerminate(t *testing.T) {
+	const (
+		lineCount = 1000
+		runs      = 5
+	)
+
+	for run := range runs {
+		run := run
+		t.Run(fmt.Sprintf("run-%d", run), func(t *testing.T) {
+			t.Parallel()
+
+			consumer := &countingLogConsumer{}
+
+			ctx := context.Background()
+			ctr, err := Run(
+				ctx,
+				"alpine:latest",
+				// Emit lineCount lines then exit.
+				WithCmd("sh", "-c", fmt.Sprintf(
+					"for i in $(seq 1 %d); do echo line-$i; done", lineCount,
+				)),
+				WithLogConsumerConfig(&LogConsumerConfig{
+					Consumers: []LogConsumer{consumer},
+				}),
+				WithWaitStrategy(wait.ForExit()),
+			)
+			// Terminate after the container has already exited so the race
+			// window is as narrow as possible.
+			err2 := TerminateContainer(ctr)
+			require.NoError(t, err)
+			require.NoError(t, err2)
+
+			got := consumer.Count()
+			require.Equalf(t, lineCount, got,
+				"run %d: expected %d log lines, got %d (%d dropped)",
+				run, lineCount, got, lineCount-got,
+			)
+		})
+	}
+}

--- a/logconsumer_test.go
+++ b/logconsumer_test.go
@@ -717,7 +717,6 @@ func TestContainerLogDrainOnTerminate(t *testing.T) {
 	)
 
 	for run := range runs {
-		run := run
 		t.Run(fmt.Sprintf("run-%d", run), func(t *testing.T) {
 			t.Parallel()
 
@@ -736,11 +735,12 @@ func TestContainerLogDrainOnTerminate(t *testing.T) {
 				}),
 				WithWaitStrategy(wait.ForExit()),
 			)
+			require.NoError(t, err)
+			CleanupContainer(t, ctr)
+
 			// Terminate after the container has already exited so the race
 			// window is as narrow as possible.
-			err2 := TerminateContainer(ctr)
-			require.NoError(t, err)
-			require.NoError(t, err2)
+			require.NoError(t, TerminateContainer(ctr))
 
 			got := consumer.Count()
 			require.Equalf(t, lineCount, got,


### PR DESCRIPTION
## What does this PR do?

Adds a logProductionDone channel that the goroutine closes on exit, and waits on it (with a bounded timeout) in stopLogProduction() before returning.

## Why is it important?

stopLogProduction() was cancelling the context and returning immediately, creating a race where in-flight log data could be dropped when Terminate() fired during active log streaming. Confirmed data loss of up to 770/1000 lines in reproduction tests.

## Related issues

Fixes #2887