### PR TITLE
fix(wait): dedupe certificate error message

### DIFF
--- a/wait/tls.go
+++ b/wait/tls.go
@@ -155,7 +155,7 @@ func (ws *TLSStrategy) WaitUntilReady(ctx context.Context, target StrategyTarget
 			ForFile(ws.certFiles.certPEMFile).WithMatcher(func(r io.Reader) error {
 				var err error
 				if certPEMBlock, err = io.ReadAll(r); err != nil {
-					return fmt.Errorf("read certificate cert %q: %w", ws.certFiles.certPEMFile, err)
+					return fmt.Errorf("read certificate %q: %w", ws.certFiles.certPEMFile, err)
 				}
 
 				return nil


### PR DESCRIPTION
Align with the key error wording: read certificate %q.