### PR TITLE
docs: fix typo in SkipIfProviderIsNotHealthy docstring

### DIFF
--- a/testing.go
+++ b/testing.go
@@ -21,7 +21,7 @@ var errAlreadyInProgress = regexp.MustCompile(`removal of container .* is alread
 // SkipIfProviderIsNotHealthy is a utility function capable of skipping tests
 // if the provider is not healthy, or running at all.
 // This is a function designed to be used in your test, when Docker is not mandatory for CI/CD.
-// In this way tests that depend on Testcontainers won't run if the provider is provisioned correctly.
+// In this way tests that depend on Testcontainers won't run if the provider is not provisioned correctly.
 func SkipIfProviderIsNotHealthy(t *testing.T) {
 	t.Helper()
 	defer func() {


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

Fixes a typo. The last sentence contradicts what docstring says before it.

Alternative: "In this way tests that depend on Testcontainers will only run if the provider is provisioned correctly."
I like this version better because the current sentence simply repeats the function name. But I chose the simpler fix

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

The current version sounds confusing