### PR TITLE
chore: bump sshd-docker image to 1.4.0

### DIFF
--- a/port_forwarding.go
+++ b/port_forwarding.go
@@ -20,7 +20,7 @@ import (
 
 const (
 	// hubSshdImage {
-	sshdImage string = "testcontainers/sshd:1.3.0"
+	sshdImage string = "testcontainers/sshd:1.4.0"
 	// }
 
 	// HostInternal is the internal hostname used to reach the host from the container,


### PR DESCRIPTION
Bumps the `testcontainers/sshd` image from `1.3.0` to `1.4.0` in `port_forwarding.go`.

Notable changes in 1.4.0:
- Alpine bumped to 3.23
- Added `AddressFamily=any` sshd option (supports IPv4 and IPv6)
- Updated CI actions

Release: https://github.com/testcontainers/sshd-docker/releases/tag/1.4.0