### PR TITLE
fix(security): remove debug code that leaks Docker credentials

### DIFF
--- a/generic.go
+++ b/generic.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"maps"
-	"strings"
 	"sync"
 
 	"github.com/testcontainers/testcontainers-go/internal/core"
@@ -78,14 +77,6 @@ func GenericContainer(ctx context.Context, req GenericContainerRequest) (Contain
 	}
 	if err != nil {
 		// At this point `c` might not be nil. Give the caller an opportunity to call Destroy on the container.
-		// TODO: Remove this debugging.
-		if strings.Contains(err.Error(), "toomanyrequests") {
-			// Debugging information for rate limiting.
-			cfg, err := getDockerConfig()
-			if err == nil {
-				fmt.Printf("XXX: too many requests: %+v", cfg)
-			}
-		}
 		return c, fmt.Errorf("create container: %w", err)
 	}
 


### PR DESCRIPTION
## What does this PR do?

Removes a leftover debugging block in `GenericContainer` that dumped the full Docker config (including registry credentials) to stdout whenever a `toomanyrequests` error was hit.

The block printed `getDockerConfig()` via `fmt.Printf("XXX: too many requests: %+v", cfg)`. That config's `AuthConfigs` map contains `Password`, `Auth` (base64 of `user:password`), `IdentityToken`, and `RegistryToken` — all real, trivially-decodable secrets — landing in stdout (and therefore CI logs).

It was always intended to be temporary: the code carried `// TODO: Remove this debugging.` and the commit that added it (#2731) deliberately used `fmt.Printf` instead of the logger "so it prints unconditionally". This just removes it (and the now-unused `strings` import).

## Why is it important?

Credentials should never be written to logs. This is an unconditional secret leak on Docker Hub rate-limiting.

Fixes #3720