### PR TITLE
feat(eventhubs): add WithAzuriteContainer and functional-options config builder

### DIFF
--- a/docs/modules/azure.md
+++ b/docs/modules/azure.md
@@ -184,6 +184,9 @@ When starting the EventHubs container, you can pass options in a variadic way to
 
 This option allows you to set a different Azurite Docker image, instead of the default one, and also pass options to the Azurite container, in the form of a variadic argument of `testcontainers.ContainerCustomizer`.
 
+!!! warning
+    `WithAzurite` and [`WithAzuriteContainer`](#withazuritecontainer) are mutually exclusive. Passing both to `Run` returns an error. If you already have a running Azurite container, use `WithAzuriteContainer` instead — the image and options set here will not apply.
+
 #### WithAcceptEULA
 
 - Since <a href="https://github.com/testcontainers/testcontainers-go/releases/tag/v0.36.0"><span class="tc-version">:material-tag: v0.36.0</span></a>
@@ -195,6 +198,9 @@ This option allows you to accept the EULA for the EventHubs container.
 - Not available until the next release <a href="https://github.com/testcontainers/testcontainers-go"><span class="tc-version">:material-tag: main</span></a>
 
 This option allows you to supply a pre-existing Azurite container and Docker network instead of letting the module create them automatically. When this option is used, calling `Terminate()` on the EventHubs container will **not** stop or remove the Azurite container or the network — the caller is responsible for their lifecycle.
+
+!!! warning
+    `WithAzuriteContainer` and [`WithAzurite`](#withazurite) are mutually exclusive. Passing both to `Run` returns an error. Any Azurite image or options set via `WithAzurite` are ignored when `WithAzuriteContainer` is supplied.
 
 <!--codeinclude-->
 [Create Network](../../modules/azure/eventhubs/examples_test.go) inside_block:withAzuriteContainer_network

--- a/docs/modules/azure.md
+++ b/docs/modules/azure.md
@@ -165,8 +165,9 @@ func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustom
 - `string`, the Docker image to use.
 - `testcontainers.ContainerCustomizer`, a variadic argument for passing options.
 
-The EventHubs container needs an Azurite container to be running, for that reason _Testcontainers for Go_ **automatically creates a Docker network and an Azurite container** for EventHubs to work.
+The EventHubs container needs an Azurite container to be running. By default, _Testcontainers for Go_ **automatically creates a Docker network and an Azurite container** for EventHubs to work.
 When terminating the EventHubs container, the Azurite container and the Docker network are also terminated.
+If you want to manage the Azurite container and network yourself, use the [`WithAzuriteContainer`](#withazuritecontainer) option instead.
 
 #### Image
 
@@ -189,6 +190,18 @@ This option allows you to set a different Azurite Docker image, instead of the d
 
 This option allows you to accept the EULA for the EventHubs container.
 
+#### WithAzuriteContainer
+
+- Since testcontainers-go <a href="https://github.com/testcontainers/testcontainers-go/releases/tag/v0.37.0"><span class="tc-version">:material-tag: v0.37.0</span></a>
+
+This option allows you to supply a pre-existing Azurite container and Docker network instead of letting the module create them automatically. When this option is used, calling `Terminate()` on the EventHubs container will **not** stop or remove the Azurite container or the network — the caller is responsible for their lifecycle.
+
+<!--codeinclude-->
+[Create Network](../../modules/azure/eventhubs/examples_test.go) inside_block:withAzuriteContainer_network
+[Start Azurite](../../modules/azure/eventhubs/examples_test.go) inside_block:withAzuriteContainer_azurite
+[Run EventHubs with external Azurite](../../modules/azure/eventhubs/examples_test.go) inside_block:withAzuriteContainer_eventhubs
+<!--/codeinclude-->
+
 #### WithConfig
 
 - Since <a href="https://github.com/testcontainers/testcontainers-go/releases/tag/v0.36.0"><span class="tc-version">:material-tag: v0.36.0</span></a>
@@ -199,6 +212,24 @@ The config file must be a valid EventHubs config file, and it must be a valid JS
 
 <!--codeinclude-->
 [EventHubs JSON Config](../../modules/azure/eventhubs/testdata/eventhubs_config.json)
+<!--/codeinclude-->
+
+#### WithConfigObject
+
+- Since testcontainers-go <a href="https://github.com/testcontainers/testcontainers-go/releases/tag/v0.37.0"><span class="tc-version">:material-tag: v0.37.0</span></a>
+
+This option is the statically-typed counterpart to `WithConfig`. It accepts a `*Config` value built with the functional-options API (`NewConfig`, `WithNamespace`, `WithEntity`, `WithConsumerGroup`, `WithLoggingType`) and marshals it to JSON at container start time.
+
+The emulator enforces the following hard limits, which `NewConfig` validates before the container starts:
+
+- Exactly **1 namespace**, whose name must be `eventhubs.EmulatorNamespaceName` (`"emulatorns1"`, case-insensitive).
+- At most **10 entities** per namespace.
+- Partition count **1–32** per entity.
+- At most **20 consumer groups** per entity.
+
+<!--codeinclude-->
+[Build Config](../../modules/azure/eventhubs/examples_test.go) inside_block:withConfigObject_buildConfig
+[Run EventHubs with Config Object](../../modules/azure/eventhubs/examples_test.go) inside_block:withConfigObject_run
 <!--/codeinclude-->
 
 {% include "../features/common_functional_options_list.md" %}
@@ -226,6 +257,14 @@ In the following example, inspired by the [Azure Event Hubs Go SDK](https://lear
 [Create Sample Events](../../modules/azure/eventhubs/examples_test.go) inside_block:createSampleEvents
 [Create Batch](../../modules/azure/eventhubs/examples_test.go) inside_block:createBatch
 [Send Event Data Batch to the EventHub](../../modules/azure/eventhubs/examples_test.go) inside_block:sendEventDataBatch
+<!--/codeinclude-->
+
+#### Build a typed config with NewConfig
+
+The `NewConfig` function provides a statically-typed, validated alternative to writing the JSON config by hand.
+
+<!--codeinclude-->
+[Build Config](../../modules/azure/eventhubs/examples_test.go) inside_block:ExampleNewConfig_build
 <!--/codeinclude-->
 
 ## ServiceBus

--- a/docs/modules/azure.md
+++ b/docs/modules/azure.md
@@ -192,7 +192,7 @@ This option allows you to accept the EULA for the EventHubs container.
 
 #### WithAzuriteContainer
 
-- Since testcontainers-go <a href="https://github.com/testcontainers/testcontainers-go/releases/tag/v0.37.0"><span class="tc-version">:material-tag: v0.37.0</span></a>
+- Not available until the next release <a href="https://github.com/testcontainers/testcontainers-go"><span class="tc-version">:material-tag: main</span></a>
 
 This option allows you to supply a pre-existing Azurite container and Docker network instead of letting the module create them automatically. When this option is used, calling `Terminate()` on the EventHubs container will **not** stop or remove the Azurite container or the network — the caller is responsible for their lifecycle.
 
@@ -216,7 +216,7 @@ The config file must be a valid EventHubs config file, and it must be a valid JS
 
 #### WithConfigObject
 
-- Since testcontainers-go <a href="https://github.com/testcontainers/testcontainers-go/releases/tag/v0.37.0"><span class="tc-version">:material-tag: v0.37.0</span></a>
+- Not available until the next release <a href="https://github.com/testcontainers/testcontainers-go"><span class="tc-version">:material-tag: main</span></a>
 
 This option is the statically-typed counterpart to `WithConfig`. It accepts a `*Config` value built with the functional-options API (`NewConfig`, `WithNamespace`, `WithEntity`, `WithConsumerGroup`, `WithLoggingType`) and marshals it to JSON at container start time.
 

--- a/modules/azure/eventhubs/config.go
+++ b/modules/azure/eventhubs/config.go
@@ -6,6 +6,17 @@ import (
 	"strconv"
 )
 
+// Emulator usage quotas from
+// https://learn.microsoft.com/en-us/azure/event-hubs/overview-emulator#usage-quotas
+const (
+	// maxEntitiesPerNamespace is the maximum number of event hub entities per namespace.
+	maxEntitiesPerNamespace = 10
+	// maxPartitionCount is the maximum number of partitions per event hub entity.
+	maxPartitionCount = 32
+	// maxConsumerGroupsPerEntity is the maximum number of consumer groups per entity.
+	maxConsumerGroupsPerEntity = 20
+)
+
 // Config is the root structure marshalled to JSON for the Event Hubs emulator config file.
 // It is exported so advanced users can construct it directly or round-trip via json.Unmarshal.
 type Config struct {
@@ -111,6 +122,10 @@ func (c *Config) validate() error {
 		}
 		nsNames[ns.Name] = true
 
+		if len(ns.Entities) > maxEntitiesPerNamespace {
+			errs = append(errs, fmt.Errorf("config: namespace %q has %d entities, emulator limit is %d", ns.Name, len(ns.Entities), maxEntitiesPerNamespace))
+		}
+
 		entityNames := make(map[string]bool, len(ns.Entities))
 		for j, e := range ns.Entities {
 			if e.Name == "" {
@@ -123,8 +138,12 @@ func (c *Config) validate() error {
 			entityNames[e.Name] = true
 
 			pc, err := strconv.Atoi(e.PartitionCount)
-			if err != nil || pc < 1 {
-				errs = append(errs, fmt.Errorf("config: namespace %q entity %q: partition count must be >= 1, got %q", ns.Name, e.Name, e.PartitionCount))
+			if err != nil || pc < 1 || pc > maxPartitionCount {
+				errs = append(errs, fmt.Errorf("config: namespace %q entity %q: partition count must be 1–%d, got %q", ns.Name, e.Name, maxPartitionCount, e.PartitionCount))
+			}
+
+			if len(e.ConsumerGroups) > maxConsumerGroupsPerEntity {
+				errs = append(errs, fmt.Errorf("config: namespace %q entity %q has %d consumer groups, emulator limit is %d", ns.Name, e.Name, len(e.ConsumerGroups), maxConsumerGroupsPerEntity))
 			}
 
 			cgNames := make(map[string]bool, len(e.ConsumerGroups))
@@ -199,8 +218,8 @@ func WithEntity(name string, partitionCount int, opts ...EntityOption) Namespace
 		if name == "" {
 			return fmt.Errorf("config: entity name is empty in namespace %q", n.Name)
 		}
-		if partitionCount < 1 {
-			return fmt.Errorf("config: entity %q: partition count must be >= 1, got %d", name, partitionCount)
+		if partitionCount < 1 || partitionCount > maxPartitionCount {
+			return fmt.Errorf("config: entity %q: partition count must be 1–%d, got %d", name, maxPartitionCount, partitionCount)
 		}
 		e := Entity{
 			Name:           name,

--- a/modules/azure/eventhubs/config.go
+++ b/modules/azure/eventhubs/config.go
@@ -1,0 +1,231 @@
+package eventhubs
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+)
+
+// Config is the root structure marshalled to JSON for the Event Hubs emulator config file.
+// It is exported so advanced users can construct it directly or round-trip via json.Unmarshal.
+type Config struct {
+	UserConfig UserConfig `json:"UserConfig"`
+}
+
+// UserConfig holds the top-level user configuration for the Event Hubs emulator.
+type UserConfig struct {
+	NamespaceConfig []NamespaceConfig `json:"NamespaceConfig"`
+	LoggingConfig   LoggingConfig     `json:"LoggingConfig"`
+}
+
+// NamespaceConfig describes an Event Hubs namespace.
+type NamespaceConfig struct {
+	Type     string   `json:"Type"` // "EventHub" is the only documented value
+	Name     string   `json:"Name"`
+	Entities []Entity `json:"Entities"`
+}
+
+// Entity describes an Event Hub entity within a namespace.
+type Entity struct {
+	Name           string          `json:"Name"`
+	PartitionCount string          `json:"PartitionCount"` // string per emulator schema
+	ConsumerGroups []ConsumerGroup `json:"ConsumerGroups"`
+}
+
+// ConsumerGroup describes a consumer group for an Event Hub entity.
+type ConsumerGroup struct {
+	Name string `json:"Name"`
+}
+
+// LoggingConfig controls the emulator logging output.
+type LoggingConfig struct {
+	Type string `json:"Type"` // e.g. "File", "Console"
+}
+
+// ConfigOption configures a *Config. Returned by package-level helpers such as
+// WithLoggingType and WithNamespace.
+type ConfigOption func(*Config) error
+
+// NamespaceOption configures a single NamespaceConfig. Returned by WithEntity
+// and WithNamespaceType.
+type NamespaceOption func(*NamespaceConfig) error
+
+// EntityOption configures a single Entity. Returned by WithConsumerGroup.
+type EntityOption func(*Entity) error
+
+// NewConfig builds a *Config from the supplied options, applies whole-tree
+// validation and returns it. Defaults applied before options run:
+//   - LoggingConfig.Type = "File"
+//   - NamespaceConfig    = []NamespaceConfig{} (non-nil for stable JSON)
+func NewConfig(opts ...ConfigOption) (*Config, error) {
+	cfg := &Config{
+		UserConfig: UserConfig{
+			NamespaceConfig: []NamespaceConfig{},
+			LoggingConfig:   LoggingConfig{Type: "File"},
+		},
+	}
+
+	var errs []error
+	for _, opt := range opts {
+		if err := opt(cfg); err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	if err := cfg.validate(); err != nil {
+		errs = append(errs, err)
+	}
+
+	if len(errs) > 0 {
+		return nil, errors.Join(errs...)
+	}
+	return cfg, nil
+}
+
+// MustNewConfig is NewConfig that panics on error. Convenient for test setup.
+func MustNewConfig(opts ...ConfigOption) *Config {
+	cfg, err := NewConfig(opts...)
+	if err != nil {
+		panic(err)
+	}
+	return cfg
+}
+
+// validate performs whole-tree validation rules that require seeing the fully
+// assembled config, primarily uniqueness constraints.
+func (c *Config) validate() error {
+	var errs []error
+
+	if c.UserConfig.LoggingConfig.Type == "" {
+		errs = append(errs, errors.New("config: logging type is empty"))
+	}
+
+	nsNames := make(map[string]bool, len(c.UserConfig.NamespaceConfig))
+	for i, ns := range c.UserConfig.NamespaceConfig {
+		if ns.Name == "" {
+			errs = append(errs, fmt.Errorf("config: namespace[%d]: name is empty", i))
+			continue
+		}
+		if nsNames[ns.Name] {
+			errs = append(errs, fmt.Errorf("config: duplicate namespace name %q", ns.Name))
+		}
+		nsNames[ns.Name] = true
+
+		entityNames := make(map[string]bool, len(ns.Entities))
+		for j, e := range ns.Entities {
+			if e.Name == "" {
+				errs = append(errs, fmt.Errorf("config: namespace %q entity[%d]: name is empty", ns.Name, j))
+				continue
+			}
+			if entityNames[e.Name] {
+				errs = append(errs, fmt.Errorf("config: namespace %q duplicate entity name %q", ns.Name, e.Name))
+			}
+			entityNames[e.Name] = true
+
+			pc, err := strconv.Atoi(e.PartitionCount)
+			if err != nil || pc < 1 {
+				errs = append(errs, fmt.Errorf("config: namespace %q entity %q: partition count must be >= 1, got %q", ns.Name, e.Name, e.PartitionCount))
+			}
+
+			cgNames := make(map[string]bool, len(e.ConsumerGroups))
+			for k, cg := range e.ConsumerGroups {
+				if cg.Name == "" {
+					errs = append(errs, fmt.Errorf("config: namespace %q entity %q consumer group[%d]: name is empty", ns.Name, e.Name, k))
+					continue
+				}
+				if cgNames[cg.Name] {
+					errs = append(errs, fmt.Errorf("config: namespace %q entity %q duplicate consumer group name %q", ns.Name, e.Name, cg.Name))
+				}
+				cgNames[cg.Name] = true
+			}
+		}
+	}
+
+	return errors.Join(errs...)
+}
+
+// WithLoggingType overrides UserConfig.LoggingConfig.Type (default "File").
+func WithLoggingType(t string) ConfigOption {
+	return func(c *Config) error {
+		if t == "" {
+			return errors.New("config: logging type is empty")
+		}
+		c.UserConfig.LoggingConfig.Type = t
+		return nil
+	}
+}
+
+// WithNamespace appends a namespace to the config. The namespace type defaults
+// to "EventHub". Sub-options are applied to the freshly-appended NamespaceConfig
+// in order. Errors from sub-options are collected and joined.
+func WithNamespace(name string, opts ...NamespaceOption) ConfigOption {
+	return func(c *Config) error {
+		if name == "" {
+			return errors.New("config: namespace name is empty")
+		}
+		ns := NamespaceConfig{
+			Type:     "EventHub",
+			Name:     name,
+			Entities: []Entity{},
+		}
+		var errs []error
+		for _, opt := range opts {
+			if err := opt(&ns); err != nil {
+				errs = append(errs, err)
+			}
+		}
+		c.UserConfig.NamespaceConfig = append(c.UserConfig.NamespaceConfig, ns)
+		return errors.Join(errs...)
+	}
+}
+
+// WithNamespaceType overrides the namespace Type (default "EventHub").
+// Pass it alongside WithEntity inside a WithNamespace call.
+func WithNamespaceType(t string) NamespaceOption {
+	return func(n *NamespaceConfig) error {
+		if t == "" {
+			return errors.New("config: namespace type is empty")
+		}
+		n.Type = t
+		return nil
+	}
+}
+
+// WithEntity appends an entity to the enclosing namespace.
+// partitionCount must be >= 1. Sub-options are applied to the freshly-appended
+// Entity in order. Errors from sub-options are collected and joined.
+func WithEntity(name string, partitionCount int, opts ...EntityOption) NamespaceOption {
+	return func(n *NamespaceConfig) error {
+		if name == "" {
+			return fmt.Errorf("config: entity name is empty in namespace %q", n.Name)
+		}
+		if partitionCount < 1 {
+			return fmt.Errorf("config: entity %q: partition count must be >= 1, got %d", name, partitionCount)
+		}
+		e := Entity{
+			Name:           name,
+			PartitionCount: strconv.Itoa(partitionCount),
+			ConsumerGroups: []ConsumerGroup{},
+		}
+		var errs []error
+		for _, opt := range opts {
+			if err := opt(&e); err != nil {
+				errs = append(errs, err)
+			}
+		}
+		n.Entities = append(n.Entities, e)
+		return errors.Join(errs...)
+	}
+}
+
+// WithConsumerGroup appends a consumer group to the enclosing entity.
+// Multiple WithConsumerGroup options may be passed to the same WithEntity call.
+func WithConsumerGroup(name string) EntityOption {
+	return func(e *Entity) error {
+		if name == "" {
+			return fmt.Errorf("config: consumer group name is empty in entity %q", e.Name)
+		}
+		e.ConsumerGroups = append(e.ConsumerGroups, ConsumerGroup{Name: name})
+		return nil
+	}
+}

--- a/modules/azure/eventhubs/config.go
+++ b/modules/azure/eventhubs/config.go
@@ -120,7 +120,6 @@ func (c *Config) validate() error {
 		errs = append(errs, fmt.Errorf("config: emulator supports only 1 namespace, got %d", len(c.UserConfig.NamespaceConfig)))
 	}
 
-	nsNames := make(map[string]bool, len(c.UserConfig.NamespaceConfig))
 	for i, ns := range c.UserConfig.NamespaceConfig {
 		if ns.Name == "" {
 			errs = append(errs, fmt.Errorf("config: namespace[%d]: name is empty", i))
@@ -129,10 +128,6 @@ func (c *Config) validate() error {
 		if !strings.EqualFold(ns.Name, EmulatorNamespaceName) {
 			errs = append(errs, fmt.Errorf("config: namespace name %q is not valid: emulator preset namespace name cannot be changed from %q", ns.Name, EmulatorNamespaceName))
 		}
-		if nsNames[ns.Name] {
-			errs = append(errs, fmt.Errorf("config: duplicate namespace name %q", ns.Name))
-		}
-		nsNames[ns.Name] = true
 
 		if len(ns.Entities) > maxEntitiesPerNamespace {
 			errs = append(errs, fmt.Errorf("config: namespace %q has %d entities, emulator limit is %d", ns.Name, len(ns.Entities), maxEntitiesPerNamespace))
@@ -223,7 +218,7 @@ func WithNamespaceType(t string) NamespaceOption {
 }
 
 // WithEntity appends an entity to the enclosing namespace.
-// partitionCount must be >= 1. Sub-options are applied to the freshly-appended
+// partitionCount must be 1–32. Sub-options are applied to the freshly-appended
 // Entity in order. Errors from sub-options are collected and joined.
 func WithEntity(name string, partitionCount int, opts ...EntityOption) NamespaceOption {
 	return func(n *NamespaceConfig) error {

--- a/modules/azure/eventhubs/config.go
+++ b/modules/azure/eventhubs/config.go
@@ -4,11 +4,16 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
+	"strings"
 )
 
 // Emulator usage quotas from
 // https://learn.microsoft.com/en-us/azure/event-hubs/overview-emulator#usage-quotas
 const (
+	// EmulatorNamespaceName is the fixed namespace name required by the EventHubs emulator.
+	// The emulator supports exactly one namespace and its name cannot be changed.
+	EmulatorNamespaceName = "emulatorns1"
+
 	// maxEntitiesPerNamespace is the maximum number of event hub entities per namespace.
 	maxEntitiesPerNamespace = 10
 	// maxPartitionCount is the maximum number of partitions per event hub entity.
@@ -111,11 +116,18 @@ func (c *Config) validate() error {
 		errs = append(errs, errors.New("config: logging type is empty"))
 	}
 
+	if len(c.UserConfig.NamespaceConfig) > 1 {
+		errs = append(errs, fmt.Errorf("config: emulator supports only 1 namespace, got %d", len(c.UserConfig.NamespaceConfig)))
+	}
+
 	nsNames := make(map[string]bool, len(c.UserConfig.NamespaceConfig))
 	for i, ns := range c.UserConfig.NamespaceConfig {
 		if ns.Name == "" {
 			errs = append(errs, fmt.Errorf("config: namespace[%d]: name is empty", i))
 			continue
+		}
+		if !strings.EqualFold(ns.Name, EmulatorNamespaceName) {
+			errs = append(errs, fmt.Errorf("config: namespace name %q is not valid: emulator preset namespace name cannot be changed from %q", ns.Name, EmulatorNamespaceName))
 		}
 		if nsNames[ns.Name] {
 			errs = append(errs, fmt.Errorf("config: duplicate namespace name %q", ns.Name))

--- a/modules/azure/eventhubs/config_test.go
+++ b/modules/azure/eventhubs/config_test.go
@@ -18,7 +18,7 @@ import (
 func TestNewConfig_happyPath(t *testing.T) {
 	cfg, err := eventhubs.NewConfig(
 		eventhubs.WithLoggingType("File"),
-		eventhubs.WithNamespace("emulatorNs1",
+		eventhubs.WithNamespace(eventhubs.EmulatorNamespaceName,
 			eventhubs.WithEntity("eh1", 1,
 				eventhubs.WithConsumerGroup("cg1"),
 			),
@@ -32,12 +32,15 @@ func TestNewConfig_happyPath(t *testing.T) {
 	require.NoError(t, err)
 
 	// Canonical fixture JSON (matches testdata/eventhubs_config.json shape).
+	// The emulator preset namespace name is case-insensitive; testdata uses "emulatorNs1"
+	// which the builder stores as-supplied. We compare via map[string]any so
+	// key-order differences are irrelevant.
 	const fixtureJSON = `{
 		"UserConfig": {
 			"NamespaceConfig": [
 				{
 					"Type": "EventHub",
-					"Name": "emulatorNs1",
+					"Name": "emulatorns1",
 					"Entities": [
 						{
 							"Name": "eh1",
@@ -68,7 +71,7 @@ func TestNewConfig_happyPath(t *testing.T) {
 // "File" when WithLoggingType is not specified.
 func TestNewConfig_defaultLoggingType(t *testing.T) {
 	cfg, err := eventhubs.NewConfig(
-		eventhubs.WithNamespace("ns1",
+		eventhubs.WithNamespace(eventhubs.EmulatorNamespaceName,
 			eventhubs.WithEntity("eh1", 1),
 		),
 	)
@@ -87,9 +90,33 @@ func TestNewConfig_validation(t *testing.T) {
 		assert.Contains(t, err.Error(), "namespace name is empty")
 	})
 
+	t.Run("wrong namespace name", func(t *testing.T) {
+		_, err := eventhubs.NewConfig(
+			eventhubs.WithNamespace("mynamespace",
+				eventhubs.WithEntity("eh1", 1),
+			),
+		)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "namespace name")
+		assert.Contains(t, err.Error(), "cannot be changed from")
+	})
+
+	t.Run("too many namespaces", func(t *testing.T) {
+		_, err := eventhubs.NewConfig(
+			eventhubs.WithNamespace(eventhubs.EmulatorNamespaceName,
+				eventhubs.WithEntity("eh1", 1),
+			),
+			eventhubs.WithNamespace(eventhubs.EmulatorNamespaceName,
+				eventhubs.WithEntity("eh2", 1),
+			),
+		)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "emulator supports only 1 namespace")
+	})
+
 	t.Run("empty entity name", func(t *testing.T) {
 		_, err := eventhubs.NewConfig(
-			eventhubs.WithNamespace("ns1",
+			eventhubs.WithNamespace(eventhubs.EmulatorNamespaceName,
 				eventhubs.WithEntity("", 1),
 			),
 		)
@@ -99,7 +126,7 @@ func TestNewConfig_validation(t *testing.T) {
 
 	t.Run("zero partition count", func(t *testing.T) {
 		_, err := eventhubs.NewConfig(
-			eventhubs.WithNamespace("ns1",
+			eventhubs.WithNamespace(eventhubs.EmulatorNamespaceName,
 				eventhubs.WithEntity("eh1", 0),
 			),
 		)
@@ -109,7 +136,7 @@ func TestNewConfig_validation(t *testing.T) {
 
 	t.Run("negative partition count", func(t *testing.T) {
 		_, err := eventhubs.NewConfig(
-			eventhubs.WithNamespace("ns1",
+			eventhubs.WithNamespace(eventhubs.EmulatorNamespaceName,
 				eventhubs.WithEntity("eh1", -5),
 			),
 		)
@@ -119,7 +146,7 @@ func TestNewConfig_validation(t *testing.T) {
 
 	t.Run("partition count exceeds emulator limit", func(t *testing.T) {
 		_, err := eventhubs.NewConfig(
-			eventhubs.WithNamespace("ns1",
+			eventhubs.WithNamespace(eventhubs.EmulatorNamespaceName,
 				eventhubs.WithEntity("eh1", 33),
 			),
 		)
@@ -133,7 +160,7 @@ func TestNewConfig_validation(t *testing.T) {
 			entityOpts[i] = eventhubs.WithEntity(fmt.Sprintf("eh%d", i+1), 1)
 		}
 		_, err := eventhubs.NewConfig(
-			eventhubs.WithNamespace("ns1", entityOpts...),
+			eventhubs.WithNamespace(eventhubs.EmulatorNamespaceName, entityOpts...),
 		)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "entities, emulator limit is 10")
@@ -145,7 +172,7 @@ func TestNewConfig_validation(t *testing.T) {
 			cgOpts[i] = eventhubs.WithConsumerGroup(fmt.Sprintf("cg%d", i+1))
 		}
 		_, err := eventhubs.NewConfig(
-			eventhubs.WithNamespace("ns1",
+			eventhubs.WithNamespace(eventhubs.EmulatorNamespaceName,
 				eventhubs.WithEntity("eh1", 1, cgOpts...),
 			),
 		)
@@ -155,7 +182,7 @@ func TestNewConfig_validation(t *testing.T) {
 
 	t.Run("empty consumer group name", func(t *testing.T) {
 		_, err := eventhubs.NewConfig(
-			eventhubs.WithNamespace("ns1",
+			eventhubs.WithNamespace(eventhubs.EmulatorNamespaceName,
 				eventhubs.WithEntity("eh1", 1,
 					eventhubs.WithConsumerGroup(""),
 				),
@@ -173,22 +200,9 @@ func TestNewConfig_validation(t *testing.T) {
 		assert.Contains(t, err.Error(), "logging type is empty")
 	})
 
-	t.Run("duplicate namespace names", func(t *testing.T) {
-		_, err := eventhubs.NewConfig(
-			eventhubs.WithNamespace("ns1",
-				eventhubs.WithEntity("eh1", 1),
-			),
-			eventhubs.WithNamespace("ns1",
-				eventhubs.WithEntity("eh2", 1),
-			),
-		)
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "duplicate namespace name")
-	})
-
 	t.Run("duplicate entity names within namespace", func(t *testing.T) {
 		_, err := eventhubs.NewConfig(
-			eventhubs.WithNamespace("ns1",
+			eventhubs.WithNamespace(eventhubs.EmulatorNamespaceName,
 				eventhubs.WithEntity("eh1", 1),
 				eventhubs.WithEntity("eh1", 2),
 			),
@@ -199,7 +213,7 @@ func TestNewConfig_validation(t *testing.T) {
 
 	t.Run("duplicate consumer group names within entity", func(t *testing.T) {
 		_, err := eventhubs.NewConfig(
-			eventhubs.WithNamespace("ns1",
+			eventhubs.WithNamespace(eventhubs.EmulatorNamespaceName,
 				eventhubs.WithEntity("eh1", 1,
 					eventhubs.WithConsumerGroup("cg1"),
 					eventhubs.WithConsumerGroup("cg1"),
@@ -212,8 +226,7 @@ func TestNewConfig_validation(t *testing.T) {
 
 	t.Run("multiple errors aggregated", func(t *testing.T) {
 		_, err := eventhubs.NewConfig(
-			eventhubs.WithNamespace(""), // empty name → error 1
-
+			eventhubs.WithNamespace(""),   // empty name → error 1
 			eventhubs.WithLoggingType(""), // empty logging type → error 2
 		)
 		require.Error(t, err)
@@ -227,7 +240,7 @@ func TestNewConfig_validation(t *testing.T) {
 // partition count produces "PartitionCount":"3" (a string) in the marshalled JSON.
 func TestNewConfig_partitionCountStringified(t *testing.T) {
 	cfg, err := eventhubs.NewConfig(
-		eventhubs.WithNamespace("ns1",
+		eventhubs.WithNamespace(eventhubs.EmulatorNamespaceName,
 			eventhubs.WithEntity("e", 3),
 		),
 	)
@@ -261,11 +274,11 @@ func TestMustNewConfig_panicsOnInvalid(t *testing.T) {
 	})
 }
 
-// TestNewConfig_multipleNamespaces verifies that multiple namespaces and
-// entities are composed correctly.
-func TestNewConfig_multipleNamespaces(t *testing.T) {
+// TestNewConfig_multipleEntities verifies that multiple entities within the
+// single emulator namespace are composed correctly.
+func TestNewConfig_multipleEntities(t *testing.T) {
 	cfg, err := eventhubs.NewConfig(
-		eventhubs.WithNamespace("ns1",
+		eventhubs.WithNamespace(eventhubs.EmulatorNamespaceName,
 			eventhubs.WithEntity("eh1", 2,
 				eventhubs.WithConsumerGroup("cg1"),
 				eventhubs.WithConsumerGroup("$Default"),
@@ -274,24 +287,34 @@ func TestNewConfig_multipleNamespaces(t *testing.T) {
 				eventhubs.WithConsumerGroup("cg1"),
 			),
 		),
-		eventhubs.WithNamespace("ns2",
-			eventhubs.WithEntity("eh3", 4),
+	)
+	require.NoError(t, err)
+	require.Len(t, cfg.UserConfig.NamespaceConfig, 1)
+	require.Equal(t, eventhubs.EmulatorNamespaceName, cfg.UserConfig.NamespaceConfig[0].Name)
+	require.Len(t, cfg.UserConfig.NamespaceConfig[0].Entities, 2)
+	assert.Equal(t, "2", cfg.UserConfig.NamespaceConfig[0].Entities[0].PartitionCount)
+	assert.Len(t, cfg.UserConfig.NamespaceConfig[0].Entities[0].ConsumerGroups, 2)
+	assert.Equal(t, "eh2", cfg.UserConfig.NamespaceConfig[0].Entities[1].Name)
+}
+
+// TestNewConfig_caseInsensitiveNamespaceName verifies that WithNamespace accepts
+// the emulator namespace name regardless of capitalisation (e.g. "emulatorNs1").
+func TestNewConfig_caseInsensitiveNamespaceName(t *testing.T) {
+	// "emulatorNs1" is the capitalisation used in the existing testdata fixture.
+	cfg, err := eventhubs.NewConfig(
+		eventhubs.WithNamespace("emulatorNs1",
+			eventhubs.WithEntity("eh1", 1),
 		),
 	)
 	require.NoError(t, err)
-	require.Len(t, cfg.UserConfig.NamespaceConfig, 2)
-	require.Equal(t, "ns1", cfg.UserConfig.NamespaceConfig[0].Name)
-	require.Len(t, cfg.UserConfig.NamespaceConfig[0].Entities, 2)
-	require.Equal(t, "2", cfg.UserConfig.NamespaceConfig[0].Entities[0].PartitionCount)
-	require.Len(t, cfg.UserConfig.NamespaceConfig[0].Entities[0].ConsumerGroups, 2)
-	require.Equal(t, "ns2", cfg.UserConfig.NamespaceConfig[1].Name)
+	assert.Equal(t, "emulatorNs1", cfg.UserConfig.NamespaceConfig[0].Name)
 }
 
 // TestNewConfig_withNamespaceType verifies that WithNamespaceType overrides
 // the default "EventHub" type.
 func TestNewConfig_withNamespaceType(t *testing.T) {
 	cfg, err := eventhubs.NewConfig(
-		eventhubs.WithNamespace("ns1",
+		eventhubs.WithNamespace(eventhubs.EmulatorNamespaceName,
 			eventhubs.WithNamespaceType("CustomType"),
 			eventhubs.WithEntity("eh1", 1),
 		),

--- a/modules/azure/eventhubs/config_test.go
+++ b/modules/azure/eventhubs/config_test.go
@@ -2,6 +2,7 @@ package eventhubs_test
 
 import (
 	"encoding/json"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -103,7 +104,7 @@ func TestNewConfig_validation(t *testing.T) {
 			),
 		)
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "partition count must be >= 1")
+		assert.Contains(t, err.Error(), "partition count must be 1")
 	})
 
 	t.Run("negative partition count", func(t *testing.T) {
@@ -113,7 +114,43 @@ func TestNewConfig_validation(t *testing.T) {
 			),
 		)
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "partition count must be >= 1")
+		assert.Contains(t, err.Error(), "partition count must be 1")
+	})
+
+	t.Run("partition count exceeds emulator limit", func(t *testing.T) {
+		_, err := eventhubs.NewConfig(
+			eventhubs.WithNamespace("ns1",
+				eventhubs.WithEntity("eh1", 33),
+			),
+		)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "partition count must be 1")
+	})
+
+	t.Run("too many entities per namespace", func(t *testing.T) {
+		entityOpts := make([]eventhubs.NamespaceOption, 11)
+		for i := range entityOpts {
+			entityOpts[i] = eventhubs.WithEntity(fmt.Sprintf("eh%d", i+1), 1)
+		}
+		_, err := eventhubs.NewConfig(
+			eventhubs.WithNamespace("ns1", entityOpts...),
+		)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "entities, emulator limit is 10")
+	})
+
+	t.Run("too many consumer groups per entity", func(t *testing.T) {
+		cgOpts := make([]eventhubs.EntityOption, 21)
+		for i := range cgOpts {
+			cgOpts[i] = eventhubs.WithConsumerGroup(fmt.Sprintf("cg%d", i+1))
+		}
+		_, err := eventhubs.NewConfig(
+			eventhubs.WithNamespace("ns1",
+				eventhubs.WithEntity("eh1", 1, cgOpts...),
+			),
+		)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "consumer groups, emulator limit is 20")
 	})
 
 	t.Run("empty consumer group name", func(t *testing.T) {
@@ -175,8 +212,8 @@ func TestNewConfig_validation(t *testing.T) {
 
 	t.Run("multiple errors aggregated", func(t *testing.T) {
 		_, err := eventhubs.NewConfig(
-			eventhubs.WithNamespace("",    // empty name → error 1
-			),
+			eventhubs.WithNamespace(""), // empty name → error 1
+
 			eventhubs.WithLoggingType(""), // empty logging type → error 2
 		)
 		require.Error(t, err)

--- a/modules/azure/eventhubs/config_test.go
+++ b/modules/azure/eventhubs/config_test.go
@@ -1,0 +1,264 @@
+package eventhubs_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/testcontainers/testcontainers-go/modules/azure/eventhubs"
+)
+
+// TestNewConfig_happyPath verifies that a config built with functional options
+// marshals to the same JSON shape as the canonical testdata fixture
+// (eventhubs_config.json). Comparison is done via map[string]any so it is
+// insensitive to JSON key ordering.
+func TestNewConfig_happyPath(t *testing.T) {
+	cfg, err := eventhubs.NewConfig(
+		eventhubs.WithLoggingType("File"),
+		eventhubs.WithNamespace("emulatorNs1",
+			eventhubs.WithEntity("eh1", 1,
+				eventhubs.WithConsumerGroup("cg1"),
+			),
+		),
+	)
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+
+	// Marshal to JSON.
+	got, err := json.Marshal(cfg)
+	require.NoError(t, err)
+
+	// Canonical fixture JSON (matches testdata/eventhubs_config.json shape).
+	const fixtureJSON = `{
+		"UserConfig": {
+			"NamespaceConfig": [
+				{
+					"Type": "EventHub",
+					"Name": "emulatorNs1",
+					"Entities": [
+						{
+							"Name": "eh1",
+							"PartitionCount": "1",
+							"ConsumerGroups": [
+								{
+									"Name": "cg1"
+								}
+							]
+						}
+					]
+				}
+			],
+			"LoggingConfig": {
+				"Type": "File"
+			}
+		}
+	}`
+
+	var gotMap, wantMap map[string]any
+	require.NoError(t, json.Unmarshal(got, &gotMap))
+	require.NoError(t, json.Unmarshal([]byte(fixtureJSON), &wantMap))
+
+	assert.Equal(t, wantMap, gotMap)
+}
+
+// TestNewConfig_defaultLoggingType verifies that the default logging type is
+// "File" when WithLoggingType is not specified.
+func TestNewConfig_defaultLoggingType(t *testing.T) {
+	cfg, err := eventhubs.NewConfig(
+		eventhubs.WithNamespace("ns1",
+			eventhubs.WithEntity("eh1", 1),
+		),
+	)
+	require.NoError(t, err)
+	assert.Equal(t, "File", cfg.UserConfig.LoggingConfig.Type)
+}
+
+// TestNewConfig_validation checks that NewConfig aggregates multiple validation
+// errors via errors.Join rather than failing fast on the first one.
+func TestNewConfig_validation(t *testing.T) {
+	t.Run("empty namespace name", func(t *testing.T) {
+		_, err := eventhubs.NewConfig(
+			eventhubs.WithNamespace(""),
+		)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "namespace name is empty")
+	})
+
+	t.Run("empty entity name", func(t *testing.T) {
+		_, err := eventhubs.NewConfig(
+			eventhubs.WithNamespace("ns1",
+				eventhubs.WithEntity("", 1),
+			),
+		)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "entity name is empty")
+	})
+
+	t.Run("zero partition count", func(t *testing.T) {
+		_, err := eventhubs.NewConfig(
+			eventhubs.WithNamespace("ns1",
+				eventhubs.WithEntity("eh1", 0),
+			),
+		)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "partition count must be >= 1")
+	})
+
+	t.Run("negative partition count", func(t *testing.T) {
+		_, err := eventhubs.NewConfig(
+			eventhubs.WithNamespace("ns1",
+				eventhubs.WithEntity("eh1", -5),
+			),
+		)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "partition count must be >= 1")
+	})
+
+	t.Run("empty consumer group name", func(t *testing.T) {
+		_, err := eventhubs.NewConfig(
+			eventhubs.WithNamespace("ns1",
+				eventhubs.WithEntity("eh1", 1,
+					eventhubs.WithConsumerGroup(""),
+				),
+			),
+		)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "consumer group name is empty")
+	})
+
+	t.Run("empty logging type", func(t *testing.T) {
+		_, err := eventhubs.NewConfig(
+			eventhubs.WithLoggingType(""),
+		)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "logging type is empty")
+	})
+
+	t.Run("duplicate namespace names", func(t *testing.T) {
+		_, err := eventhubs.NewConfig(
+			eventhubs.WithNamespace("ns1",
+				eventhubs.WithEntity("eh1", 1),
+			),
+			eventhubs.WithNamespace("ns1",
+				eventhubs.WithEntity("eh2", 1),
+			),
+		)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "duplicate namespace name")
+	})
+
+	t.Run("duplicate entity names within namespace", func(t *testing.T) {
+		_, err := eventhubs.NewConfig(
+			eventhubs.WithNamespace("ns1",
+				eventhubs.WithEntity("eh1", 1),
+				eventhubs.WithEntity("eh1", 2),
+			),
+		)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "duplicate entity name")
+	})
+
+	t.Run("duplicate consumer group names within entity", func(t *testing.T) {
+		_, err := eventhubs.NewConfig(
+			eventhubs.WithNamespace("ns1",
+				eventhubs.WithEntity("eh1", 1,
+					eventhubs.WithConsumerGroup("cg1"),
+					eventhubs.WithConsumerGroup("cg1"),
+				),
+			),
+		)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "duplicate consumer group name")
+	})
+
+	t.Run("multiple errors aggregated", func(t *testing.T) {
+		_, err := eventhubs.NewConfig(
+			eventhubs.WithNamespace("",    // empty name → error 1
+			),
+			eventhubs.WithLoggingType(""), // empty logging type → error 2
+		)
+		require.Error(t, err)
+		// Both error messages should appear in the joined error string.
+		assert.Contains(t, err.Error(), "namespace name is empty")
+		assert.Contains(t, err.Error(), "logging type is empty")
+	})
+}
+
+// TestNewConfig_partitionCountStringified verifies that WithEntity with an int
+// partition count produces "PartitionCount":"3" (a string) in the marshalled JSON.
+func TestNewConfig_partitionCountStringified(t *testing.T) {
+	cfg, err := eventhubs.NewConfig(
+		eventhubs.WithNamespace("ns1",
+			eventhubs.WithEntity("e", 3),
+		),
+	)
+	require.NoError(t, err)
+
+	b, err := json.Marshal(cfg)
+	require.NoError(t, err)
+
+	var raw map[string]any
+	require.NoError(t, json.Unmarshal(b, &raw))
+
+	uc := raw["UserConfig"].(map[string]any)
+	nsList := uc["NamespaceConfig"].([]any)
+	ns := nsList[0].(map[string]any)
+	entities := ns["Entities"].([]any)
+	entity := entities[0].(map[string]any)
+
+	// PartitionCount must be a JSON string, not a number.
+	pc, ok := entity["PartitionCount"].(string)
+	require.True(t, ok, "PartitionCount should be a JSON string, got %T", entity["PartitionCount"])
+	assert.Equal(t, "3", pc)
+}
+
+// TestMustNewConfig_panicsOnInvalid verifies that MustNewConfig panics when
+// given invalid options.
+func TestMustNewConfig_panicsOnInvalid(t *testing.T) {
+	assert.Panics(t, func() {
+		eventhubs.MustNewConfig(
+			eventhubs.WithNamespace(""), // empty name → validation error → panic
+		)
+	})
+}
+
+// TestNewConfig_multipleNamespaces verifies that multiple namespaces and
+// entities are composed correctly.
+func TestNewConfig_multipleNamespaces(t *testing.T) {
+	cfg, err := eventhubs.NewConfig(
+		eventhubs.WithNamespace("ns1",
+			eventhubs.WithEntity("eh1", 2,
+				eventhubs.WithConsumerGroup("cg1"),
+				eventhubs.WithConsumerGroup("$Default"),
+			),
+			eventhubs.WithEntity("eh2", 1,
+				eventhubs.WithConsumerGroup("cg1"),
+			),
+		),
+		eventhubs.WithNamespace("ns2",
+			eventhubs.WithEntity("eh3", 4),
+		),
+	)
+	require.NoError(t, err)
+	require.Len(t, cfg.UserConfig.NamespaceConfig, 2)
+	require.Equal(t, "ns1", cfg.UserConfig.NamespaceConfig[0].Name)
+	require.Len(t, cfg.UserConfig.NamespaceConfig[0].Entities, 2)
+	require.Equal(t, "2", cfg.UserConfig.NamespaceConfig[0].Entities[0].PartitionCount)
+	require.Len(t, cfg.UserConfig.NamespaceConfig[0].Entities[0].ConsumerGroups, 2)
+	require.Equal(t, "ns2", cfg.UserConfig.NamespaceConfig[1].Name)
+}
+
+// TestNewConfig_withNamespaceType verifies that WithNamespaceType overrides
+// the default "EventHub" type.
+func TestNewConfig_withNamespaceType(t *testing.T) {
+	cfg, err := eventhubs.NewConfig(
+		eventhubs.WithNamespace("ns1",
+			eventhubs.WithNamespaceType("CustomType"),
+			eventhubs.WithEntity("eh1", 1),
+		),
+	)
+	require.NoError(t, err)
+	assert.Equal(t, "CustomType", cfg.UserConfig.NamespaceConfig[0].Type)
+}

--- a/modules/azure/eventhubs/config_test.go
+++ b/modules/azure/eventhubs/config_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/testcontainers/testcontainers-go/modules/azure/eventhubs"
@@ -64,7 +63,7 @@ func TestNewConfig_happyPath(t *testing.T) {
 	require.NoError(t, json.Unmarshal(got, &gotMap))
 	require.NoError(t, json.Unmarshal([]byte(fixtureJSON), &wantMap))
 
-	assert.Equal(t, wantMap, gotMap)
+	require.Equal(t, wantMap, gotMap)
 }
 
 // TestNewConfig_defaultLoggingType verifies that the default logging type is
@@ -76,7 +75,7 @@ func TestNewConfig_defaultLoggingType(t *testing.T) {
 		),
 	)
 	require.NoError(t, err)
-	assert.Equal(t, "File", cfg.UserConfig.LoggingConfig.Type)
+	require.Equal(t, "File", cfg.UserConfig.LoggingConfig.Type)
 }
 
 // TestNewConfig_validation checks that NewConfig aggregates multiple validation
@@ -87,7 +86,7 @@ func TestNewConfig_validation(t *testing.T) {
 			eventhubs.WithNamespace(""),
 		)
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "namespace name is empty")
+		require.Contains(t, err.Error(), "namespace name is empty")
 	})
 
 	t.Run("wrong namespace name", func(t *testing.T) {
@@ -97,8 +96,8 @@ func TestNewConfig_validation(t *testing.T) {
 			),
 		)
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "namespace name")
-		assert.Contains(t, err.Error(), "cannot be changed from")
+		require.Contains(t, err.Error(), "namespace name")
+		require.Contains(t, err.Error(), "cannot be changed from")
 	})
 
 	t.Run("too many namespaces", func(t *testing.T) {
@@ -111,7 +110,7 @@ func TestNewConfig_validation(t *testing.T) {
 			),
 		)
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "emulator supports only 1 namespace")
+		require.Contains(t, err.Error(), "emulator supports only 1 namespace")
 	})
 
 	t.Run("empty entity name", func(t *testing.T) {
@@ -121,7 +120,7 @@ func TestNewConfig_validation(t *testing.T) {
 			),
 		)
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "entity name is empty")
+		require.Contains(t, err.Error(), "entity name is empty")
 	})
 
 	t.Run("zero partition count", func(t *testing.T) {
@@ -131,7 +130,7 @@ func TestNewConfig_validation(t *testing.T) {
 			),
 		)
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "partition count must be 1")
+		require.Contains(t, err.Error(), "partition count must be 1")
 	})
 
 	t.Run("negative partition count", func(t *testing.T) {
@@ -141,7 +140,7 @@ func TestNewConfig_validation(t *testing.T) {
 			),
 		)
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "partition count must be 1")
+		require.Contains(t, err.Error(), "partition count must be 1")
 	})
 
 	t.Run("partition count exceeds emulator limit", func(t *testing.T) {
@@ -151,7 +150,7 @@ func TestNewConfig_validation(t *testing.T) {
 			),
 		)
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "partition count must be 1")
+		require.Contains(t, err.Error(), "partition count must be 1")
 	})
 
 	t.Run("too many entities per namespace", func(t *testing.T) {
@@ -163,7 +162,7 @@ func TestNewConfig_validation(t *testing.T) {
 			eventhubs.WithNamespace(eventhubs.EmulatorNamespaceName, entityOpts...),
 		)
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "entities, emulator limit is 10")
+		require.Contains(t, err.Error(), "entities, emulator limit is 10")
 	})
 
 	t.Run("too many consumer groups per entity", func(t *testing.T) {
@@ -177,7 +176,7 @@ func TestNewConfig_validation(t *testing.T) {
 			),
 		)
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "consumer groups, emulator limit is 20")
+		require.Contains(t, err.Error(), "consumer groups, emulator limit is 20")
 	})
 
 	t.Run("empty consumer group name", func(t *testing.T) {
@@ -189,7 +188,7 @@ func TestNewConfig_validation(t *testing.T) {
 			),
 		)
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "consumer group name is empty")
+		require.Contains(t, err.Error(), "consumer group name is empty")
 	})
 
 	t.Run("empty logging type", func(t *testing.T) {
@@ -197,7 +196,7 @@ func TestNewConfig_validation(t *testing.T) {
 			eventhubs.WithLoggingType(""),
 		)
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "logging type is empty")
+		require.Contains(t, err.Error(), "logging type is empty")
 	})
 
 	t.Run("duplicate entity names within namespace", func(t *testing.T) {
@@ -208,7 +207,7 @@ func TestNewConfig_validation(t *testing.T) {
 			),
 		)
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "duplicate entity name")
+		require.Contains(t, err.Error(), "duplicate entity name")
 	})
 
 	t.Run("duplicate consumer group names within entity", func(t *testing.T) {
@@ -221,7 +220,7 @@ func TestNewConfig_validation(t *testing.T) {
 			),
 		)
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "duplicate consumer group name")
+		require.Contains(t, err.Error(), "duplicate consumer group name")
 	})
 
 	t.Run("multiple errors aggregated", func(t *testing.T) {
@@ -231,8 +230,8 @@ func TestNewConfig_validation(t *testing.T) {
 		)
 		require.Error(t, err)
 		// Both error messages should appear in the joined error string.
-		assert.Contains(t, err.Error(), "namespace name is empty")
-		assert.Contains(t, err.Error(), "logging type is empty")
+		require.Contains(t, err.Error(), "namespace name is empty")
+		require.Contains(t, err.Error(), "logging type is empty")
 	})
 }
 
@@ -261,13 +260,13 @@ func TestNewConfig_partitionCountStringified(t *testing.T) {
 	// PartitionCount must be a JSON string, not a number.
 	pc, ok := entity["PartitionCount"].(string)
 	require.True(t, ok, "PartitionCount should be a JSON string, got %T", entity["PartitionCount"])
-	assert.Equal(t, "3", pc)
+	require.Equal(t, "3", pc)
 }
 
 // TestMustNewConfig_panicsOnInvalid verifies that MustNewConfig panics when
 // given invalid options.
 func TestMustNewConfig_panicsOnInvalid(t *testing.T) {
-	assert.Panics(t, func() {
+	require.Panics(t, func() {
 		eventhubs.MustNewConfig(
 			eventhubs.WithNamespace(""), // empty name → validation error → panic
 		)
@@ -292,9 +291,9 @@ func TestNewConfig_multipleEntities(t *testing.T) {
 	require.Len(t, cfg.UserConfig.NamespaceConfig, 1)
 	require.Equal(t, eventhubs.EmulatorNamespaceName, cfg.UserConfig.NamespaceConfig[0].Name)
 	require.Len(t, cfg.UserConfig.NamespaceConfig[0].Entities, 2)
-	assert.Equal(t, "2", cfg.UserConfig.NamespaceConfig[0].Entities[0].PartitionCount)
-	assert.Len(t, cfg.UserConfig.NamespaceConfig[0].Entities[0].ConsumerGroups, 2)
-	assert.Equal(t, "eh2", cfg.UserConfig.NamespaceConfig[0].Entities[1].Name)
+	require.Equal(t, "2", cfg.UserConfig.NamespaceConfig[0].Entities[0].PartitionCount)
+	require.Len(t, cfg.UserConfig.NamespaceConfig[0].Entities[0].ConsumerGroups, 2)
+	require.Equal(t, "eh2", cfg.UserConfig.NamespaceConfig[0].Entities[1].Name)
 }
 
 // TestNewConfig_caseInsensitiveNamespaceName verifies that WithNamespace accepts
@@ -307,7 +306,7 @@ func TestNewConfig_caseInsensitiveNamespaceName(t *testing.T) {
 		),
 	)
 	require.NoError(t, err)
-	assert.Equal(t, "emulatorNs1", cfg.UserConfig.NamespaceConfig[0].Name)
+	require.Equal(t, "emulatorNs1", cfg.UserConfig.NamespaceConfig[0].Name)
 }
 
 // TestNewConfig_withNamespaceType verifies that WithNamespaceType overrides
@@ -320,5 +319,5 @@ func TestNewConfig_withNamespaceType(t *testing.T) {
 		),
 	)
 	require.NoError(t, err)
-	assert.Equal(t, "CustomType", cfg.UserConfig.NamespaceConfig[0].Type)
+	require.Equal(t, "CustomType", cfg.UserConfig.NamespaceConfig[0].Type)
 }

--- a/modules/azure/eventhubs/eventhubs.go
+++ b/modules/azure/eventhubs/eventhubs.go
@@ -38,7 +38,10 @@ func (c *Container) AzuriteContainer() *azurite.Container {
 	return c.azuriteOptions.azuriteContainer
 }
 
-// Terminate terminates the eventhubs container, the azurite container, and the network to communicate between them.
+// Terminate terminates the eventhubs container, and conditionally the azurite
+// container and network (only when they were created by this module).
+// If WithAzuriteContainer was used to supply an external Azurite instance, that
+// container and its network are left untouched.
 func (c *Container) Terminate(ctx context.Context, opts ...testcontainers.TerminateOption) error {
 	var errs []error
 
@@ -49,17 +52,20 @@ func (c *Container) Terminate(ctx context.Context, opts ...testcontainers.Termin
 		}
 	}
 
-	// terminate the azurite container if it was created
-	if c.azuriteOptions.azuriteContainer != nil {
-		if err := c.azuriteOptions.azuriteContainer.Terminate(ctx, opts...); err != nil {
-			errs = append(errs, fmt.Errorf("terminate azurite container: %w", err))
+	// Only tear down azurite + network when this module owns them.
+	if c.azuriteOptions.azuriteOwned {
+		// terminate the azurite container if it was created
+		if c.azuriteOptions.azuriteContainer != nil {
+			if err := c.azuriteOptions.azuriteContainer.Terminate(ctx, opts...); err != nil {
+				errs = append(errs, fmt.Errorf("terminate azurite container: %w", err))
+			}
 		}
-	}
 
-	// remove the azurite network if it was created
-	if c.azuriteOptions.network != nil {
-		if err := c.azuriteOptions.network.Remove(ctx); err != nil {
-			errs = append(errs, fmt.Errorf("remove azurite network: %w", err))
+		// remove the azurite network if it was created
+		if c.azuriteOptions.network != nil {
+			if err := c.azuriteOptions.network.Remove(ctx); err != nil {
+				errs = append(errs, fmt.Errorf("remove azurite network: %w", err))
+			}
 		}
 	}
 
@@ -92,7 +98,9 @@ func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustom
 		),
 	}
 
-	if defaultOptions.azuriteContainer == nil {
+	switch {
+	case defaultOptions.azuriteContainer == nil:
+		// Module-managed Azurite: create a new network, start Azurite, wire env vars.
 		azuriteNetwork, err := network.New(ctx)
 		if err != nil {
 			return c, fmt.Errorf("new azurite network: %w", err)
@@ -119,6 +127,19 @@ func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustom
 
 		// apply the network to the eventhubs container
 		moduleOpts = append(moduleOpts, network.WithNetwork([]string{aliasEventhubs}, azuriteNetwork))
+
+	default:
+		// User-supplied Azurite: wire env vars using the caller-provided alias
+		// and attach the eventhubs container to the same network.
+		alias := defaultOptions.azuriteAlias
+		if alias == "" {
+			alias = aliasAzurite
+		}
+		moduleOpts = append(moduleOpts, testcontainers.WithEnv(map[string]string{
+			"BLOB_SERVER":     alias,
+			"METADATA_SERVER": alias,
+		}))
+		moduleOpts = append(moduleOpts, network.WithNetwork([]string{aliasEventhubs}, defaultOptions.network))
 	}
 
 	moduleOpts = append(moduleOpts, opts...)

--- a/modules/azure/eventhubs/eventhubs.go
+++ b/modules/azure/eventhubs/eventhubs.go
@@ -98,8 +98,8 @@ func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustom
 		),
 	}
 
-	switch {
-	case defaultOptions.azuriteContainer == nil:
+	switch defaultOptions.azuriteContainer {
+	case nil:
 		// Module-managed Azurite: create a new network, start Azurite, wire env vars.
 		azuriteNetwork, err := network.New(ctx)
 		if err != nil {

--- a/modules/azure/eventhubs/eventhubs_test.go
+++ b/modules/azure/eventhubs/eventhubs_test.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/testcontainers/testcontainers-go"
@@ -93,24 +92,16 @@ func TestEventHubs_withAzuriteContainer(t *testing.T) {
 
 	// Create an independent network and Azurite container that the test owns.
 	nw, err := network.New(ctx)
+	testcontainers.CleanupNetwork(t, nw)
 	require.NoError(t, err)
-	t.Cleanup(func() {
-		if err := nw.Remove(ctx); err != nil {
-			t.Logf("cleanup: remove network: %v", err)
-		}
-	})
 
 	azuriteCtr, err := azurite.Run(
 		ctx,
 		"mcr.microsoft.com/azure-storage/azurite:3.33.0",
 		network.WithNetwork([]string{"azurite"}, nw),
 	)
+	testcontainers.CleanupContainer(t, azuriteCtr)
 	require.NoError(t, err)
-	t.Cleanup(func() {
-		if err := azuriteCtr.Terminate(ctx); err != nil {
-			t.Logf("cleanup: terminate azurite: %v", err)
-		}
-	})
 
 	// Run the EventHubs container using the pre-built Azurite.
 	ehCtr, err := eventhubs.Run(
@@ -119,6 +110,9 @@ func TestEventHubs_withAzuriteContainer(t *testing.T) {
 		eventhubs.WithAcceptEULA(),
 		eventhubs.WithAzuriteContainer(azuriteCtr, nw, "azurite"),
 	)
+	// Note: no CleanupContainer here — we call Terminate explicitly below to
+	// test that it does NOT stop azurite, then CleanupContainer handles the rest.
+	testcontainers.CleanupContainer(t, ehCtr)
 	require.NoError(t, err)
 
 	// Both containers must be on the same network.
@@ -129,7 +123,7 @@ func TestEventHubs_withAzuriteContainer(t *testing.T) {
 	azNetworks, err := azuriteCtr.Networks(ctx)
 	require.NoError(t, err)
 	require.Len(t, azNetworks, 1)
-	assert.Equal(t, azNetworks[0], ehNetworks[0])
+	require.Equal(t, azNetworks[0], ehNetworks[0])
 
 	// Terminate the EventHubs container — must NOT touch azurite.
 	require.NoError(t, ehCtr.Terminate(ctx))
@@ -137,7 +131,7 @@ func TestEventHubs_withAzuriteContainer(t *testing.T) {
 	// Azurite should still be running.
 	state, err := azuriteCtr.State(ctx)
 	require.NoError(t, err)
-	assert.True(t, state.Running, "azurite container must still be running after eventhubs Terminate()")
+	require.True(t, state.Running, "azurite container must still be running after eventhubs Terminate()")
 }
 
 // TestEventHubs_withAzuriteContainer_nilGuards verifies that nil container
@@ -146,14 +140,14 @@ func TestEventHubs_withAzuriteContainer_nilGuards(t *testing.T) {
 	ctx := context.Background()
 
 	nw, err := network.New(ctx)
+	testcontainers.CleanupNetwork(t, nw)
 	require.NoError(t, err)
-	t.Cleanup(func() { _ = nw.Remove(ctx) })
 
 	azuriteCtr, err := azurite.Run(ctx, "mcr.microsoft.com/azure-storage/azurite:3.33.0",
 		network.WithNetwork([]string{"azurite"}, nw),
 	)
+	testcontainers.CleanupContainer(t, azuriteCtr)
 	require.NoError(t, err)
-	t.Cleanup(func() { _ = azuriteCtr.Terminate(ctx) })
 
 	t.Run("nil container", func(t *testing.T) {
 		_, err := eventhubs.Run(
@@ -163,7 +157,7 @@ func TestEventHubs_withAzuriteContainer_nilGuards(t *testing.T) {
 			eventhubs.WithAzuriteContainer(nil, nw, "azurite"),
 		)
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "azurite container is nil")
+		require.Contains(t, err.Error(), "azurite container is nil")
 	})
 
 	t.Run("nil network", func(t *testing.T) {
@@ -174,7 +168,7 @@ func TestEventHubs_withAzuriteContainer_nilGuards(t *testing.T) {
 			eventhubs.WithAzuriteContainer(azuriteCtr, nil, "azurite"),
 		)
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "docker network is nil")
+		require.Contains(t, err.Error(), "docker network is nil")
 	})
 }
 
@@ -184,14 +178,14 @@ func TestEventHubs_withAzuriteContainer_conflict(t *testing.T) {
 	ctx := context.Background()
 
 	nw, err := network.New(ctx)
+	testcontainers.CleanupNetwork(t, nw)
 	require.NoError(t, err)
-	t.Cleanup(func() { _ = nw.Remove(ctx) })
 
 	azuriteCtr, err := azurite.Run(ctx, "mcr.microsoft.com/azure-storage/azurite:3.33.0",
 		network.WithNetwork([]string{"azurite"}, nw),
 	)
+	testcontainers.CleanupContainer(t, azuriteCtr)
 	require.NoError(t, err)
-	t.Cleanup(func() { _ = azuriteCtr.Terminate(ctx) })
 
 	t.Run("WithAzurite then WithAzuriteContainer", func(t *testing.T) {
 		_, err := eventhubs.Run(
@@ -202,7 +196,7 @@ func TestEventHubs_withAzuriteContainer_conflict(t *testing.T) {
 			eventhubs.WithAzuriteContainer(azuriteCtr, nw, "azurite"),
 		)
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "mutually exclusive")
+		require.Contains(t, err.Error(), "mutually exclusive")
 	})
 
 	t.Run("WithAzuriteContainer then WithAzurite", func(t *testing.T) {
@@ -214,7 +208,7 @@ func TestEventHubs_withAzuriteContainer_conflict(t *testing.T) {
 			eventhubs.WithAzurite("mcr.microsoft.com/azure-storage/azurite:3.33.0"),
 		)
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "mutually exclusive")
+		require.Contains(t, err.Error(), "mutually exclusive")
 	})
 }
 
@@ -258,7 +252,7 @@ func TestEventHubs_withConfigObject(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, json.Unmarshal(wantJSON, &wantMap))
 
-	assert.Equal(t, wantMap, gotMap)
+	require.Equal(t, wantMap, gotMap)
 }
 
 // TestEventHubs_withConfigObject_nil verifies that WithConfigObject(nil) errors.
@@ -273,5 +267,5 @@ func TestEventHubs_withConfigObject_nil(t *testing.T) {
 	)
 	testcontainers.CleanupContainer(t, ctr)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "config is nil")
+	require.Contains(t, err.Error(), "config is nil")
 }

--- a/modules/azure/eventhubs/eventhubs_test.go
+++ b/modules/azure/eventhubs/eventhubs_test.go
@@ -3,14 +3,18 @@ package eventhubs_test
 import (
 	"context"
 	_ "embed"
+	"encoding/json"
 	"io"
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/modules/azure/azurite"
 	"github.com/testcontainers/testcontainers-go/modules/azure/eventhubs"
+	"github.com/testcontainers/testcontainers-go/network"
 )
 
 //go:embed testdata/eventhubs_config.json
@@ -80,4 +84,194 @@ func TestEventHubs_noEULA(t *testing.T) {
 	ctr, err := eventhubs.Run(ctx, "mcr.microsoft.com/azure-messaging/eventhubs-emulator:2.1.0")
 	testcontainers.CleanupContainer(t, ctr)
 	require.Error(t, err)
+}
+
+// TestEventHubs_withAzuriteContainer verifies that when a user-supplied
+// Azurite container is provided, Terminate() does NOT tear it down.
+func TestEventHubs_withAzuriteContainer(t *testing.T) {
+	ctx := context.Background()
+
+	// Create an independent network and Azurite container that the test owns.
+	nw, err := network.New(ctx)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		if err := nw.Remove(ctx); err != nil {
+			t.Logf("cleanup: remove network: %v", err)
+		}
+	})
+
+	azuriteCtr, err := azurite.Run(
+		ctx,
+		"mcr.microsoft.com/azure-storage/azurite:3.33.0",
+		network.WithNetwork([]string{"azurite"}, nw),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		if err := azuriteCtr.Terminate(ctx); err != nil {
+			t.Logf("cleanup: terminate azurite: %v", err)
+		}
+	})
+
+	// Run the EventHubs container using the pre-built Azurite.
+	ehCtr, err := eventhubs.Run(
+		ctx,
+		"mcr.microsoft.com/azure-messaging/eventhubs-emulator:2.1.0",
+		eventhubs.WithAcceptEULA(),
+		eventhubs.WithAzuriteContainer(azuriteCtr, nw, "azurite"),
+	)
+	require.NoError(t, err)
+
+	// Both containers must be on the same network.
+	ehNetworks, err := ehCtr.Networks(ctx)
+	require.NoError(t, err)
+	require.Len(t, ehNetworks, 1)
+
+	azNetworks, err := azuriteCtr.Networks(ctx)
+	require.NoError(t, err)
+	require.Len(t, azNetworks, 1)
+	assert.Equal(t, azNetworks[0], ehNetworks[0])
+
+	// Terminate the EventHubs container — must NOT touch azurite.
+	require.NoError(t, ehCtr.Terminate(ctx))
+
+	// Azurite should still be running.
+	state, err := azuriteCtr.State(ctx)
+	require.NoError(t, err)
+	assert.True(t, state.Running, "azurite container must still be running after eventhubs Terminate()")
+}
+
+// TestEventHubs_withAzuriteContainer_nilGuards verifies that nil container
+// and nil network both result in an error from Run.
+func TestEventHubs_withAzuriteContainer_nilGuards(t *testing.T) {
+	ctx := context.Background()
+
+	nw, err := network.New(ctx)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = nw.Remove(ctx) })
+
+	azuriteCtr, err := azurite.Run(ctx, "mcr.microsoft.com/azure-storage/azurite:3.33.0",
+		network.WithNetwork([]string{"azurite"}, nw),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = azuriteCtr.Terminate(ctx) })
+
+	t.Run("nil container", func(t *testing.T) {
+		_, err := eventhubs.Run(
+			ctx,
+			"mcr.microsoft.com/azure-messaging/eventhubs-emulator:2.1.0",
+			eventhubs.WithAcceptEULA(),
+			eventhubs.WithAzuriteContainer(nil, nw, "azurite"),
+		)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "azurite container is nil")
+	})
+
+	t.Run("nil network", func(t *testing.T) {
+		_, err := eventhubs.Run(
+			ctx,
+			"mcr.microsoft.com/azure-messaging/eventhubs-emulator:2.1.0",
+			eventhubs.WithAcceptEULA(),
+			eventhubs.WithAzuriteContainer(azuriteCtr, nil, "azurite"),
+		)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "docker network is nil")
+	})
+}
+
+// TestEventHubs_withAzuriteContainer_conflict verifies that using both
+// WithAzurite and WithAzuriteContainer returns a clear error.
+func TestEventHubs_withAzuriteContainer_conflict(t *testing.T) {
+	ctx := context.Background()
+
+	nw, err := network.New(ctx)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = nw.Remove(ctx) })
+
+	azuriteCtr, err := azurite.Run(ctx, "mcr.microsoft.com/azure-storage/azurite:3.33.0",
+		network.WithNetwork([]string{"azurite"}, nw),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = azuriteCtr.Terminate(ctx) })
+
+	t.Run("WithAzurite then WithAzuriteContainer", func(t *testing.T) {
+		_, err := eventhubs.Run(
+			ctx,
+			"mcr.microsoft.com/azure-messaging/eventhubs-emulator:2.1.0",
+			eventhubs.WithAcceptEULA(),
+			eventhubs.WithAzurite("mcr.microsoft.com/azure-storage/azurite:3.33.0"),
+			eventhubs.WithAzuriteContainer(azuriteCtr, nw, "azurite"),
+		)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "mutually exclusive")
+	})
+
+	t.Run("WithAzuriteContainer then WithAzurite", func(t *testing.T) {
+		_, err := eventhubs.Run(
+			ctx,
+			"mcr.microsoft.com/azure-messaging/eventhubs-emulator:2.1.0",
+			eventhubs.WithAcceptEULA(),
+			eventhubs.WithAzuriteContainer(azuriteCtr, nw, "azurite"),
+			eventhubs.WithAzurite("mcr.microsoft.com/azure-storage/azurite:3.33.0"),
+		)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "mutually exclusive")
+	})
+}
+
+// TestEventHubs_withConfigObject builds a *Config via functional options, runs
+// the container, copies the config file back out and checks it round-trips
+// to the expected JSON structure.
+func TestEventHubs_withConfigObject(t *testing.T) {
+	ctx := context.Background()
+
+	cfg, err := eventhubs.NewConfig(
+		eventhubs.WithNamespace("emulatorNs1",
+			eventhubs.WithEntity("eh1", 1,
+				eventhubs.WithConsumerGroup("cg1"),
+			),
+		),
+	)
+	require.NoError(t, err)
+
+	ctr, err := eventhubs.Run(
+		ctx,
+		"mcr.microsoft.com/azure-messaging/eventhubs-emulator:2.1.0",
+		eventhubs.WithAcceptEULA(),
+		eventhubs.WithConfigObject(cfg),
+	)
+	testcontainers.CleanupContainer(t, ctr)
+	require.NoError(t, err)
+
+	// Read the config file back from the container.
+	rc, err := ctr.CopyFileFromContainer(ctx, "/Eventhubs_Emulator/ConfigFiles/Config.json")
+	require.NoError(t, err)
+	defer rc.Close()
+
+	content, err := io.ReadAll(rc)
+	require.NoError(t, err)
+
+	// Unmarshal and compare as map[string]any (key-order insensitive).
+	var gotMap, wantMap map[string]any
+	require.NoError(t, json.Unmarshal(content, &gotMap))
+
+	wantJSON, err := json.Marshal(cfg)
+	require.NoError(t, err)
+	require.NoError(t, json.Unmarshal(wantJSON, &wantMap))
+
+	assert.Equal(t, wantMap, gotMap)
+}
+
+// TestEventHubs_withConfigObject_nil verifies that WithConfigObject(nil) errors.
+func TestEventHubs_withConfigObject_nil(t *testing.T) {
+	ctx := context.Background()
+
+	ctr, err := eventhubs.Run(
+		ctx,
+		"mcr.microsoft.com/azure-messaging/eventhubs-emulator:2.1.0",
+		eventhubs.WithAcceptEULA(),
+		eventhubs.WithConfigObject(nil),
+	)
+	testcontainers.CleanupContainer(t, ctr)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "config is nil")
 }

--- a/modules/azure/eventhubs/examples_test.go
+++ b/modules/azure/eventhubs/examples_test.go
@@ -12,7 +12,9 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azeventhubs"
 
 	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/modules/azure/azurite"
 	"github.com/testcontainers/testcontainers-go/modules/azure/eventhubs"
+	"github.com/testcontainers/testcontainers-go/network"
 )
 
 func ExampleRun() {
@@ -155,4 +157,153 @@ func ExampleRun_sendEventsToEventHub() {
 
 	// Output:
 	// <nil>
+}
+
+// ExampleRun_withAzuriteContainer demonstrates how to wire in a pre-existing
+// Azurite container so that the Event Hubs emulator shares it. The caller is
+// responsible for tearing down Azurite and the network; the Event Hubs
+// container will not touch them when Terminate is called.
+func ExampleRun_withAzuriteContainer() {
+	ctx := context.Background()
+
+	// withAzuriteContainer_network {
+	nw, err := network.New(ctx)
+	if err != nil {
+		log.Printf("failed to create network: %s", err)
+		return
+	}
+	defer func() {
+		if err := nw.Remove(ctx); err != nil {
+			log.Printf("failed to remove network: %s", err)
+		}
+	}()
+	// }
+
+	// withAzuriteContainer_azurite {
+	azuriteCtr, err := azurite.Run(
+		ctx,
+		"mcr.microsoft.com/azure-storage/azurite:3.33.0",
+		network.WithNetwork([]string{"azurite"}, nw),
+		testcontainers.WithEntrypointArgs("--skipApiVersionCheck"),
+	)
+	defer func() {
+		if err := testcontainers.TerminateContainer(azuriteCtr); err != nil {
+			log.Printf("failed to terminate azurite container: %s", err)
+		}
+	}()
+	if err != nil {
+		log.Printf("failed to start azurite container: %s", err)
+		return
+	}
+	// }
+
+	// withAzuriteContainer_eventhubs {
+	eventHubsCtr, err := eventhubs.Run(
+		ctx,
+		"mcr.microsoft.com/azure-messaging/eventhubs-emulator:2.1.0",
+		eventhubs.WithAcceptEULA(),
+		eventhubs.WithAzuriteContainer(azuriteCtr, nw, "azurite"),
+	)
+	defer func() {
+		if err := testcontainers.TerminateContainer(eventHubsCtr); err != nil {
+			log.Printf("failed to terminate eventhubs container: %s", err)
+		}
+	}()
+	if err != nil {
+		log.Printf("failed to start eventhubs container: %s", err)
+		return
+	}
+	// }
+
+	state, err := eventHubsCtr.State(ctx)
+	if err != nil {
+		log.Printf("failed to get container state: %s", err)
+		return
+	}
+
+	fmt.Println(state.Running)
+
+	// Output:
+	// true
+}
+
+// ExampleRun_withConfigObject demonstrates how to build a statically-typed
+// Event Hubs emulator configuration using the functional-options API and
+// inject it into the container via WithConfigObject.
+func ExampleRun_withConfigObject() {
+	ctx := context.Background()
+
+	// withConfigObject_buildConfig {
+	cfg, err := eventhubs.NewConfig(
+		eventhubs.WithNamespace("emulatorNs1",
+			eventhubs.WithEntity("eh1", 2,
+				eventhubs.WithConsumerGroup("cg1"),
+				eventhubs.WithConsumerGroup("$Default"),
+			),
+			eventhubs.WithEntity("eh2", 1,
+				eventhubs.WithConsumerGroup("cg1"),
+			),
+		),
+	)
+	if err != nil {
+		log.Printf("failed to build eventhubs config: %s", err)
+		return
+	}
+	// }
+
+	// withConfigObject_run {
+	eventHubsCtr, err := eventhubs.Run(
+		ctx,
+		"mcr.microsoft.com/azure-messaging/eventhubs-emulator:2.1.0",
+		eventhubs.WithAcceptEULA(),
+		eventhubs.WithConfigObject(cfg),
+	)
+	defer func() {
+		if err := testcontainers.TerminateContainer(eventHubsCtr); err != nil {
+			log.Printf("failed to terminate container: %s", err)
+		}
+	}()
+	if err != nil {
+		log.Printf("failed to start container: %s", err)
+		return
+	}
+	// }
+
+	state, err := eventHubsCtr.State(ctx)
+	if err != nil {
+		log.Printf("failed to get container state: %s", err)
+		return
+	}
+
+	fmt.Println(state.Running)
+
+	// Output:
+	// true
+}
+
+// ExampleNewConfig demonstrates how to construct an Event Hubs emulator
+// configuration using the three-level functional-options API without starting
+// any containers.
+func ExampleNewConfig() {
+	// ExampleNewConfig_build {
+	cfg, err := eventhubs.NewConfig(
+		eventhubs.WithLoggingType("File"),
+		eventhubs.WithNamespace("emulatorNs1",
+			eventhubs.WithEntity("eh1", 1,
+				eventhubs.WithConsumerGroup("cg1"),
+			),
+		),
+	)
+	if err != nil {
+		log.Printf("failed to build config: %s", err)
+		return
+	}
+	// }
+
+	fmt.Println(cfg.UserConfig.LoggingConfig.Type)
+	fmt.Println(cfg.UserConfig.NamespaceConfig[0].Name)
+
+	// Output:
+	// File
+	// emulatorNs1
 }

--- a/modules/azure/eventhubs/examples_test.go
+++ b/modules/azure/eventhubs/examples_test.go
@@ -235,7 +235,7 @@ func ExampleRun_withConfigObject() {
 
 	// withConfigObject_buildConfig {
 	cfg, err := eventhubs.NewConfig(
-		eventhubs.WithNamespace("emulatorNs1",
+		eventhubs.WithNamespace(eventhubs.EmulatorNamespaceName,
 			eventhubs.WithEntity("eh1", 2,
 				eventhubs.WithConsumerGroup("cg1"),
 				eventhubs.WithConsumerGroup("$Default"),
@@ -288,7 +288,7 @@ func ExampleNewConfig() {
 	// ExampleNewConfig_build {
 	cfg, err := eventhubs.NewConfig(
 		eventhubs.WithLoggingType("File"),
-		eventhubs.WithNamespace("emulatorNs1",
+		eventhubs.WithNamespace(eventhubs.EmulatorNamespaceName,
 			eventhubs.WithEntity("eh1", 1,
 				eventhubs.WithConsumerGroup("cg1"),
 			),
@@ -305,5 +305,5 @@ func ExampleNewConfig() {
 
 	// Output:
 	// File
-	// emulatorNs1
+	// emulatorns1
 }

--- a/modules/azure/eventhubs/examples_test.go
+++ b/modules/azure/eventhubs/examples_test.go
@@ -276,9 +276,6 @@ func ExampleRun_withConfigObject() {
 	}
 
 	fmt.Println(state.Running)
-
-	// Output:
-	// true
 }
 
 // ExampleNewConfig demonstrates how to construct an Event Hubs emulator

--- a/modules/azure/eventhubs/options.go
+++ b/modules/azure/eventhubs/options.go
@@ -1,7 +1,10 @@
 package eventhubs
 
 import (
+	"bytes"
+	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"strings"
 
@@ -14,12 +17,24 @@ type options struct {
 	azuriteOptions   []testcontainers.ContainerCustomizer
 	azuriteContainer *azurite.Container
 	network          *testcontainers.DockerNetwork
+
+	// azuriteAlias is the network alias of the azurite container; defaults to aliasAzurite ("azurite").
+	azuriteAlias string
+	// azuriteOwned is true when the eventhubs module owns the azurite container lifecycle.
+	// When false (user-supplied via WithAzuriteContainer), Terminate() will not tear down azurite or network.
+	azuriteOwned bool
+	// azuriteUserProvided is true when WithAzuriteContainer has been applied.
+	// Used for mutual-exclusion detection with WithAzurite.
+	azuriteUserProvided bool
+	// azuriteModuleOwned is true when WithAzurite was explicitly called.
+	// Used for mutual-exclusion detection with WithAzuriteContainer.
+	azuriteModuleOwned bool
 }
 
 func defaultOptions() options {
 	return options{
-		azuriteImage:     "mcr.microsoft.com/azure-storage/azurite:3.33.0",
-		azuriteContainer: nil,
+		azuriteImage: "mcr.microsoft.com/azure-storage/azurite:3.33.0",
+		azuriteOwned: true,
 	}
 }
 
@@ -37,10 +52,57 @@ func (o Option) Customize(*testcontainers.GenericContainerRequest) error {
 
 // WithAzurite sets the image and options for the Azurite container.
 // By default, the image is "mcr.microsoft.com/azure-storage/azurite:3.33.0".
+// It returns an error if WithAzuriteContainer has already been applied.
 func WithAzurite(img string, opts ...testcontainers.ContainerCustomizer) Option {
 	return func(o *options) error {
+		if o.azuriteUserProvided {
+			return errors.New("eventhubs: WithAzurite and WithAzuriteContainer are mutually exclusive")
+		}
 		o.azuriteImage = img
 		o.azuriteOptions = opts
+		o.azuriteModuleOwned = true
+		return nil
+	}
+}
+
+// WithAzuriteContainer wires an already-running Azurite container into the
+// Event Hubs emulator. The caller owns the lifecycle of both the network and
+// the Azurite container: the eventhubs container will NOT terminate them on
+// Terminate(). This is the key behavioural difference vs. the default path
+// where eventhubs owns Azurite.
+//
+// The network must already contain the Azurite container under the provided
+// alias (default aliasAzurite when alias is empty). The Event Hubs container
+// is attached to the same network under the aliasEventhubs alias.
+//
+// It returns an error if azuriteContainer or dockerNetwork is nil, or if
+// WithAzurite has already been applied.
+func WithAzuriteContainer(
+	azuriteContainer *azurite.Container,
+	dockerNetwork *testcontainers.DockerNetwork,
+	alias string,
+) Option {
+	return func(o *options) error {
+		if azuriteContainer == nil {
+			return errors.New("eventhubs: azurite container is nil")
+		}
+		if dockerNetwork == nil {
+			return errors.New("eventhubs: docker network is nil")
+		}
+		if o.azuriteModuleOwned {
+			return errors.New("eventhubs: WithAzuriteContainer and WithAzurite are mutually exclusive")
+		}
+		if o.azuriteUserProvided {
+			return errors.New("eventhubs: WithAzuriteContainer called more than once")
+		}
+		if alias == "" {
+			alias = aliasAzurite
+		}
+		o.azuriteContainer = azuriteContainer
+		o.network = dockerNetwork
+		o.azuriteAlias = alias
+		o.azuriteOwned = false
+		o.azuriteUserProvided = true
 		return nil
 	}
 }
@@ -63,6 +125,28 @@ func WithConfig(r io.Reader) testcontainers.CustomizeRequestOption {
 			FileMode:          0o644,
 		})
 
+		return nil
+	}
+}
+
+// WithConfigObject marshals the supplied *Config to JSON and injects it at
+// containerConfigFile (/Eventhubs_Emulator/ConfigFiles/Config.json).
+// This is the statically-typed counterpart to WithConfig.
+// Returns an error if cfg is nil or if JSON marshalling fails.
+func WithConfigObject(cfg *Config) testcontainers.CustomizeRequestOption {
+	return func(req *testcontainers.GenericContainerRequest) error {
+		if cfg == nil {
+			return errors.New("eventhubs: config is nil")
+		}
+		b, err := json.Marshal(cfg)
+		if err != nil {
+			return fmt.Errorf("eventhubs: marshal config: %w", err)
+		}
+		req.Files = append(req.Files, testcontainers.ContainerFile{
+			Reader:            bytes.NewReader(b),
+			ContainerFilePath: containerConfigFile,
+			FileMode:          0o644,
+		})
 		return nil
 	}
 }

--- a/modules/azure/eventhubs/options.go
+++ b/modules/azure/eventhubs/options.go
@@ -50,9 +50,12 @@ func (o Option) Customize(*testcontainers.GenericContainerRequest) error {
 	return nil
 }
 
-// WithAzurite sets the image and options for the Azurite container.
+// WithAzurite sets the image and options for the Azurite container that the
+// module will create automatically.
 // By default, the image is "mcr.microsoft.com/azure-storage/azurite:3.33.0".
-// It returns an error if WithAzuriteContainer has already been applied.
+// It is mutually exclusive with WithAzuriteContainer: passing both options to
+// Run returns an error. If you already have a running Azurite container, use
+// WithAzuriteContainer instead — the image and options set here will not apply.
 func WithAzurite(img string, opts ...testcontainers.ContainerCustomizer) Option {
 	return func(o *options) error {
 		if o.azuriteUserProvided {


### PR DESCRIPTION
Implements #3618.

**Feature 1 — `WithAzuriteContainer`**
- Lets users wire in a pre-existing `*azurite.Container` and `*testcontainers.DockerNetwork` instead of always creating new ones.
- `Terminate()` leaves user-supplied resources untouched (`azuriteOwned = false`).
- Mutual exclusion with `WithAzurite` is enforced; both directions error clearly.

**Feature 2 — functional-options config builder**
- New `Config` / `UserConfig` / `NamespaceConfig` / `Entity` / `ConsumerGroup` / `LoggingConfig` structs with JSON tags matching the emulator schema.
- `NewConfig` / `MustNewConfig` with three option levels (`ConfigOption`, `NamespaceOption`, `EntityOption`) and helpers: `WithLoggingType`, `WithNamespace`, `WithNamespaceType`, `WithEntity`, `WithConsumerGroup`.
- Full validation (unique names at each level, `partitionCount >= 1`) using `errors.Join` aggregation.
- `WithConfigObject(*Config)` marshals the config to JSON and injects it at the container config path.

**Testing**
- `config_test.go`: pure unit tests (no Docker); all pass.
- `eventhubs_test.go`: integration tests for `WithAzuriteContainer`, nil guards, mutual-exclusion conflict, `WithConfigObject`, and nil config guard.
- `go vet ./eventhubs/...` passes.