### PR TITLE
fix: skip internal port check for Ryuk

### DIFF
--- a/reaper.go
+++ b/reaper.go
@@ -379,7 +379,8 @@ func (r *reaperSpawner) fromContainer(ctx context.Context, sessionID string, pro
 func defaultRyukWaitStrategy(port string) wait.Strategy {
 	return wait.ForAll(
 		wait.ForLog("Started"),
-		wait.ForListeningPort(port),
+		// Skip the internal check because the Ryuk image has no shell.
+		wait.ForListeningPort(port).SkipInternalCheck(),
 	)
 }
 

--- a/reaper_test.go
+++ b/reaper_test.go
@@ -1,9 +1,11 @@
 package testcontainers
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
+	"log"
 	"net"
 	"os"
 	"strconv"
@@ -20,6 +22,8 @@ import (
 
 	"github.com/testcontainers/testcontainers-go/internal/config"
 	"github.com/testcontainers/testcontainers-go/internal/core"
+	tclog "github.com/testcontainers/testcontainers-go/log"
+	"github.com/testcontainers/testcontainers-go/wait"
 )
 
 // testSessionID the tests need to create a reaper in a different session, so that it does not interfere with other tests
@@ -527,6 +531,55 @@ func TestReaper_ReuseRunning(t *testing.T) {
 	for i, containerID := range obtainedReaperContainerIDs {
 		require.Equal(t, firstContainerID, containerID, "call %d should have returned same container id", i)
 	}
+}
+
+func TestDefaultRyukWaitStrategy_SkipsIneffectiveInternalCheck(t *testing.T) {
+	req := ContainerRequest{
+		Image:        config.ReaperDefaultImage,
+		ExposedPorts: []string{"8080/tcp"},
+		Labels:       core.DefaultLabels(testSessionID),
+		HostConfigModifier: func(hostConfig *container.HostConfig) {
+			hostConfig.Binds = []string{core.MustExtractDockerSocket(context.Background()) + ":/var/run/docker.sock"}
+		},
+	}
+	provider, err := ProviderDocker.GetProvider()
+	require.NoError(t, err)
+
+	c, err := provider.CreateContainer(t.Context(), req)
+	CleanupContainer(t, c)
+	require.NoError(t, err)
+
+	err = c.Start(t.Context())
+	require.NoError(t, err)
+
+	var buf bytes.Buffer
+	origLogger := tclog.Default()
+	tclog.SetDefault(log.New(&buf, "", log.LstdFlags))
+	t.Cleanup(func() {
+		tclog.SetDefault(origLogger)
+	})
+
+	t.Run("internal check is ineffective", func(t *testing.T) {
+		buf.Reset()
+
+		err := wait.ForAll(
+			wait.ForLog("Started"),
+			wait.ForListeningPort("8080/tcp"),
+		).WaitUntilReady(t.Context(), c)
+		require.NoError(t, err)
+
+		// If this assertion fails, the internal check may have become effective.
+		// In that case, reevaluate whether SkipInternalCheck() is still necessary.
+		require.Contains(t, buf.String(), "Shell not")
+	})
+
+	t.Run("Ryuk strategy skips ineffective internal check", func(t *testing.T) {
+		buf.Reset()
+
+		err := defaultRyukWaitStrategy("8080/tcp").WaitUntilReady(t.Context(), c)
+		require.NoError(t, err)
+		require.NotContains(t, buf.String(), "Shell not")
+	})
 }
 
 // reaperConnect copies the logic from Reaper.connect() but with better error handling.


### PR DESCRIPTION

<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

This PR skips Ryuk's internal port check by calling `SkipInternalCheck()`.
The internal port check invokes `/bin/sh`, but the Ryuk images do not include a shell. As a result, it always exits with status 127, which `WaitUntilReady` ignores, so the internal check has no effect.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

I discovered this issue while using `testcontainers-go` with `socktainer`. During my investigation, I found that Ryuk's internal check effectively relies on docker exec returning exit status 127 for a missing executable. As described in https://github.com/socktainer/socktainer/issues/383, `socktainer` instead returns a different exit status, causing the check to fail.
Since the internal check is ineffective for the current Ryuk images anyway—the images do not include a shell, and `WaitUntilReady` ignores exit status 127—skipping it does not change the readiness behavior while improving compatibility with alternative Docker implementations.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Relates https://github.com/socktainer/socktainer/issues/383

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
