### PR TITLE
fix: properly wait for Ryuk startup when reusing reaper

### DIFF
--- a/reaper.go
+++ b/reaper.go
@@ -345,10 +345,12 @@ func (r *reaperSpawner) fromContainer(ctx context.Context, sessionID string, pro
 	log.Printf("⏳ Waiting for Reaper %q to be ready", dockerContainer.ID[:8])
 
 	// Reusing an existing container so we determine the port from the container's exposed ports.
-	if err := wait.ForExposedPort().
-		WithPollInterval(100*time.Millisecond).
-		SkipInternalCheck().
-		WaitUntilReady(ctx, dockerContainer); err != nil {
+	if err := wait.ForAll(
+		wait.ForLog("Started"),
+		wait.ForExposedPort().
+			WithPollInterval(100*time.Millisecond).
+			SkipInternalCheck(),
+	).WaitUntilReady(ctx, dockerContainer); err != nil {
 		return nil, fmt.Errorf("wait for reaper %s: %w", dockerContainer.ID[:8], err)
 	}
 

--- a/reaper_test.go
+++ b/reaper_test.go
@@ -539,7 +539,7 @@ func reaperConnect(t *testing.T, reaper *Reaper) {
 	defer cancel()
 	var d net.Dialer
 	conn, err := d.DialContext(ctx, "tcp", reaper.Endpoint)
-	require.NoError(t, err, "dial reaper %s: %w", reaper.Endpoint, err)
+	require.NoError(t, err, "dial reaper %s: %v", reaper.Endpoint, err)
 	defer conn.Close()
 	err = reaper.handshake(conn)
 	require.NoError(t, err, "Reaper handshake should be successful")

--- a/reaper_test.go
+++ b/reaper_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 	"os"
 	"strconv"
 	"sync"
@@ -514,6 +515,8 @@ func TestReaper_ReuseRunning(t *testing.T) {
 			cleanupReaper(t, reaper, spawner)
 			require.NoError(t, err)
 
+			reaperConnect(t, reaper)
+
 			obtainedReaperContainerIDs[i] = reaper.container.GetContainerID()
 		}(i)
 	}
@@ -524,6 +527,22 @@ func TestReaper_ReuseRunning(t *testing.T) {
 	for i, containerID := range obtainedReaperContainerIDs {
 		require.Equal(t, firstContainerID, containerID, "call %d should have returned same container id", i)
 	}
+}
+
+// reaperConnect copies the logic from Reaper.connect() but with better error handling.
+// Reaper.connect() neither returns the error from the handshake, nor the connection,
+// making the testing of the handshake flow impossible.
+func reaperConnect(t *testing.T, reaper *Reaper) {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+	defer cancel()
+	var d net.Dialer
+	conn, err := d.DialContext(ctx, "tcp", reaper.Endpoint)
+	require.NoError(t, err, "dial reaper %s: %w", reaper.Endpoint, err)
+	defer conn.Close()
+	err = reaper.handshake(conn)
+	require.NoError(t, err, "Reaper handshake should be successful")
 }
 
 func TestSpawnerBackoff(t *testing.T) {


### PR DESCRIPTION
## What does this PR do?

Adds a `wait.ForLog("Started")` when reusing an already running reaper DockerContainer.

## Why is it important?

Without the additional wait condition, when multiple concurrent tests are run in different packages, only the package where the reaper is created (and not reused) waits properly for the Ryuk startup. For all the other packages the connection to the reaper container is attempted before Ryuk is ready and it fails with errors like the following:

```
2026/06/29 11:58:58 Reaper handshake failed: read ack: read tcp [::1]:45156->[::1]:33074: read: connection reset by peer
```

or

```
2026/06/29 12:09:49 Reaper handshake failed: read ack: EOF
```

Without connection, the reaper does not know it should wait for the tests in that packages to finish before cleaning up their containers, leading to failing tests.

More details in #3743 .

## Related issues

- Closes #3743 

## How to test this PR

As  agreed in #3743 , first I'm adding only the commit updating the tests to demonstrate the failure, so we can run the CI on it to expose the failure, and then I'll add the fix itself.