### PR TITLE
fix: return reaper handshake errors

### DIFF
--- a/reaper.go
+++ b/reaper.go
@@ -542,12 +542,14 @@ func (r *Reaper) connect(ctx context.Context) (chan bool, error) {
 		return nil, fmt.Errorf("dial reaper %s: %w", r.Endpoint, err)
 	}
 
+	if err := r.handshake(conn); err != nil {
+		conn.Close()
+		return nil, fmt.Errorf("handshake reaper %s: %w", r.Endpoint, err)
+	}
+
 	terminationSignal := make(chan bool)
 	go func() {
 		defer conn.Close()
-		if err := r.handshake(conn); err != nil {
-			log.Printf("Reaper handshake failed: %s", err)
-		}
 		<-terminationSignal
 	}()
 	return terminationSignal, nil

--- a/reaper_test.go
+++ b/reaper_test.go
@@ -1,6 +1,7 @@
 package testcontainers
 
 import (
+	"bufio"
 	"context"
 	"errors"
 	"fmt"
@@ -529,20 +530,55 @@ func TestReaper_ReuseRunning(t *testing.T) {
 	}
 }
 
-// reaperConnect copies the logic from Reaper.connect() but with better error handling.
-// Reaper.connect() neither returns the error from the handshake, nor the connection,
-// making the testing of the handshake flow impossible.
+func TestReaperConnectReturnsHandshakeError(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+	defer cancel()
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, listener.Close())
+	})
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+
+		conn, err := listener.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+
+		_, _ = bufio.NewReader(conn).ReadString('\n')
+		_, _ = conn.Write([]byte("NOPE"))
+	}()
+
+	reaper := &Reaper{
+		SessionID: testSessionID,
+		Endpoint:  listener.Addr().String(),
+	}
+
+	termSignal, err := reaper.connect(ctx)
+	require.Nil(t, termSignal)
+	require.ErrorContains(t, err, "handshake reaper")
+	require.ErrorContains(t, err, "unexpected reaper response: NOPE")
+
+	select {
+	case <-done:
+	case <-ctx.Done():
+		require.FailNow(t, "test reaper server did not finish")
+	}
+}
+
 func reaperConnect(t *testing.T, reaper *Reaper) {
 	t.Helper()
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
-	defer cancel()
-	var d net.Dialer
-	conn, err := d.DialContext(ctx, "tcp", reaper.Endpoint)
-	require.NoError(t, err, "dial reaper %s: %v", reaper.Endpoint, err)
-	defer conn.Close()
-	err = reaper.handshake(conn)
+	termSignal, err := reaper.Connect()
 	require.NoError(t, err, "Reaper handshake should be successful")
+	if termSignal != nil {
+		termSignal <- true
+	}
 }
 
 func TestSpawnerBackoff(t *testing.T) {


### PR DESCRIPTION
## Related issues

- Closes #3827

## What does this PR do?

This PR makes `Reaper.connect` perform the Ryuk handshake synchronously before returning a successful connection.

If the handshake fails, the connection is closed and the handshake error is returned to the caller. The existing retry path can then handle the failure instead of treating the reaper connection as successful.

It also adds a regression test using a local TCP listener that returns an invalid ACK, verifying that `connect` returns an error and no termination channel.

## Why is it important?

Previously, handshake failures were only logged inside the connection goroutine. `Reaper.connect` still returned a non-nil termination channel and nil error, so callers could believe the reaper was connected even though Ryuk had rejected or failed the handshake.

Returning the error makes reaper startup failures visible and retryable.

## How to test this PR

```shell
go test ./ -run "TestReaperConnectReturnsHandshakeError|TestSpawnerRetryError|TestSpawnerBackoff"