### PR TITLE
chore: skip test jobs when module requires a newer Go version

### DIFF
--- a/.github/workflows/ci-test-go.yml
+++ b/.github/workflows/ci-test-go.yml
@@ -72,11 +72,29 @@ jobs:
             cache-dependency-path: '${{ inputs.project-directory }}/go.sum'
         id: go
 
+      - name: Check Go version compatibility
+        id: go-compat
+        working-directory: ./${{ inputs.project-directory }}
+        shell: bash
+        run: |
+          REQUIRED=$(grep '^go ' go.mod | head -1 | awk '{print $2}')
+          INSTALLED=$(go env GOVERSION | sed 's/^go//')
+          echo "Module requires go ${REQUIRED}, installed ${INSTALLED}"
+          # Compare: is INSTALLED >= REQUIRED?
+          if [ "$(printf '%s\n%s' "${REQUIRED}" "${INSTALLED}" | sort -V | head -n1)" = "${REQUIRED}" ]; then
+            echo "compatible=true" >> $GITHUB_OUTPUT
+          else
+            echo "::warning::Skipping: module requires go ${REQUIRED} but go ${INSTALLED} is installed"
+            echo "compatible=false" >> $GITHUB_OUTPUT
+          fi
+
       - name: ensure compilation
+        if: steps.go-compat.outputs.compatible == 'true'
         working-directory: ./${{ inputs.project-directory }}
         run: go build ./...
 
       - name: Install dependencies
+        if: steps.go-compat.outputs.compatible == 'true'
         shell: bash
         run: |
           SCRIPT_PATH="./.github/scripts/${{ inputs.project-directory }}/install-dependencies.sh"
@@ -88,23 +106,25 @@ jobs:
 
       # Setup Testcontainers Cloud Client right before your Testcontainers tests
       - name: Setup Testcontainers Cloud Client
-        if: ${{ inputs.testcontainers-cloud }}
+        if: ${{ inputs.testcontainers-cloud && steps.go-compat.outputs.compatible == 'true' }}
         uses: atomicjar/testcontainers-cloud-setup-action@7d1bab3fdfe0027c91936deca6b924d8a8a7a04d # v1.3
         with:
           token: ${{ secrets.TCC_TOKEN }}
 
       - name: go test
+        if: steps.go-compat.outputs.compatible == 'true'
         working-directory: ./${{ inputs.project-directory }}
         timeout-minutes: 30
         run: make test-unit
 
       - name: Run checker
+        if: steps.go-compat.outputs.compatible == 'true'
         run: |
             ./scripts/check_environment.sh
 
       # (Optionally) When you don't need Testcontainers Cloud anymore, you could terminate sessions eagerly
       - name: Terminate Testcontainers Cloud Client active sessions
-        if: ${{ inputs.testcontainers-cloud }}
+        if: ${{ inputs.testcontainers-cloud && steps.go-compat.outputs.compatible == 'true' }}
         uses: atomicjar/testcontainers-cloud-setup-action@7d1bab3fdfe0027c91936deca6b924d8a8a7a04d # v1.3
         with:
           action: terminate
@@ -113,10 +133,10 @@ jobs:
         uses: test-summary/action@31493c76ec9e7aa675f1585d3ed6f1da69269a86 # v2.4
         with:
             paths: "**/${{ inputs.project-directory }}/TEST-unit*.xml"
-        if: always()
+        if: ${{ always() && steps.go-compat.outputs.compatible == 'true' }}
 
       - name: Decide if Sonar must be run
-        if: ${{ matrix.platform == 'ubuntu-latest' }}
+        if: ${{ matrix.platform == 'ubuntu-latest' && steps.go-compat.outputs.compatible == 'true' }}
         run: |
           if [[ "1.25.x" == "${{ inputs.go-version }}" ]] && \
              [[ "true" != "${{ inputs.rootless-docker }}" ]] && \
@@ -128,7 +148,7 @@ jobs:
           fi
 
       - name: Set Sonar Cloud environment variables
-        if: ${{ env.SHOULD_RUN_SONAR == 'true' }}
+        if: ${{ env.SHOULD_RUN_SONAR == 'true' && steps.go-compat.outputs.compatible == 'true' }}
         run: |
           echo "PROJECT_VERSION=$(grep 'latest_version' mkdocs.yml | cut -d':' -f2 | tr -d ' ')" >> $GITHUB_ENV
           if [ "${{ inputs.project-directory }}" == "" ]; then
@@ -144,7 +164,7 @@ jobs:
           fi
 
       - name: SonarQube Scan
-        if: ${{ env.SHOULD_RUN_SONAR == 'true' }}
+        if: ${{ env.SHOULD_RUN_SONAR == 'true' && steps.go-compat.outputs.compatible == 'true' }}
         uses: SonarSource/sonarqube-scan-action@713881670b6b3676cda39549040e2d88c70d582e # v8.2.0
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
Adds a Go version compatibility check to `ci-test-go.yml` that runs after "Set up Go". It compares the module's `go.mod` minimum Go version against the installed version and skips build/test/sonar steps when incompatible, emitting a warning annotation instead of failing.

**Why**: dependency bumps (e.g. weaviate v1.38.0 requiring `go 1.26`) cause hard failures on the Go 1.25.x matrix entry with `go: go.mod requires go >= 1.26`. This is expected behavior — the module simply can't be built with an older Go, so the CI should skip gracefully.

Unblocks #3829 and any future dependency bump that raises the minimum Go version for a module.