### PR TITLE
docs: update compose module minimum Go version to 1.25

### DIFF
--- a/docs/features/docker_compose.md
+++ b/docs/features/docker_compose.md
@@ -10,7 +10,7 @@ dependent upon.
 ## Using `docker compose` directly
 
 !!!warning
-	The minimal version of Go required to use this module is **1.21**.
+	The minimal version of Go required to use this module is **1.25**.
 
 ```
 go get github.com/testcontainers/testcontainers-go/modules/compose


### PR DESCRIPTION
modules/compose/go.mod requires go 1.25.9.