### PR TITLE
chore: use testify's require instead of assert

### DIFF
--- a/modules/compose/compose_test.go
+++ b/modules/compose/compose_test.go
@@ -433,6 +433,6 @@ func checkIfError(t *testing.T, err ExecError) {
 
 	require.NoErrorf(t, err.Stderr, "An error in Stderr happened when running %v", err.Command)
 
-	assert.NotNil(t, err.StdoutOutput)
-	assert.NotNil(t, err.StderrOutput)
+	require.NotNil(t, err.StdoutOutput)
+	require.NotNil(t, err.StderrOutput)
 }

--- a/udp_port_binding_test.go
+++ b/udp_port_binding_test.go
@@ -39,7 +39,7 @@ func TestUDPPortBinding(t *testing.T) {
 		})
 		require.NoError(t, err)
 		defer func() {
-			assert.NoError(t, container.Terminate(ctx))
+			require.NoError(t, container.Terminate(ctx))
 		}()
 
 		// Test MappedPort function - this was the bug
@@ -78,7 +78,7 @@ func TestUDPPortBinding(t *testing.T) {
 		})
 		require.NoError(t, err)
 		defer func() {
-			assert.NoError(t, container.Terminate(ctx))
+			require.NoError(t, container.Terminate(ctx))
 		}()
 
 		tcpPort := "80/tcp"


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->
## What does this PR do?
Replace assert with require for critical checks that should stop test execution on failure:

- udp_port_binding_test.go: Use require.NoError for container cleanup in defer blocks
- compose_test.go: Use require.NotNil for critical error output fields
<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->
This ensures test failures stop immediately at the source rather than continuing with invalid state, making debugging easier.


## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Relates https://github.com/testcontainers/testcontainers-go/issues/2808


<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
