### PR TITLE
feat!: add PullImageWithPlatform to DockerProvider

### DIFF
--- a/docker.go
+++ b/docker.go
@@ -1905,6 +1905,19 @@ func (p *DockerProvider) PullImage(ctx context.Context, img string) error {
 	return p.attemptToPullImage(ctx, img, client.ImagePullOptions{})
 }
 
+// PullImageWithPlatform pulls an image from the registry for the given platform (e.g. "linux/amd64").
+func (p *DockerProvider) PullImageWithPlatform(ctx context.Context, img, platform string) error {
+	pullOpt := client.ImagePullOptions{}
+	if platform != "" {
+		pf, err := platforms.Parse(platform)
+		if err != nil {
+			return fmt.Errorf("invalid platform %s: %w", platform, err)
+		}
+		pullOpt.Platforms = append(pullOpt.Platforms, pf)
+	}
+	return p.attemptToPullImage(ctx, img, pullOpt)
+}
+
 var permanentClientErrors = []func(error) bool{
 	errdefs.IsNotFound,
 	errdefs.IsInvalidArgument,

--- a/docker_test.go
+++ b/docker_test.go
@@ -1870,6 +1870,16 @@ func TestDockerProvider_attemptToPullImage_retries(t *testing.T) {
 	}
 }
 
+func TestDockerProvider_PullImageWithPlatform_invalidPlatform(t *testing.T) {
+	p, err := NewDockerProvider()
+	require.NoError(t, err)
+	defer p.Close()
+
+	err = p.PullImageWithPlatform(context.Background(), "redis:latest", "not-a-valid-platform")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid platform")
+}
+
 func TestCustomPrefixTrailingSlashIsProperlyRemovedIfPresent(t *testing.T) {
 	hubPrefixWithTrailingSlash := "public.ecr.aws/"
 	dockerImage := "amazonlinux/amazonlinux:2023"

--- a/image.go
+++ b/image.go
@@ -24,4 +24,5 @@ type ImageProvider interface {
 	SaveImages(context.Context, string, ...string) error
 	SaveImagesWithOpts(context.Context, string, []string, ...SaveImageOption) error
 	PullImage(context.Context, string) error
+	PullImageWithPlatform(context.Context, string, string) error
 }


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->
Feat

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

Expose platform-specific image pulls via ImageProvider, matching the platform handling used when creating containers with ImagePlatform.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

```sh
❯ docker pull amd-64-image-in-arm-host
Error response from daemon: no matching manifest for linux/arm64/v8 in the manifest list entries: no match for platform in manifest: not found
❯ docker pull --platform linux/amd64 amd-64-image-in-arm-host
 Pulling from xxxx
```
Mimic this functionality!

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- 

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
