### PR TITLE
Add CopyDirFromContainer

### DIFF
--- a/container.go
+++ b/container.go
@@ -70,6 +70,7 @@ type Container interface {
 	CopyDirToContainer(ctx context.Context, hostDirPath string, containerParentPath string, fileMode int64) error
 	CopyFileToContainer(ctx context.Context, hostFilePath string, containerFilePath string, fileMode int64) error
 	CopyFileFromContainer(ctx context.Context, filePath string) (io.ReadCloser, error)
+	CopyDirFromContainer(ctx context.Context, containerDirPath string, hostDirPath string) error
 	GetLogProductionErrorChannel() <-chan error
 }
 

--- a/docker.go
+++ b/docker.go
@@ -681,6 +681,27 @@ func (c *DockerContainer) CopyFileFromContainer(ctx context.Context, filePath st
 	return ret, nil
 }
 
+// CopyDirFromContainer copies a directory from the container to a host path.
+func (c *DockerContainer) CopyDirFromContainer(ctx context.Context, containerDirPath string, hostDirPath string) error {
+	if err := os.MkdirAll(hostDirPath, 0o755); err != nil {
+		return fmt.Errorf("create host directory %s: %w", hostDirPath, err)
+	}
+
+	r, err := c.provider.client.CopyFromContainer(ctx, c.ID, client.CopyFromContainerOptions{
+		SourcePath: containerDirPath,
+	})
+	if err != nil {
+		return err
+	}
+	defer c.provider.Close()
+	defer r.Content.Close()
+
+	if err := extractTar(hostDirPath, r.Content); err != nil {
+		return fmt.Errorf("extract directory from container: %w", err)
+	}
+	return nil
+}
+
 // CopyDirToContainer copies the contents of a directory to a parent path in the container. This parent path must exist in the container first
 // as we cannot create it
 func (c *DockerContainer) CopyDirToContainer(ctx context.Context, hostDirPath string, containerParentPath string, fileMode int64) error {

--- a/file.go
+++ b/file.go
@@ -141,3 +141,42 @@ func tarFile(basePath string, fileContent func(tw io.Writer) error, fileContentS
 
 	return buffer, nil
 }
+
+// extractTar extracts a plain tar archive (as returned by Docker CopyFromContainer) into dst.
+func extractTar(dst string, r io.Reader) error {
+	tr := tar.NewReader(r)
+	for {
+		header, err := tr.Next()
+		switch {
+		case err == io.EOF:
+			return nil
+		case err != nil:
+			return err
+		case header == nil:
+			continue
+		}
+
+		target := filepath.Join(dst, header.Name)
+		switch header.Typeflag {
+		case tar.TypeDir:
+			if err := os.MkdirAll(target, 0o755); err != nil {
+				return err
+			}
+		case tar.TypeReg:
+			if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+				return err
+			}
+			f, err := os.OpenFile(target, os.O_CREATE|os.O_RDWR|os.O_TRUNC, os.FileMode(header.Mode))
+			if err != nil {
+				return err
+			}
+			if _, err := io.Copy(f, tr); err != nil {
+				_ = f.Close()
+				return err
+			}
+			if err := f.Close(); err != nil {
+				return err
+			}
+		}
+	}
+}


### PR DESCRIPTION
Mirror CopyDirToContainer for downloading container directories to the host. Fixes #3705.