### PR TITLE
chore(mariadb): update test image to 12.3.2

### DIFF
--- a/docs/modules/mariadb.md
+++ b/docs/modules/mariadb.md
@@ -42,7 +42,7 @@ func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustom
 #### Image
 
 Use the second argument in the `Run` function to set a valid Docker image.
-In example: `Run(context.Background(), "mariadb:11.0.3")`.
+In example: `Run(context.Background(), "mariadb:12.3.2")`.
 
 !!!info
     From MariaDB [docs](https://github.com/docker-library/docs/tree/master/mariadb#environment-variables):

--- a/modules/mariadb/examples_test.go
+++ b/modules/mariadb/examples_test.go
@@ -15,7 +15,7 @@ func ExampleRun() {
 	ctx := context.Background()
 
 	mariadbContainer, err := mariadb.Run(ctx,
-		"mariadb:11.0.3",
+		"mariadb:12.3.2",
 		mariadb.WithConfigFile(filepath.Join("testdata", "my.cnf")),
 		mariadb.WithScripts(filepath.Join("testdata", "schema.sql")),
 		mariadb.WithDatabase("foo"),

--- a/modules/mariadb/mariadb_test.go
+++ b/modules/mariadb/mariadb_test.go
@@ -17,7 +17,7 @@ import (
 func TestMariaDB(t *testing.T) {
 	ctx := context.Background()
 
-	ctr, err := mariadb.Run(ctx, "mariadb:11.0.3")
+	ctr, err := mariadb.Run(ctx, "mariadb:12.3.2")
 	testcontainers.CleanupContainer(t, ctr)
 	require.NoError(t, err)
 
@@ -49,7 +49,7 @@ func TestMariaDBWithNonRootUserAndEmptyPassword(t *testing.T) {
 	ctx := context.Background()
 
 	_, err := mariadb.Run(ctx,
-		"mariadb:11.0.3",
+		"mariadb:12.3.2",
 		mariadb.WithDatabase("foo"),
 		mariadb.WithUsername("test"),
 		mariadb.WithPassword(""))
@@ -60,7 +60,7 @@ func TestMariaDBWithRootUserAndEmptyPassword(t *testing.T) {
 	ctx := context.Background()
 
 	ctr, err := mariadb.Run(ctx,
-		"mariadb:11.0.3",
+		"mariadb:12.3.2",
 		mariadb.WithDatabase("foo"),
 		mariadb.WithUsername("root"),
 		mariadb.WithPassword(""))
@@ -99,7 +99,7 @@ func TestMariaDBWithMySQLEnvVars(t *testing.T) {
 func TestMariaDBWithConfigFile(t *testing.T) {
 	ctx := context.Background()
 
-	ctr, err := mariadb.Run(ctx, "mariadb:11.0.3",
+	ctr, err := mariadb.Run(ctx, "mariadb:12.3.2",
 		mariadb.WithConfigFile(filepath.Join("testdata", "my.cnf")))
 	testcontainers.CleanupContainer(t, ctr)
 	require.NoError(t, err)
@@ -133,7 +133,7 @@ func TestMariaDBWithScripts(t *testing.T) {
 	ctx := context.Background()
 
 	ctr, err := mariadb.Run(ctx,
-		"mariadb:11.0.3",
+		"mariadb:12.3.2",
 		mariadb.WithScripts(filepath.Join("testdata", "schema.sql")))
 	testcontainers.CleanupContainer(t, ctr)
 	require.NoError(t, err)


### PR DESCRIPTION
  ## What does this PR do?

  Updates the pinned MariaDB image used by the module tests, executable
  example, and documentation from `mariadb:11.0.3` to
  `mariadb:12.3.2`.

  The existing `mariadb:10.3.29` legacy test and the deprecated
  `RunContainer` default remain unchanged. No runtime code or public API
  is modified.

  ## Why is it important?

  MariaDB 11.0 is no longer maintained. Running the existing module test
  suite against the current `mariadb:12.3.2` official image confirms that
  the module remains compatible with MariaDB 12, including credentials,
  custom configuration, initialization scripts, connections, and SQL
  operations.

  The image uses an exact tag to keep CI reproducible.

  ## Related issues

  - N/A

  ## How to test this PR

  From `modules/mariadb`:

  ```shell
  GOTOOLCHAIN=go1.25.9 go test -race -count=1 -timeout=30m ./...
  GOTOOLCHAIN=go1.25.9 golangci-lint run -c ../../.golangci.yml ./...