### PR TITLE
fix: update Azurite image to 3.36.0 for azblob SDK v1.8.0 compatibility

### DIFF
--- a/modules/azure/azurite/azurite_test.go
+++ b/modules/azure/azurite/azurite_test.go
@@ -42,7 +42,7 @@ func TestAzurite_enabledServices(t *testing.T) {
 	services := []azurite.Service{azurite.BlobService, azurite.QueueService, azurite.TableService}
 	for _, service := range services {
 		t.Run(string(service), func(t *testing.T) {
-			ctr, err := azurite.Run(ctx, "mcr.microsoft.com/azure-storage/azurite:3.33.0", azurite.WithEnabledServices(service))
+			ctr, err := azurite.Run(ctx, "mcr.microsoft.com/azure-storage/azurite:3.36.0", azurite.WithEnabledServices(service))
 			testcontainers.CleanupContainer(t, ctr)
 			require.NoError(t, err)
 
@@ -58,12 +58,12 @@ func TestAzurite_enabledServices(t *testing.T) {
 	}
 
 	t.Run("unknown", func(t *testing.T) {
-		_, err := azurite.Run(ctx, "mcr.microsoft.com/azure-storage/azurite:3.33.0", azurite.WithEnabledServices("foo"))
+		_, err := azurite.Run(ctx, "mcr.microsoft.com/azure-storage/azurite:3.36.0", azurite.WithEnabledServices("foo"))
 		require.EqualError(t, err, "azurite option: unknown service: foo")
 	})
 
 	t.Run("duplicate", func(t *testing.T) {
-		_, err := azurite.Run(ctx, "mcr.microsoft.com/azure-storage/azurite:3.33.0", azurite.WithEnabledServices(azurite.BlobService, azurite.BlobService))
+		_, err := azurite.Run(ctx, "mcr.microsoft.com/azure-storage/azurite:3.36.0", azurite.WithEnabledServices(azurite.BlobService, azurite.BlobService))
 		require.EqualError(t, err, "azurite option: duplicate service: blob")
 	})
 }

--- a/modules/azure/azurite/examples_test.go
+++ b/modules/azure/azurite/examples_test.go
@@ -58,6 +58,7 @@ func ExampleRun_blobOperations() {
 		"mcr.microsoft.com/azure-storage/azurite:3.36.0",
 		azurite.WithInMemoryPersistence(64),
 		azurite.WithEnabledServices(azurite.BlobService),
+		testcontainers.WithCmdArgs("--skipApiVersionCheck"),
 	)
 	defer func() {
 		if err := testcontainers.TerminateContainer(azuriteContainer); err != nil {

--- a/modules/azure/azurite/examples_test.go
+++ b/modules/azure/azurite/examples_test.go
@@ -55,7 +55,7 @@ func ExampleRun_blobOperations() {
 
 	azuriteContainer, err := azurite.Run(
 		ctx,
-		"mcr.microsoft.com/azure-storage/azurite:3.33.0",
+		"mcr.microsoft.com/azure-storage/azurite:3.36.0",
 		azurite.WithInMemoryPersistence(64),
 		azurite.WithEnabledServices(azurite.BlobService),
 	)

--- a/modules/azure/eventhubs/eventhubs_test.go
+++ b/modules/azure/eventhubs/eventhubs_test.go
@@ -22,7 +22,7 @@ var eventhubsConfig string
 func TestEventHubs_topology(t *testing.T) {
 	ctx := context.Background()
 
-	const azuriteImage = "mcr.microsoft.com/azure-storage/azurite:3.33.0"
+	const azuriteImage = "mcr.microsoft.com/azure-storage/azurite:3.36.0"
 
 	ctr, err := eventhubs.Run(
 		ctx,
@@ -55,7 +55,7 @@ func TestEventHubs_topology(t *testing.T) {
 func TestEventHubs_withConfig(t *testing.T) {
 	ctx := context.Background()
 
-	const azuriteImage = "mcr.microsoft.com/azure-storage/azurite:3.33.0"
+	const azuriteImage = "mcr.microsoft.com/azure-storage/azurite:3.36.0"
 
 	ctr, err := eventhubs.Run(
 		ctx,
@@ -97,7 +97,7 @@ func TestEventHubs_withAzuriteContainer(t *testing.T) {
 
 	azuriteCtr, err := azurite.Run(
 		ctx,
-		"mcr.microsoft.com/azure-storage/azurite:3.33.0",
+		"mcr.microsoft.com/azure-storage/azurite:3.36.0",
 		network.WithNetwork([]string{"azurite"}, nw),
 	)
 	testcontainers.CleanupContainer(t, azuriteCtr)
@@ -143,7 +143,7 @@ func TestEventHubs_withAzuriteContainer_nilGuards(t *testing.T) {
 	testcontainers.CleanupNetwork(t, nw)
 	require.NoError(t, err)
 
-	azuriteCtr, err := azurite.Run(ctx, "mcr.microsoft.com/azure-storage/azurite:3.33.0",
+	azuriteCtr, err := azurite.Run(ctx, "mcr.microsoft.com/azure-storage/azurite:3.36.0",
 		network.WithNetwork([]string{"azurite"}, nw),
 	)
 	testcontainers.CleanupContainer(t, azuriteCtr)
@@ -181,7 +181,7 @@ func TestEventHubs_withAzuriteContainer_conflict(t *testing.T) {
 	testcontainers.CleanupNetwork(t, nw)
 	require.NoError(t, err)
 
-	azuriteCtr, err := azurite.Run(ctx, "mcr.microsoft.com/azure-storage/azurite:3.33.0",
+	azuriteCtr, err := azurite.Run(ctx, "mcr.microsoft.com/azure-storage/azurite:3.36.0",
 		network.WithNetwork([]string{"azurite"}, nw),
 	)
 	testcontainers.CleanupContainer(t, azuriteCtr)
@@ -192,7 +192,7 @@ func TestEventHubs_withAzuriteContainer_conflict(t *testing.T) {
 			ctx,
 			"mcr.microsoft.com/azure-messaging/eventhubs-emulator:2.1.0",
 			eventhubs.WithAcceptEULA(),
-			eventhubs.WithAzurite("mcr.microsoft.com/azure-storage/azurite:3.33.0"),
+			eventhubs.WithAzurite("mcr.microsoft.com/azure-storage/azurite:3.36.0"),
 			eventhubs.WithAzuriteContainer(azuriteCtr, nw, "azurite"),
 		)
 		require.Error(t, err)
@@ -205,7 +205,7 @@ func TestEventHubs_withAzuriteContainer_conflict(t *testing.T) {
 			"mcr.microsoft.com/azure-messaging/eventhubs-emulator:2.1.0",
 			eventhubs.WithAcceptEULA(),
 			eventhubs.WithAzuriteContainer(azuriteCtr, nw, "azurite"),
-			eventhubs.WithAzurite("mcr.microsoft.com/azure-storage/azurite:3.33.0"),
+			eventhubs.WithAzurite("mcr.microsoft.com/azure-storage/azurite:3.36.0"),
 		)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "mutually exclusive")

--- a/modules/azure/eventhubs/examples_test.go
+++ b/modules/azure/eventhubs/examples_test.go
@@ -182,7 +182,7 @@ func ExampleRun_withAzuriteContainer() {
 	// withAzuriteContainer_azurite {
 	azuriteCtr, err := azurite.Run(
 		ctx,
-		"mcr.microsoft.com/azure-storage/azurite:3.33.0",
+		"mcr.microsoft.com/azure-storage/azurite:3.36.0",
 		network.WithNetwork([]string{"azurite"}, nw),
 		testcontainers.WithEntrypointArgs("--skipApiVersionCheck"),
 	)

--- a/modules/azure/eventhubs/options.go
+++ b/modules/azure/eventhubs/options.go
@@ -33,7 +33,7 @@ type options struct {
 
 func defaultOptions() options {
 	return options{
-		azuriteImage: "mcr.microsoft.com/azure-storage/azurite:3.33.0",
+		azuriteImage: "mcr.microsoft.com/azure-storage/azurite:3.36.0",
 		azuriteOwned: true,
 	}
 }
@@ -52,7 +52,7 @@ func (o Option) Customize(*testcontainers.GenericContainerRequest) error {
 
 // WithAzurite sets the image and options for the Azurite container that the
 // module will create automatically.
-// By default, the image is "mcr.microsoft.com/azure-storage/azurite:3.33.0".
+// By default, the image is "mcr.microsoft.com/azure-storage/azurite:3.36.0".
 // It is mutually exclusive with WithAzuriteContainer: passing both options to
 // Run returns an error. If you already have a running Azurite container, use
 // WithAzuriteContainer instead — the image and options set here will not apply.


### PR DESCRIPTION
Fix for the `ExampleRun_blobOperations` test failure in #3805.

- Update Azurite image from 3.33.0 to 3.36.0 (latest) in all azure module tests
- Add `--skipApiVersionCheck` to the blob operations example, since azblob SDK v1.8.0 uses API version `2026-06-06` which even Azurite 3.36.0 doesn't support yet

All azurite and eventhubs tests verified passing locally.