### PR TITLE
fix: read exec exit code only after draining the output stream

### DIFF
--- a/docker.go
+++ b/docker.go
@@ -3,6 +3,7 @@ package testcontainers
 import (
 	"archive/tar"
 	"bufio"
+	"bytes"
 	"context"
 	"encoding/binary"
 	"errors"
@@ -586,8 +587,29 @@ func (c *DockerContainer) Exec(ctx context.Context, cmd []string, options ...tce
 	if err != nil {
 		return 0, nil, fmt.Errorf("container exec attach: %w", err)
 	}
+	defer hijack.Close()
 
-	processOptions.Reader = hijack.Reader
+	// A not-yet-started exec inspects as {Running:false, ExitCode:null->0}, which
+	// is indistinguishable from "exited 0". The daemon closes the stream only once
+	// the process ends, so drain to EOF before inspecting; buffer it so callers
+	// can still read the output from the returned reader.
+	var buf bytes.Buffer
+	drained := make(chan error, 1) // buffered so the goroutine can finish after we return on ctx cancel
+	go func() {
+		_, copyErr := io.Copy(&buf, hijack.Reader)
+		drained <- copyErr
+	}()
+
+	select {
+	case copyErr := <-drained:
+		if copyErr != nil {
+			return 0, nil, fmt.Errorf("container exec read: %w", copyErr)
+		}
+	case <-ctx.Done():
+		return 0, nil, ctx.Err()
+	}
+
+	processOptions.Reader = bytes.NewReader(buf.Bytes())
 
 	// second loop to process the multiplexed option, as now we have a reader
 	// from the created exec response.
@@ -595,6 +617,9 @@ func (c *DockerContainer) Exec(ctx context.Context, cmd []string, options ...tce
 		o.Apply(processOptions)
 	}
 
+	// The daemon marks the exec stopped asynchronously after closing the stream,
+	// so a single immediate inspect can still observe Running:true; poll until it
+	// reports terminal.
 	var exitCode int
 	for {
 		execResp, err := cli.ExecInspect(ctx, response.ID, client.ExecInspectOptions{})
@@ -607,7 +632,11 @@ func (c *DockerContainer) Exec(ctx context.Context, cmd []string, options ...tce
 			break
 		}
 
-		time.Sleep(100 * time.Millisecond)
+		select {
+		case <-ctx.Done():
+			return 0, nil, ctx.Err()
+		case <-time.After(100 * time.Millisecond):
+		}
 	}
 
 	return exitCode, processOptions.Reader, nil

--- a/docker_exec_test.go
+++ b/docker_exec_test.go
@@ -71,6 +71,29 @@ func TestExecWithOptions(t *testing.T) {
 	}
 }
 
+func TestExecReturnsNonZeroExitCodeAndOutput(t *testing.T) {
+	// Regression for exit codes read before the output stream drained: a
+	// created-but-not-yet-started exec reports {Running:false, ExitCode:null},
+	// which the SDK flattens to 0, so an inspect landing in the pre-start window
+	// returned 0 for a command that ultimately failed. Draining the stream to EOF
+	// first makes the subsequent inspect a real terminal state. The race needs
+	// daemon load to reproduce (~1 hit per few thousand concurrent execs); this
+	// asserts the correct code and full output for a short-lived failing command.
+	ctx := context.Background()
+
+	ctr, err := Run(ctx, nginxAlpineImage)
+	CleanupContainer(t, ctr)
+	require.NoError(t, err)
+
+	code, reader, err := ctr.Exec(ctx, []string{"sh", "-c", "echo MARKER; exit 7"}, tcexec.Multiplexed())
+	require.NoError(t, err)
+	require.Equal(t, 7, code)
+
+	b, err := io.ReadAll(reader)
+	require.NoError(t, err)
+	require.Contains(t, string(b), "MARKER")
+}
+
 func TestExecWithMultiplexedResponse(t *testing.T) {
 	ctx := context.Background()
 


### PR DESCRIPTION
## What does this PR do?

`DockerContainer.Exec` retrieves the exec exit code by polling `ContainerExecInspect`
immediately after `ContainerExecAttach` returns, breaking out of the loop as soon as
`Running == false`. This PR reorders the operation so the hijacked output stream is
**drained to EOF before the exec is inspected**, and buffers that output internally so
the returned `io.Reader` is unchanged for callers.

The exit code is only knowable once the exec process has finished, and the daemon
signals completion by closing the attached stream. Draining that stream first is the
synchronization barrier that was missing.

### The three-state ambiguity

An exec has three observable states, but `ContainerExecInspect` reports only two fields
that matter here (`Running`, `ExitCode`):

| State | Daemon `GET /exec/{id}/json` |
|-------|------------------------------|
| created, not yet started | `{"Running":false, "ExitCode":null, "Pid":0}` |
| running | `{"Running":true,  "ExitCode":null}` |
| exited | `{"Running":false, "ExitCode":7}` |

The docker Go SDK's `ExecInspect.ExitCode` is `int`, not `*int`, so the `null` in the
pre-start state unmarshals to `0`. `Running:false` therefore covers **both** ends -
before the process starts and after it exits - and the pre-start state is
indistinguishable from "finished with exit code 0". The first inspect fires ~1-2ms
after attach, while process start under daemon load takes tens of ms, so an inspect can
land in the attach-to-start window and return `0` while the command is still running.

### API capture (evidence)

Live against dockerd 27.4.0, single exec id, command `sh -c 'echo MARKER; exit 7'`:

```
T+2ms   GET /exec/{id}/json -> {"Running":false,"ExitCode":null,"Pid":0}   <- Exec returned 0 here
T+3ms   GET /exec/{id}/json -> {"Running":true, "ExitCode":null,"Pid":0}
T+59ms  GET /exec/{id}/json -> {"Running":true, "ExitCode":null,"Pid":731965}
T+81ms  GET /exec/{id}/json -> {"Running":false,"ExitCode":7,   "Pid":731965}  <- real exit code
```

`Running:false -> Running:true` is impossible for a finished process, so the first
response can only be the not-yet-started state.

### Design note: eager exit code vs lazy reader

The signature `Exec(...) (int, io.Reader, error)` promises an eager exit code and a
lazily-consumable stream at the same time, and those are in tension: a correct exit code
is not knowable until the stream hits EOF, but a lazy reader means EOF has not happened
when `Exec` returns. Every correct Docker client resolves this one of two ways:

- **CLI-style**: the consumer is attached *during* the completion wait, so consuming
  output and detecting completion are the same operation. The docker CLI streams the
  hijacked response to the terminal while it waits (`<-errCh`,
  [`exec.go#L196`](https://github.com/docker/cli/blob/09754bc280e9f6c361504f1c01d1649790428a3c/cli/command/container/exec.go#L196-L205)),
  then does a single unconditional `ExecInspect`. Nothing is buffered because nothing is
  returned.
- **Java-style**: consume the stream internally into a buffer, then inspect, then return
  materialized output. testcontainers-java does exactly this
  ([`ExecInContainerPattern.java#L241-L243`](https://github.com/testcontainers/testcontainers-java/blob/deb78e1e6e47675f56e8d7b3f4747093d66f1baa/core/src/main/java/org/testcontainers/containers/ExecInContainerPattern.java#L241-L243)).

This PR takes the **Java-style buffer** because it is the only option that preserves the
existing signature and caller semantics unchanged. The actual fix is the reordering
(consume before inspect); buffering is merely the default consumption strategy.

**Open question for maintainers** (not implemented here): for callers streaming large
outputs who do not want them held in memory, a CLI-style escape hatch would be a new
`ProcessOption` accepting caller-provided writer(s), e.g. `exec.WithOutputWriter(w io.Writer)`.
When set, `Exec` would copy the hijacked stream into the writer during the completion
wait instead of into the internal buffer. That interacts with `exec.Multiplexed` (which
today returns `io.MultiReader(&outBuff, &errBuff)`), so it needs a small design call -
demux into the caller writer when both are set, or reject the combination - which is why
it is left out of this bug fix. Happy to follow up with it if you'd prefer that shape.

## Why is it important?

A test asserting a command fails (e.g. `require.NotZero(exitCode)`) flakes when `Exec`
reports `0` for a command that actually exited non-zero. Observed roughly 1 hit per
1500-3000 execs with 24 concurrent exec workers plus container churn against dockerd
27.4.0.

This ordering is what every other Docker client does - docker CLI and testcontainers-java
references above, and moby's own integration test helper reads the output before
`ExecInspect`
([integration/internal/container/exec.go](https://github.com/moby/moby/blob/master/integration/internal/container/exec.go)).

The change also closes the hijacked response, which was previously leaked.

## Related issues

- 

## How to test this PR

`TestExecReturnsNonZeroExitCodeAndOutput` asserts a short-lived failing command
(`sh -c 'echo MARKER; exit 7'`) returns exit code `7` and `MARKER` in the output.

The race itself needs daemon load to reproduce and is not deterministic in a single-exec
unit test; to reproduce the original bug, run many concurrent execs of that command
asserting code `7` (~1 hit per few thousand execs on a loaded daemon).

```
go test -run 'TestExec' -v .
```
