### PR TITLE
fix(docs): update tekton sidecar reference

### DIFF
--- a/docs/system_requirements/ci/tekton.md
+++ b/docs/system_requirements/ci/tekton.md
@@ -1,7 +1,7 @@
 # Tekton
 
 To enable access to Docker in Tekton, a dind sidecar needs to be added. An example of it can be found 
-[here](https://github.com/tektoncd/pipeline/blob/main/examples/v1beta1/taskruns/dind-sidecar.yaml)
+[here]((https://github.com/tektoncd/pipeline/blob/main/examples/v1/taskruns/dind-sidecar.yaml)
 
 This is an example
 


### PR DESCRIPTION
## What does this PR do?

Update a broken documentation reference to Tekton.

## Why is it important?

A documentation link is broken.