### PR TITLE
fix: dial the sshd container on the Docker daemon host

### DIFF
--- a/port_forwarding.go
+++ b/port_forwarding.go
@@ -205,7 +205,7 @@ func newSshdContainer(ctx context.Context, opts ...ContainerCustomizer) (*sshdCo
 // It's an internal type that extends the DockerContainer type, to add the SSH tunnelling capabilities.
 type sshdContainer struct {
 	Container
-	port           string
+	addr           string
 	sshConfig      *ssh.ClientConfig
 	portForwarders []*portForwarder
 }
@@ -240,12 +240,17 @@ func (sshdC *sshdContainer) closePorts() error {
 
 // clientConfig sets up the SSHD client configuration.
 func (sshdC *sshdContainer) clientConfig(ctx context.Context) error {
+	host, err := sshdC.Host(ctx)
+	if err != nil {
+		return fmt.Errorf("host: %w", err)
+	}
+
 	mappedPort, err := sshdC.MappedPort(ctx, sshPort)
 	if err != nil {
 		return fmt.Errorf("mapped port: %w", err)
 	}
 
-	sshdC.port = mappedPort.Port()
+	sshdC.addr = net.JoinHostPort(host, mappedPort.Port())
 	sshdC.sshConfig = &ssh.ClientConfig{
 		User:            user,
 		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
@@ -263,7 +268,7 @@ func (sshdC *sshdContainer) exposeHostPort(ctx context.Context, ports ...int) (e
 		}
 	}()
 	for _, port := range ports {
-		pf, err := newPortForwarder(ctx, "localhost:"+sshdC.port, sshdC.sshConfig, port)
+		pf, err := newPortForwarder(ctx, sshdC.addr, sshdC.sshConfig, port)
 		if err != nil {
 			return fmt.Errorf("new port forwarder: %w", err)
 		}


### PR DESCRIPTION
## What does this PR do?

Host port access (`WithHostPortAccess`) dialed its sshd sidecar at `localhost:<mapped port>`. It now resolves the host through `Container.Host()`, so the dial goes to the Docker daemon host like every other exposed port.

## Why is it important?

With a remote daemon, for example a `docker:dind` service in GitLab CI reached via `DOCKER_HOST=tcp://docker:2376`, the mapped port is published on the daemon host and not on the test process's loopback. Host port access then always fails with:

```
new port forwarder: ssh dial: dial tcp [::1]:32837: connect: connection refused
```

`TESTCONTAINERS_HOST_OVERRIDE` does not help because this code path never consulted it. testcontainers-java already uses `container.getHost()` for the same connection.

## Related issues

None found.

## How to test this PR

`TestExposeHostPorts` still passes against a local daemon. For the remote case, run `docker:dind` on a user-defined network with the alias `docker`, then run a program that uses `WithHostPortAccess` in a sibling container on that network with `DOCKER_HOST=tcp://docker:2376`. Before this change the sshd dial fails as above; after it the container reaches `host.testcontainers.internal:<port>`.