### PR TITLE
fix: escape the container name in the Docker name filter

### DIFF
--- a/docker.go
+++ b/docker.go
@@ -1382,7 +1382,7 @@ func (p *DockerProvider) findContainerByName(ctx context.Context, name string) (
 	// Note that, 'name' filter will use regex to find the containers
 	containers, err := p.client.ContainerList(ctx, client.ContainerListOptions{
 		All:     true,
-		Filters: make(client.Filters).Add("name", fmt.Sprintf("^%s$", name)),
+		Filters: make(client.Filters).Add("name", fmt.Sprintf("^%s$", regexp.QuoteMeta(name))),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("container list: %w", err)

--- a/docker_test.go
+++ b/docker_test.go
@@ -1594,6 +1594,25 @@ func TestDockerProviderFindContainerByName(t *testing.T) {
 	require.Contains(t, c.Names, c1Name)
 }
 
+func TestDockerProviderFindContainerByNameEscapesRegex(t *testing.T) {
+	ctx := context.Background()
+	provider, err := NewDockerProvider(WithLogger(log.TestLogger(t)))
+	require.NoError(t, err)
+	defer provider.Close()
+
+	ctr, err := Run(ctx, nginxAlpineImage,
+		WithName("testX1"),
+		WithWaitStrategy(wait.ForExposedPort()),
+	)
+	CleanupContainer(t, ctr)
+	require.NoError(t, err)
+
+	// The dot must be matched literally, so it must not match the X in testX1.
+	c, err := provider.findContainerByName(ctx, "test.1")
+	require.NoError(t, err)
+	require.Nil(t, c)
+}
+
 func TestImageBuiltFromDockerfile_KeepBuiltImage(t *testing.T) {
 	tests := []struct {
 		keepBuiltImage bool


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

Quotes the `name` filter of the Docker container list API is a regular expression, so metacharacters in a container name are interpreted instead of matched literally.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

A lookup for "cache.1" also matches "cacheX1", and `ReuseOrCreateContainer` can reuse the wrong container.

Since container names may only include `^[a-zA-Z0-9][a-zA-Z0-9_.-]+$` char `.` (dot) is the only metacharacter reachable through a legal container name.

## Related issues

Not related to, by raised in #3051 by an [LLM code review](https://github.com/testcontainers/testcontainers-go/pull/3051#pullrequestreview-4856522740).

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
