### PR TITLE
fix(rabbitmq): pass the node config from memory instead of a shared temp file

### DIFF
--- a/modules/rabbitmq/rabbitmq.go
+++ b/modules/rabbitmq/rabbitmq.go
@@ -5,8 +5,6 @@ import (
 	"context"
 	_ "embed"
 	"fmt"
-	"os"
-	"path/filepath"
 	"text/template"
 	"time"
 
@@ -93,12 +91,6 @@ func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustom
 		return nil, err
 	}
 
-	tmpConfigFile := filepath.Join(os.TempDir(), "rabbitmq-testcontainers.conf")
-	err = os.WriteFile(tmpConfigFile, nodeConfig, 0o600)
-	if err != nil {
-		return nil, err
-	}
-
 	moduleOpts := []testcontainers.ContainerCustomizer{
 		testcontainers.WithEnv(map[string]string{
 			"RABBITMQ_DEFAULT_USER": settings.AdminUsername,
@@ -111,7 +103,7 @@ func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustom
 			DefaultHTTPPort,
 		),
 		testcontainers.WithWaitStrategy(wait.ForLog(".*Server startup complete.*").AsRegexp().WithStartupTimeout(60 * time.Second)),
-		withConfig(tmpConfigFile),
+		withConfig(nodeConfig),
 	}
 
 	if settings.SSLSettings != nil {
@@ -137,14 +129,17 @@ func Run(ctx context.Context, img string, opts ...testcontainers.ContainerCustom
 	return c, nil
 }
 
-func withConfig(hostPath string) testcontainers.CustomizeRequestOption {
+func withConfig(config []byte) testcontainers.CustomizeRequestOption {
 	return func(req *testcontainers.GenericContainerRequest) error {
 		if err := testcontainers.WithEnv(map[string]string{"RABBITMQ_CONFIG_FILE": defaultCustomConfPath})(req); err != nil {
 			return err
 		}
 
+		// Copied from memory rather than from a file on the host: a fixed path
+		// under the temporary directory is shared by every user on the machine,
+		// so the file left behind by one user makes the next one fail.
 		return testcontainers.WithFiles(testcontainers.ContainerFile{
-			HostFilePath:      hostPath,
+			Reader:            bytes.NewReader(config),
 			ContainerFilePath: defaultCustomConfPath,
 			FileMode:          0o644,
 		})(req)


### PR DESCRIPTION
## What does this PR do?

The RabbitMQ module no longer writes its rendered node configuration to a file on the host. `ContainerFile` already takes a `Reader` instead of a `HostFilePath`, and the file is copied into the container in the `PostCreates` hook either way, so the config can be handed over from memory and the temporary file disappears entirely.

## Why is it important?

The path was fixed: `filepath.Join(os.TempDir(), "rabbitmq-testcontainers.conf")`, written with mode `0600` and never removed. On a shared machine that path belongs to whoever created it first, so a run under a different user fails with `open /tmp/rabbitmq-testcontainers.conf: permission denied` before the container ever starts. Removing the file after each run would fix the symptom; not writing it at all also removes the leftover, the fixed name, and the two failure modes that come with writing to a shared directory.

## Related issues

- Closes #3880

## How to test this PR

`go test ./...` in `modules/rabbitmq` (needs a Docker daemon). The existing suite covers this: `ExampleRun_withSSL` and the plugin examples assert the config actually lands at `/etc/rabbitmq/rabbitmq-testcontainers.conf` inside the container, which is the path that matters and is unchanged.

To see the original bug, run any test in the module as root, then again as a normal user.
