### PR TITLE
fix(ollama): align local exec test with Ollama 0.30.6 log format

### DIFF
--- a/modules/ollama/local_test.go
+++ b/modules/ollama/local_test.go
@@ -518,7 +518,7 @@ func TestRun_localExec(t *testing.T) {
 
 		bs, err = io.ReadAll(logs)
 		require.NoError(t, err)
-		require.Contains(t, string(bs), "llama runner started")
+		require.Contains(t, string(bs), "llama-server started")
 	})
 }
 


### PR DESCRIPTION
## What does this PR do?

Updates the substring assertion in `TestRun_localExec/pull-and-run-model` so it matches the log format emitted by current Ollama releases. The check at `modules/ollama/local_test.go:521` now looks for `"llama-server started"` instead of the legacy `"llama runner started"`.

## Why is it important?

The CI job that exercises the local Ollama integration installs the Ollama binary directly from `https://ollama.com/install.sh` (see `.github/scripts/modules/ollama/install-dependencies.sh`), so it always picks up the latest upstream release. Upstream Ollama renamed the runner log line (`llama runner` → `llama-server`) somewhere before 0.30.6, which broke main as soon as CI pulled the new binary — the failure was the only red signal in the `Main pipeline` run on `00988b99` (see https://github.com/testcontainers/testcontainers-go/actions/runs/26867884686). No production code changed; the test assertion just needs to track the upstream rename.

## Related issues

- 

## How to test this PR

- Install the latest Ollama binary locally (`curl -fsSL https://ollama.com/install.sh | sh`) so `ollama` is on `$PATH`.
- Run the ollama module's local exec test:

  ```bash
  cd modules/ollama
  go test -run TestRun_localExec/pull-and-run-model -v ./...
  ```

- Confirm the test passes and that the captured logs contain `llama-server started in <N> seconds`.

## Follow-ups

- Consider pinning the Ollama binary version installed in CI to insulate against future upstream log-format changes.
