### PR TITLE
fix: add doc.go to modules/azure for golangci-lint compatibility

### DIFF
--- a/modules/azure/doc.go
+++ b/modules/azure/doc.go
@@ -1,0 +1,2 @@
+// Package azure provides Testcontainers modules for Azure services.
+package azure


### PR DESCRIPTION
The `modules/azure` directory has no root-level `.go` files — all code lives in subdirectories (`azurite/`, `eventhubs/`, etc.). This causes `golangci-lint` to fail with `no go files to analyze`.

Adding a minimal `doc.go` provides the root package declaration and fixes the lint failure in #3805.