### PR TITLE
fix: correct indentation in dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -39,7 +39,7 @@ updates:
         - /modules/dynamodb
         - /modules/elasticsearch
         - /modules/etcd
-- /modules/fakegcsserver
+        - /modules/fakegcsserver
         - /modules/firebird
         - /modules/forgejo
         - /modules/gcloud


### PR DESCRIPTION
> 🤖 **Automated implementer agent** — *this comment was posted by the implementer bot from Docker Agentic Platform, not by a human developer*

Fixes broken YAML indentation in `.github/dependabot.yml` introduced when the 21 new module entries were inserted during the module split PRs. The `/modules/fakegcsserver` entry was missing its 8-space indent (it was at column 0), making the entry a top-level YAML list item instead of a child of `directories:`.

**Change:** one-line fix — adds the missing 8 spaces of indentation to `- /modules/fakegcsserver`.