### PR TITLE
fix: bound the reaper connect dial so the spawner backoff can retry

### DIFF
--- a/reaper.go
+++ b/reaper.go
@@ -536,8 +536,13 @@ func (r *Reaper) useTermSignal() chan bool {
 // It returns a channel that can be sent true to terminate the connection.
 // Returns an error if config.RyukDisabled is true.
 func (r *Reaper) connect(ctx context.Context) (chan bool, error) {
+	// Bound the dial: with dropped SYNs it would sit in the kernel's ~2min
+	// connect timeout and eat the spawner's 20s backoff budget in one attempt.
+	dialCtx, cancel := context.WithTimeout(ctx, time.Second*5)
+	defer cancel()
+
 	var d net.Dialer
-	conn, err := d.DialContext(ctx, "tcp", r.Endpoint)
+	conn, err := d.DialContext(dialCtx, "tcp", r.Endpoint)
 	if err != nil {
 		return nil, fmt.Errorf("dial reaper %s: %w", r.Endpoint, err)
 	}

--- a/reaper_dial_bound_test.go
+++ b/reaper_dial_bound_test.go
@@ -1,0 +1,33 @@
+package testcontainers
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/cenkalti/backoff/v4"
+)
+
+// A blackholed endpoint (SYNs dropped, no RST) must fail within the 5s dial
+// bound and be classified retryable, so the spawner's 20s backoff can retry.
+func TestReaperConnectDialBounded(t *testing.T) {
+	r := &Reaper{Endpoint: "192.0.2.1:8080"} // TEST-NET-1, not routed
+	start := time.Now()
+	_, err := r.connect(context.Background())
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected dial error")
+	}
+	if elapsed > 10*time.Second {
+		t.Fatalf("dial not bounded: took %v", elapsed)
+	}
+	s := &reaperSpawner{}
+	rerr := s.retryError(err)
+	var perm *backoff.PermanentError
+	if errors.As(rerr, &perm) {
+		t.Fatalf("timeout classified permanent, backoff would stop: %v", rerr)
+	}
+	t.Logf("dial failed after %v, retryable: %v", elapsed, err)
+}


### PR DESCRIPTION
## What does this PR do?

Bound the dial in `Reaper.connect()` to 5s, same as `Connect()`. Add a
regression test.

## Why is it important?

The spawner's connect check dials with the caller's context, which has
no deadline. With dropped SYNs (we hit a conntrack/DNAT race under
container churn) the dial sits in the kernel's ~2min connect timeout.
One attempt eats the whole 20s backoff budget, so the ETIMEDOUT retry
never happens. With a 5s bound the retry dials from a fresh source port
(fresh conntrack entry) and connects.

## Related issues

- None that I know of.

## How to test this PR

```
go test -run TestReaperConnectDialBounded .
```

Dials 192.0.2.1:8080 (TEST-NET-1, not routed), checks the dial fails
within the bound and is classified retryable. Without the fix it takes
~2min and fails. On networks that answer for TEST-NET-1 the dial fails
instantly, so the test passes without exercising the timeout path.

## Follow-ups

Later maybe: blackhole locally with a backlog-0 listener (Linux only)
instead of relying on TEST-NET-1.
