### PR TITLE
fix(auth): use the credentials store when no registry matches

### DIFF
--- a/container.go
+++ b/container.go
@@ -383,14 +383,14 @@ func getAuthConfigsFromDockerfile(c *ContainerRequest) (map[string]registry.Auth
 	}
 
 	// Get the auth configs once for all images as it can be a time-consuming operation.
-	configs, err := getDockerAuthConfigs()
+	cfg, configs, err := loadDockerAuth()
 	if err != nil {
 		return nil, err
 	}
 
 	authConfigs := map[string]registry.AuthConfig{}
 	for _, image := range images {
-		registry, authConfig, err := dockerImageAuth(context.Background(), image, configs)
+		registry, authConfig, err := dockerImageAuth(context.Background(), image, cfg, configs)
 		if err != nil {
 			if !errors.Is(err, dockercfg.ErrCredentialsNotFound) {
 				return nil, fmt.Errorf("docker image auth %q: %w", image, err)

--- a/docker_auth.go
+++ b/docker_auth.go
@@ -55,7 +55,41 @@ func dockerImageAuth(ctx context.Context, image string, configs map[string]regis
 		return reg, cfg, nil
 	}
 
+	if cfg, ok := credentialsStoreAuth(reg); ok {
+		return reg, cfg, nil
+	}
+
 	return reg, registry.AuthConfig{}, dockercfg.ErrCredentialsNotFound
+}
+
+// credentialsStoreAuth returns the auth config the credentials store holds for reg,
+// if one is configured and it has an entry for that registry.
+//
+// A credentials store serves every registry, so unlike auths and credHelpers it has
+// no entries to enumerate up front: it can only be asked once the registry is known.
+// See https://docs.docker.com/reference/cli/docker/login/#credential-stores
+func credentialsStoreAuth(reg string) (registry.AuthConfig, bool) {
+	cfg, err := getDockerConfig()
+	if err != nil || cfg.CredentialsStore == "" {
+		return registry.AuthConfig{}, false
+	}
+
+	key, err := configKey(cfg)
+	if err != nil {
+		return registry.AuthConfig{}, false
+	}
+
+	var ac registry.AuthConfig
+	if err := creds.AuthConfig(reg, key, &ac); err != nil {
+		return registry.AuthConfig{}, false
+	}
+
+	// The store reports an unknown registry as empty credentials rather than an error.
+	if ac.Username == "" && ac.Password == "" && ac.IdentityToken == "" {
+		return registry.AuthConfig{}, false
+	}
+
+	return ac, true
 }
 
 func getRegistryAuth(reg string, cfgs map[string]registry.AuthConfig) (registry.AuthConfig, bool) {

--- a/docker_auth.go
+++ b/docker_auth.go
@@ -109,7 +109,11 @@ func credentialsStoreAuth(cfg *dockercfg.Config, reg string) (registry.AuthConfi
 	}
 
 	var ac registry.AuthConfig
-	if err := creds.AuthConfig(cfg, reg, key, &ac); err != nil {
+	// Keep store-only results separate from the general credential resolver,
+	// which may fall back to other sources when this store has no entry.
+	if err := creds.AuthConfig(reg, "store:"+key, &ac, func() (string, string, error) {
+		return dockercfg.GetCredentialsFromHelper(cfg.CredentialsStore, reg)
+	}); err != nil {
 		return registry.AuthConfig{}, false, err
 	}
 
@@ -187,9 +191,9 @@ type credentials struct {
 var creds = &credentialsCache{entries: map[string]credentials{}}
 
 // AuthConfig updates the details in authConfig for the given hostname
-// as determined by the details in configKey.
-func (c *credentialsCache) AuthConfig(cfg *dockercfg.Config, hostname, configKey string, authConfig *registry.AuthConfig) error {
-	u, p, err := creds.get(cfg, hostname, configKey)
+// as determined by configKey, calling lookup only on a cache miss.
+func (c *credentialsCache) AuthConfig(hostname, configKey string, authConfig *registry.AuthConfig, lookup func() (string, string, error)) error {
+	u, p, err := c.get(hostname, configKey, lookup)
 	if err != nil {
 		return err
 	}
@@ -205,9 +209,9 @@ func (c *credentialsCache) AuthConfig(cfg *dockercfg.Config, hostname, configKey
 }
 
 // get returns the username and password for the given hostname
-// as determined by the details in configPath.
+// as determined by configKey, calling lookup only on a cache miss.
 // If the username is empty, the password is an identity token.
-func (c *credentialsCache) get(cfg *dockercfg.Config, hostname, configKey string) (string, string, error) {
+func (c *credentialsCache) get(hostname, configKey string, lookup func() (string, string, error)) (string, string, error) {
 	key := configKey + ":" + hostname
 	c.mtx.RLock()
 	entry, ok := c.entries[key]
@@ -218,7 +222,7 @@ func (c *credentialsCache) get(cfg *dockercfg.Config, hostname, configKey string
 	}
 
 	// No entry found, request and cache.
-	user, password, err := getRegistryCredentials(cfg, hostname)
+	user, password, err := lookup()
 	if err != nil {
 		return "", "", fmt.Errorf("getting credentials for %s: %w", hostname, err)
 	}
@@ -285,7 +289,9 @@ func getDockerAuthConfigsFromConfig(cfg *dockercfg.Config) (map[string]registry.
 			switch {
 			case ac.Username == "" && ac.Password == "":
 				// Look up credentials from the credential store.
-				if err := creds.AuthConfig(cfg, k, key, &ac); err != nil {
+				if err := creds.AuthConfig(k, key, &ac, func() (string, string, error) {
+					return getRegistryCredentials(cfg, k)
+				}); err != nil {
 					results <- authConfigResult{err: err}
 					return
 				}
@@ -305,7 +311,9 @@ func getDockerAuthConfigsFromConfig(cfg *dockercfg.Config) (map[string]registry.
 			defer wg.Done()
 
 			var ac registry.AuthConfig
-			if err := creds.AuthConfig(cfg, k, key, &ac); err != nil {
+			if err := creds.AuthConfig(k, key, &ac, func() (string, string, error) {
+				return getRegistryCredentials(cfg, k)
+			}); err != nil {
 				results <- authConfigResult{err: err}
 				return
 			}

--- a/docker_auth.go
+++ b/docker_auth.go
@@ -23,24 +23,48 @@ import (
 // defaultRegistryFn is variable overwritten in tests to check for behaviour with different default values.
 var defaultRegistryFn = defaultRegistry
 
-// getRegistryCredentials is a variable overwritten in tests to mock the dockercfg.GetRegistryCredentials function.
-var getRegistryCredentials = dockercfg.GetRegistryCredentials
+// getRegistryCredentials is a variable overwritten in tests to mock the credentials lookup.
+// It resolves against the config already loaded, which honours DOCKER_AUTH_CONFIG, rather than
+// reloading the default config file.
+var getRegistryCredentials = func(cfg *dockercfg.Config, hostname string) (string, string, error) {
+	return cfg.GetRegistryCredentials(hostname)
+}
 
 // DockerImageAuth returns the auth config for the given Docker image, extracting first its Docker registry.
 // Finally, it will use the credential helpers to extract the information from the docker config file
 // for that registry, if it exists.
 func DockerImageAuth(ctx context.Context, image string) (string, registry.AuthConfig, error) {
-	configs, err := getDockerAuthConfigs()
+	cfg, configs, err := loadDockerAuth()
 	if err != nil {
 		reg := core.ExtractRegistry(image, defaultRegistryFn(ctx))
 		return reg, registry.AuthConfig{}, err
 	}
 
-	return dockerImageAuth(ctx, image, configs)
+	return dockerImageAuth(ctx, image, cfg, configs)
+}
+
+// loadDockerAuth loads the docker config once and the auth configs derived from it,
+// so that both the map lookup and the credentials store lookup see the same config.
+// A missing config file is not an error: it yields an empty config.
+func loadDockerAuth() (*dockercfg.Config, map[string]registry.AuthConfig, error) {
+	cfg, err := getDockerConfig()
+	if err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			return nil, nil, err
+		}
+		cfg = &dockercfg.Config{}
+	}
+
+	configs, err := getDockerAuthConfigsFromConfig(cfg)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return cfg, configs, nil
 }
 
 // dockerImageAuth returns the auth config for the given Docker image.
-func dockerImageAuth(ctx context.Context, image string, configs map[string]registry.AuthConfig) (string, registry.AuthConfig, error) {
+func dockerImageAuth(ctx context.Context, image string, cfg *dockercfg.Config, configs map[string]registry.AuthConfig) (string, registry.AuthConfig, error) {
 	defaultRegistry := defaultRegistryFn(ctx)
 	reg := core.ExtractRegistry(image, defaultRegistry)
 
@@ -51,12 +75,16 @@ func dockerImageAuth(ctx context.Context, image string, configs map[string]regis
 		reg = defaultRegistry // This is https://index.docker.io/v1/
 	}
 
-	if cfg, ok := getRegistryAuth(reg, configs); ok {
-		return reg, cfg, nil
+	if ac, ok := getRegistryAuth(reg, configs); ok {
+		return reg, ac, nil
 	}
 
-	if cfg, ok := credentialsStoreAuth(reg); ok {
-		return reg, cfg, nil
+	ac, ok, err := credentialsStoreAuth(cfg, reg)
+	if err != nil {
+		return reg, registry.AuthConfig{}, err
+	}
+	if ok {
+		return reg, ac, nil
 	}
 
 	return reg, registry.AuthConfig{}, dockercfg.ErrCredentialsNotFound
@@ -68,28 +96,29 @@ func dockerImageAuth(ctx context.Context, image string, configs map[string]regis
 // A credentials store serves every registry, so unlike auths and credHelpers it has
 // no entries to enumerate up front: it can only be asked once the registry is known.
 // See https://docs.docker.com/reference/cli/docker/login/#credential-stores
-func credentialsStoreAuth(reg string) (registry.AuthConfig, bool) {
-	cfg, err := getDockerConfig()
-	if err != nil || cfg.CredentialsStore == "" {
-		return registry.AuthConfig{}, false
+func credentialsStoreAuth(cfg *dockercfg.Config, reg string) (registry.AuthConfig, bool, error) {
+	// A store cannot be asked about an empty host, and a missing helper binary
+	// already reads as "no credentials" further down.
+	if cfg.CredentialsStore == "" || reg == "" {
+		return registry.AuthConfig{}, false, nil
 	}
 
 	key, err := configKey(cfg)
 	if err != nil {
-		return registry.AuthConfig{}, false
+		return registry.AuthConfig{}, false, err
 	}
 
 	var ac registry.AuthConfig
-	if err := creds.AuthConfig(reg, key, &ac); err != nil {
-		return registry.AuthConfig{}, false
+	if err := creds.AuthConfig(cfg, reg, key, &ac); err != nil {
+		return registry.AuthConfig{}, false, err
 	}
 
 	// The store reports an unknown registry as empty credentials rather than an error.
 	if ac.Username == "" && ac.Password == "" && ac.IdentityToken == "" {
-		return registry.AuthConfig{}, false
+		return registry.AuthConfig{}, false, nil
 	}
 
-	return ac, true
+	return ac, true, nil
 }
 
 func getRegistryAuth(reg string, cfgs map[string]registry.AuthConfig) (registry.AuthConfig, bool) {
@@ -159,8 +188,8 @@ var creds = &credentialsCache{entries: map[string]credentials{}}
 
 // AuthConfig updates the details in authConfig for the given hostname
 // as determined by the details in configKey.
-func (c *credentialsCache) AuthConfig(hostname, configKey string, authConfig *registry.AuthConfig) error {
-	u, p, err := creds.get(hostname, configKey)
+func (c *credentialsCache) AuthConfig(cfg *dockercfg.Config, hostname, configKey string, authConfig *registry.AuthConfig) error {
+	u, p, err := creds.get(cfg, hostname, configKey)
 	if err != nil {
 		return err
 	}
@@ -178,7 +207,7 @@ func (c *credentialsCache) AuthConfig(hostname, configKey string, authConfig *re
 // get returns the username and password for the given hostname
 // as determined by the details in configPath.
 // If the username is empty, the password is an identity token.
-func (c *credentialsCache) get(hostname, configKey string) (string, string, error) {
+func (c *credentialsCache) get(cfg *dockercfg.Config, hostname, configKey string) (string, string, error) {
 	key := configKey + ":" + hostname
 	c.mtx.RLock()
 	entry, ok := c.entries[key]
@@ -189,7 +218,7 @@ func (c *credentialsCache) get(hostname, configKey string) (string, string, erro
 	}
 
 	// No entry found, request and cache.
-	user, password, err := getRegistryCredentials(hostname)
+	user, password, err := getRegistryCredentials(cfg, hostname)
 	if err != nil {
 		return "", "", fmt.Errorf("getting credentials for %s: %w", hostname, err)
 	}
@@ -224,6 +253,12 @@ func getDockerAuthConfigs() (map[string]registry.AuthConfig, error) {
 		return nil, err
 	}
 
+	return getDockerAuthConfigsFromConfig(cfg)
+}
+
+// getDockerAuthConfigsFromConfig returns a map with the auth configs from the given docker config
+// using the registry as the key
+func getDockerAuthConfigsFromConfig(cfg *dockercfg.Config) (map[string]registry.AuthConfig, error) {
 	key, err := configKey(cfg)
 	if err != nil {
 		return nil, err
@@ -250,7 +285,7 @@ func getDockerAuthConfigs() (map[string]registry.AuthConfig, error) {
 			switch {
 			case ac.Username == "" && ac.Password == "":
 				// Look up credentials from the credential store.
-				if err := creds.AuthConfig(k, key, &ac); err != nil {
+				if err := creds.AuthConfig(cfg, k, key, &ac); err != nil {
 					results <- authConfigResult{err: err}
 					return
 				}
@@ -270,7 +305,7 @@ func getDockerAuthConfigs() (map[string]registry.AuthConfig, error) {
 			defer wg.Done()
 
 			var ac registry.AuthConfig
-			if err := creds.AuthConfig(k, key, &ac); err != nil {
+			if err := creds.AuthConfig(cfg, k, key, &ac); err != nil {
 				results <- authConfigResult{err: err}
 				return
 			}

--- a/docker_auth_test.go
+++ b/docker_auth_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	_ "embed"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -147,7 +148,7 @@ func TestDockerImageAuth(t *testing.T) {
 			getRegistryCredentials = old
 			creds.reset()
 		})
-		getRegistryCredentials = func(hostname string) (string, string, error) {
+		getRegistryCredentials = func(_ *dockercfg.Config, hostname string) (string, string, error) {
 			if hostname == exampleAuth {
 				return "gopher", "secret", nil
 			}
@@ -161,6 +162,48 @@ func TestDockerImageAuth(t *testing.T) {
 		require.Equal(t, "secret", cfg.Password)
 	})
 
+	t.Run("retrieve auth from the credentials store for a scheme-less registry", func(t *testing.T) {
+		// Registries in image references carry no scheme, and that is the host the
+		// store is asked for, as the docker CLI does.
+		t.Setenv("DOCKER_AUTH_CONFIG", `{"credsStore":"desktop"}`)
+		creds.reset()
+
+		old := getRegistryCredentials
+		t.Cleanup(func() {
+			getRegistryCredentials = old
+			creds.reset()
+		})
+		getRegistryCredentials = func(_ *dockercfg.Config, hostname string) (string, string, error) {
+			if hostname == "example-auth.com" {
+				return "gopher", "secret", nil
+			}
+			return "", "", nil
+		}
+
+		reg, cfg, err := DockerImageAuth(context.Background(), "example-auth.com/my/image:latest")
+		require.NoError(t, err)
+		require.Equal(t, "example-auth.com", reg)
+		require.Equal(t, "gopher", cfg.Username)
+		require.Equal(t, "secret", cfg.Password)
+	})
+
+	t.Run("credentials store errors are reported", func(t *testing.T) {
+		t.Setenv("DOCKER_AUTH_CONFIG", `{"credsStore":"desktop"}`)
+		creds.reset()
+
+		old := getRegistryCredentials
+		t.Cleanup(func() {
+			getRegistryCredentials = old
+			creds.reset()
+		})
+		getRegistryCredentials = func(*dockercfg.Config, string) (string, string, error) {
+			return "", "", errors.New("helper exploded")
+		}
+
+		_, _, err := DockerImageAuth(context.Background(), exampleAuth+"/my/image:latest")
+		require.ErrorContains(t, err, "helper exploded")
+	})
+
 	t.Run("credentials store without an entry for the registry", func(t *testing.T) {
 		t.Setenv("DOCKER_AUTH_CONFIG", `{"credsStore":"desktop"}`)
 		creds.reset()
@@ -171,7 +214,7 @@ func TestDockerImageAuth(t *testing.T) {
 			creds.reset()
 		})
 		// A store reports an unknown registry as empty credentials, not an error.
-		getRegistryCredentials = func(string) (string, string, error) {
+		getRegistryCredentials = func(*dockercfg.Config, string) (string, string, error) {
 			return "", "", nil
 		}
 
@@ -467,7 +510,7 @@ func Test_getDockerAuthConfigs(t *testing.T) {
 			getRegistryCredentials = old
 			creds.reset() // Ensure our mocked results aren't cached.
 		})
-		getRegistryCredentials = func(hostname string) (string, string, error) {
+		getRegistryCredentials = func(_ *dockercfg.Config, hostname string) (string, string, error) {
 			switch hostname {
 			case core.IndexDockerIO:
 				return "", "identity-token", nil

--- a/docker_auth_test.go
+++ b/docker_auth_test.go
@@ -136,6 +136,50 @@ func TestDockerImageAuth(t *testing.T) {
 		require.Equal(t, base64, cfg.Auth)
 	})
 
+	t.Run("retrieve auth from the credentials store", func(t *testing.T) {
+		// A config with only credsStore serves every registry through the store,
+		// so it has no auths or credHelpers entries to enumerate.
+		t.Setenv("DOCKER_AUTH_CONFIG", `{"credsStore":"desktop"}`)
+		creds.reset()
+
+		old := getRegistryCredentials
+		t.Cleanup(func() {
+			getRegistryCredentials = old
+			creds.reset()
+		})
+		getRegistryCredentials = func(hostname string) (string, string, error) {
+			if hostname == exampleAuth {
+				return "gopher", "secret", nil
+			}
+			return "", "", nil
+		}
+
+		reg, cfg, err := DockerImageAuth(context.Background(), exampleAuth+"/my/image:latest")
+		require.NoError(t, err)
+		require.Equal(t, exampleAuth, reg)
+		require.Equal(t, "gopher", cfg.Username)
+		require.Equal(t, "secret", cfg.Password)
+	})
+
+	t.Run("credentials store without an entry for the registry", func(t *testing.T) {
+		t.Setenv("DOCKER_AUTH_CONFIG", `{"credsStore":"desktop"}`)
+		creds.reset()
+
+		old := getRegistryCredentials
+		t.Cleanup(func() {
+			getRegistryCredentials = old
+			creds.reset()
+		})
+		// A store reports an unknown registry as empty credentials, not an error.
+		getRegistryCredentials = func(string) (string, string, error) {
+			return "", "", nil
+		}
+
+		_, cfg, err := DockerImageAuth(context.Background(), exampleAuth+"/my/image:latest")
+		require.ErrorIs(t, err, dockercfg.ErrCredentialsNotFound)
+		require.Empty(t, cfg)
+	})
+
 	t.Run("fail to match registry authentication due to invalid host", func(t *testing.T) {
 		imageReg := "example-auth.com"
 		imagePath := "/my/image:latest"

--- a/docker_auth_test.go
+++ b/docker_auth_test.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	_ "embed"
 	"encoding/base64"
-	"errors"
 	"fmt"
 	"net"
 	"os"
 	"path/filepath"
+	"runtime"
+	"strconv"
 	"testing"
 
 	"github.com/containerd/errdefs"
@@ -137,92 +138,6 @@ func TestDockerImageAuth(t *testing.T) {
 		require.Equal(t, base64, cfg.Auth)
 	})
 
-	t.Run("retrieve auth from the credentials store", func(t *testing.T) {
-		// A config with only credsStore serves every registry through the store,
-		// so it has no auths or credHelpers entries to enumerate.
-		t.Setenv("DOCKER_AUTH_CONFIG", `{"credsStore":"desktop"}`)
-		creds.reset()
-
-		old := getRegistryCredentials
-		t.Cleanup(func() {
-			getRegistryCredentials = old
-			creds.reset()
-		})
-		getRegistryCredentials = func(_ *dockercfg.Config, hostname string) (string, string, error) {
-			if hostname == exampleAuth {
-				return "gopher", "secret", nil
-			}
-			return "", "", nil
-		}
-
-		reg, cfg, err := DockerImageAuth(context.Background(), exampleAuth+"/my/image:latest")
-		require.NoError(t, err)
-		require.Equal(t, exampleAuth, reg)
-		require.Equal(t, "gopher", cfg.Username)
-		require.Equal(t, "secret", cfg.Password)
-	})
-
-	t.Run("retrieve auth from the credentials store for a scheme-less registry", func(t *testing.T) {
-		// Registries in image references carry no scheme, and that is the host the
-		// store is asked for, as the docker CLI does.
-		t.Setenv("DOCKER_AUTH_CONFIG", `{"credsStore":"desktop"}`)
-		creds.reset()
-
-		old := getRegistryCredentials
-		t.Cleanup(func() {
-			getRegistryCredentials = old
-			creds.reset()
-		})
-		getRegistryCredentials = func(_ *dockercfg.Config, hostname string) (string, string, error) {
-			if hostname == "example-auth.com" {
-				return "gopher", "secret", nil
-			}
-			return "", "", nil
-		}
-
-		reg, cfg, err := DockerImageAuth(context.Background(), "example-auth.com/my/image:latest")
-		require.NoError(t, err)
-		require.Equal(t, "example-auth.com", reg)
-		require.Equal(t, "gopher", cfg.Username)
-		require.Equal(t, "secret", cfg.Password)
-	})
-
-	t.Run("credentials store errors are reported", func(t *testing.T) {
-		t.Setenv("DOCKER_AUTH_CONFIG", `{"credsStore":"desktop"}`)
-		creds.reset()
-
-		old := getRegistryCredentials
-		t.Cleanup(func() {
-			getRegistryCredentials = old
-			creds.reset()
-		})
-		getRegistryCredentials = func(*dockercfg.Config, string) (string, string, error) {
-			return "", "", errors.New("helper exploded")
-		}
-
-		_, _, err := DockerImageAuth(context.Background(), exampleAuth+"/my/image:latest")
-		require.ErrorContains(t, err, "helper exploded")
-	})
-
-	t.Run("credentials store without an entry for the registry", func(t *testing.T) {
-		t.Setenv("DOCKER_AUTH_CONFIG", `{"credsStore":"desktop"}`)
-		creds.reset()
-
-		old := getRegistryCredentials
-		t.Cleanup(func() {
-			getRegistryCredentials = old
-			creds.reset()
-		})
-		// A store reports an unknown registry as empty credentials, not an error.
-		getRegistryCredentials = func(*dockercfg.Config, string) (string, string, error) {
-			return "", "", nil
-		}
-
-		_, cfg, err := DockerImageAuth(context.Background(), exampleAuth+"/my/image:latest")
-		require.ErrorIs(t, err, dockercfg.ErrCredentialsNotFound)
-		require.Empty(t, cfg)
-	})
-
 	t.Run("fail to match registry authentication due to invalid host", func(t *testing.T) {
 		imageReg := "example-auth.com"
 		imagePath := "/my/image:latest"
@@ -255,6 +170,103 @@ func TestDockerImageAuth(t *testing.T) {
 		require.Empty(t, cfg)
 		require.Equal(t, imageReg, registry)
 	})
+}
+
+func TestDockerImageAuthCredentialsStore(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("credential helper fixtures use shell scripts")
+	}
+
+	oldDefaultRegistry := defaultRegistryFn
+	defaultRegistryFn = func(context.Context) string { return core.IndexDockerIO }
+	t.Cleanup(func() { defaultRegistryFn = oldDefaultRegistry })
+
+	for _, tt := range []struct {
+		name     string
+		response string
+		exitCode int
+		want     registry.AuthConfig
+		wantErr  string
+	}{
+		{
+			name:     "username and password",
+			response: `{"Username":"gopher","Secret":"secret"}`,
+			want:     registry.AuthConfig{Username: "gopher", Password: "secret"},
+		},
+		{
+			name:     "identity token",
+			response: `{"Username":"<token>","Secret":"identity-token"}`,
+			want:     registry.AuthConfig{IdentityToken: "identity-token"},
+		},
+		{
+			name:     "empty store does not use the platform helper",
+			response: `{"Username":"","Secret":""}`,
+			wantErr:  dockercfg.ErrCredentialsNotFound.Error(),
+		},
+		{
+			name:     "missing entry does not use the platform helper",
+			response: dockercfg.ErrCredentialsNotFound.Error(),
+			exitCode: 1,
+			wantErr:  dockercfg.ErrCredentialsNotFound.Error(),
+		},
+		{
+			name:     "helper errors are propagated",
+			response: "helper exploded",
+			exitCode: 1,
+			wantErr:  "helper exploded",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			creds.reset()
+			t.Cleanup(creds.reset)
+			dir := t.TempDir()
+			t.Setenv("PATH", dir)
+			t.Setenv("DOCKER_AUTH_CONFIG", `{"credsStore":"test-store"}`)
+			t.Setenv("TEST_HELPER_CALLS", filepath.Join(dir, "calls"))
+			t.Setenv("TEST_HELPER_RESPONSE", tt.response)
+			t.Setenv("TEST_HELPER_EXIT", strconv.Itoa(tt.exitCode))
+
+			// Use the real dockercfg lookup. Any fallback to a platform helper
+			// returns unrelated credentials and is recorded in the call log.
+			helper := `#!/bin/sh
+host=
+read -r host
+printf '%s %s %s\n' "${0##*/}" "$1" "$host" >> "$TEST_HELPER_CALLS"
+case "$0" in
+  */docker-credential-test-store)
+    printf '%s\n' "$TEST_HELPER_RESPONSE"
+    exit "$TEST_HELPER_EXIT"
+    ;;
+  *) printf '%s\n' '{"Username":"unrelated","Secret":"wrong-store"}' ;;
+esac
+`
+			// dockercfg v0.3.2 shadows its default helper name and looks for
+			// docker-credential- instead. Trap that fallback as well.
+			for _, name := range []string{"test-store", "", "osxkeychain", "pass", "secretservice", "wincred"} {
+				require.NoError(t, os.WriteFile(filepath.Join(dir, "docker-credential-"+name), []byte(helper), 0o700))
+			}
+
+			for range 2 {
+				reg, ac, err := DockerImageAuth(context.Background(), "example-auth.com/my/image:latest")
+				require.Equal(t, "example-auth.com", reg)
+				if tt.wantErr != "" {
+					require.ErrorContains(t, err, tt.wantErr)
+				} else {
+					require.NoError(t, err)
+				}
+				require.Equal(t, tt.want, ac)
+			}
+
+			calls, err := os.ReadFile(filepath.Join(dir, "calls"))
+			require.NoError(t, err)
+			wantCalls := "docker-credential-test-store get example-auth.com\n"
+			if tt.wantErr == "helper exploded" {
+				// Failures must be retried; successful and empty results are cached.
+				wantCalls += wantCalls
+			}
+			require.Equal(t, wantCalls, string(calls))
+		})
+	}
 }
 
 func TestBuildContainerFromDockerfile(t *testing.T) {
@@ -417,8 +429,7 @@ func setAuthConfig(t *testing.T, host, username, password string) string {
 			"password": %q,
 			"auth": %q
 		}
-	},
-	"credsStore": "desktop"
+	}
 }`,
 		host,
 		username,


### PR DESCRIPTION
## What does this PR do?

When a Docker config contains only `credsStore`, registries absent from `auths` and `credHelpers` now authenticate through that store. The config is loaded once, including `DOCKER_AUTH_CONFIG`, and reused for image pulls and Dockerfile builds.

Store lookups call `GetCredentialsFromHelper` with the configured store explicitly. An empty result remains `ErrCredentialsNotFound`, without falling back to another helper. Successful and empty results are cached separately from general credential resolution; helper errors propagate and are retried. Identity tokens retain their existing mapping.

## Why is it important?

`getDockerAuthConfigs` enumerates `auths` and `credHelpers`, so a config such as `{"credsStore":"ecr-login"}` produces an empty map and pulls fail with `no basic auth credentials`. A global store must be queried when the target registry is known.

## Related issues

- Closes #3602
- Relates #1078

## How to test this PR

- `go test -race -run '^(TestDockerImageAuth|TestDockerImageAuthCredentialsStore|Test_getDockerConfig|Test_getDockerAuthConfigs)$' -count=1 .` passes on macOS arm64.
- The new helper fixtures exercise the real dockercfg lookup, covering username/password, identity tokens, empty and missing entries, errors, cache hits and retries. Both missing-credential cases fail with the previous implementation. These shell fixtures are skipped on Windows.
- `golangci-lint v2.9.0 run --timeout=5m`: 0 issues.
- The known `TestContainerCustomPlatformImage/valid-platform` and `TestParallelContainersWithReuse` failures were reproduced on current `main`: an `amd64` assertion on arm64, and a `postgis/postgis` image without an arm64 manifest, respectively.
- The full package run exceeded my 12-minute limit. It also reported log-consumer and reaper timeouts; both tests, plus the test active at the deadline (`TestWithEndpointSettingsModifier`), pass in isolated runs on both `main` and this branch. The full local suite is not claimed as passing.
