### PR TITLE
fix: update lowkey-vault image to 7.3.48 for azsecrets SDK v1.5.0 compatibility

### DIFF
--- a/docs/modules/azure.md
+++ b/docs/modules/azure.md
@@ -420,7 +420,7 @@ func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustom
 #### Image
 
 Use the second argument in the `Run` function to set a valid Docker image.
-In example: `Run(context.Background(), "nagyesta/lowkey-vault:7.0.9-ubi10-minimal")`.
+In example: `Run(context.Background(), "nagyesta/lowkey-vault:7.3.48-ubi10-minimal")`.
 
 ### Container Options
 
@@ -443,7 +443,7 @@ and is made available using the host address.
 To prepare the container for running in a network and making it accessible from other containers in the network, you can use the 
 `WithNetworkAlias` option. For example:
 ```golang
-Run(ctx, "nagyesta/lowkey-vault:7.0.9-ubi10-minimal",
+Run(ctx, "nagyesta/lowkey-vault:7.3.48-ubi10-minimal",
     lowkeyvault.WithNetworkAlias("lowkey-vault", aNetwork),
 )
 ```

--- a/modules/azure/go.mod
+++ b/modules/azure/go.mod
@@ -20,7 +20,6 @@ require (
 	github.com/stretchr/testify v1.11.1
 	github.com/testcontainers/testcontainers-go v0.43.0
 	github.com/testcontainers/testcontainers-go/modules/mssql v0.43.0
-	golang.org/x/crypto v0.54.0
 	software.sslmate.com/src/go-pkcs12 v0.7.0
 )
 
@@ -78,6 +77,7 @@ require (
 	go.opentelemetry.io/otel v1.44.0 // indirect
 	go.opentelemetry.io/otel/metric v1.44.0 // indirect
 	go.opentelemetry.io/otel/trace v1.44.0 // indirect
+	golang.org/x/crypto v0.54.0 // indirect
 	golang.org/x/net v0.56.0 // indirect
 	golang.org/x/sys v0.47.0 // indirect
 	golang.org/x/text v0.40.0 // indirect

--- a/modules/azure/lowkeyvault/examples_test.go
+++ b/modules/azure/lowkeyvault/examples_test.go
@@ -28,7 +28,7 @@ import (
 func ExampleRun() {
 	ctx := context.Background()
 
-	lowkeyVaultContainer, err := lowkeyvault.Run(ctx, "nagyesta/lowkey-vault:7.0.9-ubi10-minimal")
+	lowkeyVaultContainer, err := lowkeyvault.Run(ctx, "nagyesta/lowkey-vault:7.3.48-ubi10-minimal")
 	defer func() {
 		if err := testcontainers.TerminateContainer(lowkeyVaultContainer); err != nil {
 			log.Printf("failed to terminate container: %s", err)
@@ -68,7 +68,7 @@ func ExampleRun_secretOperationsNetwork() {
 	}
 
 	// createContainerWithNetwork {
-	lowkeyVaultContainer, err := lowkeyvault.Run(ctx, "nagyesta/lowkey-vault:7.0.9-ubi10-minimal",
+	lowkeyVaultContainer, err := lowkeyvault.Run(ctx, "nagyesta/lowkey-vault:7.3.48-ubi10-minimal",
 		lowkeyvault.WithNetworkAlias("lowkey-vault", aNetwork),
 	)
 	defer func() {
@@ -140,7 +140,7 @@ func ExampleRun_secretOperations() {
 	ctx := context.Background()
 
 	// createContainerWithLocalMode {
-	lowkeyVaultContainer, err := lowkeyvault.Run(ctx, "nagyesta/lowkey-vault:7.0.9-ubi10-minimal")
+	lowkeyVaultContainer, err := lowkeyvault.Run(ctx, "nagyesta/lowkey-vault:7.3.48-ubi10-minimal")
 	defer func() {
 		if err := testcontainers.TerminateContainer(lowkeyVaultContainer); err != nil {
 			log.Printf("failed to terminate container: %s", err)
@@ -232,7 +232,7 @@ func ExampleRun_secretOperations() {
 func ExampleRun_keyOperations() {
 	ctx := context.Background()
 
-	lowkeyVaultContainer, err := lowkeyvault.Run(ctx, "nagyesta/lowkey-vault:7.0.9-ubi10-minimal")
+	lowkeyVaultContainer, err := lowkeyvault.Run(ctx, "nagyesta/lowkey-vault:7.3.48-ubi10-minimal")
 	defer func() {
 		if err := testcontainers.TerminateContainer(lowkeyVaultContainer); err != nil {
 			log.Printf("failed to terminate container: %s", err)
@@ -352,7 +352,7 @@ func ExampleRun_keyOperations() {
 func ExampleRun_certificateOperations() {
 	ctx := context.Background()
 
-	lowkeyVaultContainer, err := lowkeyvault.Run(ctx, "nagyesta/lowkey-vault:7.0.9-ubi10-minimal")
+	lowkeyVaultContainer, err := lowkeyvault.Run(ctx, "nagyesta/lowkey-vault:7.3.48-ubi10-minimal")
 	defer func() {
 		if err := testcontainers.TerminateContainer(lowkeyVaultContainer); err != nil {
 			log.Printf("failed to terminate container: %s", err)

--- a/modules/azure/lowkeyvault/lowkeyvault.go
+++ b/modules/azure/lowkeyvault/lowkeyvault.go
@@ -11,7 +11,7 @@ import (
 	"net/http"
 
 	dockernetwork "github.com/moby/moby/api/types/network"
-	"golang.org/x/crypto/pkcs12"
+	"software.sslmate.com/src/go-pkcs12"
 
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/network"

--- a/modules/azure/lowkeyvault/lowkeyvault_test.go
+++ b/modules/azure/lowkeyvault/lowkeyvault_test.go
@@ -27,7 +27,7 @@ import (
 func TestRun(t *testing.T) {
 	ctx := context.Background()
 
-	lowkeyVaultContainer, err := lowkeyvault.Run(ctx, "nagyesta/lowkey-vault:7.0.9-ubi10-minimal")
+	lowkeyVaultContainer, err := lowkeyvault.Run(ctx, "nagyesta/lowkey-vault:7.3.48-ubi10-minimal")
 	testcontainers.CleanupContainer(t, lowkeyVaultContainer)
 	require.NoError(t, err)
 
@@ -44,7 +44,7 @@ func TestRun_secretOperationsNetwork(t *testing.T) {
 	testcontainers.CleanupNetwork(t, aNetwork)
 	require.NoError(t, err)
 
-	lowkeyVaultContainer, err := lowkeyvault.Run(ctx, "nagyesta/lowkey-vault:7.0.9-ubi10-minimal",
+	lowkeyVaultContainer, err := lowkeyvault.Run(ctx, "nagyesta/lowkey-vault:7.3.48-ubi10-minimal",
 		lowkeyvault.WithNetworkAlias("lowkey-vault", aNetwork),
 	)
 	testcontainers.CleanupContainer(t, lowkeyVaultContainer)
@@ -87,7 +87,7 @@ func TestRun_secretOperationsNetwork(t *testing.T) {
 func TestRun_secretOperations(t *testing.T) {
 	ctx := context.Background()
 
-	lowkeyVaultContainer, err := lowkeyvault.Run(ctx, "nagyesta/lowkey-vault:7.0.9-ubi10-minimal")
+	lowkeyVaultContainer, err := lowkeyvault.Run(ctx, "nagyesta/lowkey-vault:7.3.48-ubi10-minimal")
 	testcontainers.CleanupContainer(t, lowkeyVaultContainer)
 	require.NoError(t, err)
 
@@ -138,7 +138,7 @@ func TestRun_secretOperations(t *testing.T) {
 func TestRun_keyOperations(t *testing.T) {
 	ctx := context.Background()
 
-	lowkeyVaultContainer, err := lowkeyvault.Run(ctx, "nagyesta/lowkey-vault:7.0.9-ubi10-minimal")
+	lowkeyVaultContainer, err := lowkeyvault.Run(ctx, "nagyesta/lowkey-vault:7.3.48-ubi10-minimal")
 	testcontainers.CleanupContainer(t, lowkeyVaultContainer)
 	require.NoError(t, err)
 
@@ -212,7 +212,7 @@ func TestRun_keyOperations(t *testing.T) {
 func TestRun_certificateOperations(t *testing.T) {
 	ctx := context.Background()
 
-	lowkeyVaultContainer, err := lowkeyvault.Run(ctx, "nagyesta/lowkey-vault:7.0.9-ubi10-minimal")
+	lowkeyVaultContainer, err := lowkeyvault.Run(ctx, "nagyesta/lowkey-vault:7.3.48-ubi10-minimal")
 	testcontainers.CleanupContainer(t, lowkeyVaultContainer)
 	require.NoError(t, err)
 


### PR DESCRIPTION
Fix for the lowkeyvault test failures in #3806.

- Update lowkey-vault image from 7.0.9 to 7.3.48-ubi10-minimal
- Switch pkcs12 import from `golang.org/x/crypto/pkcs12` to `software.sslmate.com/src/go-pkcs12` (already a dependency) to support SHA-256 based PKCS#12 encoding used by newer lowkey-vault versions

All lowkeyvault tests verified passing locally.