### PR TITLE
chore(azurite): tidy module dependencies

### DIFF
--- a/modules/azurite/go.sum
+++ b/modules/azurite/go.sum
@@ -8,8 +8,8 @@ github.com/Azure/azure-sdk-for-go/sdk/data/aztables v1.3.0 h1:NnE8y/opvxowwNcSNH
 github.com/Azure/azure-sdk-for-go/sdk/data/aztables v1.3.0/go.mod h1:GhHzPHiiHxZloo6WvKu9X7krmSAKTyGoIwoKMbrKTTA=
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.12.0 h1:fhqpLE3UEXi9lPaBRpQ6XuRW0nU7hgg4zlmZZa+a9q4=
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.12.0/go.mod h1:7dCRMLwisfRH3dBupKeNCioWYUZ4SS09Z14H+7i8ZoY=
-github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.6.0 h1:UXT0o77lXQrikd1kgwIPQOUect7EoR/+sbP4wQKdzxM=
-github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.6.0/go.mod h1:cTvi54pg19DoT07ekoeMgE/taAwNtCShVeZqA+Iv2xI=
+github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.8.0 h1:irsmOWwkp0KCTTNS5e2hdFeIvSQClQo2No3IaNmL3Vw=
+github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.8.0/go.mod h1:GWcBkQj3MqN7ozHKLaCCAuNLiXoIGv2RtanfAwSjY/Y=
 github.com/Azure/azure-sdk-for-go/sdk/storage/azqueue v1.0.0 h1:lJwNFV+xYjHREUTHJKx/ZF6CJSt9znxmLw9DqSTvyRU=
 github.com/Azure/azure-sdk-for-go/sdk/storage/azqueue v1.0.0/go.mod h1:GfT0aGew8Qj5yiQVqOO5v7N8fanbJGyUoHqXg56qcVY=
 github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c h1:udKWzYgxTojEKWjV8V+WSxDXJ4NFATAsZjh8iIbsQIg=


### PR DESCRIPTION
## What does this PR do?

Runs `make tidy-all` and commits the only resulting diff: `modules/azurite/go.sum` now records `github.com/Azure/azure-sdk-for-go/sdk/storage/azblob` at `v1.8.0` instead of `v1.6.0` (both the module and `go.mod` checksum lines).

`modules/azurite/go.mod` is unchanged — azblob is a transitive dependency pulled in through the local `replace` on `modules/azure`, so only the lockfile was stale. No other module in the repo produced a diff.

## Why is it important?

#3805 bumped azblob to `v1.8.0` in `modules/azure`, but `modules/azurite` consumes `modules/azure` via a `replace` directive, so its `go.sum` was left pinning the old `v1.6.0` checksums. That leaves the repo in a state where `go mod tidy` is not a no-op for `azurite`, which makes the tidy check noisy for unrelated PRs touching that module.

## Related issues

- Relates #3805

## How to test this PR

```bash
make tidy-all
git diff --exit-code          # no diff -> the tree is tidy

cd modules/azurite
go build ./... && go vet ./... && go test ./...
```

`go build`, `go vet` and `go test ./...` all pass locally for `modules/azurite` (tests run against a real Azurite container, ~9s).
