### PR TITLE
docs: fix incomplete CleanupContainer documentation

### DIFF
--- a/docs/features/creating_container.md
+++ b/docs/features/creating_container.md
@@ -25,7 +25,7 @@ func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustom
 The following test creates an NGINX container on both the `bridge` (docker default
 network) and the `foo` network and validates that it returns 200 for the status code.
 
-It also demonstrates how to use `CleanupContainer`, that ensures that nginx container
+It also demonstrates how to use `CleanupContainer`, that ensures that the nginx container
 is removed when the test ends even if the underlying container errored,
 as well as the `CleanupNetwork` which does the same for networks.
 
@@ -51,7 +51,7 @@ and `Network.Remove` which can be seen in the examples.
 The following test creates an NGINX container on both the `bridge` (docker default
 network) and the `foo` network and validates that it returns 200 for the status code.
 
-It also demonstrates how to use `CleanupContainer`, that ensures that nginx container
+It also demonstrates how to use `CleanupContainer`, that ensures that the nginx container
 is removed when the test ends even if the underlying `GenericContainer` errored,
 as well as the `CleanupNetwork` which does the same for networks.
 

--- a/docs/features/creating_container.md
+++ b/docs/features/creating_container.md
@@ -51,8 +51,8 @@ and `Network.Remove` which can be seen in the examples.
 The following test creates an NGINX container on both the `bridge` (docker default
 network) and the `foo` network and validates that it returns 200 for the status code.
 
-It also demonstrates how to use `CleanupContainer` ensures that nginx container
-is removed when the test ends even if the underlying `GenericContainer` errored
+It also demonstrates how to use `CleanupContainer`, that ensures that nginx container
+is removed when the test ends even if the underlying `GenericContainer` errored,
 as well as the `CleanupNetwork` which does the same for networks.
 
 The alternatives for these outside of tests as a `defer` are `TerminateContainer`

--- a/docs/features/creating_container.md
+++ b/docs/features/creating_container.md
@@ -25,7 +25,7 @@ func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustom
 The following test creates an NGINX container on both the `bridge` (docker default
 network) and the `foo` network and validates that it returns 200 for the status code.
 
-It also demonstrates how to use `CleanupContainer`, that ensures that the nginx container
+It also demonstrates how to use `CleanupContainer`, which ensures that the nginx container
 is removed when the test ends even if the underlying container errored,
 as well as the `CleanupNetwork` which does the same for networks.
 
@@ -51,7 +51,7 @@ and `Network.Remove` which can be seen in the examples.
 The following test creates an NGINX container on both the `bridge` (docker default
 network) and the `foo` network and validates that it returns 200 for the status code.
 
-It also demonstrates how to use `CleanupContainer`, that ensures that the nginx container
+It also demonstrates how to use `CleanupContainer`, which ensures that the nginx container
 is removed when the test ends even if the underlying `GenericContainer` errored,
 as well as the `CleanupNetwork` which does the same for networks.
 

--- a/testing.go
+++ b/testing.go
@@ -94,7 +94,7 @@ func (lc *StdoutLogConsumer) Accept(l Log) {
 
 // CleanupContainer is a helper function that schedules the container
 // to be stopped / terminated when the test ends.
-// This should be the first call after [GenericContainer](...) or a modules
+// This should be the first call after [GenericContainer](...) or a module's
 // Run(...) in a test before any error check. If container is nil, it's a no-op.
 func CleanupContainer(tb testing.TB, ctr Container, options ...TerminateOption) {
 	tb.Helper()

--- a/testing.go
+++ b/testing.go
@@ -94,12 +94,8 @@ func (lc *StdoutLogConsumer) Accept(l Log) {
 
 // CleanupContainer is a helper function that schedules the container
 // to be stopped / terminated when the test ends.
-//
-// This should be called as a defer directly after (before any error check)
-// of [GenericContainer](...) or a modules Run(...) in a test to ensure the
-// container is stopped when the function ends.
-//
-// before any error check. If container is nil, it's a no-op.
+// This should be the first call after [GenericContainer](...) or a modules
+// Run(...) in a test before any error check. If container is nil, it's a no-op.
 func CleanupContainer(tb testing.TB, ctr Container, options ...TerminateOption) {
 	tb.Helper()
 


### PR DESCRIPTION
## Summary
- Repair the `CleanupContainer` godoc so the usage sentence is complete and matches the `CleanupNetwork` wording.
- Fix the broken sentence in `docs/features/creating_container.md` (missing comma / relative clause).

Fixes #3514

## Test plan
- [x] Review godoc and markdown side by side with the surrounding examples
- [ ] Confirm rendered docs read cleanly on the site preview if available