### PR TITLE
feat: allow overriding the default startup timeout

### DIFF
--- a/docs/features/wait/introduction.md
+++ b/docs/features/wait/introduction.md
@@ -24,6 +24,8 @@ When defining a wait strategy, it should define a way to set the startup timeout
 
 If the default 60s timeout is not sufficient, it can be updated with the `WithStartupTimeout(startupTimeout time.Duration)` function.
 
+To change that default for every wait strategy at once, set the `TESTCONTAINERS_STARTUP_TIMEOUT` environment variable, or the `startup.timeout` property, as described in [Custom configuration](../configuration.md). It is not applied to strategies that set their own timeout with `WithStartupTimeout`.
+
 Besides that, it's possible to define a poll interval, which will actually stop 100 milliseconds the test execution.
 
 If the default 100 milliseconds poll interval is not sufficient, it can be updated with the `WithPollInterval(pollInterval time.Duration)` function.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -94,6 +94,12 @@ type Config struct {
 	//
 	// Environment variable: TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE
 	TestcontainersHost string `properties:"tc.host,default="`
+
+	// StartupTimeout is the default maximum time a wait strategy waits for a container to become ready.
+	// It is not applied to wait strategies that set their own timeout.
+	//
+	// Environment variable: TESTCONTAINERS_STARTUP_TIMEOUT
+	StartupTimeout time.Duration `properties:"startup.timeout,default=1m"`
 }
 
 // }
@@ -155,6 +161,11 @@ func read() Config {
 		ryukConnectionTimeoutEnv := readTestcontainersEnv("RYUK_CONNECTION_TIMEOUT")
 		if timeout, err := time.ParseDuration(ryukConnectionTimeoutEnv); err == nil {
 			config.RyukConnectionTimeout = timeout
+		}
+
+		startupTimeoutEnv := os.Getenv("TESTCONTAINERS_STARTUP_TIMEOUT")
+		if timeout, err := time.ParseDuration(startupTimeoutEnv); err == nil {
+			config.StartupTimeout = timeout
 		}
 
 		return config

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -29,6 +29,7 @@ func resetTestEnv(t *testing.T) {
 	t.Setenv("RYUK_VERBOSE", "")
 	t.Setenv("RYUK_RECONNECTION_TIMEOUT", "")
 	t.Setenv("RYUK_CONNECTION_TIMEOUT", "")
+	t.Setenv("TESTCONTAINERS_STARTUP_TIMEOUT", "")
 }
 
 func TestReadConfig(t *testing.T) {
@@ -86,6 +87,7 @@ func TestReadTCConfig(t *testing.T) {
 		t.Setenv("TESTCONTAINERS_RYUK_CONTAINER_PRIVILEGED", "true")
 		t.Setenv("RYUK_RECONNECTION_TIMEOUT", "13s")
 		t.Setenv("RYUK_CONNECTION_TIMEOUT", "12s")
+		t.Setenv("TESTCONTAINERS_STARTUP_TIMEOUT", "3m")
 
 		config := read()
 
@@ -97,6 +99,7 @@ func TestReadTCConfig(t *testing.T) {
 			Host:                    "", // docker socket is empty at the properties file
 			RyukReconnectionTimeout: 13 * time.Second,
 			RyukConnectionTimeout:   12 * time.Second,
+			StartupTimeout:          3 * time.Minute,
 		}
 
 		assert.Equal(t, expected, config)
@@ -160,10 +163,12 @@ func TestReadTCConfig(t *testing.T) {
 	t.Run("HOME contains TC properties file", func(t *testing.T) {
 		defaultRyukConnectionTimeout := 60 * time.Second
 		defaultRyukReconnectionTimeout := 10 * time.Second
+		defaultStartupTimeout := time.Minute
 		defaultConfig := Config{
 			SessionID:               bootstrap.SessionID(),
 			RyukConnectionTimeout:   defaultRyukConnectionTimeout,
 			RyukReconnectionTimeout: defaultRyukReconnectionTimeout,
+			StartupTimeout:          defaultStartupTimeout,
 		}
 
 		tests := []struct {
@@ -181,6 +186,7 @@ func TestReadTCConfig(t *testing.T) {
 					Host:                    tcpDockerHost33293,
 					RyukConnectionTimeout:   defaultRyukConnectionTimeout,
 					RyukReconnectionTimeout: defaultRyukReconnectionTimeout,
+					StartupTimeout:          defaultStartupTimeout,
 				},
 			},
 			{
@@ -194,6 +200,7 @@ func TestReadTCConfig(t *testing.T) {
 					Host:                    tcpDockerHost4711,
 					RyukConnectionTimeout:   defaultRyukConnectionTimeout,
 					RyukReconnectionTimeout: defaultRyukReconnectionTimeout,
+					StartupTimeout:          defaultStartupTimeout,
 				},
 			},
 			{
@@ -210,6 +217,7 @@ func TestReadTCConfig(t *testing.T) {
 					TLSVerify:               1,
 					RyukConnectionTimeout:   defaultRyukConnectionTimeout,
 					RyukReconnectionTimeout: defaultRyukReconnectionTimeout,
+					StartupTimeout:          defaultStartupTimeout,
 				},
 			},
 			{
@@ -220,6 +228,7 @@ func TestReadTCConfig(t *testing.T) {
 					SessionID:               bootstrap.SessionID(),
 					RyukConnectionTimeout:   defaultRyukConnectionTimeout,
 					RyukReconnectionTimeout: defaultRyukReconnectionTimeout,
+					StartupTimeout:          defaultStartupTimeout,
 				},
 			},
 			{
@@ -233,6 +242,7 @@ func TestReadTCConfig(t *testing.T) {
 					Host:                    tcpDockerHost1234,
 					RyukConnectionTimeout:   defaultRyukConnectionTimeout,
 					RyukReconnectionTimeout: defaultRyukReconnectionTimeout,
+					StartupTimeout:          defaultStartupTimeout,
 				},
 			},
 			{
@@ -244,6 +254,7 @@ func TestReadTCConfig(t *testing.T) {
 					Host:                    tcpDockerHost33293,
 					RyukConnectionTimeout:   defaultRyukConnectionTimeout,
 					RyukReconnectionTimeout: defaultRyukReconnectionTimeout,
+					StartupTimeout:          defaultStartupTimeout,
 				},
 			},
 			{
@@ -265,6 +276,7 @@ func TestReadTCConfig(t *testing.T) {
 					CertPath:                "/tmp/certs",
 					RyukConnectionTimeout:   defaultRyukConnectionTimeout,
 					RyukReconnectionTimeout: defaultRyukReconnectionTimeout,
+					StartupTimeout:          defaultStartupTimeout,
 				},
 			},
 			{
@@ -276,6 +288,7 @@ func TestReadTCConfig(t *testing.T) {
 					RyukDisabled:            true,
 					RyukConnectionTimeout:   defaultRyukConnectionTimeout,
 					RyukReconnectionTimeout: defaultRyukReconnectionTimeout,
+					StartupTimeout:          defaultStartupTimeout,
 				},
 			},
 			{
@@ -287,6 +300,7 @@ func TestReadTCConfig(t *testing.T) {
 					RyukPrivileged:          true,
 					RyukConnectionTimeout:   defaultRyukConnectionTimeout,
 					RyukReconnectionTimeout: defaultRyukReconnectionTimeout,
+					StartupTimeout:          defaultStartupTimeout,
 				},
 			},
 			{
@@ -298,6 +312,7 @@ func TestReadTCConfig(t *testing.T) {
 					SessionID:               bootstrap.SessionID(),
 					RyukReconnectionTimeout: 13 * time.Second,
 					RyukConnectionTimeout:   12 * time.Second,
+					StartupTimeout:          defaultStartupTimeout,
 				},
 			},
 			{
@@ -311,6 +326,31 @@ func TestReadTCConfig(t *testing.T) {
 					SessionID:               bootstrap.SessionID(),
 					RyukReconnectionTimeout: 13 * time.Second,
 					RyukConnectionTimeout:   12 * time.Second,
+					StartupTimeout:          defaultStartupTimeout,
+				},
+			},
+			{
+				"With startup timeout configured using properties",
+				`startup.timeout=2m`,
+				map[string]string{},
+				Config{
+					SessionID:               bootstrap.SessionID(),
+					RyukConnectionTimeout:   defaultRyukConnectionTimeout,
+					RyukReconnectionTimeout: defaultRyukReconnectionTimeout,
+					StartupTimeout:          2 * time.Minute,
+				},
+			},
+			{
+				"With startup timeout configured using env var and properties. Env var wins",
+				`startup.timeout=2m`,
+				map[string]string{
+					"TESTCONTAINERS_STARTUP_TIMEOUT": "3m",
+				},
+				Config{
+					SessionID:               bootstrap.SessionID(),
+					RyukConnectionTimeout:   defaultRyukConnectionTimeout,
+					RyukReconnectionTimeout: defaultRyukReconnectionTimeout,
+					StartupTimeout:          3 * time.Minute,
 				},
 			},
 			{
@@ -325,6 +365,7 @@ func TestReadTCConfig(t *testing.T) {
 					SessionID:               bootstrap.SessionID(),
 					RyukReconnectionTimeout: 13 * time.Second,
 					RyukConnectionTimeout:   12 * time.Second,
+					StartupTimeout:          defaultStartupTimeout,
 				},
 			},
 			{
@@ -336,6 +377,7 @@ func TestReadTCConfig(t *testing.T) {
 					RyukVerbose:             true,
 					RyukConnectionTimeout:   defaultRyukConnectionTimeout,
 					RyukReconnectionTimeout: defaultRyukReconnectionTimeout,
+					StartupTimeout:          defaultStartupTimeout,
 				},
 			},
 			{
@@ -349,6 +391,7 @@ func TestReadTCConfig(t *testing.T) {
 					RyukDisabled:            true,
 					RyukConnectionTimeout:   defaultRyukConnectionTimeout,
 					RyukReconnectionTimeout: defaultRyukReconnectionTimeout,
+					StartupTimeout:          defaultStartupTimeout,
 				},
 			},
 			{
@@ -362,6 +405,7 @@ func TestReadTCConfig(t *testing.T) {
 					RyukPrivileged:          true,
 					RyukConnectionTimeout:   defaultRyukConnectionTimeout,
 					RyukReconnectionTimeout: defaultRyukReconnectionTimeout,
+					StartupTimeout:          defaultStartupTimeout,
 				},
 			},
 			{
@@ -375,6 +419,7 @@ func TestReadTCConfig(t *testing.T) {
 					RyukDisabled:            true,
 					RyukConnectionTimeout:   defaultRyukConnectionTimeout,
 					RyukReconnectionTimeout: defaultRyukReconnectionTimeout,
+					StartupTimeout:          defaultStartupTimeout,
 				},
 			},
 			{
@@ -388,6 +433,7 @@ func TestReadTCConfig(t *testing.T) {
 					RyukDisabled:            true,
 					RyukConnectionTimeout:   defaultRyukConnectionTimeout,
 					RyukReconnectionTimeout: defaultRyukReconnectionTimeout,
+					StartupTimeout:          defaultStartupTimeout,
 				},
 			},
 			{
@@ -417,6 +463,7 @@ func TestReadTCConfig(t *testing.T) {
 					RyukVerbose:             true,
 					RyukConnectionTimeout:   defaultRyukConnectionTimeout,
 					RyukReconnectionTimeout: defaultRyukReconnectionTimeout,
+					StartupTimeout:          defaultStartupTimeout,
 				},
 			},
 			{
@@ -430,6 +477,7 @@ func TestReadTCConfig(t *testing.T) {
 					RyukVerbose:             true,
 					RyukConnectionTimeout:   defaultRyukConnectionTimeout,
 					RyukReconnectionTimeout: defaultRyukReconnectionTimeout,
+					StartupTimeout:          defaultStartupTimeout,
 				},
 			},
 			{
@@ -459,6 +507,7 @@ func TestReadTCConfig(t *testing.T) {
 					RyukPrivileged:          true,
 					RyukConnectionTimeout:   defaultRyukConnectionTimeout,
 					RyukReconnectionTimeout: defaultRyukReconnectionTimeout,
+					StartupTimeout:          defaultStartupTimeout,
 				},
 			},
 			{
@@ -472,6 +521,7 @@ func TestReadTCConfig(t *testing.T) {
 					RyukPrivileged:          true,
 					RyukConnectionTimeout:   defaultRyukConnectionTimeout,
 					RyukReconnectionTimeout: defaultRyukReconnectionTimeout,
+					StartupTimeout:          defaultStartupTimeout,
 				},
 			},
 			{
@@ -529,6 +579,7 @@ func TestReadTCConfig(t *testing.T) {
 					HubImageNamePrefix:      defaultHubPrefix + "/props/",
 					RyukConnectionTimeout:   defaultRyukConnectionTimeout,
 					RyukReconnectionTimeout: defaultRyukReconnectionTimeout,
+					StartupTimeout:          defaultStartupTimeout,
 				},
 			},
 			{
@@ -542,6 +593,7 @@ func TestReadTCConfig(t *testing.T) {
 					HubImageNamePrefix:      defaultHubPrefix + "/env/",
 					RyukConnectionTimeout:   defaultRyukConnectionTimeout,
 					RyukReconnectionTimeout: defaultRyukReconnectionTimeout,
+					StartupTimeout:          defaultStartupTimeout,
 				},
 			},
 			{
@@ -555,6 +607,7 @@ func TestReadTCConfig(t *testing.T) {
 					HubImageNamePrefix:      defaultHubPrefix + "/env/",
 					RyukConnectionTimeout:   defaultRyukConnectionTimeout,
 					RyukReconnectionTimeout: defaultRyukReconnectionTimeout,
+					StartupTimeout:          defaultStartupTimeout,
 				},
 			},
 			//
@@ -566,6 +619,7 @@ func TestReadTCConfig(t *testing.T) {
 					SessionID:               "foo",
 					RyukConnectionTimeout:   defaultRyukConnectionTimeout,
 					RyukReconnectionTimeout: defaultRyukReconnectionTimeout,
+					StartupTimeout:          defaultStartupTimeout,
 				},
 			},
 			{
@@ -578,6 +632,7 @@ func TestReadTCConfig(t *testing.T) {
 					SessionID:               "foo",
 					RyukConnectionTimeout:   defaultRyukConnectionTimeout,
 					RyukReconnectionTimeout: defaultRyukReconnectionTimeout,
+					StartupTimeout:          defaultStartupTimeout,
 				},
 			},
 		}

--- a/options.go
+++ b/options.go
@@ -1,6 +1,7 @@
 package testcontainers
 
 import (
+	"cmp"
 	"context"
 	"errors"
 	"fmt"
@@ -13,6 +14,7 @@ import (
 	"github.com/moby/moby/api/types/network"
 
 	tcexec "github.com/testcontainers/testcontainers-go/exec"
+	"github.com/testcontainers/testcontainers-go/internal/config"
 	"github.com/testcontainers/testcontainers-go/internal/core"
 	"github.com/testcontainers/testcontainers-go/wait"
 )
@@ -391,14 +393,16 @@ func WithAfterReadyCommand(execs ...Executable) CustomizeRequestOption {
 	}
 }
 
-// WithWaitStrategy replaces the wait strategy for a container, using 60 seconds as deadline
+// WithWaitStrategy replaces the wait strategy for a container, using the configured
+// startup timeout as deadline, 60 seconds by default.
 func WithWaitStrategy(strategies ...wait.Strategy) CustomizeRequestOption {
-	return WithWaitStrategyAndDeadline(60*time.Second, strategies...)
+	return WithWaitStrategyAndDeadline(cmp.Or(config.Read().StartupTimeout, 60*time.Second), strategies...)
 }
 
-// WithAdditionalWaitStrategy appends the wait strategy for a container, using 60 seconds as deadline
+// WithAdditionalWaitStrategy appends the wait strategy for a container, using the
+// configured startup timeout as deadline, 60 seconds by default.
 func WithAdditionalWaitStrategy(strategies ...wait.Strategy) CustomizeRequestOption {
-	return WithAdditionalWaitStrategyAndDeadline(60*time.Second, strategies...)
+	return WithAdditionalWaitStrategyAndDeadline(cmp.Or(config.Read().StartupTimeout, 60*time.Second), strategies...)
 }
 
 // WithWaitStrategyAndDeadline replaces the wait strategy for a container, including deadline

--- a/wait/wait.go
+++ b/wait/wait.go
@@ -1,6 +1,7 @@
 package wait
 
 import (
+	"cmp"
 	"context"
 	"errors"
 	"fmt"
@@ -11,6 +12,7 @@ import (
 	"github.com/moby/moby/api/types/network"
 
 	"github.com/testcontainers/testcontainers-go/exec"
+	"github.com/testcontainers/testcontainers-go/internal/config"
 )
 
 // Strategy defines the basic interface for a Wait Strategy
@@ -57,7 +59,7 @@ func checkState(state *container.State) error {
 }
 
 func defaultStartupTimeout() time.Duration {
-	return 60 * time.Second
+	return cmp.Or(config.Read().StartupTimeout, 60*time.Second)
 }
 
 func defaultPollInterval() time.Duration {


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?

Adds a `TESTCONTAINERS_STARTUP_TIMEOUT` environment variable, and the matching `startup.timeout` property, to configure the default startup timeout for wait strategies. It follows the existing configuration pattern: a `StartupTimeout` field on `config.Config` with a `default=1m` struct tag, read from `~/.testcontainers.properties` and overridden by the environment variable.

The configured value feeds `wait.defaultStartupTimeout()`, which every wait strategy falls back to, and the deadline applied by `WithWaitStrategy` and `WithAdditionalWaitStrategy`, replacing the hardcoded 60 seconds in both. Both resolve it with `cmp.Or(config.Read().StartupTimeout, 60*time.Second)`, so the default is unchanged at 60 seconds when nothing is configured. Wait strategies that set their own timeout, and deadlines passed explicitly to `WithWaitStrategyAndDeadline`, are not affected.


## Why is it important?

The 60 second default is not always enough for containers that are expensive to start, or for CI runners under load. It can currently only be raised per strategy with `WithStartupTimeout`, which is out of reach when a module builds its wait strategy internally, so there is no way to raise it globally without patching each call site.


## Related issues

- Closes #3845

## How to test this PR

The new setting is covered by unit tests for the environment variable, the property, and the precedence between them:

    go test ./internal/config/

To see it applied end to end, set it low enough to force a failure and run any module test, then unset it and re-run:

    cd modules/elasticsearch
    TESTCONTAINERS_STARTUP_TIMEOUT=1s go test ./...   # wait strategy times out
    go test ./...                                     # passes with the 60s default

The modules `replace` the root module with `../..`, so they pick up these changes without a release. The property form works the same way by adding `startup.timeout=1s` to `~/.testcontainers.properties`.



## Follow-ups

Modules that pass their own deadline to `WithWaitStrategyAndDeadline` do not honour this setting: `ravendb`, `timeplus` and `grafana-lgtm`. A possible follow-up could some conditional logic to only set it when the default is below the custom value set there. The other 91 modules build their strategies through the plain helpers and pick it up automatically.


