### PR TITLE
fix: consume `ImagePushResponse`

### DIFF
--- a/modules/registry/registry.go
+++ b/modules/registry/registry.go
@@ -192,7 +192,7 @@ func (c *RegistryContainer) PushImage(ctx context.Context, ref string) error {
 		return fmt.Errorf("failed to encode image auth: %w", err)
 	}
 
-	_, err = dockerCli.ImagePush(ctx, ref, client.ImagePushOptions{
+	output, err := dockerCli.ImagePush(ctx, ref, client.ImagePushOptions{
 		All:          true,
 		RegistryAuth: encodedAuth,
 	})
@@ -200,7 +200,16 @@ func (c *RegistryContainer) PushImage(ctx context.Context, ref string) error {
 		return fmt.Errorf("push image %q: %w", ref, err)
 	}
 
-	return c.ImageExists(ctx, ref)
+	for m, err := range output.JSONMessages(ctx) {
+		if err != nil {
+			return fmt.Errorf("push image %q: %w", ref, err)
+		}
+		if err := m.Error; err != nil {
+			return fmt.Errorf("push image %q: %w", ref, err)
+		}
+	}
+
+	return nil
 }
 
 // PullImage pulls an image from an external registry into the local Docker daemon.


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?

Fix to consume the image push response (mirrors existing handling for image pull response).

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?

Encountered an issue this afternoon where pushing to the testcontainers-hosted `registry` silently failed, leaving tests to hang on the `c.ImageExists(...)` check.

I initially patched this locally just to bubble the error message, but surprisingly enough it also fixed the silent failure. I'm not sure if it's entirely deterministic (e.g., tcp backpressure?), or depends on the complexity of the image being pushed _(in my case, pushing the `registry:latest` image into the testcontainers-hosted `registry:latest` container :D)_.

This bug probably deserves more test coverage, but I'm short on time tonight, and wanted to at least get the patch posted before I lose track of it _(c'est la vie)_.