### PR TITLE
chore(compose): use require instead of assert for service name checks

### DIFF
--- a/modules/compose/compose_api_test.go
+++ b/modules/compose/compose_api_test.go
@@ -60,7 +60,7 @@ func TestDockerComposeAPIStrategyForInvalidService(t *testing.T) {
 	serviceNames := compose.Services()
 
 	require.Len(t, serviceNames, 1)
-	assert.Contains(t, serviceNames, "api-nginx")
+	require.Contains(t, serviceNames, "api-nginx")
 }
 
 func TestDockerComposeAPIWithWaitLogStrategy(t *testing.T) {
@@ -104,7 +104,7 @@ func TestDockerComposeAPIWithRunServices(t *testing.T) {
 	require.Error(t, err, "Make sure there is no mysql container")
 
 	require.Len(t, serviceNames, 1)
-	assert.Contains(t, serviceNames, "api-nginx")
+	require.Contains(t, serviceNames, "api-nginx")
 }
 
 func TestDockerComposeAPIWithProfiles(t *testing.T) {
@@ -156,7 +156,7 @@ func TestDockerComposeAPIWithProfiles(t *testing.T) {
 			cleanup(t, compose)
 			require.NoError(t, err, "compose.Up()")
 
-			assert.ElementsMatch(t, test.wantServices, compose.Services())
+			require.ElementsMatch(t, test.wantServices, compose.Services())
 		})
 	}
 }
@@ -307,7 +307,7 @@ func TestDockerComposeAPIWithWaitForService(t *testing.T) {
 	serviceNames := compose.Services()
 
 	require.Len(t, serviceNames, 1)
-	assert.Contains(t, serviceNames, "api-nginx")
+	require.Contains(t, serviceNames, "api-nginx")
 }
 
 func TestDockerComposeAPIWithWaitHTTPStrategy(t *testing.T) {
@@ -330,7 +330,7 @@ func TestDockerComposeAPIWithWaitHTTPStrategy(t *testing.T) {
 	serviceNames := compose.Services()
 
 	require.Len(t, serviceNames, 1)
-	assert.Contains(t, serviceNames, "api-nginx")
+	require.Contains(t, serviceNames, "api-nginx")
 }
 
 func TestDockerComposeAPIWithContainerName(t *testing.T) {
@@ -353,7 +353,7 @@ func TestDockerComposeAPIWithContainerName(t *testing.T) {
 	serviceNames := compose.Services()
 
 	require.Len(t, serviceNames, 1)
-	assert.Contains(t, serviceNames, "api-nginx")
+	require.Contains(t, serviceNames, "api-nginx")
 }
 
 func TestDockerComposeAPIWithWaitStrategy_NoExposedPorts(t *testing.T) {
@@ -373,7 +373,7 @@ func TestDockerComposeAPIWithWaitStrategy_NoExposedPorts(t *testing.T) {
 	serviceNames := compose.Services()
 
 	require.Len(t, serviceNames, 1)
-	assert.Contains(t, serviceNames, "api-nginx")
+	require.Contains(t, serviceNames, "api-nginx")
 }
 
 func TestDockerComposeAPIWithMultipleWaitStrategies(t *testing.T) {
@@ -420,7 +420,7 @@ func TestDockerComposeAPIWithFailedStrategy(t *testing.T) {
 	serviceNames := compose.Services()
 
 	require.Len(t, serviceNames, 1)
-	assert.Contains(t, serviceNames, "api-nginx")
+	require.Contains(t, serviceNames, "api-nginx")
 }
 
 func TestDockerComposeAPIComplex(t *testing.T) {
@@ -472,7 +472,7 @@ services:
 	serviceNames := compose.Services()
 
 	require.Len(t, serviceNames, 1)
-	assert.Contains(t, serviceNames, "api-nginx")
+	require.Contains(t, serviceNames, "api-nginx")
 
 	require.NoError(t, compose.Down(context.Background(), RemoveOrphans(true), RemoveVolumes(true), RemoveImagesLocal), "compose.Down()")
 
@@ -516,8 +516,8 @@ services:
 	serviceNames := compose.Services()
 
 	require.Len(t, serviceNames, 2)
-	assert.Contains(t, serviceNames, "api-nginx")
-	assert.Contains(t, serviceNames, "api-postgres")
+	require.Contains(t, serviceNames, "api-nginx")
+	require.Contains(t, serviceNames, "api-postgres")
 
 	present := map[string]string{
 		"bar": "BAR",
@@ -549,7 +549,7 @@ func TestDockerComposeAPIWithEnvironment(t *testing.T) {
 	serviceNames := compose.Services()
 
 	require.Len(t, serviceNames, 1)
-	assert.Contains(t, serviceNames, "api-nginx")
+	require.Contains(t, serviceNames, "api-nginx")
 
 	present := map[string]string{
 		"bar": "BAR",
@@ -586,9 +586,9 @@ func TestDockerComposeAPIWithMultipleComposeFiles(t *testing.T) {
 	serviceNames := compose.Services()
 
 	require.Len(t, serviceNames, 3)
-	assert.Contains(t, serviceNames, "api-nginx")
-	assert.Contains(t, serviceNames, "api-mysql")
-	assert.Contains(t, serviceNames, "api-postgres")
+	require.Contains(t, serviceNames, "api-nginx")
+	require.Contains(t, serviceNames, "api-mysql")
+	require.Contains(t, serviceNames, "api-postgres")
 
 	present := map[string]string{
 		"bar": "BAR",
@@ -687,8 +687,8 @@ func TestDockerComposeApiWithWaitForShortLifespanService(t *testing.T) {
 	services := compose.Services()
 
 	require.Len(t, services, 2)
-	assert.Contains(t, services, "falafel")
-	assert.Contains(t, services, "tzatziki")
+	require.Contains(t, services, "falafel")
+	require.Contains(t, services, "tzatziki")
 }
 
 func testNameHash(name string) StackIdentifier {

--- a/modules/compose/compose_test.go
+++ b/modules/compose/compose_test.go
@@ -57,7 +57,7 @@ func TestLocalDockerComposeStrategyForInvalidService(t *testing.T) {
 	require.Error(t, err.Error, "Expected error to be thrown because service with wait strategy is not running")
 
 	require.Len(t, compose.Services, 1)
-	assert.Contains(t, compose.Services, "local-nginx")
+	require.Contains(t, compose.Services, "local-nginx")
 }
 
 func TestLocalDockerComposeWithWaitLogStrategy(t *testing.T) {
@@ -80,8 +80,8 @@ func TestLocalDockerComposeWithWaitLogStrategy(t *testing.T) {
 	checkIfError(t, err)
 
 	require.Len(t, compose.Services, 2)
-	assert.Contains(t, compose.Services, "local-nginx")
-	assert.Contains(t, compose.Services, "local-mysql")
+	require.Contains(t, compose.Services, "local-nginx")
+	require.Contains(t, compose.Services, "local-mysql")
 }
 
 func TestLocalDockerComposeWithWaitForService(t *testing.T) {
@@ -106,7 +106,7 @@ func TestLocalDockerComposeWithWaitForService(t *testing.T) {
 	checkIfError(t, err)
 
 	require.Len(t, compose.Services, 1)
-	assert.Contains(t, compose.Services, "local-nginx")
+	require.Contains(t, compose.Services, "local-nginx")
 }
 
 func TestLocalDockerComposeWithWaitForShortLifespanService(t *testing.T) {
@@ -130,8 +130,8 @@ func TestLocalDockerComposeWithWaitForShortLifespanService(t *testing.T) {
 	checkIfError(t, err)
 
 	require.Len(t, compose.Services, 2)
-	assert.Contains(t, compose.Services, "falafel")
-	assert.Contains(t, compose.Services, "tzatziki")
+	require.Contains(t, compose.Services, "falafel")
+	require.Contains(t, compose.Services, "tzatziki")
 }
 
 func TestLocalDockerComposeWithWaitHTTPStrategy(t *testing.T) {
@@ -156,7 +156,7 @@ func TestLocalDockerComposeWithWaitHTTPStrategy(t *testing.T) {
 	checkIfError(t, err)
 
 	require.Len(t, compose.Services, 1)
-	assert.Contains(t, compose.Services, "local-nginx")
+	require.Contains(t, compose.Services, "local-nginx")
 }
 
 func TestLocalDockerComposeWithContainerName(t *testing.T) {
@@ -181,7 +181,7 @@ func TestLocalDockerComposeWithContainerName(t *testing.T) {
 	checkIfError(t, err)
 
 	require.Len(t, compose.Services, 1)
-	assert.Contains(t, compose.Services, "local-nginx")
+	require.Contains(t, compose.Services, "local-nginx")
 }
 
 func TestLocalDockerComposeWithWaitStrategy_NoExposedPorts(t *testing.T) {
@@ -203,7 +203,7 @@ func TestLocalDockerComposeWithWaitStrategy_NoExposedPorts(t *testing.T) {
 	checkIfError(t, err)
 
 	require.Len(t, compose.Services, 1)
-	assert.Contains(t, compose.Services, "local-nginx")
+	require.Contains(t, compose.Services, "local-nginx")
 }
 
 func TestLocalDockerComposeWithMultipleWaitStrategies(t *testing.T) {
@@ -226,8 +226,8 @@ func TestLocalDockerComposeWithMultipleWaitStrategies(t *testing.T) {
 	checkIfError(t, err)
 
 	require.Len(t, compose.Services, 2)
-	assert.Contains(t, compose.Services, "local-nginx")
-	assert.Contains(t, compose.Services, "local-mysql")
+	require.Contains(t, compose.Services, "local-nginx")
+	require.Contains(t, compose.Services, "local-mysql")
 }
 
 func TestLocalDockerComposeWithFailedStrategy(t *testing.T) {
@@ -254,7 +254,7 @@ func TestLocalDockerComposeWithFailedStrategy(t *testing.T) {
 	require.Error(t, err.Error, "Expected error to be thrown because of a wrong supplied wait strategy")
 
 	require.Len(t, compose.Services, 1)
-	assert.Contains(t, compose.Services, "local-nginx")
+	require.Contains(t, compose.Services, "local-nginx")
 }
 
 func TestLocalDockerComposeComplex(t *testing.T) {
@@ -275,8 +275,8 @@ func TestLocalDockerComposeComplex(t *testing.T) {
 	checkIfError(t, err)
 
 	require.Len(t, compose.Services, 2)
-	assert.Contains(t, compose.Services, "local-nginx")
-	assert.Contains(t, compose.Services, "local-mysql")
+	require.Contains(t, compose.Services, "local-nginx")
+	require.Contains(t, compose.Services, "local-mysql")
 }
 
 func TestLocalDockerComposeWithEnvironment(t *testing.T) {
@@ -300,7 +300,7 @@ func TestLocalDockerComposeWithEnvironment(t *testing.T) {
 	checkIfError(t, err)
 
 	require.Len(t, compose.Services, 1)
-	assert.Contains(t, compose.Services, "local-nginx")
+	require.Contains(t, compose.Services, "local-nginx")
 
 	present := map[string]string{
 		"bar": "BAR",
@@ -336,9 +336,9 @@ func TestLocalDockerComposeWithMultipleComposeFiles(t *testing.T) {
 	checkIfError(t, err)
 
 	require.Len(t, compose.Services, 3)
-	assert.Contains(t, compose.Services, "local-nginx")
-	assert.Contains(t, compose.Services, "local-mysql")
-	assert.Contains(t, compose.Services, "local-postgres")
+	require.Contains(t, compose.Services, "local-nginx")
+	require.Contains(t, compose.Services, "local-mysql")
+	require.Contains(t, compose.Services, "local-postgres")
 
 	present := map[string]string{
 		"bar": "BAR",


### PR DESCRIPTION
## Summary
- Replace `assert.Contains` with `require.Contains` for service name validations in compose module tests (`compose_api_test.go`, `compose_test.go`)
- Replace `assert.ElementsMatch` with `require.ElementsMatch` in profile test
- Ensures consistency with other tests in the same files that already use `require.Contains` for the same pattern

## Rationale
These assertions validate expected service names after `compose.Up()`. If a service is missing, subsequent test logic (e.g., `ServiceContainer()` calls) would fail with misleading errors. Using `require` stops the test immediately, making the root cause clear.

Assertions inside loops (label checks, env var checks) are intentionally kept as `assert` for comprehensive feedback on all iterations.

## Related Issue
Closes #2808

## Test plan
- [ ] Existing compose module tests pass (`go test ./modules/compose/...`)
- [ ] No behavioral change — only fail-fast semantics improved

🤖 Generated with [Claude Code](https://claude.com/claude-code)