### PR TITLE
ci: skip test jobs for modules that do not support Go 1.25

### DIFF
--- a/.github/workflows/ci-test-go.yml
+++ b/.github/workflows/ci-test-go.yml
@@ -72,11 +72,30 @@ jobs:
             cache-dependency-path: '${{ inputs.project-directory }}/go.sum'
         id: go
 
+      - name: Check Go version compatibility
+        id: go-compat
+        shell: bash
+        run: |
+          # Modules that require Go 1.26+ and do not support Go 1.25.x
+          NO_SUPPORT_125=("modules/weaviate")
+
+          SKIP=false
+          for mod in "${NO_SUPPORT_125[@]}"; do
+            if [[ "${{ inputs.project-directory }}" == "${mod}" ]] && [[ "${{ inputs.go-version }}" == 1.25.* ]]; then
+              echo "Skipping: ${mod} does not support Go 1.25.x"
+              SKIP=true
+              break
+            fi
+          done
+          echo "skip=${SKIP}" >> $GITHUB_OUTPUT
+
       - name: ensure compilation
+        if: steps.go-compat.outputs.skip != 'true'
         working-directory: ./${{ inputs.project-directory }}
         run: go build ./...
 
       - name: Install dependencies
+        if: steps.go-compat.outputs.skip != 'true'
         shell: bash
         run: |
           SCRIPT_PATH="./.github/scripts/${{ inputs.project-directory }}/install-dependencies.sh"
@@ -88,23 +107,25 @@ jobs:
 
       # Setup Testcontainers Cloud Client right before your Testcontainers tests
       - name: Setup Testcontainers Cloud Client
-        if: ${{ inputs.testcontainers-cloud }}
+        if: ${{ inputs.testcontainers-cloud && steps.go-compat.outputs.skip != 'true' }}
         uses: atomicjar/testcontainers-cloud-setup-action@7d1bab3fdfe0027c91936deca6b924d8a8a7a04d # v1.3
         with:
           token: ${{ secrets.TCC_TOKEN }}
 
       - name: go test
+        if: steps.go-compat.outputs.skip != 'true'
         working-directory: ./${{ inputs.project-directory }}
         timeout-minutes: 30
         run: make test-unit
 
       - name: Run checker
+        if: steps.go-compat.outputs.skip != 'true'
         run: |
             ./scripts/check_environment.sh
 
       # (Optionally) When you don't need Testcontainers Cloud anymore, you could terminate sessions eagerly
       - name: Terminate Testcontainers Cloud Client active sessions
-        if: ${{ inputs.testcontainers-cloud }}
+        if: ${{ inputs.testcontainers-cloud && steps.go-compat.outputs.skip != 'true' }}
         uses: atomicjar/testcontainers-cloud-setup-action@7d1bab3fdfe0027c91936deca6b924d8a8a7a04d # v1.3
         with:
           action: terminate
@@ -113,10 +134,10 @@ jobs:
         uses: test-summary/action@31493c76ec9e7aa675f1585d3ed6f1da69269a86 # v2.4
         with:
             paths: "**/${{ inputs.project-directory }}/TEST-unit*.xml"
-        if: always()
+        if: ${{ always() && steps.go-compat.outputs.skip != 'true' }}
 
       - name: Decide if Sonar must be run
-        if: ${{ matrix.platform == 'ubuntu-latest' }}
+        if: ${{ matrix.platform == 'ubuntu-latest' && steps.go-compat.outputs.skip != 'true' }}
         run: |
           if [[ "1.25.x" == "${{ inputs.go-version }}" ]] && \
              [[ "true" != "${{ inputs.rootless-docker }}" ]] && \


### PR DESCRIPTION
Fixes the Go 1.25.x CI failure on #3829.

weaviate v1.38.0 bumps the go directive to `go 1.26`, so Go 1.25.x fails with:
```
go: go.mod requires go >= 1.26 (running go 1.25.12; GOTOOLCHAIN=local)
```

Adds a `NO_SUPPORT_125` list to `ci-test-go.yml` (similar to `no_build_modules` in `changed-modules.sh`). When a module is in the list and the Go version is 1.25.x, all build/test/sonar steps are skipped.