### PR TITLE
feat!: add PullImageWithOpts and PullDockerImageWithPlatform

### DIFF
--- a/docker.go
+++ b/docker.go
@@ -1905,17 +1905,25 @@ func (p *DockerProvider) PullImage(ctx context.Context, img string) error {
 	return p.attemptToPullImage(ctx, img, client.ImagePullOptions{})
 }
 
-// PullImageWithPlatform pulls an image from the registry for the given platform (e.g. "linux/amd64").
-func (p *DockerProvider) PullImageWithPlatform(ctx context.Context, img, platform string) error {
-	pullOpt := client.ImagePullOptions{}
-	if platform != "" {
-		pf, err := platforms.Parse(platform)
-		if err != nil {
-			return fmt.Errorf("invalid platform %s: %w", platform, err)
+// PullImageWithOpts pulls image from registry, passing options to the provider.
+func (p *DockerProvider) PullImageWithOpts(ctx context.Context, img string, opts ...PullImageOption) error {
+	pullOpts := pullImageOptions{}
+
+	for _, opt := range opts {
+		if err := opt(&pullOpts); err != nil {
+			return fmt.Errorf("applying pull image option: %w", err)
 		}
-		pullOpt.Platforms = append(pullOpt.Platforms, pf)
 	}
-	return p.attemptToPullImage(ctx, img, pullOpt)
+
+	return p.attemptToPullImage(ctx, img, pullOpts.dockerPullOpts)
+}
+
+func PullDockerImageWithPlatform(platform specs.Platform) PullImageOption {
+	return func(opts *pullImageOptions) error {
+		opts.dockerPullOpts.Platforms = append(opts.dockerPullOpts.Platforms, platform)
+
+		return nil
+	}
 }
 
 var permanentClientErrors = []func(error) bool{

--- a/docker_test.go
+++ b/docker_test.go
@@ -19,8 +19,10 @@ import (
 	"time"
 
 	"github.com/containerd/errdefs"
+	"github.com/containerd/platforms"
 	"github.com/moby/moby/api/types/container"
 	"github.com/moby/moby/client"
+	specs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/stretchr/testify/require"
 
 	"github.com/testcontainers/testcontainers-go/internal/core"
@@ -1654,6 +1656,7 @@ type errMockCli struct {
 	imageBuildCount    int
 	containerListCount int
 	imagePullCount     int
+	imagePullOpts      []client.ImagePullOptions
 }
 
 type fakeStreamResult struct {
@@ -1674,8 +1677,9 @@ func (f *errMockCli) ContainerList(_ context.Context, _ client.ContainerListOpti
 	return client.ContainerListResult{Items: []container.Summary{{}}}, f.err
 }
 
-func (f *errMockCli) ImagePull(_ context.Context, _ string, _ client.ImagePullOptions) (client.ImagePullResponse, error) {
+func (f *errMockCli) ImagePull(_ context.Context, _ string, opts client.ImagePullOptions) (client.ImagePullResponse, error) {
 	f.imagePullCount++
+	f.imagePullOpts = append(f.imagePullOpts, opts)
 	return fakeStreamResult{ReadCloser: io.NopCloser(&bytes.Buffer{})}, f.err
 }
 
@@ -1870,14 +1874,58 @@ func TestDockerProvider_attemptToPullImage_retries(t *testing.T) {
 	}
 }
 
-func TestDockerProvider_PullImageWithPlatform_invalidPlatform(t *testing.T) {
-	p, err := NewDockerProvider()
-	require.NoError(t, err)
-	defer p.Close()
+func TestPullDockerImageWithPlatform(t *testing.T) {
+	t.Run("single platform", func(t *testing.T) {
+		platform, err := platforms.Parse("linux/amd64")
+		require.NoError(t, err)
 
-	err = p.PullImageWithPlatform(context.Background(), "redis:latest", "not-a-valid-platform")
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "invalid platform")
+		opts := pullImageOptions{}
+		err = PullDockerImageWithPlatform(platform)(&opts)
+		require.NoError(t, err)
+		require.Equal(t, []specs.Platform{platform}, opts.dockerPullOpts.Platforms)
+	})
+
+	t.Run("multiple platforms via separate options", func(t *testing.T) {
+		amd64, err := platforms.Parse("linux/amd64")
+		require.NoError(t, err)
+		arm64, err := platforms.Parse("linux/arm64")
+		require.NoError(t, err)
+
+		opts := pullImageOptions{}
+		require.NoError(t, PullDockerImageWithPlatform(amd64)(&opts))
+		require.NoError(t, PullDockerImageWithPlatform(arm64)(&opts))
+		require.Equal(t, []specs.Platform{amd64, arm64}, opts.dockerPullOpts.Platforms)
+	})
+
+	t.Run("invalid platform", func(t *testing.T) {
+		_, err := platforms.Parse("not-a-valid-platform")
+		require.Error(t, err)
+	})
+}
+
+func TestDockerProvider_PullImageWithOpts_separatePullsWithDifferentPlatforms(t *testing.T) {
+	amd64, err := platforms.Parse("linux/amd64")
+	require.NoError(t, err)
+	arm64, err := platforms.Parse("linux/arm64")
+	require.NoError(t, err)
+
+	mock := &errMockCli{}
+	p := &DockerProvider{
+		DockerProviderOptions: &DockerProviderOptions{
+			GenericProviderOptions: &GenericProviderOptions{
+				Logger: log.Default(),
+			},
+		},
+		client: mock,
+	}
+
+	ctx := context.Background()
+	require.NoError(t, p.PullImageWithOpts(ctx, "nginx:mainline", PullDockerImageWithPlatform(amd64)))
+	require.NoError(t, p.PullImageWithOpts(ctx, "nginx:mainline", PullDockerImageWithPlatform(arm64)))
+
+	require.Equal(t, 2, mock.imagePullCount)
+	require.Equal(t, []specs.Platform{amd64}, mock.imagePullOpts[0].Platforms)
+	require.Equal(t, []specs.Platform{arm64}, mock.imagePullOpts[1].Platforms)
 }
 
 func TestCustomPrefixTrailingSlashIsProperlyRemovedIfPresent(t *testing.T) {

--- a/image.go
+++ b/image.go
@@ -18,11 +18,17 @@ type saveImageOptions struct {
 
 type SaveImageOption func(*saveImageOptions) error
 
+type pullImageOptions struct {
+	dockerPullOpts client.ImagePullOptions
+}
+
+type PullImageOption func(*pullImageOptions) error
+
 // ImageProvider allows manipulating images
 type ImageProvider interface {
 	ListImages(context.Context) ([]ImageInfo, error)
 	SaveImages(context.Context, string, ...string) error
 	SaveImagesWithOpts(context.Context, string, []string, ...SaveImageOption) error
 	PullImage(context.Context, string) error
-	PullImageWithPlatform(context.Context, string, string) error
+	PullImageWithOpts(context.Context, string, ...PullImageOption) error
 }


### PR DESCRIPTION
Replace PullImageWithPlatform with a flexible pull options API that mirrors SaveImagesWithOpts, allowing platform-specific pulls via PullDockerImageWithPlatform.

<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?

Honors PullImageWithOpts, replacing the PullImageWithPlatform (which hasn't made it to any release yet, but was recently merged).
Will follow up some k3s changes in a separate PR.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Related issues
Relates to: https://github.com/testcontainers/testcontainers-go/pull/3716
<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- 

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
