### PR TITLE
docs: fix NewDockerProvider godoc

### DIFF
--- a/provider.go
+++ b/provider.go
@@ -128,7 +128,7 @@ func (t ProviderType) GetProvider(opts ...GenericProviderOption) (GenericProvide
 	return nil, errors.New("unknown provider")
 }
 
-// NewDockerProvider creates a Docker provider with the EnvClient
+// NewDockerProvider creates a Docker provider using the Docker host and client from the environment.
 func NewDockerProvider(provOpts ...DockerProviderOption) (*DockerProvider, error) {
 	o := &DockerProviderOptions{
 		GenericProviderOptions: &GenericProviderOptions{


### PR DESCRIPTION
EnvClient is not used; the provider builds a client from the environment Docker host.